### PR TITLE
Refactor common sensor setup interactions

### DIFF
--- a/src/systems/CMakeLists.txt
+++ b/src/systems/CMakeLists.txt
@@ -58,6 +58,12 @@ function(gz_add_system system_name)
       ignition-plugin${IGN_PLUGIN_VER}::register
   )
 
+  target_include_directories(${system_target}
+    PRIVATE
+      ${PROJECT_SOURCE_DIR}/src/systems/common
+  )
+
+
   if(gz_add_system_PRIVATE_INCLUDE_DIRS)
     target_include_directories(${system_target}
       PRIVATE

--- a/src/systems/common/gz_sensor/GzSensorImpl.hh
+++ b/src/systems/common/gz_sensor/GzSensorImpl.hh
@@ -15,12 +15,12 @@
  *
  */
 
-#ifndef IGNITION_GAZEBO_SYSTEMS_SENSORIMPL_HH_
-#define IGNITION_GAZEBO_SYSTEMS_SENSORIMPL_HH_
+#ifndef IGNITION_GAZEBO_SYSTEMS_GZSENSORIMPL_HH_
+#define IGNITION_GAZEBO_SYSTEMS_GZSENSORIMPL_HH_
 
-#include <map>
 #include <memory>
-#include <set>
+#include <unordered_map>
+#include <unordered_set>
 
 #include <ignition/common/Profiler.hh>
 
@@ -29,7 +29,7 @@
 
 #include <ignition/sensors/SensorFactory.hh>
 
-namespace ignition 
+namespace ignition
 {
 namespace gazebo
 {
@@ -39,14 +39,14 @@ namespace systems
 {
 
 template <typename SensorT, typename ComponentT>
-class SensorImpl
+class GzSensorImpl
 {
-  public: using SensorPtr = std::unique_ptr<SensorT>;
+  public: using GzSensorPtr = std::unique_ptr<SensorT>;
 
-  public: using EntitySensorMap = std::unordered_map<Entity, SensorPtr>;
+  public: using EntitySensorMap = std::unordered_map<Entity, GzSensorPtr>;
 
   /// \brief A map of Sensor entity to its gz-sensors object.
-  public: EntitySensorMap entitySensorMap; 
+  public: EntitySensorMap entitySensorMap;
 
   /// \brief gz-sensors sensor factory for creating sensors
   public: ignition::sensors::SensorFactory sensorFactory;
@@ -60,7 +60,7 @@ class SensorImpl
 
   /// \brief Create sensors in gz-sensors
   /// \param[in] _ecm Immutable reference to ECM.
-  public: void CreateSensors(const EntityComponentManager &_ecm) 
+  public: void CreateSensors(const EntityComponentManager &_ecm)
   {
     IGN_PROFILE("SensorImpl::CreateSensors");
 

--- a/src/systems/force_torque/ForceTorque.cc
+++ b/src/systems/force_torque/ForceTorque.cc
@@ -16,7 +16,7 @@
  */
 
 #include "ForceTorque.hh"
-#include "SensorImpl.hh"
+#include "gz_sensor/GzSensorImpl.hh"
 
 #include <unordered_map>
 #include <utility>
@@ -40,7 +40,6 @@
 #include "ignition/gazebo/components/ParentLinkName.hh"
 #include "ignition/gazebo/components/Pose.hh"
 #include "ignition/gazebo/components/Sensor.hh"
-#include "ignition/gazebo/components/World.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/Util.hh"
 
@@ -50,7 +49,7 @@ using namespace systems;
 
 /// \brief Private ForceTorque data class.
 class ignition::gazebo::systems::ForceTorquePrivate
-: public SensorImpl<sensors::ForceTorqueSensor, components::ForceTorque>
+: public GzSensorImpl<sensors::ForceTorqueSensor, components::ForceTorque>
 {
   /// \brief A struct to hold the joint and link entities associated with a
   /// sensor

--- a/src/systems/force_torque/SensorImpl.hh
+++ b/src/systems/force_torque/SensorImpl.hh
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef IGNITION_GAZEBO_SYSTEMS_SENSORIMPL_HH_
+#define IGNITION_GAZEBO_SYSTEMS_SENSORIMPL_HH_
+
+#include <map>
+#include <memory>
+#include <set>
+
+#include <ignition/common/Profiler.hh>
+
+#include <ignition/gazebo/EntityComponentManager.hh>
+#include <ignition/gazebo/components/ParentEntity.hh>
+
+#include <ignition/sensors/SensorFactory.hh>
+
+namespace ignition 
+{
+namespace gazebo
+{
+// Inline bracket to help doxygen filtering.
+inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
+namespace systems
+{
+
+template <typename SensorT, typename ComponentT>
+class SensorImpl
+{
+  public: using SensorPtr = std::unique_ptr<SensorT>;
+
+  public: using EntitySensorMap = std::unordered_map<Entity, SensorPtr>;
+
+  /// \brief A map of Sensor entity to its gz-sensors object.
+  public: EntitySensorMap entitySensorMap; 
+
+  /// \brief gz-sensors sensor factory for creating sensors
+  public: ignition::sensors::SensorFactory sensorFactory;
+
+  /// \brief Keep list of sensors that were created during the previous
+  /// `PostUpdate`, so that components can be created during the next
+  /// `PreUpdate`.
+  public: std::unordered_set<Entity> newSensors;
+
+  public: bool initialized = false;
+
+  /// \brief Create sensors in gz-sensors
+  /// \param[in] _ecm Immutable reference to ECM.
+  public: void CreateSensors(const EntityComponentManager &_ecm) 
+  {
+    IGN_PROFILE("SensorImpl::CreateSensors");
+
+    if (!this->initialized)
+    {
+      // Create Sensors
+      _ecm.Each<ComponentT, components::ParentEntity>(
+      [&](const Entity &_entity,
+          const ComponentT *_sensor,
+          const components::ParentEntity *_parent)->bool
+        {
+          this->AddSensor(_ecm, _entity, _sensor, _parent);
+          return true;
+        });
+      this->initialized = true;
+    }
+    else
+    {
+      _ecm.EachNew<ComponentT, components::ParentEntity>(
+        [&](const Entity &_entity,
+            const ComponentT *_sensor,
+            const components::ParentEntity *_parent)->bool
+          {
+            this->AddSensor(_ecm, _entity, _sensor, _parent);
+            return true;
+        });
+    }
+  }
+
+  public: void PreUpdate(const UpdateInfo &/*_info*/,
+                         EntityComponentManager &_ecm)
+  {
+    IGN_PROFILE("SensorImpl::PreUpdate");
+
+    // Create components
+    for (auto entity : this->newSensors)
+    {
+      auto it = this->entitySensorMap.find(entity);
+      if (it == this->entitySensorMap.end())
+      {
+        ignerr << "Entity [" << entity
+               << "] isn't in sensor map, this shouldn't happen." << std::endl;
+        continue;
+      }
+
+      this->CreateComponents(_ecm, entity, it->second.get());
+    }
+    this->newSensors.clear();
+  }
+
+  /// \brief Update sensor data based on physics data
+  /// \param[in] _ecm Immutable reference to ECM.
+  public: void PostUpdate(const UpdateInfo &_info,
+                          const EntityComponentManager &_ecm)
+  {
+    IGN_PROFILE("SensorImpl::PostUpdate");
+
+    // \TODO(anyone) Support rewind
+    if (_info.dt < std::chrono::steady_clock::duration::zero())
+    {
+      ignwarn << "Detected jump back in time ["
+          << std::chrono::duration_cast<std::chrono::seconds>(_info.dt).count()
+          << "s]. System may not work properly." << std::endl;
+    }
+
+    // Only update and publish if not paused.
+    if (!_info.paused)
+    {
+      this->Update(_ecm);
+
+      for (auto &it : this->entitySensorMap)
+      {
+        it.second->Update(_info.simTime, false);
+      }
+    }
+
+    this->RemoveSensorEntities(_ecm);
+  }
+
+  /// \brief Remove sensors if their entities have been removed from
+  /// simulation.
+  /// \param[in] _ecm Immutable reference to ECM.
+  public: void RemoveSensorEntities(const EntityComponentManager &_ecm)
+  {
+    IGN_PROFILE("SensorImpl::RemoveSensorEntities");
+    _ecm.EachRemoved<ComponentT>(
+      [&](const Entity &_entity,
+        const ComponentT *)->bool
+      {
+        auto sensorId = this->entitySensorMap.find(_entity);
+        if (sensorId == this->entitySensorMap.end())
+        {
+          ignerr << "Internal error, missing sensor for entity ["
+                 << _entity << "]" << std::endl;
+          return true;
+        }
+
+        this->entitySensorMap.erase(sensorId);
+
+        return true;
+      });
+  }
+
+  public: virtual void CreateComponents(
+              EntityComponentManager &_ecm,
+              const Entity _entity,
+              const SensorT *_sensor) = 0;
+
+  public: virtual void AddSensor(
+    const EntityComponentManager &_ecm,
+    const Entity _entity,
+    const ComponentT *_sensor,
+    const components::ParentEntity *_parent) = 0;
+
+  public: virtual void Update(const EntityComponentManager &_ecm) = 0;
+};
+}  // namespace systems
+}
+}  // namespace gazebo
+}  // namespace ignition
+
+#endif  // IGNITION_GAZEBO_SYSTEMS_SENSORIMPL_HH_


### PR DESCRIPTION
This addresses a bug uncovered when using the `Reset` implementation with the `ForceTorqueSensor`.

Not all sensor system implementations were updated as part of https://github.com/ignitionrobotics/ign-gazebo/pull/1281, one of which being the `ForceTorqueSensor`.  This makes the reset behavior incorrect and the sensor won't be respawned.

As part of this, I'm also experimenting with refactoring out the common functionality that is boilerplate in any GzSensors  system implementation.    To view the diff for a single system that was already updated, see https://github.com/ignitionrobotics/ign-gazebo/commit/20b15b619a3d67d607d8bbcb238b34689a8b9b9c

Once complete, this should close out: https://github.com/ignitionrobotics/ign-gazebo/issues/797 as all sensors will be updated.