### PR TITLE
Extruded 2D polyline geometries

### DIFF
--- a/examples/worlds/polylines.sdf
+++ b/examples/worlds/polylines.sdf
@@ -1,0 +1,233 @@
+<?xml version="1.0" ?>
+<!--
+
+  Demo of polyline geometries for collisions and visuals.
+
+-->
+<sdf version="1.6">
+  <world name="polylines">
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.8 0.8 0.8 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="triangle">
+      <pose>-5 0 5 0 1.57 0</pose>
+      <link name="link">
+        <inertial>
+          <pose>0 0 0.5 0 0 0</pose>
+          <mass>1.0</mass>
+          <inertia>
+            <ixx>0.1666</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1666</iyy>
+            <iyz>0</iyz>
+            <izz>0.1666</izz>
+          </inertia>
+        </inertial>
+
+        <collision name="collision">
+          <geometry>
+            <polyline>
+              <point>-0.5 -0.5</point>
+              <point>-0.5 0.5</point>
+              <point>0.5 0.5</point>
+              <point>0 0</point>
+              <point>0.5 -0.5</point>
+              <height>1</height>
+            </polyline>
+          </geometry>
+        </collision>
+
+        <visual name="triangle">
+          <geometry>
+            <polyline>
+              <point>-0.5 -0.5</point>
+              <point>-0.5 0.5</point>
+              <point>0.5 0.5</point>
+              <point>0 0</point>
+              <point>0.5 -0.5</point>
+              <height>1</height>
+            </polyline>
+          </geometry>
+          <material>
+            <ambient>1.0 0 0 1</ambient>
+            <diffuse>1.0 0 0 1</diffuse>
+            <specular>1.0 0 0 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="pentagon">
+      <pose>-5 -3 5 0 1.3 0</pose>
+      <link name="polyLine2">
+        <inertial>
+          <pose>0 0 2 0 0 0</pose>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <polyline>
+              <point>-0.3 0.5</point>
+              <point>0.3 0.3</point>
+              <point>0.3 -0.3</point>
+              <point>-0.3 -0.5</point>
+              <point>-0.5 0</point>
+              <height>4</height>
+            </polyline>
+          </geometry>
+        </collision>
+
+        <visual name="polyLineGeom2">
+          <geometry>
+            <polyline>
+              <point>-0.3 0.5</point>
+              <point>0.3 0.3</point>
+              <point>0.3 -0.3</point>
+              <point>-0.3 -0.5</point>
+              <point>-0.5 0</point>
+              <height>4</height>
+            </polyline>
+          </geometry>
+          <material>
+            <ambient>0 1.0 0 1</ambient>
+            <diffuse>0 1.0 0 1</diffuse>
+            <specular>0 1.0 0 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="cube">
+      <pose>-5 2 5 0 1.57 0</pose>
+      <link name="polyLine2">
+        <inertial>
+          <pose>0.5 0.5 0.75 0 0 0</pose>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <polyline>
+              <point>0 0</point>
+              <point>0 1</point>
+              <point>1 1</point>
+              <point>1 0 </point>
+              <height>1.5</height>
+            </polyline>
+          </geometry>
+        </collision>
+
+        <visual name="polyLineGeom2">
+          <geometry>
+            <polyline>
+              <point>0 0</point>
+              <point>0 1</point>
+              <point>1 1</point>
+              <point>1 0 </point>
+              <height>1.5</height>
+            </polyline>
+          </geometry>
+          <material>
+            <ambient>0 1.0 1.0 1</ambient>
+            <diffuse>0 1.0 1.0 1</diffuse>
+            <specular>0 1.0 1.0 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="letter">
+      <pose>-5 2 5 0 1.57 0</pose>
+      <link name="link">
+        <inertial>
+          <pose>2.2 1.5 0.5 0 0 0</pose>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <polyline>
+              <point>2.27467 1.0967</point>
+              <point>1.81094 2.35418</point>
+              <point>2.74009 2.35418</point>
+              <height>1.0</height>
+            </polyline>
+            <polyline>
+              <point>2.08173 0.7599</point>
+              <point>2.4693 0.7599</point>
+              <point>3.4323 3.28672</point>
+              <point>3.07689 3.28672</point>
+              <point>2.84672 2.63851</point>
+              <point>1.7077 2.63851</point>
+              <point>1.47753 3.28672</point>
+              <point>1.11704 3.28672</point>
+              <height>1.0</height>
+            </polyline>
+          </geometry>
+        </collision>
+
+        <visual name="visual">
+          <geometry>
+            <polyline>
+              <point>2.27467 1.0967</point>
+              <point>1.81094 2.35418</point>
+              <point>2.74009 2.35418</point>
+              <height>1.0</height>
+            </polyline>
+            <polyline>
+              <point>2.08173 0.7599</point>
+              <point>2.4693 0.7599</point>
+              <point>3.4323 3.28672</point>
+              <point>3.07689 3.28672</point>
+              <point>2.84672 2.63851</point>
+              <point>1.7077 2.63851</point>
+              <point>1.47753 3.28672</point>
+              <point>1.11704 3.28672</point>
+              <height>1.0</height>
+            </polyline>
+          </geometry>
+          <material>
+            <ambient>1.0 0 1.0 1</ambient>
+            <diffuse>1.0 0 1.0 1</diffuse>
+            <specular>1.0 0 1.0 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+  </world>
+</sdf>

