### PR TITLE
Download models in the background

### DIFF
--- a/examples/worlds/fuel.sdf
+++ b/examples/worlds/fuel.sdf
@@ -17,46 +17,13 @@
       name="ignition::gazebo::systems::SceneBroadcaster">
     </plugin>
 
-    <light type="directional" name="sun">
-      <cast_shadows>true</cast_shadows>
-      <pose>0 0 10 0 0 0</pose>
-      <diffuse>0.8 0.8 0.8 1</diffuse>
-      <specular>0.2 0.2 0.2 1</specular>
-      <attenuation>
-        <range>1000</range>
-        <constant>0.9</constant>
-        <linear>0.01</linear>
-        <quadratic>0.001</quadratic>
-      </attenuation>
-      <direction>-0.5 0.1 -0.9</direction>
-    </light>
+    <include>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Sun</uri>
+    </include>
 
-    <model name="ground_plane">
-      <static>true</static>
-      <link name="link">
-        <collision name="collision">
-          <geometry>
-            <plane>
-              <normal>0 0 1</normal>
-              <size>100 100</size>
-            </plane>
-          </geometry>
-        </collision>
-        <visual name="visual">
-          <geometry>
-            <plane>
-              <normal>0 0 1</normal>
-              <size>100 100</size>
-            </plane>
-          </geometry>
-          <material>
-            <ambient>0.8 0.8 0.8 1</ambient>
-            <diffuse>0.8 0.8 0.8 1</diffuse>
-            <specular>0.8 0.8 0.8 1</specular>
-          </material>
-        </visual>
-      </link>
-    </model>
+    <include>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Ground Plane</uri>
+    </include>
 
     <!-- Included model without meshes -->
     <include>

--- a/include/ignition/gazebo/Server.hh
+++ b/include/ignition/gazebo/Server.hh
@@ -120,6 +120,20 @@ namespace ignition
       /// \brief Destructor
       public: ~Server();
 
+      /// \brief Construct the server using the parameters specified in a
+      /// ServerConfig and choose it should download models in the background
+      /// \param[in] _config Server configuration parameters. If this
+      /// parameter is omitted, then an empty world is loaded.
+      public: Server(bool _downloadInParallel,
+                     const ServerConfig &_config = ServerConfig());
+
+      /// \brief Initialize server
+      private: void Init();
+
+      /// \brief Download models from the sdf
+      /// \return True if everything was fine False otherwise
+      private: bool DownloadModels();
+
       /// \brief Set the update period. The update period is the wall-clock time
       /// between ECS updates.
       /// Note that this is different from the simulation update rate. ECS

--- a/include/ignition/gazebo/ServerConfig.hh
+++ b/include/ignition/gazebo/ServerConfig.hh
@@ -192,6 +192,16 @@ namespace ignition
       /// \return True if -r is setted or False otherwise
       public: bool RunOption() const;
 
+      /// \brief True if the models are downloaded in a thread false otherwise
+      /// \param _downloadInParallel True if the models are downloaded in a
+      /// thread false otherwise
+      public: void SetDownloadInParallel(bool _downloadInParallel);
+
+      /// \brief Return True if the models are downloaded in a thread false
+      /// otherwise
+      /// \return True if the models are downloaded in a thread false otherwise
+      public: bool DownloadInParallel() const;
+
       /// \brief Get whether the server is using the level system
       /// \return True if the server is set to use the level system
       public: bool UseLevels() const;

--- a/include/ignition/gazebo/ServerConfig.hh
+++ b/include/ignition/gazebo/ServerConfig.hh
@@ -184,6 +184,14 @@ namespace ignition
       /// an UpdateRate has not been set.
       public: std::optional<double> UpdateRate() const;
 
+      /// \brief Set the run option
+      /// \return True if -r is setted or False otherwise
+      public: void SetRunOption(bool _run);
+
+      /// \brief Get the run option
+      /// \return True if -r is setted or False otherwise
+      public: bool RunOption() const;
+
       /// \brief Get whether the server is using the level system
       /// \return True if the server is set to use the level system
       public: bool UseLevels() const;

--- a/src/LevelManager.cc
+++ b/src/LevelManager.cc
@@ -469,6 +469,12 @@ void LevelManager::ConfigureDefaultLevel()
 }
 
 /////////////////////////////////////////////////
