### PR TITLE
Quality of life improvements for examples_build

### DIFF
--- a/test/integration/examples_build.cc
+++ b/test/integration/examples_build.cc
@@ -19,8 +19,9 @@
 #include <string>
 
 #include <ignition/common/Console.hh>
-#include <ignition/common/Util.hh>
 #include <ignition/common/Filesystem.hh>
+#include <ignition/common/TempDirectory.hh>
+#include <ignition/common/Util.hh>
 #include <ignition/math/SemanticVersion.hh>
 #include <ignition/utils/ExtraTestMacros.hh>
 
@@ -32,154 +33,112 @@
 
 using namespace ignition;
 
-#ifndef _WIN32
-#include <climits>  // NOLINT(build/include_order)
-#include <cstdlib>  // NOLINT(build/include_order)
-#include <fcntl.h>  // NOLINT(build/include_order)
-#include <sys/stat.h>  // NOLINT(build/include_order)
-#include <sys/types.h>  // NOLINT(build/include_order)
-#include <unistd.h>  // NOLINT(build/include_order)
-
-/////////////////////////////////////////////////
-bool createAndSwitchToTempDir(std::string &_newTempPath)
-{
-  std::string tmppath;
-  const char *tmp = std::getenv("TMPDIR");
-  if (tmp)
-  {
-    tmppath = std::string(tmp);
-  }
-  else
-  {
-    tmppath = std::string("/tmp");
-  }
-
-  tmppath += "/XXXXXX";
-
-  char *dtemp = mkdtemp(const_cast<char *>(tmppath.c_str()));
-  if (dtemp == nullptr)
-  {
-    return false;
-  }
-  if (chdir(dtemp) < 0)
-  {
-    return false;
-  }
-
-  char resolved[PATH_MAX];
-  if (realpath(dtemp, resolved) == nullptr)
-  {
-    return false;
-  }
-
-  _newTempPath = std::string(resolved);
-
-  return true;
-}
-
-#else
-#include <windows.h>  // NOLINT(build/include_order)
-#include <winnt.h>  // NOLINT(build/include_order)
-#include <cstdint>
-
-/////////////////////////////////////////////////
-bool createAndSwitchToTempDir(std::string &_newTempPath)
-{
-  char tempPath[MAX_PATH + 1];
-  DWORD pathLen = ::GetTempPathA(MAX_PATH, tempPath);
-  if (pathLen >= MAX_PATH || pathLen <= 0)
-  {
-    return false;
-  }
-  std::string pathToCreate(tempPath);
-  srand(static_cast<uint32_t>(time(nullptr)));
-
-  for (int count = 0; count < 50; ++count)
-  {
-    // Try creating a new temporary directory with a randomly generated name.
-    // If the one we chose exists, keep trying another path name until we reach
-    // some limit.
-    std::string newDirName;
-    newDirName.append(std::to_string(::GetCurrentProcessId()));
-    newDirName.push_back('_');
-    // On Windows, rand_r() doesn't exist as an alternative to rand(), so the
-    // cpplint warning is spurious.  This program is not multi-threaded, so
-    // it is safe to suppress the threadsafe_fn warning here.
-    newDirName.append(
-       std::to_string(rand()    // NOLINT(runtime/threadsafe_fn)
-                      % ((int16_t)0x7fff)));
-
-    pathToCreate += newDirName;
-    if (::CreateDirectoryA(pathToCreate.c_str(), nullptr))
-    {
-      _newTempPath = pathToCreate;
-      return ::SetCurrentDirectoryA(_newTempPath.c_str()) != 0;
-    }
-  }
-
-  return false;
-}
-
-#endif
+auto kExampleTypes = std::vector<std::string>{"plugin", "standalone"};
 
 //////////////////////////////////////////////////
-class ExamplesBuild
-  : public InternalFixture<::testing::TestWithParam<const char*>>
+struct ExampleEntry
 {
-  /// \brief Build code in a temporary build folder.
-  /// \param[in] _type Type of example to build (plugins, standalone).
-  public: void Build(const std::string &_type);
+  /// Type of example (eg plugin/standalone)
+  std::string type;
+
+  /// Example plugin directory name
+  std::string base;
+
+  /// Full path to the source directory of the example
+  std::string sourceDir;
+
+  /// Used to pretty print with gtest
+  /// \param[in] _os stream to print to
+  /// \param[in] _example Entry to print to the stream
+  friend std::ostream& operator<<(std::ostream &_os,
+                                  const ExampleEntry &_entry)
+  {
+    return _os << "[" << _entry.type << ", " << _entry.base << "]";
+  }
 };
 
 //////////////////////////////////////////////////
