### PR TITLE
Fix performance level test flakiness

### DIFF
--- a/test/performance/level_manager.cc
+++ b/test/performance/level_manager.cc
@@ -46,6 +46,17 @@ TEST(LevelManagerPerfrormance, LevelVsNoLevel)
 
   const std::size_t iters = 5000;
 
+
+  // Reduce potential startup costs by running the server once before
+  // measuring time differences between levels and no levels.
+  {
+    serverConfig.SetUseLevels(true);
+    gazebo::Server server(serverConfig);
+    server.SetUpdatePeriod(1ns);
+
+    server.Run(true, 1, false);
+  }
+
   // Server with levels
   {
     serverConfig.SetUseLevels(true);


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

Closes #826 

## Summary

Fixes the `PERFORMANCE_level_manager` by running the server once before measuring.

## Test it

Run the test with and without the change. You should see a big difference in the time `Using levels = X ms`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**