+void LevelManager::AddWorld(const sdf::World *_world)
+{
+  this->entityCreator->CreateEntities(_world);
+}
+
+/////////////////////////////////////////////////
 void LevelManager::CreatePerformers()
 {
   IGN_PROFILE("LevelManager::CreatePerformers");

--- a/src/LevelManager.hh
+++ b/src/LevelManager.hh
@@ -88,6 +88,10 @@ namespace ignition
       /// every update cycle
       public: void UpdateLevelsState();
 
+      /// \brief This will add a world to the scene
+      /// \param[in] _world SDF world to add to the scene
+      public: void AddWorld(const sdf::World *_world);
+
       /// \brief Load entities that have been marked for loading.
       /// \param[in] _namesToLoad List of of entity names to load
       private: void LoadActiveEntities(
@@ -184,4 +188,3 @@ namespace ignition
 }
 // IGNITION_GAZEBO_LEVELMANAGER_HH
 #endif
-

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -260,7 +260,7 @@ void Server::Init()
     std::string filePath = systemPaths.FindFile(this->dataPtr->config.SdfFile());
 
     std::string worldName;
-    auto errors2 = this->dataPtr->sdfRoot.GetWorldName(filePath, worldName);
+    auto errors2 = this->dataPtr->sdfRoot.WorldName(filePath, worldName);
 
     // Load an empty world.
     /// \todo(nkoenig) Add a "AddWorld" function to sdf::Root.

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -183,9 +183,11 @@ Server::Server(const ServerConfig &_config)
         return;
       }
 
-      for (std::unique_ptr<SimulationRunner> &runner : this->dataPtr->simRunners)
+      for (std::unique_ptr<SimulationRunner> &runner :
+           this->dataPtr->simRunners)
       {
-        for (size_t j = 0; j < this->dataPtr->sdfRoot.WorldCount(); ++j){
+        for (size_t j = 0; j < this->dataPtr->sdfRoot.WorldCount(); ++j)
+        {
             runner->AddWorld(this->dataPtr->sdfRoot.WorldByIndex(j));
         }
         runner->SetFetchedAllIncludes(true);

--- a/src/ServerConfig.cc
+++ b/src/ServerConfig.cc
@@ -232,6 +232,7 @@ class ignition::gazebo::ServerConfigPrivate
             physicsEngine(_cfg->physicsEngine),
             renderEngineServer(_cfg->renderEngineServer),
             renderEngineGui(_cfg->renderEngineGui),
+            running(_cfg->running),
             plugins(_cfg->plugins),
             networkRole(_cfg->networkRole),
             networkSecondaries(_cfg->networkSecondaries),
@@ -283,6 +284,10 @@ class ignition::gazebo::ServerConfigPrivate
   /// \brief File containing render engine gui plugin. If empty, OGRE2
   /// will be used.
   public: std::string renderEngineGui = "";
+
+  /// \brief This is used to indicate that Run has been called, and the
+  /// server is in the run state.
+  public: bool running{false};
 
   /// \brief List of plugins to load.
   public: std::list<ServerConfig::PluginInfo> plugins;
@@ -371,6 +376,18 @@ std::optional<std::chrono::steady_clock::duration>
   }
 
   return std::nullopt;
+}
+
+/////////////////////////////////////////////////
+bool ServerConfig::RunOption() const
+{
+  return this->dataPtr->running;
+}
+
+/////////////////////////////////////////////////
+void ServerConfig::SetRunOption(bool _run)
+{
+  this->dataPtr->running = _run;
 }
 
 /////////////////////////////////////////////////
@@ -928,4 +945,3 @@ ignition::gazebo::loadPluginInfo(bool _isPlayback)
 
   return ret;
 }
-

--- a/src/ServerConfig.cc
+++ b/src/ServerConfig.cc
@@ -220,6 +220,7 @@ class ignition::gazebo::ServerConfigPrivate
   public: explicit ServerConfigPrivate(
               const std::unique_ptr<ServerConfigPrivate> &_cfg)
           : sdfFile(_cfg->sdfFile),
+            sdfString(_cfg->sdfString),
             updateRate(_cfg->updateRate),
             useLevels(_cfg->useLevels),
             useLogRecord(_cfg->useLogRecord),
