### PR TITLE
Create GUI config folder before copying config

### DIFF
--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -96,8 +96,8 @@ std::unique_ptr<ignition::gui::Application> createGui(
     defaultConfigFolder =
       ignition::common::joinPaths(defaultConfig, ".ignition",
         "gazebo", IGNITION_GAZEBO_MAJOR_VERSION_STR);
-    defaultConfig = ignition::common::joinPaths(defaultConfig, ".ignition",
-        "gazebo", IGNITION_GAZEBO_MAJOR_VERSION_STR, defaultGuiConfigName);
+    defaultConfig = ignition::common::joinPaths(defaultConfigFolder,
+        defaultGuiConfigName);
   }
   else
   {
@@ -271,15 +271,25 @@ std::unique_ptr<ignition::gui::Application> createGui(
     {
       if (!ignition::common::exists(defaultConfigFolder))
       {
-        if(!ignition::common::createDirectories(defaultConfigFolder))
+        if (!ignition::common::createDirectories(defaultConfigFolder))
         {
           ignerr << "Failed to create the default config folder ["
             << defaultConfigFolder << "]\n";
           return nullptr;
         }
       }
+
       auto installedConfig = ignition::common::joinPaths(
           IGNITION_GAZEBO_GUI_CONFIG_PATH, defaultGuiConfigName);
+      if (!ignition::common::exists(installedConfig))
+      {
+        ignerr << "Failed to copy installed config [" << installedConfig
+               << "] to default config [" << defaultConfig << "]."
+               << "(file " << installedConfig << " doesn't exist)"
+               << std::endl;
+        return nullptr;
+      }
+
       if (!ignition::common::copyFile(installedConfig, defaultConfig))
       {
         ignerr << "Failed to copy installed config [" << installedConfig


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>
I should have filed an issue for this, however this is a tiny fix so...

Basically when I was running some worlds of my own I came accross the following error
```
[GUI] [Wrn] [Filesystem.cc:376] Failed to create file [/home/arjo/.ignition/gazebo/6/gui.config]: No such file or directory
[GUI] [Err] [Gui.cc:269] Failed to copy installed config [/home/arjo/workspaces/ign_ws/install/share/ignition/ignition-gazebo6/gui/gui.config] to default config [/home/arjo/.ignition/gazebo/6/gui.config].
[GUI] [Dbg] [Application.cc:130] Terminating application.
[Dbg] [SignalHandler.cc:141] Received signal[2].
[Dbg] [ServerPrivate.cc:106] Server received signal[2]
[Msg] Found no publishers on /stats, adding root stats topic
[Msg] Found no publishers on /clock, adding root clock topic
[Dbg] [ign.cc:356] Shutting down ign-gazebo-server
```


## Summary

Turns out we were not creating the directories before copying the config files.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