--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -197,9 +197,9 @@ msgs::Geometry ignition::gazebo::convert(const sdf::Geometry &_in)
     {
       auto polylineMsg = out.add_polyline();
       polylineMsg->set_height(polyline.Height());
-      for (auto point : polyline.Points())
+      for (auto i = 0; i < polyline.PointCount(); ++i)
       {
-        msgs::Set(polylineMsg->add_point(), point);
+        msgs::Set(polylineMsg->add_point(), *polyline.PointByIndex(i));
       }
     }
   }

--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -193,13 +193,13 @@ msgs::Geometry ignition::gazebo::convert(const sdf::Geometry &_in)
       !_in.PolylineShape().empty())
   {
     out.set_type(msgs::Geometry::POLYLINE);
-    for (auto polyline : _in.PolylineShape())
+    for (const auto &polyline : _in.PolylineShape())
     {
       auto polylineMsg = out.add_polyline();
       polylineMsg->set_height(polyline.Height());
-      for (auto i = 0; i < polyline.PointCount(); ++i)
+      for (const auto &point : polyline.Points())
       {
-        msgs::Set(polylineMsg->add_point(), *polyline.PointByIndex(i));
+        msgs::Set(polylineMsg->add_point(), point);
       }
     }
   }

--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -30,6 +30,7 @@
 #include <sdf/Pbr.hh>
 #include <sdf/Physics.hh>
 #include <sdf/Plane.hh>
+#include <sdf/Polyline.hh>
 #include <sdf/Root.hh>
 #include <sdf/Scene.hh>
 #include <sdf/Sphere.hh>
@@ -425,6 +426,40 @@ TEST(Conversions, GeometryPlane)
 }
 
 /////////////////////////////////////////////////