-void ExamplesBuild::Build(const std::string &_type)
+/// Filter examples that are known to not build or require
+/// specific configurations
+/// \param[in] _entry Example entry to check
+/// \return true if example entry should be built, false otherwise
+bool FilterEntry(const ExampleEntry &_entry)
+{
+  math::SemanticVersion cmakeVersion{std::string(CMAKE_VERSION)};
+  if (cmakeVersion < math::SemanticVersion(3, 11, 0) &&
+      (_entry.base == "custom_sensor_system" ||
+       _entry.base == "gtest_setup"))
+  {
+    igndbg << "Skipping [" << _entry.base
+           << "] test, which requires CMake version "
+           << ">= 3.11.0. Currently using CMake "
+           << cmakeVersion
+           << std::endl;
+    return false;
+  }
+  return true;
+}
+
+//////////////////////////////////////////////////
+/// Generate a list of examples to be built.
+std::vector<ExampleEntry> GetExamples()
+{
+  std::vector<ExampleEntry> examples;
+  for (auto type : kExampleTypes)
+  {
+    auto examplesDir =
+      common::joinPaths(PROJECT_SOURCE_PATH, "/examples/", type);
+
+    // Iterate over directory
+    ignition::common::DirIter endIter;
+    for (ignition::common::DirIter dirIter(examplesDir);
+        dirIter != endIter; ++dirIter)
+    {
+      auto base = ignition::common::basename(*dirIter);
+      auto sourceDir = common::joinPaths(examplesDir, base);
+      examples.push_back({ type, base, sourceDir });
+    }
+  }
+  return examples;
+}
+
+//////////////////////////////////////////////////
+class ExamplesBuild
+  : public InternalFixture<::testing::TestWithParam<ExampleEntry>>
+{
+  /// \brief Build code in a temporary build folder.
+  /// \param[in] _type Type of example to build (plugins, standalone).
+  public: void Build(const ExampleEntry &_type);
+};
+
+//////////////////////////////////////////////////
+void ExamplesBuild::Build(const ExampleEntry &_entry)
 {
   common::Console::SetVerbosity(4);
 
-  // Path to examples of the given type
-  auto examplesDir = std::string(PROJECT_SOURCE_PATH) + "/examples/" + _type;
-  ASSERT_TRUE(ignition::common::exists(examplesDir));
-
-  // Iterate over directory
-  ignition::common::DirIter endIter;
-  for (ignition::common::DirIter dirIter(examplesDir);
-      dirIter != endIter; ++dirIter)
+  if (!FilterEntry(_entry))
   {
-    auto base = ignition::common::basename(*dirIter);
-
-    math::SemanticVersion cmakeVersion{std::string(CMAKE_VERSION)};
-    if (cmakeVersion < math::SemanticVersion(3, 11, 0) &&
-        (base == "custom_sensor_system" ||
-         base == "gtest_setup"))
-    {
-      igndbg << "Skipping [" << base << "] test, which requires CMake version "
-             << ">= 3.11.0. Currently using CMake " << cmakeVersion
-             << std::endl;
-      continue;
-    }
-
-    // Source directory for this example
-    auto sourceDir = examplesDir;
-    sourceDir += "/" + base;
-    ASSERT_TRUE(ignition::common::exists(sourceDir));
-    igndbg << "Source: " << sourceDir << std::endl;
-
-    // Create a temp build directory
-    std::string tmpBuildDir;
-    ASSERT_TRUE(createAndSwitchToTempDir(tmpBuildDir));
-    EXPECT_TRUE(ignition::common::exists(tmpBuildDir));
-    igndbg << "Build directory: " << tmpBuildDir<< std::endl;
-
-    char cmd[1024];
-
-    // cd build && cmake source
-    snprintf(cmd, sizeof(cmd), "cd %s && cmake %s && make",
-      tmpBuildDir.c_str(), sourceDir.c_str());
-    EXPECT_EQ(system(cmd), 0) << base;
-
-    // Remove temp dir
-    EXPECT_TRUE(common::removeAll(tmpBuildDir));
+    GTEST_SKIP();
   }
+
+  // Path to examples of the given type
+  ASSERT_TRUE(ignition::common::exists(_entry.sourceDir));
+
+  igndbg << "Source: " << _entry.sourceDir << std::endl;
+
+  // Create a temp build directory
+  common::TempDirectory tmpBuildDir;
+  ASSERT_TRUE(tmpBuildDir.Valid());
+  igndbg << "Build directory: " << tmpBuildDir.Path() << std::endl;
+
+  char cmd[1024];
+
+  // cd build && cmake source
+  snprintf(cmd, sizeof(cmd), "cd %s && cmake %s",
+    tmpBuildDir.Path().c_str(), _entry.sourceDir.c_str());
+
+  ASSERT_EQ(system(cmd), 0);
+  ASSERT_EQ(system("make"), 0);
 }
 
 //////////////////////////////////////////////////
