### PR TITLE
Allow rendering to be forced externally

### DIFF
--- a/include/gz/sim/rendering/Events.hh
+++ b/include/gz/sim/rendering/Events.hh
@@ -44,9 +44,9 @@ namespace gz
       using SceneUpdate = gz::common::EventT<void(void),
           struct SceneUpdateTag>;
 
-      /// \brief The render event is emitted before rendering updates.
+      /// \brief The pre render event is emitted before rendering updates.
       /// The event is emitted in the rendering thread so rendering
-      /// calls can ben make in this event callback
+      /// calls can be made in this event callback
       ///
       /// For example:
       /// \code
@@ -55,9 +55,20 @@ namespace gz
       using PreRender = gz::common::EventT<void(void),
           struct PreRenderTag>;
 
-      /// \brief The render event is emitted after rendering updates.
+      /// \brief The render event is emitted during rendering updates.
       /// The event is emitted in the rendering thread so rendering
-      /// calls can ben make in this event callback
+      /// calls can be made in this event callback
+      ///
+      /// For example:
+      /// \code
+      /// eventManager.Emit<gz::sim::events::Render>();
+      /// \endcode
+      using Render = gz::common::EventT<void(void),
+          struct RenderTag>;
+
+      /// \brief The post render event is emitted after rendering updates.
+      /// The event is emitted in the rendering thread so rendering
+      /// calls can be made in this event callback
       ///
       /// For example:
       /// \code
@@ -65,6 +76,20 @@ namespace gz
       /// \endcode
       using PostRender = gz::common::EventT<void(void),
           struct PostRenderTag>;
+
+      /// \brief The force render event may be emitted outside the
+      /// rendering thread to force rendering calls ie. to ensure
+      /// rendering occurs even if it wasn't seemingly necessary.
+      ///
+      /// Useful for custom, out-of-tree rendering sensors that
+      /// need the rendering thread to perform an update.
+      ///
+      /// For example:
+      /// \code
+      /// eventManager.Emit<gz::sim::events::ForceRender>();
+      /// \endcode
+      using ForceRender = gz::common::EventT<void(void),
+          struct ForceRenderTag>;
       }
     }  // namespace events
   }  // namespace sim

--- a/tutorials/rendering_plugins.md
+++ b/tutorials/rendering_plugins.md
@@ -100,7 +100,7 @@ events. Here's how to do it:
 
 ### Render events on the server
 
-The server plugin will need to listen to `gz::sim::events::PreRender` or
+The server plugin will need to listen `gz::sim::events::PreRender`, `gz::sim::events::Render` or
 `gz::sim::events::PostRender` events.
 
 Here's how to do it:


### PR DESCRIPTION
# 🎉 New feature

## Summary
`ignition::gazebo::systems::Sensors` will only update its rendering sensors when there's a need for it. While perfectly reasonable, this also means that any custom rendering sensor relying on pre/post render hooks to do its work must wait for a builtin sensor that is known to this system to require an update. 

This patch works around this by introducing a `ForceRender` event that other systems can emit to force a rendering pass.

## Test it
...

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.