+TEST(Conversions, GeometryPolyline)
+{
+  sdf::Geometry geometry;
+  geometry.SetType(sdf::GeometryType::POLYLINE);
+
+  sdf::Polyline polylineShape;
+  polylineShape.SetHeight(1.23);
+  polylineShape.AddPoint({4.5, 6.7});
+  polylineShape.AddPoint({8.9, 10.11});
+  geometry.SetPolylineShape({polylineShape});
+
+  auto geometryMsg = convert<msgs::Geometry>(geometry);
+  EXPECT_EQ(msgs::Geometry::POLYLINE, geometryMsg.type());
+  ASSERT_EQ(1, geometryMsg.polyline_size());
+  EXPECT_DOUBLE_EQ(1.23, geometryMsg.polyline(0).height());
+  ASSERT_EQ(2, geometryMsg.polyline(0).point_size());
+  EXPECT_DOUBLE_EQ(4.5, geometryMsg.polyline(0).point(0).x());
+  EXPECT_DOUBLE_EQ(6.7, geometryMsg.polyline(0).point(0).y());
+  EXPECT_DOUBLE_EQ(8.9, geometryMsg.polyline(0).point(1).x());
+  EXPECT_DOUBLE_EQ(10.11, geometryMsg.polyline(0).point(1).y());
+
+  auto newGeometry = convert<sdf::Geometry>(geometryMsg);
+  EXPECT_EQ(sdf::GeometryType::POLYLINE, newGeometry.Type());
+  ASSERT_FALSE(newGeometry.PolylineShape().empty());
+  ASSERT_EQ(1u, newGeometry.PolylineShape().size());
+  EXPECT_DOUBLE_EQ(1.23, newGeometry.PolylineShape()[0].Height());
+  ASSERT_EQ(2u, newGeometry.PolylineShape()[0].Points().size());
+  EXPECT_DOUBLE_EQ(4.5, newGeometry.PolylineShape()[0].Points()[0].X());
+  EXPECT_DOUBLE_EQ(6.7, newGeometry.PolylineShape()[0].Points()[0].Y());
+  EXPECT_DOUBLE_EQ(8.9, newGeometry.PolylineShape()[0].Points()[1].X());
+  EXPECT_DOUBLE_EQ(10.11, newGeometry.PolylineShape()[0].Points()[1].Y());
+}
+
+/////////////////////////////////////////////////
 TEST(Conversions, Inertial)
 {
   math::MassMatrix3d massMatrix;
@@ -543,7 +578,7 @@ TEST(Conversions, Atmosphere)
 }
 
 /////////////////////////////////////////////////
-TEST(CONVERSIONS, MagnetometerSensor)
+TEST(Conversions, MagnetometerSensor)
 {
   sdf::Sensor sensor;
   sensor.SetName("my_sensor");
@@ -583,7 +618,7 @@ TEST(CONVERSIONS, MagnetometerSensor)
 }
 
 /////////////////////////////////////////////////
