### PR TITLE
Add Metal support to Gazebo for macOS

### DIFF
--- a/src/cmd/cmdsim.rb.in
+++ b/src/cmd/cmdsim.rb.in
@@ -470,13 +470,6 @@ Please use [GZ_SIM_RESOURCE_PATH] instead."
       # Neither the -s nor -g options were used, so run both the server
       # and gui.
       if options['server'] == 0 && options['gui'] == 0
-
-        if plugin.end_with? ".dylib"
-          puts "`gz sim` currently only works with the -s argument on macOS.
-See https://github.com/gazebosim/gz-sim/issues/44 for more info."
-          exit(-1)
-        end
-
         serverPid = Process.fork do
           ENV['RMT_PORT'] = '1500'
           Process.setpgid(0, 0)
@@ -530,12 +523,6 @@ See https://github.com/gazebosim/gz-sim/issues/44 for more info."
             options['wait_gui'], options['headless-rendering'])
             # Otherwise run the gui
       else options['gui']
-        if plugin.end_with? ".dylib"
-          puts "`gz sim` currently only works with the -s argument on macOS.
-See https://github.com/gazebosim/gz-sim/issues/44 for more info."
-          exit(-1)
-        end
-
         ENV['RMT_PORT'] = '1501'
         Importer.runGui(options['gui_config'], options['file'],
             options['wait_gui'], options['render_engine_gui'])

--- a/src/cmd/cmdsim.rb.in
+++ b/src/cmd/cmdsim.rb.in
@@ -470,6 +470,14 @@ Please use [GZ_SIM_RESOURCE_PATH] instead."
       # Neither the -s nor -g options were used, so run both the server
       # and gui.
       if options['server'] == 0 && options['gui'] == 0
+
+        if plugin.end_with? ".dylib"
+          puts "On macOS `ign gazebo` currently only works with either the -s argument
+or the -g argument, you cannot run both server and gui in one terminal. 
+See https://github.com/ignitionrobotics/ign-gazebo/issues/44 for more info."
+          exit(-1)
+        end
+
         serverPid = Process.fork do
           ENV['RMT_PORT'] = '1500'
           Process.setpgid(0, 0)

--- a/src/cmd/cmdsim.rb.in
+++ b/src/cmd/cmdsim.rb.in
@@ -472,9 +472,9 @@ Please use [GZ_SIM_RESOURCE_PATH] instead."
       if options['server'] == 0 && options['gui'] == 0
 
         if plugin.end_with? ".dylib"
-          puts "On macOS `ign gazebo` currently only works with either the -s argument
+          puts "On macOS `gz sim` currently only works with either the -s argument
 or the -g argument, you cannot run both server and gui in one terminal. 
-See https://github.com/ignitionrobotics/ign-gazebo/issues/44 for more info."
+See https://github.com/gazebosim/gz-sim/issues/44 for more info."
           exit(-1)
         end
 

