### PR TITLE
Filter rendering nodes to allow for rendering node tree reconstruction

### DIFF
--- a/include/ignition/gazebo/rendering/SceneManager.hh
+++ b/include/ignition/gazebo/rendering/SceneManager.hh
@@ -129,6 +129,18 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     public: rendering::VisualPtr CreateLink(Entity _id,
         const sdf::Link &_link, Entity _parentId = 0);
 
+    /// \brief Filter a node and its children according to specific criteria.
+    /// \param[in] _node The name of the node where filtering should start.
+    /// \param[in] _filter Callback function that defines how _node and its
+    /// children should be filtered. The function parameter is a node. The
+    /// callback returns true if the node should be filtered; false otherwise.
+    /// \return A list of filtered nodes in top level order. This list can
+    /// contain _node itself, or child nodes of _node. An empty list means no
+    /// nodes were filtered.
+    public: std::vector<rendering::NodePtr> Filter(const std::string &_node,
+                std::function<bool(
+                  const rendering::NodePtr _nodeToFilter)> _filter) const;
+
     /// \brief Copy a visual that currently exists in the scene
     /// \param[in] _id Unique visual id of the copied visual
     /// \param[in] _visual Name of the visual to copy

--- a/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc
+++ b/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc
@@ -951,7 +951,7 @@ rendering::VisualPtr VisualizationCapabilitiesPrivate::CreateJointVisual(
     std::dynamic_pointer_cast<rendering::Visual>(jointVisual);
   jointVis->SetUserData("gazebo-entity", static_cast<int>(_id));
   jointVis->SetUserData("pause-update", static_cast<int>(0));
-  jointVis->SetUserData("skip-visual-clone", static_cast<bool>(true));
+  jointVis->SetUserData("gui-only", static_cast<bool>(true));
   jointVis->SetLocalPose(_joint.RawPose());
   this->visuals[_id] = jointVis;
   return jointVis;
@@ -996,7 +996,7 @@ rendering::VisualPtr VisualizationCapabilitiesPrivate::CreateInertiaVisual(
     std::dynamic_pointer_cast<rendering::Visual>(inertiaVisual);
   inertiaVis->SetUserData("gazebo-entity", static_cast<int>(_id));
   inertiaVis->SetUserData("pause-update", static_cast<int>(0));
-  inertiaVis->SetUserData("skip-visual-clone", static_cast<bool>(true));
+  inertiaVis->SetUserData("gui-only", static_cast<bool>(true));
   this->visuals[_id] = inertiaVis;
   if (_parent)
   {
@@ -1025,7 +1025,7 @@ rendering::VisualPtr VisualizationCapabilitiesPrivate::CreateCollision(
   visual.SetName(_collision.Name());
 
   rendering::VisualPtr collisionVis = CreateVisual(_id, visual, _parent);
-  collisionVis->SetUserData("skip-visual-clone", static_cast<bool>(true));
+  collisionVis->SetUserData("gui-only", static_cast<bool>(true));
   return collisionVis;
 }
 
@@ -1455,7 +1455,7 @@ rendering::VisualPtr VisualizationCapabilitiesPrivate::createCOMVisual(
     std::dynamic_pointer_cast<rendering::Visual>(comVisual);
   comVis->SetUserData("gazebo-entity", static_cast<int>(_id));
   comVis->SetUserData("pause-update", static_cast<int>(0));
-  comVis->SetUserData("skip-visual-clone", static_cast<bool>(true));
+  comVis->SetUserData("gui-only", static_cast<bool>(true));
   this->visuals[_id] = comVis;
 
   if (_parent)

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -2674,7 +2674,7 @@ void RenderUtilPrivate::HighlightNode(const rendering::NodePtr &_node)
     wireBoxVis->SetInheritScale(false);
     wireBoxVis->AddGeometry(wireBox);
     wireBoxVis->SetMaterial(white, false);
-    wireBoxVis->SetUserData("skip-visual-clone", static_cast<bool>(true));
+    wireBoxVis->SetUserData("gui-only", static_cast<bool>(true));
     vis->AddChild(wireBoxVis);
 
     // Add wire box to map for setting visibility


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

# 🎉 New feature

Addresses the conversation in https://github.com/ignitionrobotics/ign-rendering/pull/442/files#r723569058, and may close https://github.com/ignitionrobotics/ign-rendering/pull/442.

## Summary
When working on copy/paste in #1013, it was discovered that visuals created by the GUI should be ignored when generating the visual preview of the object to be copied.

The original approach I took to solve this issue was to perform the visual ignoring logic in https://github.com/ignitionrobotics/ign-rendering/pull/442. However, it was discussed in https://github.com/ignitionrobotics/ign-rendering/pull/442/files#r723569058 that this logic should be taken care of in `ign-gazebo`, since the visuals to be ignored were created by `ign-gazebo`.

I have proposed a solution here that allows for users to filter rendering nodes according to user-specific criteria. This allows users to do whatever is needed with the filtered nodes.

For an example of how this "filtering" may be used, I have made changes in this PR that flag visuals created by the gui by setting the visual's `UserData` with a key of `gui-only` (before this PR, I flagged these visuals with a `UserData` key of `skip-visual-clone`, and then had https://github.com/ignitionrobotics/ign-rendering/pull/442 check for this flag). When performing copy/paste, I filter visuals with this `UserData` and temporarily remove them when generating a preview of what's being copied, and then re-attach the visuals to the original object once copying is complete.

## Test it
Here's a demo of filtering and temporarily removing `gui-only` visuals when doing copy/paste. If anyone would like to try this, they will need to use [the gui config that uses `Scene3d`](https://github.com/ignitionrobotics/ign-gazebo/blob/91e3e4901b469a7300de3835c92d26d081d0d254/src/gui/gui.config), since #1013 hasn't been updated to be a part of the `MinimalScene` yet.

Once you have the proper gui config, run `ign gazebo -r pendulum_links.sdf`, load the copy/paste plugin, and see what happens when you copy/paste the pendulum with various gui visuals enabled.

![copy_paste_visual_filtering](https://user-images.githubusercontent.com/42042756/137192499-eadbc72c-0131-4ce4-90b4-63e0142de764.gif)


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**