### PR TITLE
Add interface to allow systems to declare parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ set(IGN_PLUGIN_VER ${ignition-plugin1_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-transport
-ign_find_package(ignition-transport11 REQUIRED COMPONENTS log)
+ign_find_package(ignition-transport11 REQUIRED COMPONENTS log parameters)
 set(IGN_TRANSPORT_VER ${ignition-transport11_VERSION_MAJOR})
 
 #--------------------------------------

--- a/include/ignition/gazebo/System.hh
+++ b/include/ignition/gazebo/System.hh
@@ -25,6 +25,8 @@
 #include <ignition/gazebo/Export.hh>
 #include <ignition/gazebo/Types.hh>
 
+#include <ignition/transport/parameters/Registry.hh>
+
 #include <sdf/Element.hh>
 
 namespace ignition
@@ -98,6 +100,19 @@ namespace ignition
                   const std::shared_ptr<const sdf::Element> &_sdf,
                   EntityComponentManager &_ecm,
                   EventManager &_eventMgr) = 0;
+    };
+
+    /// \class ISystemConfigureParameters ISystem.hh ignition/gazebo/System.hh
+    /// \brief Interface for a system that declares parameters.
+    ///
+    /// ISystemConfigureParameters::ConfigureParameters is called after
+    /// ISystemConfigure::Configure.
+    class ISystemConfigureParameters {
+      /// \brief Configure the parameters of the system.
+      /// \param[in] _registry The parameter registry.
+      public: virtual void ConfigureParameters(
+                  ignition::transport::parameters::ParametersRegistry & _registry,
+                  EntityComponentManager &_ecm) = 0;
     };
 
     /// \class ISystemPreUpdate ISystem.hh ignition/gazebo/System.hh

