### PR TITLE
Optimize performance by skipping scene update when possible

### DIFF
--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -107,6 +107,10 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     /// \brief Flag to indicate if hover event is dirty
     public: bool hoverDirty = false;
 
+    /// \brief Flag to indicate if we have to call
+    /// SceneManager::updateAllTransforms before rayQuery
+    public: bool rayQuerySceneDirty = true;
+
     /// \brief Mouse event
     public: common::MouseEvent mouseEvent;
 
@@ -659,6 +663,10 @@ void IgnRenderer::Render(RenderSync *_renderSync)
   this->dataPtr->renderUtil.SetTransformActive(
       this->dataPtr->transformControl.Active());
   this->dataPtr->renderUtil.Update();
+
+  // Every new frame we consider the whole scene dirty since
+  // that's very likely
+  this->dataPtr->rayQuerySceneDirty = true;
 
   // view control
   this->HandleMouseEvent();
@@ -2504,7 +2512,9 @@ math::Vector3d IgnRenderer::ScreenToScene(
   this->dataPtr->rayQuery->SetFromCamera(
       this->dataPtr->camera, math::Vector2d(nx, ny));
 
-  auto result = this->dataPtr->rayQuery->ClosestPoint();
+  auto result =
+    this->dataPtr->rayQuery->ClosestPoint(this->dataPtr->rayQuerySceneDirty);
+  this->dataPtr->rayQuerySceneDirty = false;
   if (result)
     return result.point;
 


### PR DESCRIPTION
## Summary

> **IMPORTANT:**
>
> This PR depends on ignitionrobotics/ign-rendering#415 and should not be merged until that PR is.

Ray queries (performed every time the mouse moves) had a negative
performance impact caused by
https://github.com/ignitionrobotics/ign-rendering/pull/415

This commit prevents repetead calls to IgnRenderer::ScreenToScene to
perform unnecessary performance degradation since calling
ClosestPoint(true) the first time during the frame is enough

Code will not compile until PR ignitionrobotics/ign-rendering#415 is
merged

Signed-off-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>


## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
