### PR TITLE
Prevent crash when using <specular> workflow PBR material

### DIFF
--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -513,8 +513,22 @@ rendering::MaterialPtr SceneManager::LoadMaterial(
     }
     else
     {
-      ignerr << "PBR material: currently only metal workflow is supported"
-             << std::endl;
+      const sdf::PbrWorkflow *specular=
+          pbr->Workflow(sdf::PbrWorkflowType::SPECULAR);
+      if (specular)
+      {
+        ignerr << "PBR material: currently only metal workflow is supported. "
+               << "Ignition Gazebo will try to render the material using "
+               << "metal workflow but without Roughness / Metalness settings."
+               << std::endl;
+      }
+      workflow = const_cast<sdf::PbrWorkflow *>(specular);
+    }
+
+    if (!workflow)
+    {
+      ignerr << "No valid PBR workflow found. " << std::endl;
+      return rendering::MaterialPtr();
     }
 
     // albedo map


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

Fixes #1038 

## Summary

The PR prevents a crash when `<material><pbr><specular>` is specified in the SDF, and expanded the error msg. It will still try to render the material using the metal workflow but without metalness and roughness settings.

To test, try changing a model with PBR material to use the specular workflow, i.e. change `<metal>` to `<specular>` or just add `<pbr><specular></specular></pbr>` to `<material>` in any model, and ignition gazebo will crash without these changes.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

