### PR TITLE
fix updating a component's data via SerializedState msg

### DIFF
--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -1667,6 +1667,12 @@ void EntityComponentManager::SetState(
       if (nullptr == comp)
       {
         auto newComp = components::Factory::Instance()->New(type);
+        if (nullptr == newComp)
+        {
+          ignerr << "Failed to create component type ["
+            << compMsg.type() << "]" << std::endl;
+          continue;
+        }
         std::istringstream istr(compMsg.component());
         newComp->Deserialize(istr);
         this->CreateComponentImplementation(entity, type, newComp.get());

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -3014,11 +3014,20 @@ TEST_P(EntityComponentManagerFixture, StateMsgUpdateComponent)
   auto entity = originalECMStateMap.CreateEntity();
   originalECMStateMap.CreateComponent(entity, components::IntComponent(1));
 
+  int foundEntities = 0;
+  otherECMStateMap.Each<components::IntComponent>(
+      [&](const Entity &, const components::IntComponent *)
+      {
+        foundEntities++;
+        return true;
+      });
+  EXPECT_EQ(0, foundEntities);
+
   // update the other ECM to have the new entity and component
   msgs::SerializedStateMap stateMapMsg;
   originalECMStateMap.State(stateMapMsg);
   otherECMStateMap.SetState(stateMapMsg);
-  int foundEntities = 0;
+  foundEntities = 0;
   otherECMStateMap.Each<components::IntComponent>(
       [&](const Entity &, const components::IntComponent *_intComp)
       {
@@ -3047,6 +3056,15 @@ TEST_P(EntityComponentManagerFixture, StateMsgUpdateComponent)
   // instead of a msgs::SerializedStateMap
   EntityComponentManager originalECMState;
   EntityComponentManager otherECMState;
+
+  foundEntities = 0;
+  otherECMState.Each<components::IntComponent>(
+      [&](const Entity &, const components::IntComponent *)
+      {
+        foundEntities++;
+        return true;
+      });
+  EXPECT_EQ(0, foundEntities);
 
   entity = originalECMState.CreateEntity();
   originalECMState.CreateComponent(entity, components::IntComponent(1));


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

# 🦟 Bug fix

## Summary
While working on #1109, I found that there's a bug in `ign-gazebo` where an existing component's data isn't modified correctly through a `msgs::SerializedState`. There's also a `TODO` note about this in the code, which makes me think that this issue has existed for a while: https://github.com/ignitionrobotics/ign-gazebo/blob/447e5c231ec312bd0ce4e4d349222145e0e135d5/src/EntityComponentManager.cc#L1692-L1697

The issue is that if the default assignment operator is used between base classes, derived class data is lost in the assignment (we are using `BaseComponent` in `src/EntityComponentManager.cc` since that file doesn't have access to template types). The solution is to use `BaseComponent::Deserialize`, since this method is implemented by derived classes: https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo6_6.0.0/include/ignition/gazebo/components/Component.hh#L358-L359

For a simple example of how derived class data is lost when using the default assignment operator between base classes, see https://godbolt.org/z/hezKTbeEj

I should also mention that this fix will need to be backported. I didn't target an older branch in this PR because this fix is needed by #1109, which is urgent and doesn't have time to wait for forward-ports/releases.

## Test it

I have added unit tests for the `EntityComponentManager` class in this PR. Without the changes in this PR, the test that updates an ECM's component via a `msgs::SerializedState` fails.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**