@@ -288,6 +289,9 @@ class ignition::gazebo::ServerConfigPrivate
   /// \brief This is used to indicate that Run has been called, and the
   /// server is in the run state.
   public: bool running{false};
+
+  /// \brief True if models are downloaded in the background, false otherwise
+  public: bool downloadInParallel{false};
 
   /// \brief List of plugins to load.
   public: std::list<ServerConfig::PluginInfo> plugins;
@@ -388,6 +392,18 @@ bool ServerConfig::RunOption() const
 void ServerConfig::SetRunOption(bool _run)
 {
   this->dataPtr->running = _run;
+}
+
+/////////////////////////////////////////////////
+void ServerConfig::SetDownloadInParallel(bool _downloadInParallel)
+{
+  this->dataPtr->downloadInParallel = _downloadInParallel;
+}
+
+/////////////////////////////////////////////////
+bool ServerConfig::DownloadInParallel() const
+{
+  return this->dataPtr->downloadInParallel;
 }
 
 /////////////////////////////////////////////////

--- a/src/ServerConfig.cc
+++ b/src/ServerConfig.cc
@@ -234,6 +234,7 @@ class ignition::gazebo::ServerConfigPrivate
             renderEngineServer(_cfg->renderEngineServer),
             renderEngineGui(_cfg->renderEngineGui),
             running(_cfg->running),
+            downloadInParallel(_cfg->downloadInParallel),
             plugins(_cfg->plugins),
             networkRole(_cfg->networkRole),
             networkSecondaries(_cfg->networkSecondaries),

--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -104,6 +104,10 @@ ServerPrivate::~ServerPrivate()
   {
     this->stopThread->join();
   }
+  if (this->downloadModelsThread.joinable())
+  {
+    this->downloadModelsThread.join();
+  }
 }
 
 //////////////////////////////////////////////////

--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -108,6 +108,10 @@ ServerPrivate::~ServerPrivate()
   {
     this->downloadModelsThread.join();
   }
+  if (this->downloadModelsThread.joinable())
+  {
+    this->downloadModelsThread.join();
+  }
 }
 
 //////////////////////////////////////////////////

--- a/src/ServerPrivate.hh
+++ b/src/ServerPrivate.hh
@@ -163,6 +163,9 @@ namespace ignition
       /// Server. It is used in the SDFormat world generator when saving worlds
       public: std::unordered_map<std::string, std::string> fuelUriMap;
 
+      /// \brief Thread to download the models
+      public: std::thread * downloadModelsThread;
+
       /// \brief List of names for all worlds loaded in this server.
       private: std::vector<std::string> worldNames;
 

--- a/src/ServerPrivate.hh
+++ b/src/ServerPrivate.hh
@@ -164,7 +164,11 @@ namespace ignition
       public: std::unordered_map<std::string, std::string> fuelUriMap;
 
       /// \brief Thread to download the models
-      public: std::thread * downloadModelsThread;
+      public: std::thread downloadModelsThread;
+
+      /// \brief True if models are downloaded in the background, false
+      /// otherwise
+      public: bool downloadInParallel{false};
 
       /// \brief List of names for all worlds loaded in this server.
       private: std::vector<std::string> worldNames;

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -82,7 +82,7 @@ TEST_P(ServerFixture, DefaultServerConfig)
   EXPECT_EQ(0u, *server.IterationCount());
 
   EXPECT_EQ(3u, *server.EntityCount());
-  EXPECT_TRUE(server.HasEntity("default"));
+  EXPECT_TRUE(server.HasEntity("empty_world"));
 
   EXPECT_EQ(3u, *server.SystemCount());
 }
@@ -157,6 +157,25 @@ TEST_P(ServerFixture, ServerConfigPluginInfo)
     EXPECT_EQ(cfgPlugins.front().Name(), plugins.front().Name());
     EXPECT_EQ(cfgPlugins.front().Sdf(), plugins.front().Sdf());
   }
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, ServerDownloadParallel)
+{
+  // Start server
+  ServerConfig serverConfig;
+  serverConfig.SetUpdateRate(10000);
+  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
+      "/test/worlds/shapes.sdf");
+
+  gazebo::Server server(true, serverConfig);
+
+  EXPECT_TRUE(server.Run(false, 0, false));
+  while (*server.IterationCount() == 0)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  EXPECT_EQ(18u, *server.EntityCount());
 }
 
 /////////////////////////////////////////////////

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -731,18 +731,21 @@ bool SimulationRunner::Run(const uint64_t _iterations)
 
     // If the models are still being downloaded, it doesn't allow to start
     // the simulation