--- a/include/ignition/gazebo/System.hh
+++ b/include/ignition/gazebo/System.hh
@@ -111,7 +111,8 @@ namespace ignition
       /// \brief Configure the parameters of the system.
       /// \param[in] _registry The parameter registry.
       public: virtual void ConfigureParameters(
-                  ignition::transport::parameters::ParametersRegistry & _registry,
+                  ignition::transport::parameters::ParametersRegistry &
+                    _registry,
                   EntityComponentManager &_ecm) = 0;
     };
 

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -61,6 +61,10 @@ SimulationRunner::SimulationRunner(const sdf::World *_world,
   // Keep world name
   this->worldName = _world->Name();
 
+  this->parametersRegistry = std::make_unique<
+    ignition::transport::parameters::ParametersRegistry>(
+      std::string{"world/"} + this->worldName);
+
   // Get the physics profile
   // TODO(luca): remove duplicated logic in SdfEntityCreator and LevelManager
   auto physics = _world->PhysicsByIndex(0);
@@ -133,7 +137,7 @@ SimulationRunner::SimulationRunner(const sdf::World *_world,
 
   // Create the system manager
   this->systemMgr = std::make_unique<SystemManager>(_systemLoader,
-      &this->entityCompMgr, &this->eventMgr, validNs);
+      &this->entityCompMgr, &this->eventMgr, validNs, this->parametersRegistry.get());
 
   this->pauseConn = this->eventMgr.Connect<events::Pause>(
       std::bind(&SimulationRunner::SetPaused, this, std::placeholders::_1));

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -136,8 +136,9 @@ SimulationRunner::SimulationRunner(const sdf::World *_world,
   this->node = std::make_unique<transport::Node>(opts);
 
   // Create the system manager
-  this->systemMgr = std::make_unique<SystemManager>(_systemLoader,
-      &this->entityCompMgr, &this->eventMgr, validNs, this->parametersRegistry.get());
+  this->systemMgr = std::make_unique<SystemManager>(
+      _systemLoader, &this->entityCompMgr, &this->eventMgr, validNs,
+      this->parametersRegistry.get());
 
   this->pauseConn = this->eventMgr.Connect<events::Pause>(
       std::bind(&SimulationRunner::SetPaused, this, std::placeholders::_1));

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -396,6 +396,11 @@ namespace ignition
       /// Note: must be before EntityComponentManager
       private: EventManager eventMgr;
 
+      /// \brief Manager all parameters
+      private: std::unique_ptr<
+        ignition::transport::parameters::ParametersRegistry
+      > parametersRegistry;
+
       /// \brief Manager of all components.
       private: EntityComponentManager entityCompMgr;
 

--- a/src/SystemInternal.hh
+++ b/src/SystemInternal.hh
@@ -45,6 +45,8 @@ namespace ignition
               : systemPlugin(std::move(_systemPlugin)),
                 system(systemPlugin->QueryInterface<System>()),
                 configure(systemPlugin->QueryInterface<ISystemConfigure>()),
+                configureParameters(
+                  systemPlugin->QueryInterface<ISystemConfigureParameters>()),
                 preupdate(systemPlugin->QueryInterface<ISystemPreUpdate>()),
                 update(systemPlugin->QueryInterface<ISystemUpdate>()),
                 postupdate(systemPlugin->QueryInterface<ISystemPostUpdate>()),
@@ -60,6 +62,8 @@ namespace ignition
               : systemShared(_system),
                 system(_system.get()),
                 configure(dynamic_cast<ISystemConfigure *>(_system.get())),
+                configureParameters(
+                  dynamic_cast<ISystemConfigureParameters *>(_system.get())),
                 preupdate(dynamic_cast<ISystemPreUpdate *>(_system.get())),
                 update(dynamic_cast<ISystemUpdate *>(_system.get())),
                 postupdate(dynamic_cast<ISystemPostUpdate *>(_system.get())),
@@ -82,6 +86,11 @@ namespace ignition
       /// \brief Access this system via the ISystemConfigure interface
       /// Will be nullptr if the System doesn't implement this interface.
       public: ISystemConfigure *configure = nullptr;
+
+      /// \brief Access this system via the ISystemConfigureParameters
+      ///   interface.
+      /// Will be nullptr if the System doesn't implement this interface.
+      public: ISystemConfigureParameters *configureParameters = nullptr;
 
       /// \brief Access this system via the ISystemPreUpdate interface
       /// Will be nullptr if the System doesn't implement this interface.

--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -28,13 +28,16 @@ using namespace ignition;
 using namespace gazebo;
 
 //////////////////////////////////////////////////
-SystemManager::SystemManager(const SystemLoaderPtr &_systemLoader,
-                             EntityComponentManager *_entityCompMgr,
-                             EventManager *_eventMgr,
-                             const std::string &_namespace)
+SystemManager::SystemManager(
+  const SystemLoaderPtr &_systemLoader,
+  EntityComponentManager *_entityCompMgr,
+  EventManager *_eventMgr,
+  const std::string &_namespace,
+  ignition::transport::parameters::ParametersRegistry *_parametersRegistry)
   : systemLoader(_systemLoader),
     entityCompMgr(_entityCompMgr),
-    eventMgr(_eventMgr)
+    eventMgr(_eventMgr),
+    parametersRegistry(_parametersRegistry)
 {
   transport::NodeOptions opts;
   opts.SetNameSpace(_namespace);
@@ -101,6 +104,9 @@ size_t SystemManager::ActivatePendingSystems()
 
     if (system.configure)
       this->systemsConfigure.push_back(system.configure);
+    
+    if (system.configureParameters)
+      this->systemsConfigureParameters.push_back(system.configureParameters);
 
     if (system.preupdate)
       this->systemsPreupdate.push_back(system.preupdate);
@@ -169,6 +175,14 @@ void SystemManager::AddSystemImpl(
                                  *this->eventMgr);
   }
 
+  // Configure the system parameters, if necessary
+  if (_system.configureParameters && this->entityCompMgr && this->parametersRegistry)
+  {
+    _system.configureParameters->ConfigureParameters(
+      *this->parametersRegistry,
+      *this->entityCompMgr);
+  }
+
   // Update callbacks will be handled later, add to queue
   std::lock_guard<std::mutex> lock(this->pendingSystemsMutex);
   this->pendingSystems.push_back(_system);
@@ -178,6 +192,12 @@ void SystemManager::AddSystemImpl(
 const std::vector<ISystemConfigure *>& SystemManager::SystemsConfigure()
 {
   return this->systemsConfigure;
+}
+
+//////////////////////////////////////////////////
+const std::vector<ISystemConfigureParameters *>& SystemManager::SystemsConfigureParameters()
+{
+  return this->systemsConfigureParameters;
 }
 
 //////////////////////////////////////////////////

--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -104,7 +104,7 @@ size_t SystemManager::ActivatePendingSystems()
 
     if (system.configure)
       this->systemsConfigure.push_back(system.configure);
-    
+
     if (system.configureParameters)
       this->systemsConfigureParameters.push_back(system.configureParameters);
 
@@ -176,7 +176,9 @@ void SystemManager::AddSystemImpl(
   }
 
   // Configure the system parameters, if necessary
-  if (_system.configureParameters && this->entityCompMgr && this->parametersRegistry)
+  if (
+    _system.configureParameters && this->entityCompMgr &&
+    this->parametersRegistry)
   {
     _system.configureParameters->ConfigureParameters(
       *this->parametersRegistry,
@@ -195,7 +197,8 @@ const std::vector<ISystemConfigure *>& SystemManager::SystemsConfigure()
 }
 
 //////////////////////////////////////////////////
-const std::vector<ISystemConfigureParameters *>& SystemManager::SystemsConfigureParameters()
+const std::vector<ISystemConfigureParameters *>&
+SystemManager::SystemsConfigureParameters()
 {
   return this->systemsConfigureParameters;
 }

--- a/src/SystemManager.hh
+++ b/src/SystemManager.hh
@@ -105,7 +105,8 @@ namespace ignition
       /// \brief Get an vector of all active systems implementing
       ///   "ConfigureParameters"
       /// \return Vector of systems's configure interfaces.
-      public: const std::vector<ISystemConfigureParameters *>& SystemsConfigureParameters();
+      public: const std::vector<ISystemConfigureParameters *>&
+      SystemsConfigureParameters();
 
       /// \brief Get an vector of all active systems implementing "PreUpdate"
       /// \return Vector of systems's pre-update interfaces.
@@ -171,7 +172,8 @@ namespace ignition
       private: std::vector<ISystemConfigure *> systemsConfigure;
 
       /// \brief Systems implementing ConfigureParameters
-      private: std::vector<ISystemConfigureParameters *> systemsConfigureParameters;
+      private: std::vector<ISystemConfigureParameters *>
+        systemsConfigureParameters;
 
       /// \brief Systems implementing PreUpdate
       private: std::vector<ISystemPreUpdate *> systemsPreupdate;
@@ -204,7 +206,8 @@ namespace ignition
       private: std::unique_ptr<transport::Node> node{nullptr};
 
       /// \brief Pointer to associated parameters registry
-      private: ignition::transport::parameters::ParametersRegistry *parametersRegistry;
+      private: ignition::transport::parameters::ParametersRegistry *
+        parametersRegistry;
     };
     }
   }  // namespace gazebo

--- a/src/SystemManager.hh
+++ b/src/SystemManager.hh
@@ -52,10 +52,13 @@ namespace ignition
       /// \param[in] _eventMgr Pointer to the event manager to be used when
       ///  configuring new systems
       /// \param[in] _namespace Namespace to use for the transport node
-      public: explicit SystemManager(const SystemLoaderPtr &_systemLoader,
-                            EntityComponentManager *_entityCompMgr = nullptr,
-                            EventManager *_eventMgr = nullptr,
-                            const std::string &_namespace = std::string());
+      public: explicit SystemManager(
+        const SystemLoaderPtr &_systemLoader,
+        EntityComponentManager *_entityCompMgr = nullptr,
+        EventManager *_eventMgr = nullptr,
+        const std::string &_namespace = std::string(),
+        ignition::transport::parameters::ParametersRegistry *
+          _parametersRegistry = nullptr);
 
       /// \brief Load system plugin for a given entity.
       /// \param[in] _entity Entity
@@ -98,6 +101,11 @@ namespace ignition
       /// \brief Get an vector of all active systems implementing "Configure"
       /// \return Vector of systems's configure interfaces.
       public: const std::vector<ISystemConfigure *>& SystemsConfigure();
+
+      /// \brief Get an vector of all active systems implementing
+      ///   "ConfigureParameters"
+      /// \return Vector of systems's configure interfaces.
+      public: const std::vector<ISystemConfigureParameters *>& SystemsConfigureParameters();
 
       /// \brief Get an vector of all active systems implementing "PreUpdate"
       /// \return Vector of systems's pre-update interfaces.
@@ -162,6 +170,9 @@ namespace ignition
       /// \brief Systems implementing Configure
       private: std::vector<ISystemConfigure *> systemsConfigure;
 
+      /// \brief Systems implementing ConfigureParameters
+      private: std::vector<ISystemConfigureParameters *> systemsConfigureParameters;
+
       /// \brief Systems implementing PreUpdate
       private: std::vector<ISystemPreUpdate *> systemsPreupdate;
 
@@ -191,6 +202,9 @@ namespace ignition
 
       /// \brief Node for communication.
       private: std::unique_ptr<transport::Node> node{nullptr};
+
+      /// \brief Pointer to associated parameters registry
+      private: ignition::transport::parameters::ParametersRegistry *parametersRegistry;
     };
     }
   }  // namespace gazebo