-TEST(CONVERSIONS, AltimeterSensor)
+TEST(Conversions, AltimeterSensor)
 {
   sdf::Sensor sensor;
   sensor.SetName("my_sensor");

--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -452,11 +452,11 @@ TEST(Conversions, GeometryPolyline)
   ASSERT_FALSE(newGeometry.PolylineShape().empty());
   ASSERT_EQ(1u, newGeometry.PolylineShape().size());
   EXPECT_DOUBLE_EQ(1.23, newGeometry.PolylineShape()[0].Height());
-  ASSERT_EQ(2u, newGeometry.PolylineShape()[0].Points().size());
-  EXPECT_DOUBLE_EQ(4.5, newGeometry.PolylineShape()[0].Points()[0].X());
-  EXPECT_DOUBLE_EQ(6.7, newGeometry.PolylineShape()[0].Points()[0].Y());
-  EXPECT_DOUBLE_EQ(8.9, newGeometry.PolylineShape()[0].Points()[1].X());
-  EXPECT_DOUBLE_EQ(10.11, newGeometry.PolylineShape()[0].Points()[1].Y());
+  ASSERT_EQ(2u, newGeometry.PolylineShape()[0].PointCount());
+  EXPECT_DOUBLE_EQ(4.5, newGeometry.PolylineShape()[0].PointByIndex(0)->X());
+  EXPECT_DOUBLE_EQ(6.7, newGeometry.PolylineShape()[0].PointByIndex(0)->Y());
+  EXPECT_DOUBLE_EQ(8.9, newGeometry.PolylineShape()[0].PointByIndex(1)->X());
+  EXPECT_DOUBLE_EQ(10.11, newGeometry.PolylineShape()[0].PointByIndex(1)->Y());
 }
 
 /////////////////////////////////////////////////

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -455,14 +455,9 @@ rendering::GeometryPtr SceneManager::LoadGeometry(const sdf::Geometry &_geom,
   else if (_geom.Type() == sdf::GeometryType::POLYLINE)
   {
     std::vector<std::vector<math::Vector2d>> vertices;
-    for (auto polyline : _geom.PolylineShape())
+    for (const auto &polyline : _geom.PolylineShape())
     {
-      std::vector<math::Vector2d> points;
-      for (uint64_t i = 0; i < polyline.PointCount(); ++i)
-      {
-        points.push_back(*polyline.PointByIndex(i));
-      }
-      vertices.push_back(points);
+      vertices.push_back(polyline.Points());
     }
 
     std::string name("POLYLINE_" + common::Uuid().String());

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -457,7 +457,12 @@ rendering::GeometryPtr SceneManager::LoadGeometry(const sdf::Geometry &_geom,
     std::vector<std::vector<math::Vector2d>> vertices;
     for (auto polyline : _geom.PolylineShape())
     {
-      vertices.push_back(polyline.Points());
+      std::vector<math::Vector2d> points;
+      for (uint64_t i = 0; i < polyline.PointCount(); ++i)
+      {
+        points.push_back(*polyline.PointByIndex(i));
+      }
+      vertices.push_back(points);
     }
 
     std::string name("POLYLINE_" + common::Uuid().String());

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -25,6 +25,7 @@
 #include <sdf/Mesh.hh>
 #include <sdf/Pbr.hh>
 #include <sdf/Plane.hh>
+#include <sdf/Polyline.hh>
 #include <sdf/Sphere.hh>
 
 #include <ignition/common/Animation.hh>
@@ -33,6 +34,7 @@
 #include <ignition/common/Skeleton.hh>
 #include <ignition/common/SkeletonAnimation.hh>
 #include <ignition/common/MeshManager.hh>
+#include <ignition/common/Uuid.hh>
 
 #include <ignition/rendering/Geometry.hh>
 #include <ignition/rendering/Light.hh>
@@ -449,6 +451,26 @@ rendering::GeometryPtr SceneManager::LoadGeometry(const sdf::Geometry &_geom,
     descriptor.mesh = meshManager->Load(descriptor.meshName);
     geom = this->dataPtr->scene->CreateMesh(descriptor);
     scale = _geom.MeshShape()->Scale();
+  }
+  else if (_geom.Type() == sdf::GeometryType::POLYLINE)
+  {
+    std::vector<std::vector<math::Vector2d>> vertices;
+    for (auto polyline : _geom.PolylineShape())
+    {
+      vertices.push_back(polyline.Points());
+    }
+
+    std::string name("POLYLINE_" + common::Uuid().String());
+
+    auto meshManager = ignition::common::MeshManager::Instance();
+    meshManager->CreateExtrudedPolyline(name, vertices,
+        _geom.PolylineShape()[0].Height());
+
+    rendering::MeshDescriptor descriptor;
+    descriptor.meshName = name;
+    descriptor.mesh = meshManager->MeshByName(name);
+
+    geom = this->dataPtr->scene->CreateMesh(descriptor);
   }
   else
   {

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -966,14 +966,9 @@ void PhysicsPrivate::CreatePhysicsEntities(const EntityComponentManager &_ecm)
           }
 
           std::vector<std::vector<math::Vector2d>> vertices;
-          for (auto polyline : _geom->Data().PolylineShape())
+          for (const auto &polyline : _geom->Data().PolylineShape())
           {
-            std::vector<math::Vector2d> points;
-            for (uint64_t i = 0; i < polyline.PointCount(); ++i)
-            {
-              points.push_back(*polyline.PointByIndex(i));
-            }
-            vertices.push_back(points);
+            vertices.push_back(polyline.Points());
           }
 
           std::string name("POLYLINE_" + common::Uuid().String());

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -968,7 +968,12 @@ void PhysicsPrivate::CreatePhysicsEntities(const EntityComponentManager &_ecm)
           std::vector<std::vector<math::Vector2d>> vertices;
           for (auto polyline : _geom->Data().PolylineShape())
           {
-            vertices.push_back(polyline.Points());
+            std::vector<math::Vector2d> points;
+            for (uint64_t i = 0; i < polyline.PointCount(); ++i)
+            {
+              points.push_back(*polyline.PointByIndex(i));
+            }
+            vertices.push_back(points);
           }
 
           std::string name("POLYLINE_" + common::Uuid().String());

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -979,8 +979,8 @@ void PhysicsPrivate::CreatePhysicsEntities(const EntityComponentManager &_ecm)
           auto polyline = meshManager->MeshByName(name);
           if (nullptr == polyline)
           {
-            ignwarn << "Failed to create polyline for collision [" << _name->Data()
-                    << "]." << std::endl;
+            ignwarn << "Failed to create polyline for collision ["
+                    << _name->Data() << "]." << std::endl;
             return true;
           }
 
@@ -991,8 +991,8 @@ void PhysicsPrivate::CreatePhysicsEntities(const EntityComponentManager &_ecm)
             static bool informed{false};
             if (!informed)
             {
-              igndbg << "Attempting to process polyline geometries, but the physics"
-                     << " engine doesn't support feature "
+              igndbg << "Attempting to process polyline geometries, but the"
+                     << " physics engine doesn't support feature "
                      << "[AttachMeshShapeFeature]. Polylines will be ignored."
                      << std::endl;
               informed = true;

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -179,6 +179,31 @@ class ignition::gazebo::systems::PhysicsPrivate
   /// \param[in] _ecm Constant reference to ECM.
   public: void CreatePhysicsEntities(const EntityComponentManager &_ecm);
 
+
+  /// \brief Create world entities
+  /// \param[in] _ecm Constant reference to ECM.
+  public: void CreateWorldEntities(const EntityComponentManager &_ecm);
+
+  /// \brief Create model entities
+  /// \param[in] _ecm Constant reference to ECM.
+  public: void CreateModelEntities(const EntityComponentManager &_ecm);
+
+  /// \brief Create link entities
+  /// \param[in] _ecm Constant reference to ECM.
+  public: void CreateLinkEntities(const EntityComponentManager &_ecm);
+
+  /// \brief Create collision entities
+  /// \param[in] _ecm Constant reference to ECM.
+  public: void CreateCollisionEntities(const EntityComponentManager &_ecm);
+
+  /// \brief Create joint entities
+  /// \param[in] _ecm Constant reference to ECM.
+  public: void CreateJointEntities(const EntityComponentManager &_ecm);
+
+  /// \brief Create Battery entities
+  /// \param[in] _ecm Constant reference to ECM.
+  public: void CreateBatteryEntities(const EntityComponentManager &_ecm);
+
   /// \brief Remove physics entities if they are removed from the ECM
   /// \param[in] _ecm Constant reference to ECM.
   public: void RemovePhysicsEntities(const EntityComponentManager &_ecm);
@@ -667,6 +692,18 @@ void Physics::Update(const UpdateInfo &_info, EntityComponentManager &_ecm)
 //////////////////////////////////////////////////
 void PhysicsPrivate::CreatePhysicsEntities(const EntityComponentManager &_ecm)
 {
+  this->CreateWorldEntities(_ecm);
+  this->CreateModelEntities(_ecm);
+  this->CreateLinkEntities(_ecm);
+  // We don't need to add visuals to the physics engine.
+  this->CreateCollisionEntities(_ecm);
+  this->CreateJointEntities(_ecm);
+  this->CreateBatteryEntities(_ecm);
+}
+
+//////////////////////////////////////////////////
+void PhysicsPrivate::CreateWorldEntities(const EntityComponentManager &_ecm)
+{
   // Get all the new worlds
   _ecm.EachNew<components::World, components::Name, components::Gravity>(
       [&](const Entity &_entity,
@@ -691,7 +728,11 @@ void PhysicsPrivate::CreatePhysicsEntities(const EntityComponentManager &_ecm)
 
         return true;
       });
+}
 
+//////////////////////////////////////////////////
+void PhysicsPrivate::CreateModelEntities(const EntityComponentManager &_ecm)
+{
   _ecm.EachNew<components::Model, components::Name, components::Pose,
             components::ParentEntity>(
       [&](const Entity &_entity,
@@ -819,7 +860,11 @@ void PhysicsPrivate::CreatePhysicsEntities(const EntityComponentManager &_ecm)
 
         return true;
       });
+}
 
+//////////////////////////////////////////////////
+void PhysicsPrivate::CreateLinkEntities(const EntityComponentManager &_ecm)
+{
   _ecm.EachNew<components::Link, components::Name, components::Pose,
             components::ParentEntity>(
       [&](const Entity &_entity,
@@ -873,10 +918,11 @@ void PhysicsPrivate::CreatePhysicsEntities(const EntityComponentManager &_ecm)
 
         return true;
       });
+}
 
-  // We don't need to add visuals to the physics engine.
-
-  // collisions
+//////////////////////////////////////////////////
+void PhysicsPrivate::CreateCollisionEntities(const EntityComponentManager &_ecm)
+{
   _ecm.EachNew<components::Collision, components::Name, components::Pose,
             components::Geometry, components::CollisionElement,
             components::ParentEntity>(
@@ -1054,8 +1100,11 @@ void PhysicsPrivate::CreatePhysicsEntities(const EntityComponentManager &_ecm)
             topLevelModel(_entity, _ecm)));
         return true;
       });
+}
 
-  // joints
+//////////////////////////////////////////////////
+void PhysicsPrivate::CreateJointEntities(const EntityComponentManager &_ecm)
+{
   _ecm.EachNew<components::Joint, components::Name, components::JointType,
                components::Pose, components::ThreadPitch,
                components::ParentEntity, components::ParentLinkName,
@@ -1137,15 +1186,6 @@ void PhysicsPrivate::CreatePhysicsEntities(const EntityComponentManager &_ecm)
           this->topLevelModelMap.insert(std::make_pair(_entity,
               topLevelModel(_entity, _ecm)));
         }
-        return true;
-      });
-
-  _ecm.EachNew<components::BatterySoC>(
-      [&](const Entity & _entity, const components::BatterySoC *)->bool
-      {
-        // Parent entity of battery is model entity
-        this->entityOffMap.insert(std::make_pair(
-          _ecm.ParentEntity(_entity), false));
         return true;
       });
 
