### PR TITLE
Adding rssi

### DIFF
--- a/src/systems/rf_comms/RFComms.cc
+++ b/src/systems/rf_comms/RFComms.cc
@@ -15,6 +15,8 @@
  *
  */
 
+#include <ignition/msgs/dataframe.pb.h>
+
 #include <limits>
 #include <list>
 #include <random>
@@ -447,7 +449,18 @@ void RFComms::Step(
 #endif
 
         if (sendPacket)
-          _newRegistry[msg->dst_address()].inboundMsgs.push_back(msg);
+        {
+          // We create a copy of the outbound message because each destination
+          // might have a different rssi value.
+          auto inboundMsg = std::make_shared<ignition::msgs::Dataframe>(*msg);
+
+          // Add rssi.
+          auto *rssiPtr = inboundMsg->mutable_header()->add_data();
+          rssiPtr->set_key("rssi");
+          rssiPtr->add_value(std::to_string(rssi));
+
+          _newRegistry[msg->dst_address()].inboundMsgs.push_back(inboundMsg);
+        }
       }
     }
 

--- a/test/integration/rf_comms.cc
+++ b/test/integration/rf_comms.cc
@@ -65,7 +65,10 @@ TEST_F(RFCommsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(RFComms))
 
     ignition::msgs::StringMsg receivedMsg;
     receivedMsg.ParseFromString(_msg.data());
+
     EXPECT_EQ(expected, receivedMsg.data());
+    ASSERT_GT(_msg.header().data_size(), 0);
+    EXPECT_EQ("rssi", _msg.header().data(0).key());
     msgCounter++;
   };
 


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

This PR adds the `rssi` value to the message sent between two robots using the comms infrastructure. This can be useful for estimating the range between the robots.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

* Run the tests.
* Run the example:

1. Launch Gazebo:
```
ign gazebo -v 4 <your_ws>/src/ign-gazebo/examples/worlds/rf_comms.sdf
```
2. Launch a subscriber:
```
ign topic -e -t addr2/rx
```
3. Launch a publisher:
```
cd <your_ws>/src/ign-gazebo/examples/standalone/comms
mkdir build && cd build
cmake ..
make
./publisher addr2
```
You should observe messages on the subscriber terminal with the new `rssi` field.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
