### PR TITLE
use uint64_t for ComponentInspector Entity IDs

### DIFF
--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -322,6 +322,7 @@ ComponentInspector::ComponentInspector()
   : GuiSystem(), dataPtr(std::make_unique<ComponentInspectorPrivate>())
 {
   qRegisterMetaType<ignition::gazebo::ComponentTypeId>();
+  qRegisterMetaType<Entity>("Entity");
 }
 
 /////////////////////////////////////////////////
@@ -752,13 +753,13 @@ bool ComponentInspector::eventFilter(QObject *_obj, QEvent *_event)
 }
 
 /////////////////////////////////////////////////
-int ComponentInspector::Entity() const
+Entity ComponentInspector::GetEntity() const
 {
   return this->dataPtr->entity;
 }
 
 /////////////////////////////////////////////////
-void ComponentInspector::SetEntity(const int &_entity)
+void ComponentInspector::SetEntity(const Entity &_entity)
 {
   // If nothing is selected, display world properties
   if (_entity == kNullEntity)

--- a/src/gui/plugins/component_inspector/ComponentInspector.hh
+++ b/src/gui/plugins/component_inspector/ComponentInspector.hh
@@ -156,8 +156,8 @@ namespace gazebo
 
     /// \brief Entity
     Q_PROPERTY(
-      int entity
-      READ Entity
+      Entity entity
+      READ GetEntity
       WRITE SetEntity
       NOTIFY EntityChanged
     )
@@ -233,11 +233,11 @@ namespace gazebo
 
     /// \brief Get the entity currently inspected.
     /// \return Entity ID.
-    public: Q_INVOKABLE int Entity() const;
+    public: Q_INVOKABLE Entity GetEntity() const;
 
     /// \brief Set the entity currently inspected.
     /// \param[in] _entity Entity ID.
-    public: Q_INVOKABLE void SetEntity(const int &_entity);
+    public: Q_INVOKABLE void SetEntity(const Entity &_entity);
 
     /// \brief Notify that entity has changed.
     signals: void EntityChanged();


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

# 🦟 Bug fix

## Summary
On the server, an [Entity ID is defined as a uint64_t](https://github.com/ignitionrobotics/ign-gazebo/blob/ignition-gazebo6_6.1.0/include/ignition/gazebo/Entity.hh#L59). This PR updates the component inspector to use the same type for entity IDs in the GUI plugin.

This should help with some of the issues seen in #1138.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**