### PR TITLE
Trivial Fuel URL fix in example

### DIFF
--- a/examples/worlds/multi_lrauv_race.sdf
+++ b/examples/worlds/multi_lrauv_race.sdf
@@ -65,7 +65,7 @@
       See https://github.com/ignitionrobotics/ign-gazebo/pull/730 -->
     <include>
       <pose>-5 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/mabel/models/Turquoise turbidity generator</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/mabelzhang/models/Turquoise turbidity generator</uri>
     </include>
 
     <include>
@@ -352,12 +352,12 @@
     <!-- Swimming race lane signs -->
     <include>
       <pose>0 0 -1 0 0 3.1415926</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/mabel/models/ABCSign_5m</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/mabelzhang/models/ABCSign_5m</uri>
       <name>start_line</name>
     </include>
     <include>
       <pose>0 -25 -1 0 0 3.1415926</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/mabel/models/ABCSign_5m</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/mabelzhang/models/ABCSign_5m</uri>
       <name>finish_line</name>
     </include>
 


### PR DESCRIPTION
# 🦟 Bug fix

I broke my Gazebo Fuel accounts. The authorities fixed the mess for me. But that means I’ve consolidated my accounts, and there’s an URL change to model files under my account. Thankfully it only affects one SDF file that only exists from ign-gazebo6 onwards.

Sorry to anyone using it. My fault for not knowing how to Internet.

## Summary

Just make sure the models show up:
```
ign gazebo src/ign-gazebo/examples/worlds/multi_lrauv_race.sdf 
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.