### PR TITLE
Optimize sensor updates

### DIFF
--- a/src/systems/air_pressure/AirPressure.cc
+++ b/src/systems/air_pressure/AirPressure.cc
@@ -140,6 +140,24 @@ void AirPressure::PostUpdate(const UpdateInfo &_info,
 
   if (!_info.paused)
   {
+    // check to see if update is necessary
+    // we only update if there is at least one sensor that needs data
+    // and that sensor has subscribers.
+    // note: ign-sensors does its own throttling. Here the check is mainly
+    // to void doing work in the AirPressurePrivate::UpdatePressures function
+    bool needsUpdate = false;
+    for (auto &it : this->dataPtr->entitySensorMap)
+    {
+      if (it.second->NextDataUpdateTime() <= _info.simTime &&
+          it.second->HasConnections())
+      {
+        needsUpdate = true;
+        break;
+      }
+    }
+    if (!needsUpdate)
+      return;
+
     this->dataPtr->UpdateAirPressures(_ecm);
 
     for (auto &it : this->dataPtr->entitySensorMap)

--- a/src/systems/altimeter/Altimeter.cc
+++ b/src/systems/altimeter/Altimeter.cc
@@ -141,6 +141,24 @@ void Altimeter::PostUpdate(const UpdateInfo &_info,
   // Only update and publish if not paused.
   if (!_info.paused)
   {
+    // check to see if update is necessary
+    // we only update if there is at least one sensor that needs data
+    // and that sensor has subscribers.
+    // note: ign-sensors does its own throttling. Here the check is mainly
+    // to void doing work in the AltimeterPrivate::UpdateAltimeters function
+    bool needsUpdate = false;
+    for (auto &it : this->dataPtr->entitySensorMap)
+    {
+      if (it.second->NextDataUpdateTime() <= _info.simTime &&
+          it.second->HasConnections())
+      {
+        needsUpdate = true;
+        break;
+      }
+    }
+    if (!needsUpdate)
+      return;
+
     this->dataPtr->UpdateAltimeters(_ecm);
 
     for (auto &it : this->dataPtr->entitySensorMap)

--- a/src/systems/force_torque/ForceTorque.cc
+++ b/src/systems/force_torque/ForceTorque.cc
@@ -132,6 +132,24 @@ void ForceTorque::PostUpdate(const UpdateInfo &_info,
   // Only update and publish if not paused.
   if (!_info.paused)
   {
+    // check to see if update is necessary
+    // we only update if there is at least one sensor that needs data
+    // and that sensor has subscribers.
+    // note: ign-sensors does its own throttling. Here the check is mainly
+    // to void doing work in the ForceTorquePrivate::Update function
+    bool needsUpdate = false;
+    for (auto &it : this->dataPtr->entitySensorMap)
+    {
+      if (it.second->NextDataUpdateTime() <= _info.simTime &&
+          it.second->HasConnections())
+      {
+        needsUpdate = true;
+        break;
+      }
+    }
+    if (!needsUpdate)
+      return;
+
     this->dataPtr->Update(_ecm);
 
     for (auto &it : this->dataPtr->entitySensorMap)

--- a/src/systems/imu/Imu.cc
+++ b/src/systems/imu/Imu.cc
@@ -145,6 +145,24 @@ void Imu::PostUpdate(const UpdateInfo &_info,
   // Only update and publish if not paused.
   if (!_info.paused)
   {
+    // check to see if update is necessary
+    // we only update if there is at least one sensor that needs data
+    // and that sensor has subscribers.
+    // note: ign-sensors does its own throttling. Here the check is mainly
+    // to void doing work in the ImuPrivate::Update function
+    bool needsUpdate = false;
+    for (auto &it : this->dataPtr->entitySensorMap)
+    {
+      if (it.second->NextDataUpdateTime() <= _info.simTime &&
+          it.second->HasConnections())
+      {
+        needsUpdate = true;
+        break;
+      }
+    }
+    if (!needsUpdate)
+      return;
+
     this->dataPtr->Update(_ecm);
 
     for (auto &it : this->dataPtr->entitySensorMap)

--- a/src/systems/logical_camera/LogicalCamera.cc
+++ b/src/systems/logical_camera/LogicalCamera.cc
@@ -143,6 +143,25 @@ void LogicalCamera::PostUpdate(const UpdateInfo &_info,
   // Only update and publish if not paused.
   if (!_info.paused)
   {
+    // check to see if update is necessary
+    // we only update if there is at least one sensor that needs data
+    // and that sensor has subscribers.
+    // note: ign-sensors does its own throttling. Here the check is mainly
+    // to void doing work in the LogicalCameraPrivate::UpdateLogicalCameras
+    // function
+    bool needsUpdate = false;
+    for (auto &it : this->dataPtr->entitySensorMap)
+    {
+      if (it.second->NextDataUpdateTime() <= _info.simTime &&
+          it.second->HasConnections())
+      {
+        needsUpdate = true;
+        break;
+      }
+    }
+    if (!needsUpdate)
+      return;
+
     this->dataPtr->UpdateLogicalCameras(_ecm);
 
     for (auto &it : this->dataPtr->entitySensorMap)

--- a/src/systems/magnetometer/Magnetometer.cc
+++ b/src/systems/magnetometer/Magnetometer.cc
@@ -142,6 +142,24 @@ void Magnetometer::PostUpdate(const UpdateInfo &_info,
   // Only update and publish if not paused.
   if (!_info.paused)
   {
+    // check to see if update is necessary
+    // we only update if there is at least one sensor that needs data
+    // and that sensor has subscribers.
+    // note: ign-sensors does its own throttling. Here the check is mainly
+    // to void doing work in the MagnetometerPrivate::Update function
+    bool needsUpdate = false;
+    for (auto &it : this->dataPtr->entitySensorMap)
+    {
+      if (it.second->NextDataUpdateTime() <= _info.simTime &&
+          it.second->HasConnections())
+      {
+        needsUpdate = true;
+        break;
+      }
+    }
+    if (!needsUpdate)
+      return;
+
     this->dataPtr->Update(_ecm);
 
     for (auto &it : this->dataPtr->entitySensorMap)

--- a/src/systems/navsat/NavSat.cc
+++ b/src/systems/navsat/NavSat.cc
@@ -137,6 +137,24 @@ void NavSat::PostUpdate(const UpdateInfo &_info,
   // Only update and publish if not paused.
   if (!_info.paused)
   {
+    // check to see if update is necessary
+    // we only update if there is at least one sensor that needs data
+    // and that sensor has subscribers.
+    // note: ign-sensors does its own throttling. Here the check is mainly
+    // to void doing work in the NavSat::Implementation::Update function
+    bool needsUpdate = false;
+    for (auto &it : this->dataPtr->entitySensorMap)
+    {
+      if (it.second->NextDataUpdateTime() <= _info.simTime &&
+          it.second->HasConnections())
+      {
+        needsUpdate = true;
+        break;
+      }
+    }
+    if (!needsUpdate)
+      return;
+
     this->dataPtr->Update(_ecm);
 
     for (auto &it : this->dataPtr->entitySensorMap)

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -838,11 +838,6 @@ bool SensorsPrivate::HasConnections(sensors::RenderingSensor *_sensor) const
   // \todo(iche033) Remove this function once a virtual
   // sensors::RenderingSensor::HasConnections function is available
   {
-    auto s = dynamic_cast<sensors::CameraSensor *>(_sensor);
-    if (s)
-      return s->HasConnections();
-  }
-  {
     auto s = dynamic_cast<sensors::DepthCameraSensor *>(_sensor);
     if (s)
       return s->HasConnections();
@@ -859,6 +854,11 @@ bool SensorsPrivate::HasConnections(sensors::RenderingSensor *_sensor) const
   }
   {
     auto s = dynamic_cast<sensors::ThermalCameraSensor *>(_sensor);
+    if (s)
+      return s->HasConnections();
+  }
+  {
+    auto s = dynamic_cast<sensors::CameraSensor *>(_sensor);
     if (s)
       return s->HasConnections();
   }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This PR optimizes sensor updates by avoiding any unnecessary computation when:
* it's not time for the sensor to update
* there are not subscribers or event connections to the sensors

For non-rendering sensors, before these changes, the sensors themselves are throttled correctly but we are still doing updates (copying data from sim to sensor object) every iteration in `PostUpdate` function.

For rendering sensors, i.e. sensors system, I noticed that the `RGBDCameraSensor` and `GpuLidarSensor` are still doing updates when there are no subscribers so I added the check in the sensors system.  

After these changes, the `sensors_demo.sdf` world gives me consistent ~9x% RTF after closing all `ImageDisplay`s. Before the changes, the RTF still fluctuates between 3x% to 8x% after closing the `ImageDisplay`s (because `GpuLidarSensor` and `RGBDCameraSensor` are still updating)

I verified the behavior by enabling remotery in ign-sensors. This is the output from running `sensors_demo.sdf` world.

The output below shows the sensor updates after the `sensors_demo.sdf` world is launched and running. We see that `GpuLidarSensor` is no longer updating because there are no subscribers. On the other hand, all the other rendering sensors are updating because there are `ImageDisplay`s connecting to the sensors.
![sensors_demo_profile_a](https://user-images.githubusercontent.com/4000684/167779048-4cfa8e6a-9346-4c7e-bdcf-3567438db911.png)

The output below shows the result after closing the RGBD cameras and thermal camera's `ImageDisplay`s. Now only the depth and RGB cameras are updating, which is the desired behavior.
![sensors_demo_profile_b](https://user-images.githubusercontent.com/4000684/167779055-89685489-5a7e-44a6-be0c-4a5ffc0fab92.png)

## Alternatives considered

The alternative approach, which I implemented but then reverted, was to check for connection count inside the sensor classes in ign-sensors. The main reason I didn't go with this approach is because classes like `Lidar` (which `GpuLidarSensor` is derived from) also offers [Ranges](https://github.com/gazebosim/gz-sensors/blob/ign-sensors6/src/Lidar.cc#L409) APIs to get range data directly. If I skipped updates when there are no connections, `Ranges` returned invalid / empty data, and that broke integration tests.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

