### PR TITLE
[garden] Apply shininess value to visuals

### DIFF
--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -374,6 +374,7 @@ msgs::Material ignition::gazebo::convert(const sdf::Material &_in)
   msgs::Set(out.mutable_ambient(), _in.Ambient());
   msgs::Set(out.mutable_diffuse(), _in.Diffuse());
   msgs::Set(out.mutable_specular(), _in.Specular());
+  out.set_shininess(_in.Shininess());
   msgs::Set(out.mutable_emissive(), _in.Emissive());
   out.set_render_order(_in.RenderOrder());
   out.set_lighting(_in.Lighting());
@@ -433,6 +434,7 @@ sdf::Material ignition::gazebo::convert(const msgs::Material &_in)
   out.SetAmbient(msgs::Convert(_in.ambient()));
   out.SetDiffuse(msgs::Convert(_in.diffuse()));
   out.SetSpecular(msgs::Convert(_in.specular()));
+  out.SetShininess(_in.shininess());
   out.SetEmissive(msgs::Convert(_in.emissive()));
   out.SetRenderOrder(_in.render_order());
   out.SetLighting(_in.lighting());

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -778,6 +778,7 @@ rendering::MaterialPtr SceneManager::LoadMaterial(
   material->SetAmbient(_material.Ambient());
   material->SetDiffuse(_material.Diffuse());
   material->SetSpecular(_material.Specular());
+  material->SetShininess(_material.Shininess());
   material->SetEmissive(_material.Emissive());
   material->SetRenderOrder(_material.RenderOrder());
 

--- a/test/worlds/shininess.sdf
+++ b/test/worlds/shininess.sdf
@@ -1,0 +1,114 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="empty">
+    <physics name="fast" type="ignored">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>0</real_time_factor>
+    </physics>
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-user-commands-system"
+      name="ignition::gazebo::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-scene-broadcaster-system"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-contact-system"
+      name="ignition::gazebo::systems::Contact">
+    </plugin>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="sphere">
+      <link name="sphere_link">
+        <visual name="sphere_visual">
+          <pose>0 -6 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <size>1 1 1</size>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0 0 0 1</ambient>
+            <diffuse>0 0 0 1</diffuse>
+            <specular>1 1 1 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="sphere2">
+      <link name="sphere2_link">
+        <visual name="sphere2_visual">
+          <pose>0 -3 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <size>1 1 1</size>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0 0 0 1</ambient>
+            <diffuse>0 0 0 1</diffuse>
+            <specular>1 1 1 1</specular>
+            <shininess>1</shininess>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="sphere3">
+      <link name="sphere3_link">
+        <visual name="sphere3_visual">
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <size>1 1 1</size>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0 0 0 1</ambient>
+            <diffuse>0 0 0 1</diffuse>
+            <specular>1 1 1 1</specular>
+            <shininess>5</shininess>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="sphere4">
+      <link name="sphere4_link">
+        <visual name="sphere4_visual">
+          <pose>0 3 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <size>1 1 1</size>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0 0 0 1</ambient>
+            <diffuse>0 0 0 1</diffuse>
+            <specular>1 1 1 1</specular>
+            <shininess>10</shininess>
+          </material>
+        </visual>
+      </link>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
# 🎉 New feature

Depends on:
* https://github.com/gazebosim/sdformat/pull/1018
* https://github.com/gazebosim/gz-msgs/pull/251

## Summary
Applies a shininess value to visuals from the given ```<shininess>``` SDF element. Only works with ogre1 since ogre2 uses a different shading model.

## Test it
```
ign gazebo ign-gazebo/test/worlds/shininess.sdf --render-engine ogre
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.