@@ -190,10 +149,11 @@ TEST_P(ExamplesBuild, IGN_UTILS_TEST_DISABLED_ON_WIN32(Build))
 }
 
 //////////////////////////////////////////////////
-INSTANTIATE_TEST_SUITE_P(Plugins, ExamplesBuild, ::testing::Values(
-  "plugin",
-  "standalone"
-));
+INSTANTIATE_TEST_SUITE_P(Plugins, ExamplesBuild,
+    ::testing::ValuesIn(GetExamples()),
+    [](const ::testing::TestParamInfo<ExamplesBuild::ParamType>& param) {
+      return param.param.type + "_" + param.param.base;
+    });
 
 //////////////////////////////////////////////////
 int main(int _argc, char **_argv)


### PR DESCRIPTION
# 🎉 New feature

## Summary
This changes the examples_build test to enumerate the tests as parameters, which makes it easier to enumerate, inspect and filter test results.

A few other bits:

* Splits `cmake` and `make` phases to make failures easier to diagnose
* Removes the custom temporary directory code in favor of the `ignition::common::TempDirectory`
* Breaks out the "filter" functionality for clarity.

## Test it

Works the same way, except tests enumerate now:

```
# List available tests
./bin/INTEGRATION_examples_build --gtest_list_tests
Plugins/ExamplesBuild.
  Build/plugin_gui_system_plugin  # GetParam() = [plugin, gui_system_plugin]
  Build/plugin_hello_world  # GetParam() = [plugin, hello_world]
  Build/plugin_command_actor  # GetParam() = [plugin, command_actor]
  Build/plugin_reset_plugin  # GetParam() = [plugin, reset_plugin]
  Build/plugin_system_plugin  # GetParam() = [plugin, system_plugin]
  Build/plugin_custom_component  # GetParam() = [plugin, custom_component]
  Build/plugin_custom_sensor_system  # GetParam() = [plugin, custom_sensor_system]
  Build/plugin_rendering_plugins  # GetParam() = [plugin, rendering_plugins]
  Build/standalone_light_control  # GetParam() = [standalone, light_control]
  Build/standalone_each_performance  # GetParam() = [standalone, each_performance]
  Build/standalone_gtest_setup  # GetParam() = [standalone, gtest_setup]
  Build/standalone_multi_lrauv_race  # GetParam() = [standalone, multi_lrauv_race]
  Build/standalone_comms  # GetParam() = [standalone, comms]
  Build/standalone_keyboard  # GetParam() = [standalone, keyboard]
  Build/standalone_joy_to_twist  # GetParam() = [standalone, joy_to_twist]
  Build/standalone_entity_creation  # GetParam() = [standalone, entity_creation]
  Build/standalone_custom_server  # GetParam() = [standalone, custom_server]
  Build/standalone_external_ecm  # GetParam() = [standalone, external_ecm]
  Build/standalone_joystick  # GetParam() = [standalone, joystick]
  Build/standalone_scene_requester  # GetParam() = [standalone, scene_requester]
```



## Checklist
- [x] Signed all commits for DCO
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

