### PR TITLE
Add new GZ_GUI_RESOURCE_PATH to help message

### DIFF
--- a/src/cmd/cmdgazebo.rb.in
+++ b/src/cmd/cmdgazebo.rb.in
@@ -159,6 +159,8 @@ COMMANDS = { 'gazebo' =>
   "  IGN_GAZEBO_SERVER_CONFIG_PATH    Path to server configuration file. \n\n"\
   "  IGN_GUI_PLUGIN_PATH    Colon separated paths used to locate GUI       \n"\
   " plugins.                                                             \n\n"\
+  "  GZ_GUI_RESOURCE_PATH    Colon separated paths used to locate GUI      \n"\
+  " resources such as configuration files.                               \n\n"\
   "  IGN_GAZEBO_NETWORK_ROLE     Participant role used in a distributed    \n"\
   " simulation environment. Role is one of [PRIMARY, SECONDARY]. This is   \n"\
   " deprecated in ign-gazebo2. Please use --network-role instead.        \n\n"\


### PR DESCRIPTION
# 🎉 New feature

Trivial followup to https://github.com/ignitionrobotics/ign-gui/pull/386

## Summary

Trivial PR.

## Test it

Check the new var is printed:
```
$ ign gazebo --help
...
  GZ_GUI_RESOURCE_PATH    Colon separated paths used to locate GUI      
 resources such as configuration files.
...
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.