--- a/src/SystemManager_TEST.cc
+++ b/src/SystemManager_TEST.cc
@@ -40,7 +40,7 @@ class SystemWithConfigure:
                 const std::shared_ptr<const sdf::Element> &,
                 EntityComponentManager &,
                 EventManager &) override { configured++; };
-  
+
   public: void ConfigureParameters(
                 ignition::transport::parameters::ParametersRegistry &,
                 EntityComponentManager &) override { configuredParameters++; }

--- a/src/SystemManager_TEST.cc
+++ b/src/SystemManager_TEST.cc
@@ -31,7 +31,8 @@ using namespace ignition::gazebo;
 /////////////////////////////////////////////////
 class SystemWithConfigure:
   public System,
-  public ISystemConfigure
+  public ISystemConfigure,
+  public ISystemConfigureParameters
 {
   // Documentation inherited
   public: void Configure(
@@ -39,8 +40,13 @@ class SystemWithConfigure:
                 const std::shared_ptr<const sdf::Element> &,
                 EntityComponentManager &,
                 EventManager &) override { configured++; };
+  
+  public: void ConfigureParameters(
+                ignition::transport::parameters::ParametersRegistry &,
+                EntityComponentManager &) override { configuredParameters++; }
 
   public: int configured = 0;
+  public: int configuredParameters = 0;
 };
 
 /////////////////////////////////////////////////