--- a/src/gui/plugins/component_inspector/Boolean.qml
+++ b/src/gui/plugins/component_inspector/Boolean.qml
@@ -34,6 +34,8 @@ Rectangle {
   // Horizontal margins
   property int margin: 5
 
+  property int tooltipDelay: 500
+
   RowLayout {
     anchors.fill: parent
 

--- a/src/gui/plugins/modules/TypeIcon.qml
+++ b/src/gui/plugins/modules/TypeIcon.qml
@@ -31,6 +31,8 @@ Image {
    */
   property string entityType: ''
 
+  property int tooltipDelay: 500
+
   /**
    * Image address according to type
    */

--- a/src/gui/plugins/visualize_lidar/VisualizeLidar.qml
+++ b/src/gui/plugins/visualize_lidar/VisualizeLidar.qml
@@ -30,6 +30,9 @@ GridLayout {
   anchors.leftMargin: 10
   anchors.rightMargin: 10
 
+  property int tooltipDelay: 500
+  property int tooltipTimeout: 1000
+
   CheckBox {
     Layout.alignment: Qt.AlignHCenter
     id: displayVisual

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -2583,11 +2583,20 @@ void RenderUtil::Init()
   rendering::setPluginPaths(pluginPath.PluginPaths());
 
   std::map<std::string, std::string> params;
+#ifdef __APPLE__
+  // TODO(srmainwaring): implement facility for overriding the default
+  //    graphics API in macOS, in which case there are restrictions on
+  //    the version of OpenGL used.
+  params["metal"] = "1";
+#else
   if (this->dataPtr->useCurrentGLContext)
     params["useCurrentGLContext"] = "1";
+#endif
+
   if (this->dataPtr->isHeadlessRendering)
     params["headless"] = "1";
   params["winID"] = this->dataPtr->winID;
+
   this->dataPtr->engine = rendering::engine(this->dataPtr->engineName, params);
   if (!this->dataPtr->engine)
   {

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -608,7 +608,8 @@ void Sensors::Update(const UpdateInfo &_info,
 #ifdef __APPLE__
   // On macOS the render engine must be initialised on the main thread.
   if (!this->dataPtr->initialized &&
-      (_ecm.HasComponentType(components::Camera::typeId) ||
+      (_ecm.HasComponentType(components::BoundingBoxCamera::typeId) ||
+       _ecm.HasComponentType(components::Camera::typeId) ||
        _ecm.HasComponentType(components::DepthCamera::typeId) ||
        _ecm.HasComponentType(components::GpuLidar::typeId) ||
        _ecm.HasComponentType(components::RgbdCamera::typeId) ||


### PR DESCRIPTION
# 🎉 New feature

Fixes #44
Fixes #960

## Summary

This PR provides support for running Gazebo on macOS using the Metal graphics API.

For platforms other than macOS the default behaviour is unchanged and will use the OpenGL graphics API. On macOS the graphics API is set to Metal and only the ogre2 render engine is supported.

## Details

### `ign` command scripts

The ruby script has been updated to allow `ign gazebo -g` to be run on macOS. Because of macOS's rules about using `fork` the server and gui must be run in separate terminals. 

### C++ code

There are two changes to support Metal

- `src/rendering/RenderUtil.cc`: if `__APPLE__` is defined the render engine parameters are set to `metal`.
- `src/systems/sensors/Sensors.cc`: the render engine initialisation is moved to `Update` so that it occurs on the main thread.

### QML

Finally there are a number of small changes to QML files to address warnings and errors that show up up on macOS where we are using Qt 5.15.2_1. The are mostly to do with tool tip behaviour.

## Test it

A document describing how to build Ignition for Metal support is here: https://github.com/srmainwaring/ign-rendering/wiki. The main changes to note are the dependencies are now:

- https://github.com/ignitionrobotics/ign-rendering/tree/main
- https://github.com/ignitionrobotics/ign-gui/pull/323

and the MinimalScene plugin element to override the default graphics interface in `gui.config` is now `<graphics_api>metal</graphics_api>`.

#### `examples/worlds/shapes.sdf`

Update the MinimalScene plugin element in `~/.ignition/gazebo/7/gui.config` to include `<graphics_api>metal</graphics_api>`.

Run the server:

```bash
$ ign gazebo -v4 -s -r shapes.sdf
```

Run the client:

```bash
$ ign gazebo -v4 -g shapes.sdf
```

![gazebo_metal_shapes](https://user-images.githubusercontent.com/24916364/144756379-c058fe05-81ae-45af-920a-223acc6140af.png)

#### `examples/worlds/camera_sensor.sdf`

Two changes are required in `camera_sensor.sdf`:

```xml
<!-- Modify the sensors system plugin element to use the `ogre2` render engine -->
<plugin
  filename="ignition-gazebo-sensors-system"
  name="ignition::gazebo::systems::Sensors">
  <render_engine>ogre2</render_engine>
</plugin>

<!-- Modify the MinimalScene gui plugin element to use `ogre2` and the `metal` graphics API -->
<gui fullscreen="0">
  <plugin filename="MinimalScene" name="3D View">
    <ignition-gui>
      <title>3D View</title>
      <property type="bool" key="showTitleBar">false</property>
      <property type="string" key="state">docked</property>
    </ignition-gui>
    <engine>ogre2</engine>
    <scene>scene</scene>
    <ambient_light>0.4 0.4 0.4</ambient_light>
    <background_color>0.8 0.8 0.8</background_color>
    <camera_pose>-6 0 6 0 0.5 0</camera_pose>
    <graphics_api>metal</graphics_api>
</plugin>
```

Then rebuild with `colcon` (to install the change) and run as above substituting `camera_sensor.sdf` for `shapes.sdf`
 
![gazebo_metal_camera_sensor](https://user-images.githubusercontent.com/24916364/144759203-7921907a-b792-475f-b1a4-f5f69665a1f6.png)
### Tests

These test are failing on macOS:

```
$ make test
...
The following tests FAILED:
	 49 - UNIT_ModelCommandAPI_TEST (SEGFAULT)
	 75 - INTEGRATION_buoyancy_engine (SEGFAULT)
	165 - INTEGRATION_touch_plugin (Subprocess aborted)
	171 - INTEGRATION_user_commands (SEGFAULT)
```

However `INTEGRATION_buoyancy_engine` and `INTEGRATION_touch_plugin` pass when run individually. 

### Code check

There are quite a few code check failures on macOS, however these don't seem to be connected to this PR.
<details>

```bash
% make codecheck
Built target cpplint
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/include/ignition/gazebo/Conversions.hh:631:7: error: Found a exit path from function with non-void return type that has missing return statement [missingReturn]
      Out::ConversionNotImplemented;
      ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/include/ignition/gazebo/components/Component.hh:115:0: information: Unmatched suppression: syntaxError [unmatchedSuppression]
      if constexpr (traits::IsSharedPtr<DataType>::value) // NOLINT
^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/include/ignition/gazebo/components/Factory.hh:305:51: error: There is an unknown macro here somewhere. Configuration is required. If IGN_DEPRECATED is a macro then please configure it. [unknownMacro]
    public: std::unique_ptr<ComponentStorageBase> IGN_DEPRECATED(6) NewStorage(
                                                  ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/include/ignition/gazebo/components/Model.hh:70:26: style: Variable 'errors' is assigned a value that is never used. [unreadVariable]
      sdf::Errors errors = root.LoadSdfString(sdf);
                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/include/ignition/gazebo/detail/BaseView.hh:52:12: style: Consider using std::accumulate algorithm instead of a raw loop. [useStlAlgorithm]
      hash ^= i + 0x9e3779b9 + (hash << 6) + (hash >> 2);
           ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/include/ignition/gazebo/detail/ComponentStorageBase.hh:35:15: error: There is an unknown macro here somewhere. Configuration is required. If IGN_DEPRECATED is a macro then please configure it. [unknownMacro]
      public: IGN_DEPRECATED(6) ComponentStorageBase() = default;
              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/include/ignition/gazebo/detail/EntityComponentManager.hh:512:16: style: Variable 'viewLock' is assigned a value that is never used. [unreadVariable]
      viewLock = std::make_unique<std::lock_guard<std::mutex>>(*mutexPtr);
               ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/include/ignition/gazebo/detail/EntityComponentManager.hh:73:0: information: Unmatched suppression: syntaxError [unmatchedSuppression]
  if constexpr (std::is_same<DataType, double>::value)
^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/EntityComponentManager.cc:1730:31: performance: Searching before insertion is not necessary. [stlFindInsert]
          printedComps.insert(type);
                              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/EventManager_TEST.cc:75:23: performance: Function parameter '_val1' should be passed by const reference. [passedByValue]
      [&](std::string _val1, std::string _val2)
                      ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/EventManager_TEST.cc:75:42: performance: Function parameter '_val2' should be passed by const reference. [passedByValue]
      [&](std::string _val1, std::string _val2)
                                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/LevelManager.hh:83:15: style: Class 'LevelManager' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
      public: LevelManager(SimulationRunner *_runner, bool _useLevels = false);
              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/Model_TEST.cc:150:7: style: Consider using std::count_if algorithm instead of a raw loop. [useStlAlgorithm]
      foundLinks++;
      ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/Model_TEST.cc:211:7: style: Consider using std::count_if algorithm instead of a raw loop. [useStlAlgorithm]
      foundModels++;
      ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/SdfGenerator.cc:85:19: style: Consider using std::accumulate algorithm instead of a raw loop. [useStlAlgorithm]
          newPath /= segment;
                  ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/SdfGenerator_TEST.cc:218:17: style: Variable 'errors' is assigned a value that is never used. [unreadVariable]
    auto errors = this->root.Load(common::joinPaths(PROJECT_SOURCE_PATH,
                ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/SdfGenerator_TEST.cc:229:17: style: Variable 'errors' is assigned a value that is never used. [unreadVariable]
    auto errors = this->root.LoadSdfString(_worldSdf);
                ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/ServerConfig.cc:64:0: information: Unmatched suppression: passedByValue [unmatchedSuppression]
  public: PluginInfoPrivate(std::string _entityName,
^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/ServerConfig.cc:66:0: information: Unmatched suppression: passedByValue [unmatchedSuppression]
                            std::string _entityType,
^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/ServerConfig.cc:68:0: information: Unmatched suppression: passedByValue [unmatchedSuppression]
                            std::string _filename,
^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/ServerConfig.cc:70:0: information: Unmatched suppression: passedByValue [unmatchedSuppression]
                            std::string _name)
^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/ServerPrivate.cc:249:23: style: Variable 'recordTopicElem' is assigned a value that is never used. [unreadVariable]
      recordTopicElem = recordTopicElem->GetNextElement();
                      ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/SimulationRunner.cc:762:15: style: Variable 'sleepTime' is reassigned a value before the old one has been used. [redundantAssignment]
    sleepTime = std::max(0ns, this->prevUpdateRealTime +
              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/SimulationRunner.cc:759:15: note: sleepTime is assigned
    sleepTime = 0ns;
              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/SimulationRunner.cc:762:15: note: sleepTime is overwritten
    sleepTime = std::max(0ns, this->prevUpdateRealTime +
              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/Util.cc:543:10: style: Local variable 'validTopic' shadows outer function [shadowFunction]
    auto validTopic = transport::TopicUtils::AsValidTopic(topic);
         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/Util.cc:539:13: note: Shadowed declaration
std::string validTopic(const std::vector<std::string> &_topics)
            ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/Util.cc:543:10: note: Shadow variable
    auto validTopic = transport::TopicUtils::AsValidTopic(topic);
         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/Util.cc:474:17: style: Consider using std::accumulate algorithm instead of a raw loop. [useStlAlgorithm]
    sdfPathsStr += ':' + path;
                ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/Util.cc:480:17: style: Consider using std::accumulate algorithm instead of a raw loop. [useStlAlgorithm]
    ignPathsStr += ':' + path;
                ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/Util.cc:487:16: style: Consider using std::accumulate algorithm instead of a raw loop. [useStlAlgorithm]
    gzPathsStr += ':' + path;
               ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/gui/plugins/banana_for_scale/BananaForScale.cc:100:17: style: Variable 'result' is assigned a value that is never used. [unreadVariable]
    auto result = this->dataPtr->fuelClient->DownloadModel(modelUri, localPath);
                ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/gui/plugins/entity_tree/EntityTree.cc:489:22: style: Variable 'errTxt' is assigned a value that is never used. [unreadVariable]
      QString errTxt = QString::fromStdString("Invalid URI: " + meshStr +
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/gui/plugins/component_inspector/ComponentInspector.cc:559:5: warning: Either the condition 'nullptr==item' is redundant or there is possible null pointer dereference: item. [nullPointerRedundantCheck]
    item->setData(QString::number(this->dataPtr->entity),
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/gui/plugins/component_inspector/ComponentInspector.cc:562:17: note: Assuming that condition 'nullptr==item' is not redundant
    if (nullptr == item)
                ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/gui/plugins/component_inspector/ComponentInspector.cc:559:5: note: Null pointer dereference
    item->setData(QString::number(this->dataPtr->entity),
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/gui/plugins/entity_tree/EntityTree.hh:86:0: information: Unmatched suppression: unusedStructMember [unmatchedSuppression]
      Entity entity;
^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/gui/plugins/entity_tree/EntityTree.hh:93:0: information: Unmatched suppression: unusedStructMember [unmatchedSuppression]
      Entity parentEntity;
^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/gui/plugins/resource_spawner/ResourceSpawner.cc:336:21: style: Consider using std::copy algorithm instead of a raw loop. [useStlAlgorithm]
      fuelResources.push_back(resource);
                    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/gui/plugins/resource_spawner/ResourceSpawner.cc:505:9: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]
        {
        ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/gui/plugins/spawn/Spawn.cc:332:34: style: Variable 'rootVis' is assigned a value that is never used. [unreadVariable]
    rendering::VisualPtr rootVis = this->scene->RootVisual();
                                 ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/gui/plugins/scene3d/Scene3D.cc:990:36: style: Variable 'rootVis' is assigned a value that is never used. [unreadVariable]
      rendering::VisualPtr rootVis = scene->RootVisual();
                                   ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/network/PeerTracker.hh:134:23: style: Consider using std::transform algorithm instead of a raw loop. [useStlAlgorithm]
                  ret.push_back(it.first);
                      ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc:1232:29: warning: Possible null pointer dereference: workflow [nullPointer]
    std::string albedoMap = workflow->AlbedoMap();
                            ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc:1190:34: note: Assignment 'workflow=nullptr', assigned value is 0
    sdf::PbrWorkflow *workflow = nullptr;
                                 ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc:1193:9: note: Assuming condition is false
    if (metal)
        ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc:1232:29: note: Null pointer dereference
    std::string albedoMap = workflow->AlbedoMap();
                            ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/network/NetworkManagerPrimary.cc:121:11: style: Consider using std::any_of, std::all_of, std::none_of, or std::accumulate algorithm instead of a raw loop. [useStlAlgorithm]
    ready &= secondary.second->ready;
          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/network/PeerTracker.cc:113:7: style: Consider using std::count_if algorithm instead of a raw loop. [useStlAlgorithm]
      count++;
      ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/network/PeerTracker.cc:99:13: style: Variable 'lock' is assigned a value that is never used. [unreadVariable]
  auto lock = PeerLock(this->peersMutex);
            ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/network/PeerTracker.cc:106:13: style: Variable 'lock' is assigned a value that is never used. [unreadVariable]
  auto lock = PeerLock(this->peersMutex);
            ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/network/PeerTracker.cc:161:13: style: Variable 'lock' is assigned a value that is never used. [unreadVariable]
  auto lock = PeerLock(this->peersMutex);
            ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/network/PeerTracker.cc:208:13: style: Variable 'lock' is assigned a value that is never used. [unreadVariable]
  auto lock = PeerLock(this->peersMutex);
            ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/network/PeerTracker.cc:228:13: style: Variable 'lock' is assigned a value that is never used. [unreadVariable]
  auto lock = PeerLock(this->peersMutex);
            ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/battery_plugin/LinearBatteryPlugin.cc:562:18: style: Consider using std::accumulate algorithm instead of a raw loop. [useStlAlgorithm]
      totalpower += powerLoad.second;
                 ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/rendering/SceneManager.cc:1733:29: style: Variable 'key' is assigned a value that is never used. [unreadVariable]
      const std::string key = "particle_scatter_ratio";
                            ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/buoyancy/Buoyancy.cc:202:20: style: Variable 'centerOfBuoyancy' is assigned a value that is never used. [unreadVariable]
  centerOfBuoyancy = cov;
                   ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/hydrodynamics/Hydrodynamics.cc:344:12: style: Redundant initialization for 'stateDot'. The initialized value is overwritten before it is read. [redundantInitialization]
  stateDot = (state - this->dataPtr->prevState)/dt;
           ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/hydrodynamics/Hydrodynamics.cc:304:28: note: stateDot is initialized
  Eigen::VectorXd stateDot = Eigen::VectorXd(6);
                           ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/hydrodynamics/Hydrodynamics.cc:344:12: note: stateDot is overwritten
  stateDot = (state - this->dataPtr->prevState)/dt;
           ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/joint_controller/JointController.cc:205:20: style: The if condition is the same as the previous if condition [duplicateCondition]
  if (jointVelComp == nullptr)
                   ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/joint_controller/JointController.cc:200:20: note: First condition
  if (jointVelComp == nullptr)
                   ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/joint_controller/JointController.cc:205:20: note: Second condition
  if (jointVelComp == nullptr)
                   ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/lift_drag/LiftDrag.cc:440:6: style: Variable 'cm' is reassigned a value before the old one has been used. [redundantAssignment]
  cm = 0.0;
     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/lift_drag/LiftDrag.cc:436:8: note: cm is assigned
    cm = this->cma * alpha * cosSweepAngle;
       ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/lift_drag/LiftDrag.cc:440:6: note: cm is overwritten
  cm = 0.0;
     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/multicopter_control/Common.hh:101:34: warning: Found suspicious operator ',' [constStatement]
        -_vector.y(), _vector.x(), 0;
                                 ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/multicopter_control/Common.cc:263:41: style: Parameter '_val' can be declared with const [constParameter]
  auto applyNoise = [](Eigen::Vector3d &_val, const Eigen::Vector3d &_mean,
                                        ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/multicopter_motor_model/MulticopterMotorModel.cc:70:37: error: Found a exit path from function with non-void return type that has missing return statement [missingReturn]
      previousState(_initialState) {}
                                    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/particle_emitter/ParticleEmitter.hh:122:13: error: There is an unknown macro here somewhere. Configuration is required. If IGN_DEPRECATED is a macro then please configure it. [unknownMacro]
    public: IGN_DEPRECATED(6) ParticleEmitter();
            ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc:657:7: style: Consider using std::any_of algorithm instead of a raw loop. [useStlAlgorithm]
      {
      ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/particle_emitter2/ParticleEmitter2.cc:165:23: style: Consider using std::accumulate algorithm instead of a raw loop. [useStlAlgorithm]
                topic = data.value(0);
                      ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/physics/EntityFeatureMap.hh:101:0: information: Unmatched suppression: syntaxError [unmatchedSuppression]
      if constexpr (!HasFeatureList<ToFeatureList>::value) // NOLINT
^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/thruster/Thruster.cc:293:13: style: Variable 'pose' is assigned a value that is never used. [unreadVariable]
  auto pose = worldPose(this->dataPtr->linkEntity, _ecm);
            ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/triggered_publisher/TriggeredPublisher.cc:317:15: warning: Either the condition 'nullptr==fieldMsgType' is redundant or there is possible null pointer dereference: fieldMsgType. [nullPointerRedundantCheck]
           << fieldMsgType->full_name() << "] does not have any fields\n";
              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/triggered_publisher/TriggeredPublisher.cc:313:15: note: Assuming that condition 'nullptr==fieldMsgType' is not redundant
  if (nullptr == fieldMsgType)
              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/triggered_publisher/TriggeredPublisher.cc:317:15: note: Null pointer dereference
           << fieldMsgType->full_name() << "] does not have any fields\n";
              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/velocity_control/VelocityControl.cc:370:5: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]
    {
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/apply_joint_force_system.cc:110:36: error: Out of bounds access in expression 'jointForceCmd.back()' because 'jointForceCmd' is empty and 'back' may be non-zero. [containerOutOfBounds]
    if (std::abs(jointForceCmd.back() - testJointForce) < 1e-6)
                                   ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/ackermann_steering_system.cc:358:0: information: Unmatched suppression: knownConditionTrueFalse [unmatchedSuppression]
  for (; odomPosesCount < 5 && sleep < maxSleep; ++sleep) // NOLINT
^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/ackermann_steering_system.cc:409:0: information: Unmatched suppression: knownConditionTrueFalse [unmatchedSuppression]
  for (; odomPosesCount < 5 && sleep < maxSleep; ++sleep)
^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/helpers/EnvTestFixture.hh:55:29: warning: The class 'InternalFixture < InternalFixture < :: testing :: Test > >' defines member variable with name 'kFakeHome' also defined in its parent class 'InternalFixture < :: testing :: Test >'. [duplInheritedMember]
  public: const std::string kFakeHome = common::joinPaths(PROJECT_BINARY_PATH,
                            ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/helpers/EnvTestFixture.hh:55:29: note: Parent variable 'InternalFixture < :: testing :: Test >::kFakeHome'
  public: const std::string kFakeHome = common::joinPaths(PROJECT_BINARY_PATH,
                            ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/helpers/EnvTestFixture.hh:55:29: note: Derived variable 'InternalFixture < InternalFixture < :: testing :: Test > >::kFakeHome'
  public: const std::string kFakeHome = common::joinPaths(PROJECT_BINARY_PATH,
                            ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/helpers/EnvTestFixture.hh:59:23: warning: The class 'InternalFixture < InternalFixture < :: testing :: Test > >' defines member variable with name 'realHome' also defined in its parent class 'InternalFixture < :: testing :: Test >'. [duplInheritedMember]
  public: std::string realHome;
                      ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/helpers/EnvTestFixture.hh:59:23: note: Parent variable 'InternalFixture < :: testing :: Test >::realHome'
  public: std::string realHome;
                      ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/helpers/EnvTestFixture.hh:59:23: note: Derived variable 'InternalFixture < InternalFixture < :: testing :: Test > >::realHome'
  public: std::string realHome;
                      ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/camera_video_record_system.cc:69:7: style: Consider using std::any_of algorithm instead of a raw loop. [useStlAlgorithm]
      {
      ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/detachable_joint.cc:127:26: error: Out of bounds access in expression 'm1Poses.front()' because 'm1Poses' is empty and 'front' may be non-zero. [containerOutOfBounds]
  EXPECT_EQ(m1Poses.front(), m1Poses.back());
                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/detachable_joint.cc:127:42: error: Out of bounds access in expression 'm1Poses.back()' because 'm1Poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
  EXPECT_EQ(m1Poses.front(), m1Poses.back());
                                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/detachable_joint.cc:134:26: error: Out of bounds access in expression 'm2Poses.front()' because 'm2Poses' is empty and 'front' may be non-zero. [containerOutOfBounds]
  EXPECT_GT(m2Poses.front().Pos().Z() - m2Poses.back().Pos().Z(), expDist);
                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/detachable_joint.cc:134:53: error: Out of bounds access in expression 'm2Poses.back()' because 'm2Poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
  EXPECT_GT(m2Poses.front().Pos().Z() - m2Poses.back().Pos().Z(), expDist);
                                                    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/detachable_joint.cc:205:26: error: Out of bounds access in expression 'b1Poses.front()' because 'b1Poses' is empty and 'front' may be non-zero. [containerOutOfBounds]
  EXPECT_EQ(b1Poses.front(), b1Poses.back());
                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/detachable_joint.cc:205:42: error: Out of bounds access in expression 'b1Poses.back()' because 'b1Poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
  EXPECT_EQ(b1Poses.front(), b1Poses.back());
                                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/detachable_joint.cc:212:26: error: Out of bounds access in expression 'b2Poses.front()' because 'b2Poses' is empty and 'front' may be non-zero. [containerOutOfBounds]
  EXPECT_GT(b2Poses.front().Pos().Z() - b2Poses.back().Pos().Z(), expDist);
                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/detachable_joint.cc:212:53: error: Out of bounds access in expression 'b2Poses.back()' because 'b2Poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
  EXPECT_GT(b2Poses.front().Pos().Z() - b2Poses.back().Pos().Z(), expDist);
                                                    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/diff_drive_system.cc:504:0: information: Unmatched suppression: knownConditionTrueFalse [unmatchedSuppression]
  for (; odomPosesCount < 5 && sleep < maxSleep; ++sleep) // NOLINT
^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/diff_drive_system.cc:561:0: information: Unmatched suppression: knownConditionTrueFalse [unmatchedSuppression]
  for (; odomPosesCount < 5 && sleep < maxSleep; ++sleep)
^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/diff_drive_system.cc:621:0: information: Unmatched suppression: knownConditionTrueFalse [unmatchedSuppression]
  for (; odomPosesCount < 5 && sleep < maxSleep; ++sleep)
^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/diff_drive_system.cc:681:0: information: Unmatched suppression: knownConditionTrueFalse [unmatchedSuppression]
  for (; odomPosesCount < 5 && sleep < maxSleep; ++sleep)
^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/diff_drive_system.cc:742:0: information: Unmatched suppression: knownConditionTrueFalse [unmatchedSuppression]
  for (; odomPosesCount < 5 && sleep < maxSleep; ++sleep)
^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/components.cc:110:15: style: Variable 'comp12' is assigned a value that is never used. [unreadVariable]
  auto comp12 = components::Actor(data1);
              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/components.cc:111:14: style: Variable 'comp2' is assigned a value that is never used. [unreadVariable]
  auto comp2 = components::Actor(data2);
             ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/components.cc:425:15: style: Variable 'comp12' is assigned a value that is never used. [unreadVariable]
  auto comp12 = components::Geometry(data1);
              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/components.cc:426:14: style: Variable 'comp2' is assigned a value that is never used. [unreadVariable]
  auto comp2 = components::Geometry(data2);
             ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/components.cc:578:15: style: Variable 'comp12' is assigned a value that is never used. [unreadVariable]
  auto comp12 = components::JointAxis(data1);
              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/components.cc:579:14: style: Variable 'comp2' is assigned a value that is never used. [unreadVariable]
  auto comp2 = components::JointAxis(data2);
             ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/components.cc:883:15: style: Variable 'comp12' is assigned a value that is never used. [unreadVariable]
  auto comp12 = components::Light(data1);
              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/components.cc:884:14: style: Variable 'comp2' is assigned a value that is never used. [unreadVariable]
  auto comp2 = components::Light(data2);
             ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/components.cc:1167:14: style: Variable 'comp2' is assigned a value that is never used. [unreadVariable]
  auto comp2 = components::Material(data2);
             ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/components.cc:1429:15: style: Variable 'comp12' is assigned a value that is never used. [unreadVariable]
  auto comp12 = components::PerformerLevels({1, 2, 3});
              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/components.cc:1430:14: style: Variable 'comp2' is assigned a value that is never used. [unreadVariable]
  auto comp2 = components::PerformerLevels({4, 5});
             ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/components.cc:1455:15: style: Variable 'comp12' is assigned a value that is never used. [unreadVariable]
  auto comp12 = components::PhysicsEnginePlugin("engine-plugin");
              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/components.cc:1456:14: style: Variable 'comp2' is assigned a value that is never used. [unreadVariable]
  auto comp2 = components::PhysicsEnginePlugin("another-engine-plugin");
             ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/components.cc:1753:14: style: Variable 'comp2' is assigned a value that is never used. [unreadVariable]
  auto comp2 = components::ParticleEmitter(emitter2);
             ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/force_torque_system.cc:163:39: error: Out of bounds access in expression 'wrenches.back()' because 'wrenches' is empty and 'back' may be non-zero. [containerOutOfBounds]
    const auto &wrench = wrenches.back();
                                      ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/joint_controller_system.cc:136:29: style: Iterating over container 'angularVelocities' that is always empty. [knownEmptyContainer]
  for (const auto &angVel : angularVelocities)
                            ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/kinetic_energy_monitor_system.cc:66:32: style: Variable 'sensorName' is assigned a value that is never used. [unreadVariable]
  const std::string sensorName = "altimeter_sensor";
                               ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/logical_camera_system.cc:82:8: style: The scope of the variable 'topic1' can be reduced. [variableScope]
  auto topic1 = "world/logical_camera_sensor/model/logical_camera-1/link/"
       ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/log_system.cc:116:12: style: Consider using std::transform algorithm instead of a raw loop. [useStlAlgorithm]
    _paths.push_back(entry.path().string());
           ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/odometry_publisher.cc:388:0: information: Unmatched suppression: knownConditionTrueFalse [unmatchedSuppression]
    for (; odomPosesCount < 5 && sleep < maxSleep; ++sleep)
^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/save_world.cc:90:8: style: The scope of the variable 'modelStr' can be reduced. [variableScope]
  auto modelStr = R"(
       ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/physics_system.cc:2173:47: style: Checking if unsigned expression 'i' is less than zero. [unsignedLessThanZero]
  for (std::size_t i = iterOfContact + 300; i < wrenches.size(); ++i)
                                              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/touch_plugin.cc:96:37: style: Condition '!whiteTouched' is always true [knownConditionTrueFalse]
  for (int sleep = 0; sleep < 50 && !whiteTouched; ++sleep)
                                    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/touch_plugin.cc:92:18: note: Assignment 'whiteTouched=false', assigned value is 0
  whiteTouched = false;
                 ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/touch_plugin.cc:96:37: note: Condition '!whiteTouched' is always true
  for (int sleep = 0; sleep < 50 && !whiteTouched; ++sleep)
                                    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/touch_plugin.cc:176:37: style: Condition '!blueTouched' is always true [knownConditionTrueFalse]
  for (int sleep = 0; sleep < 50 && !blueTouched; ++sleep)
                                    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/touch_plugin.cc:173:17: note: Assignment 'blueTouched=false', assigned value is 0
  blueTouched = false;
                ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/touch_plugin.cc:176:37: note: Condition '!blueTouched' is always true
  for (int sleep = 0; sleep < 50 && !blueTouched; ++sleep)
                                    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:233:20: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_LT(poses[0].Pos().X(), poses[999].Pos().X());
                   ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:233:40: error: Out of bounds access in expression 'poses[999]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_LT(poses[0].Pos().X(), poses[999].Pos().X());
                                       ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:234:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Y(), poses[999].Pos().Y(), tol);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:234:42: error: Out of bounds access in expression 'poses[999]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Y(), poses[999].Pos().Y(), tol);
                                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:235:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Z(), poses[999].Pos().Z(), tol);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:235:42: error: Out of bounds access in expression 'poses[999]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Z(), poses[999].Pos().Z(), tol);
                                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:236:5: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses[0].Rot().X(), poses[999].Rot().X(), tol);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:236:5: error: Out of bounds access in expression 'poses[999]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses[0].Rot().X(), poses[999].Rot().X(), tol);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:237:5: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses[0].Rot().Y(), poses[999].Rot().Y(), tol);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:237:5: error: Out of bounds access in expression 'poses[999]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses[0].Rot().Y(), poses[999].Rot().Y(), tol);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:238:5: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses[0].Rot().Z(), poses[999].Rot().Z(), tol);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:238:5: error: Out of bounds access in expression 'poses[999]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses[0].Rot().Z(), poses[999].Rot().Z(), tol);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:241:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().X(), odomPoses[0].Pos().X() + 3.0, 3e-2);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:242:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Y(), odomPoses[0].Pos().Y(), 1e-2);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:243:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().X(), odomPoses.back().Pos().X() + 3, 1e-1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:244:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Y(), odomPoses.back().Pos().Y(), 1e-2);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:249:21: error: Out of bounds access in expression 'poses[999]' because 'poses' is empty. [containerOutOfBounds]
    double d = poses[999].Pos().Distance(poses[0].Pos());
                    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:249:47: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    double d = poses[999].Pos().Distance(poses[0].Pos());
                                              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:265:38: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    const auto startPose = poses.back();
                                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:273:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().X(), startPose.Pos().X() + linearSpeed, 0.1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:274:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Y(), startPose.Pos().Y(), 1e-1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:275:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Z(), startPose.Pos().Z(), 1e-2);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:276:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), startPose.Rot().Roll(), 1e-2);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:277:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:279:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Yaw(), startPose.Rot().Yaw(), 1e-1);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:283:39: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    const auto middlePose = poses.back();
                                      ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:293:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().X(), middlePose.Pos().X(), 1e-1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:294:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Y(), middlePose.Pos().Y(), 1e-1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:295:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Z(), middlePose.Pos().Z(), 1e-2);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:296:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), middlePose.Rot().Roll(), 1e-2);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:297:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:299:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Yaw(),
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:304:37: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    const auto lastPose = poses.back();
                                    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:311:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().X(), lastPose.Pos().X() + 0.4, 1e-1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:312:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Y(), lastPose.Pos().Y() + 0.15, 1e-1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:313:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Z(), lastPose.Pos().Z(), 1e-2);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:314:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), lastPose.Rot().Roll(), 1e-2);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:315:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Pitch(), lastPose.Rot().Pitch(), 1e-2);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:316:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:334:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().X(), beforeStairsPose.X() + 3.4, 0.15);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:335:25: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_LE(poses.back().Pos().Y(), 0.7);
                        ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:336:25: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_GT(poses.back().Pos().Z(), 0.6);
                        ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:337:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), 0.0, 1e-1);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:338:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Pitch(), -0.4, 1e-1);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:339:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:360:25: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_LT(poses.back().Pos().X(), -0.99);  // The driving is wild
                        ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:361:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Y(), 0, 0.5);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:362:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Z(), 0.0, 1e-1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:363:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), 0.0, 1e-1);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:364:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Pitch(), 0.0, 1e-1);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:366:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:388:25: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_GT(poses.back().Pos().X(), 3.5);
                        ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:389:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Y(), 2, 0.1);  // The driving is wild
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:390:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Z(), 0.0, 1e-1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:391:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), 0.0, 1e-1);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:392:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Pitch(), 0.0, 1e-1);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:394:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:405:25: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_LT(poses.back().Pos().X(), 1);
                        ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:406:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Y(), 2, 0.1);  // The driving is wild
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:407:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Z(), 0.0, 1e-1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:408:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), 0.0, 1e-1);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:409:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Pitch(), 0.0, 1e-1);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:411:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:437:15: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    poses.back().SetZ(beforeCylinderPose.Pos().Z());  // ignore Z offset
              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:438:26: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    verifyPose(poses.back(), beforeCylinderPose);
                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:530:34: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(0.125, poses.back().Pos().X(), 1e-1);
                                 ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:531:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Y(), poses.back().Pos().Y(), 1e-2);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:531:47: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Y(), poses.back().Pos().Y(), 1e-2);
                                              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:532:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Z(), poses.back().Pos().Z(), 1e-2);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:532:47: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Z(), poses.back().Pos().Z(), 1e-2);
                                              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:533:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), 0, 1e-3);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:534:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Pitch(), 0, 1e-3);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:535:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Yaw(), 0, 1e-3);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:542:32: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(0.5, poses.back().Pos().X(), 1e-1);
                               ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:543:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Y(), poses.back().Pos().Y(), 1e-2);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:543:47: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Y(), poses.back().Pos().Y(), 1e-2);
                                              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:544:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Z(), poses.back().Pos().Z(), 1e-2);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:544:47: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Z(), poses.back().Pos().Z(), 1e-2);
                                              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:545:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), 0, 1e-3);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:546:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Pitch(), 0, 1e-3);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:547:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Yaw(), 0, 1e-3);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:554:34: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(0.875, poses.back().Pos().X(), 1e-1);
                                 ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:555:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Y(), poses.back().Pos().Y(), 1e-2);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:555:47: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Y(), poses.back().Pos().Y(), 1e-2);
                                              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:556:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Z(), poses.back().Pos().Z(), 1e-2);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:556:47: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Z(), poses.back().Pos().Z(), 1e-2);
                                              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:557:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), 0, 1e-3);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:558:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Pitch(), 0, 1e-3);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:559:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Yaw(), 0, 1e-3);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/wind_effects.cc:69:11: style: Class 'LinkComponentRecorder < components :: WindMode >' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
  public: LinkComponentRecorder(std::string _linkName, bool _createComp = false)
          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/wind_effects.cc:69:11: style: Class 'LinkComponentRecorder < components :: WorldLinearAcceleration >' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
  public: LinkComponentRecorder(std::string _linkName, bool _createComp = false)
          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/wind_effects.cc:69:11: style: Class 'LinkComponentRecorder < components :: WorldLinearVelocity >' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
  public: LinkComponentRecorder(std::string _linkName, bool _createComp = false)
          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/include/ignition/gazebo/Conversions.hh:631:7: error: Found a exit path from function with non-void return type that has missing return statement [missingReturn]
      Out::ConversionNotImplemented;
      ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/include/ignition/gazebo/components/Factory.hh:305:51: error: There is an unknown macro here somewhere. Configuration is required. If IGN_DEPRECATED is a macro then please configure it. [unknownMacro]
    public: std::unique_ptr<ComponentStorageBase> IGN_DEPRECATED(6) NewStorage(
                                                  ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/include/ignition/gazebo/detail/ComponentStorageBase.hh:35:15: error: There is an unknown macro here somewhere. Configuration is required. If IGN_DEPRECATED is a macro then please configure it. [unknownMacro]
      public: IGN_DEPRECATED(6) ComponentStorageBase() = default;
              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc:1232:29: warning: Possible null pointer dereference: workflow [nullPointer]
    std::string albedoMap = workflow->AlbedoMap();
                            ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc:1190:34: note: Assignment 'workflow=nullptr', assigned value is 0
    sdf::PbrWorkflow *workflow = nullptr;
                                 ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc:1193:9: note: Assuming condition is false
    if (metal)
        ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc:1232:29: note: Null pointer dereference
    std::string albedoMap = workflow->AlbedoMap();
                            ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/multicopter_motor_model/MulticopterMotorModel.cc:70:37: error: Found a exit path from function with non-void return type that has missing return statement [missingReturn]
      previousState(_initialState) {}
                                    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/src/systems/particle_emitter/ParticleEmitter.hh:122:13: error: There is an unknown macro here somewhere. Configuration is required. If IGN_DEPRECATED is a macro then please configure it. [unknownMacro]
    public: IGN_DEPRECATED(6) ParticleEmitter();
            ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/apply_joint_force_system.cc:110:36: error: Out of bounds access in expression 'jointForceCmd.back()' because 'jointForceCmd' is empty and 'back' may be non-zero. [containerOutOfBounds]
    if (std::abs(jointForceCmd.back() - testJointForce) < 1e-6)
                                   ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/detachable_joint.cc:127:26: error: Out of bounds access in expression 'm1Poses.front()' because 'm1Poses' is empty and 'front' may be non-zero. [containerOutOfBounds]
  EXPECT_EQ(m1Poses.front(), m1Poses.back());
                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/detachable_joint.cc:127:42: error: Out of bounds access in expression 'm1Poses.back()' because 'm1Poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
  EXPECT_EQ(m1Poses.front(), m1Poses.back());
                                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/detachable_joint.cc:134:26: error: Out of bounds access in expression 'm2Poses.front()' because 'm2Poses' is empty and 'front' may be non-zero. [containerOutOfBounds]
  EXPECT_GT(m2Poses.front().Pos().Z() - m2Poses.back().Pos().Z(), expDist);
                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/detachable_joint.cc:134:53: error: Out of bounds access in expression 'm2Poses.back()' because 'm2Poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
  EXPECT_GT(m2Poses.front().Pos().Z() - m2Poses.back().Pos().Z(), expDist);
                                                    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/detachable_joint.cc:205:26: error: Out of bounds access in expression 'b1Poses.front()' because 'b1Poses' is empty and 'front' may be non-zero. [containerOutOfBounds]
  EXPECT_EQ(b1Poses.front(), b1Poses.back());
                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/detachable_joint.cc:205:42: error: Out of bounds access in expression 'b1Poses.back()' because 'b1Poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
  EXPECT_EQ(b1Poses.front(), b1Poses.back());
                                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/detachable_joint.cc:212:26: error: Out of bounds access in expression 'b2Poses.front()' because 'b2Poses' is empty and 'front' may be non-zero. [containerOutOfBounds]
  EXPECT_GT(b2Poses.front().Pos().Z() - b2Poses.back().Pos().Z(), expDist);
                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/detachable_joint.cc:212:53: error: Out of bounds access in expression 'b2Poses.back()' because 'b2Poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
  EXPECT_GT(b2Poses.front().Pos().Z() - b2Poses.back().Pos().Z(), expDist);
                                                    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/force_torque_system.cc:163:39: error: Out of bounds access in expression 'wrenches.back()' because 'wrenches' is empty and 'back' may be non-zero. [containerOutOfBounds]
    const auto &wrench = wrenches.back();
                                      ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:233:20: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_LT(poses[0].Pos().X(), poses[999].Pos().X());
                   ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:233:40: error: Out of bounds access in expression 'poses[999]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_LT(poses[0].Pos().X(), poses[999].Pos().X());
                                       ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:234:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Y(), poses[999].Pos().Y(), tol);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:234:42: error: Out of bounds access in expression 'poses[999]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Y(), poses[999].Pos().Y(), tol);
                                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:235:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Z(), poses[999].Pos().Z(), tol);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:235:42: error: Out of bounds access in expression 'poses[999]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Z(), poses[999].Pos().Z(), tol);
                                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:236:5: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses[0].Rot().X(), poses[999].Rot().X(), tol);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:236:5: error: Out of bounds access in expression 'poses[999]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses[0].Rot().X(), poses[999].Rot().X(), tol);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:237:5: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses[0].Rot().Y(), poses[999].Rot().Y(), tol);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:237:5: error: Out of bounds access in expression 'poses[999]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses[0].Rot().Y(), poses[999].Rot().Y(), tol);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:238:5: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses[0].Rot().Z(), poses[999].Rot().Z(), tol);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:238:5: error: Out of bounds access in expression 'poses[999]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses[0].Rot().Z(), poses[999].Rot().Z(), tol);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:241:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().X(), odomPoses[0].Pos().X() + 3.0, 3e-2);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:242:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Y(), odomPoses[0].Pos().Y(), 1e-2);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:243:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().X(), odomPoses.back().Pos().X() + 3, 1e-1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:244:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Y(), odomPoses.back().Pos().Y(), 1e-2);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:249:21: error: Out of bounds access in expression 'poses[999]' because 'poses' is empty. [containerOutOfBounds]
    double d = poses[999].Pos().Distance(poses[0].Pos());
                    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:249:47: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    double d = poses[999].Pos().Distance(poses[0].Pos());
                                              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:265:38: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    const auto startPose = poses.back();
                                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:273:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().X(), startPose.Pos().X() + linearSpeed, 0.1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:274:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Y(), startPose.Pos().Y(), 1e-1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:275:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Z(), startPose.Pos().Z(), 1e-2);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:276:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), startPose.Rot().Roll(), 1e-2);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:277:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:279:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Yaw(), startPose.Rot().Yaw(), 1e-1);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:283:39: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    const auto middlePose = poses.back();
                                      ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:293:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().X(), middlePose.Pos().X(), 1e-1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:294:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Y(), middlePose.Pos().Y(), 1e-1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:295:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Z(), middlePose.Pos().Z(), 1e-2);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:296:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), middlePose.Rot().Roll(), 1e-2);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:297:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:299:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Yaw(),
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:304:37: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    const auto lastPose = poses.back();
                                    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:311:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().X(), lastPose.Pos().X() + 0.4, 1e-1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:312:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Y(), lastPose.Pos().Y() + 0.15, 1e-1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:313:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Z(), lastPose.Pos().Z(), 1e-2);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:314:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), lastPose.Rot().Roll(), 1e-2);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:315:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Pitch(), lastPose.Rot().Pitch(), 1e-2);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:316:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:334:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().X(), beforeStairsPose.X() + 3.4, 0.15);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:335:25: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_LE(poses.back().Pos().Y(), 0.7);
                        ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:336:25: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_GT(poses.back().Pos().Z(), 0.6);
                        ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:337:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), 0.0, 1e-1);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:338:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Pitch(), -0.4, 1e-1);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:339:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:360:25: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_LT(poses.back().Pos().X(), -0.99);  // The driving is wild
                        ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:361:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Y(), 0, 0.5);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:362:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Z(), 0.0, 1e-1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:363:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), 0.0, 1e-1);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:364:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Pitch(), 0.0, 1e-1);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:366:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:388:25: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_GT(poses.back().Pos().X(), 3.5);
                        ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:389:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Y(), 2, 0.1);  // The driving is wild
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:390:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Z(), 0.0, 1e-1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:391:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), 0.0, 1e-1);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:392:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Pitch(), 0.0, 1e-1);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:394:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:405:25: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_LT(poses.back().Pos().X(), 1);
                        ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:406:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Y(), 2, 0.1);  // The driving is wild
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:407:27: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses.back().Pos().Z(), 0.0, 1e-1);
                          ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:408:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), 0.0, 1e-1);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:409:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Pitch(), 0.0, 1e-1);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:411:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:437:15: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    poses.back().SetZ(beforeCylinderPose.Pos().Z());  // ignore Z offset
              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:438:26: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    verifyPose(poses.back(), beforeCylinderPose);
                         ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:530:34: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(0.125, poses.back().Pos().X(), 1e-1);
                                 ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:531:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Y(), poses.back().Pos().Y(), 1e-2);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:531:47: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Y(), poses.back().Pos().Y(), 1e-2);
                                              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:532:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Z(), poses.back().Pos().Z(), 1e-2);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:532:47: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Z(), poses.back().Pos().Z(), 1e-2);
                                              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:533:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), 0, 1e-3);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:534:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Pitch(), 0, 1e-3);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:535:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Yaw(), 0, 1e-3);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:542:32: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(0.5, poses.back().Pos().X(), 1e-1);
                               ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:543:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Y(), poses.back().Pos().Y(), 1e-2);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:543:47: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Y(), poses.back().Pos().Y(), 1e-2);
                                              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:544:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Z(), poses.back().Pos().Z(), 1e-2);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:544:47: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Z(), poses.back().Pos().Z(), 1e-2);
                                              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:545:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), 0, 1e-3);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:546:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Pitch(), 0, 1e-3);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:547:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Yaw(), 0, 1e-3);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:554:34: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(0.875, poses.back().Pos().X(), 1e-1);
                                 ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:555:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Y(), poses.back().Pos().Y(), 1e-2);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:555:47: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Y(), poses.back().Pos().Y(), 1e-2);
                                              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:556:22: error: Out of bounds access in expression 'poses[0]' because 'poses' is empty. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Z(), poses.back().Pos().Z(), 1e-2);
                     ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:556:47: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_NEAR(poses[0].Pos().Z(), poses.back().Pos().Z(), 1e-2);
                                              ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:557:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), 0, 1e-3);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:558:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Pitch(), 0, 1e-3);
    ^
/Users/rhys/Code/osrf/ign_fortress_ws/src/ign-gazebo/test/integration/tracked_vehicle_system.cc:559:5: error: Out of bounds access in expression 'poses.back()' because 'poses' is empty and 'back' may be non-zero. [containerOutOfBounds]
    EXPECT_ANGLE_NEAR(poses.back().Rot().Yaw(), 0, 1e-3);
```

</details>

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**