-    if (!this->FetchedAllIncludes())
+    if (this->serverConfig.DownloadInParallel())
     {
-      this->SetPaused(true);
-    }
-    else
-    {
-      // when the models are downloaded we should set which is the run option
-      // used by the user.
-      if (!isInitialRunOfSimulationSet)
+      if (!this->FetchedAllIncludes())
       {
-        isInitialRunOfSimulationSet = true;
-        this->SetPaused(!this->serverConfig.RunOption());
+        this->SetPaused(true);
+      }
+      else
+      {
+        // when the models are downloaded we should set which is the run option
+        // used by the user.
+        if (!isInitialRunOfSimulationSet)
+        {
+          isInitialRunOfSimulationSet = true;
+          this->SetPaused(!this->serverConfig.RunOption());
+        }
       }
     }
 

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -181,8 +181,8 @@ namespace ignition
       public: void AddWorld(const sdf::World *_world);
 
       /// \brief Check if there is any model being downloaded in the backgound.
-      /// \return False if there is any model being downloaded in the background,
-      /// true otherwise
+      /// \return False if there is any model being downloaded in the
+      /// background, True otherwise
       public: bool FetchedAllIncludes() const;
 
       /// \brief Set if there is any model being downloaded in the backgound.

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -176,6 +176,20 @@ namespace ignition
       /// \return True if the operation completed successfully.
       public: bool Run(const uint64_t _iterations);
 
+      /// \brief This will add a world to the scene
+      /// \param[in] _light SDF world to add to the scene
+      public: void AddWorld(const sdf::World *_world);
+
+      /// \brief Check if there is any model being downloaded in the backgound.
+      /// \return False if there is any model being downloaded in the background,
+      /// true otherwise
+      public: bool FetchedAllIncludes() const;
+
+      /// \brief Set if there is any model being downloaded in the backgound.
+      /// \param[in] _downloadedAllModels False if there is any model being
+      /// downloaded in the background, true otherwise.
+      public: void SetFetchedAllIncludes(bool _downloadedAllModels);
+
       /// \brief Perform a simulation step:
       /// * Publish stats and process control messages
       /// * Update levels and systems
@@ -585,6 +599,12 @@ namespace ignition
 
       /// \brief True if Server::RunOnce triggered a blocking paused step
       private: bool blockingPausedStepPending{false};
+
+      /// \brief Mutex to protect the runner when a new model is inserted
+      private: std::mutex mutexDownloadParallel;
+
+      /// \brief True if all model are downloaded, false otherwise
+      private: std::atomic<bool> downloadedAllModels{false};
 
       friend class LevelManager;
     };

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -128,6 +128,8 @@ extern "C" IGNITION_GAZEBO_VISIBLE int runServer(const char *_sdfString,
   // Path for logs
   std::string recordPathMod = serverConfig.LogRecordPath();
 
+  serverConfig.SetRunOption(_run);
+
   // Path for compressed log, used to check for duplicates
   std::string cmpPath = std::string(recordPathMod);
   if (!std::string(1, cmpPath.back()).compare(ignition::common::separator("")))

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -356,7 +356,8 @@ extern "C" IGNITION_GAZEBO_VISIBLE int runServer(const char *_sdfString,
   }
 
   // Create the Gazebo server
-  ignition::gazebo::Server server(serverConfig);
+  serverConfig.SetDownloadInParallel(true);
+  ignition::gazebo::Server server(true, serverConfig);
 
   // Run the server
   server.Run(true, _iterations, _run == 0);


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>
# 🎉 New feature

Related to https://github.com/ignitionrobotics/ign-gazebo/issues/1260

it requires https://github.com/gazebosim/sdformat/tree/ahcorde/sdf9/worldName

## Summary

This PR allows to download models in the background, the simulation will not start until all models are downloaded and inserted in the world.

![downloadParallel](https://user-images.githubusercontent.com/1933907/165631060-77529ebd-b76d-44cf-a2e6-63249bacea2b.gif)

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