@@ -1269,6 +1309,19 @@ void PhysicsPrivate::CreatePhysicsEntities(const EntityComponentManager &_ecm)
             }
           }
         }
+        return true;
+      });
+}
+
+//////////////////////////////////////////////////
+void PhysicsPrivate::CreateBatteryEntities(const EntityComponentManager &_ecm)
+{
+  _ecm.EachNew<components::BatterySoC>(
+      [&](const Entity & _entity, const components::BatterySoC *)->bool
+      {
+        // Parent entity of battery is model entity
+        this->entityOffMap.insert(std::make_pair(
+          _ecm.ParentEntity(_entity), false));
         return true;
       });
 }


### PR DESCRIPTION
# 🎉 New feature

* Closes https://github.com/ignitionrobotics/ign-gazebo/issues/186
* Requires https://github.com/ignitionrobotics/sdformat/pull/1000

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Support extruded polyline geometries as visuals or collisions.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

Try the example world:

```
ign gazebo polylines.sdf
```

![polylines](https://user-images.githubusercontent.com/5751272/164607035-4855800b-f587-47d6-b4da-3e522d3134f7.gif)

## TODO

- [x] cppcheck isn't happy about the length of the `CreatePhysicsEntities` function. I'll open a separate PR breaking it apart like it was done for `ign-gazebo5` on #661

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] ~~Updated migration guide (as needed)~~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