@@ -99,6 +105,7 @@ TEST(SystemManager, AddSystemNoEcm)
 
   // SystemManager without an ECM/EventmManager will mean no config occurs
   EXPECT_EQ(0, configSystem->configured);
+  EXPECT_EQ(0, configSystem->configuredParameters);
 
   EXPECT_EQ(0u, systemMgr.ActiveCount());
   EXPECT_EQ(1u, systemMgr.PendingCount());
@@ -150,7 +157,10 @@ TEST(SystemManager, AddSystemEcm)
   auto ecm = EntityComponentManager();
   auto eventManager = EventManager();
 
-  SystemManager systemMgr(loader, &ecm, &eventManager);
+  auto paramRegistry = std::make_unique<
+    ignition::transport::parameters::ParametersRegistry>("SystemManager_TEST");
+  SystemManager systemMgr(
+    loader, &ecm, &eventManager, std::string(), paramRegistry.get());
 
   EXPECT_EQ(0u, systemMgr.ActiveCount());
   EXPECT_EQ(0u, systemMgr.PendingCount());
@@ -165,6 +175,7 @@ TEST(SystemManager, AddSystemEcm)
 
   // Configure called during AddSystem
   EXPECT_EQ(1, configSystem->configured);
+  EXPECT_EQ(1, configSystem->configuredParameters);
 
   EXPECT_EQ(0u, systemMgr.ActiveCount());
   EXPECT_EQ(1u, systemMgr.PendingCount());


### PR DESCRIPTION
# 🎉 New feature

Based on https://github.com/ignitionrobotics/ign-transport/pull/305.
Replacement of https://github.com/ignitionrobotics/ign-gazebo/pull/1280.

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->
This PR adds:

