### PR TITLE
Hotfix: Point integration test to correct header

### DIFF
--- a/test/integration/reset.cc
+++ b/test/integration/reset.cc
@@ -34,7 +34,7 @@
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/SystemLoader.hh"
 #include "ignition/gazebo/Types.hh"
-#include "ignition/gazebo/test_config.hh"
+#include "gz/sim/test_config.hh"
 
 #include "ignition/gazebo/components/Model.hh"
 #include "ignition/gazebo/components/Name.hh"


### PR DESCRIPTION
With the ign -> gz header migration, `ignition/gazebo/test_config.hh` no longer exists.