### PR TITLE
Add support for GUI entity creation

### DIFF
--- a/src/gui/GuiRunner.cc
+++ b/src/gui/GuiRunner.cc
@@ -217,7 +217,7 @@ void GuiRunner::UpdatePlugins()
   {
     plugin->Update(this->dataPtr->updateInfo, this->dataPtr->ecm);
   }
-  this->ecm.ClearRemovedComponents();
-  this->ecm.ClearNewlyCreatedEntities();
-  this->ecm.ProcessRemoveEntityRequests();
+  this->dataPtr->ecm.ClearRemovedComponents();
+  this->dataPtr->ecm.ClearNewlyCreatedEntities();
+  this->dataPtr->ecm.ProcessRemoveEntityRequests();
 }


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

# 🎉 New feature

Related to #1106

## Summary
In order to create entities in the GUI (while paused) and then share these new entities with the server, we need to:
1. Make sure that entity IDs in the GUI are unique (i.e., they don't collide with server Entity IDs)
2. Update the "new entity state" in the GUI's ECM after new GUI entity additions are processed. Otherwise, on consecutive iterations while paused, the `RenderUtil` will try to create entities that were already created.

Item 1 above was resolved through a hack that sets the GUI ECM's entity creation ID offset to one that is (probably) larger than the server ECM's entity creation ID offset (I left a `TODO` note in the code about improving this). Item 2 above actually appears to be a bug that was never fixed. The fix for this is to move the GUI ECM's `ClearNewlyCreatedEntities` and `ProcessRemoveEntityRequests` calls to the `GuiRunner::Implementation::UpdatePlugins` method. This allows the GUI ECM's state to be properly updated when simulation is both running and paused (the previous approach of having these ECM method calls in `GuiRunner::Implementation::ProcessState` meant that these ECM method calls were only made when simulation is running).

## Test it
@iche033 can you try to test this with your GUI model editor work in https://github.com/ignitionrobotics/ign-gazebo/compare/ign-gazebo6...model_editor_add_link? You should be able to remove [these lines](https://github.com/ignitionrobotics/ign-gazebo/blob/cdd9e5096ebaf57cd603a877d926a149e58dbc1c/src/gui/plugins/model_editor/ModelEditor.cc#L129-L134) from your branch because this PR sets the entity creation offset for the ECM that's used by all GUI plugins.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**