- An interface that can be implemented by systems that allows them to declare parameters (`ISystemConfigureParameters`):
  - The gazebo simulation runner creates an instance of `ignition::transport::parameters::ParametersRegistry` (see https://github.com/ignitionrobotics/ign-transport/pull/305) with a namespace `/world/<world_name>` that provides the following services:
  - `/world/<world_name>/list_parameters` service: List available parameters names and types.
  - `/world/<world_name>/get_parameter` service: Get the type and value of a parameter.
  - `/world/<world_name>/set_parameter` service: Set a parameter: parameter name, value and type need to be provided.

Summary of what's needed to declare and use a parameter can be seen in the wheel slip demo [branch](https://github.com/ignitionrobotics/ign-gazebo/tree/ivanpauno/parameters-component-wheel-slip-demo6): [diff](https://github.com/ignitionrobotics/ign-gazebo/compare/b7b290cfd1e6984f66216bc1434a4df697844fd7..317f44880c837c7e887fcc35858a1b165e2bfb77).

## Test it
<!--Explain how reviewers can test this new feature manually.-->

I haven't written automated tests yet, but there's a demo using parameters in the wheel slip plugin:

- https://github.com/ignitionrobotics/ign-gazebo/tree/ivanpauno/parameters-component-wheel-slip-demo6
- https://github.com/ignitionrobotics/ign-msgs/tree/ivanpauno/parameters-component-wheel-slip-demo8

Steps to run the demo:

- Build from source ignition `fortress` checking out the two branches specified above (I can provide PRs for another version if needed).
- Launch the trisphere cycle world:
  ```
  ign gazebo trisphere_cycle_wheel_slip.sdf
  ```
- In another terminal with the workspace sourced:
  - List available parameters:
    ```
    ign param -r /world/wheel_slip -l
    ```
    <details>
      <summary>Expected output</summary>

      > systems.wheel_slip.trisphere_cycle1.wheel_front            [ignition.msgs.WheelSlipParameters]
      > systems.wheel_slip.trisphere_cycle1.wheel_rear_right            [ignition.msgs.WheelSlipParameters]
      > systems.wheel_slip.trisphere_cycle0.wheel_rear_right            [ignition.msgs.WheelSlipParameters]
      > systems.wheel_slip.trisphere_cycle1.wheel_rear_left            [ignition.msgs.WheelSlipParameters]
      > systems.wheel_slip.trisphere_cycle0.wheel_rear_left            [ignition.msgs.WheelSlipParameters]
      > systems.wheel_slip.trisphere_cycle0.wheel_front            [ignition.msgs.WheelSlipParameters]

    </details>
  - Get the `systems.wheel_slip.trisphere_cycle1.wheel_front` parameter:
    ```
    ign param -r /world/wheel_slip -g -n systems.wheel_slip.trisphere_cycle1.wheel_front
    ```
    <details>
      <summary>Expected output</summary>

      >
      > Getting parameter [systems.wheel_slip.trisphere_cycle1.wheel_front] for registry namespace [/world/wheel_slip]...
      > Parameter type [ign_msgs.WheelSlipParameters]
      >
      > ------------------------------------------------
      > slip_compliance_lateral: 1
      > slip_compliance_longitudinal: 1
      > ------------------------------------------------

    </details>
  - Set the `systems.wheel_slip.trisphere_cycle1.wheel_front` parameter to a different value:
    ```
    ign param -r /world/wheel_slip -s -n systems.wheel_slip.trisphere_cycle1.wheel_front -t ign_msgs.WheelSlipParameters -m "
      slip_compliance_lateral: 1
      slip_compliance_longitudinal: 2"
    ```
    <details>
      <summary>Expected output</summary>

      >
      > Setting parameter [systems.wheel_slip.trisphere_cycle1.wheel_front] for world [wheel_slip]...
      >
      > Parameter successfully set!

    </details>
  - Get the `systems.wheel_slip.trisphere_cycle1.wheel_front` parameter again, its value should have changed:
    ```
    ign param -r /world/wheel_slip -g -n systems.wheel_slip.trisphere_cycle1.wheel_front
    ```
    <details>
      <summary>Expected output</summary>

      >
      > Getting parameter [systems.wheel_slip.trisphere_cycle1.wheel_front] for registry namespace [/world/wheel_slip]...
      > Parameter type [ign_msgs.WheelSlipParameters]
      >
      > ------------------------------------------------
      > slip_compliance_lateral: 1
      > slip_compliance_longitudinal: 2
      > ------------------------------------------------

    </details>

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.