### PR TITLE
Update documentation in the linear battery plugin example.

### DIFF
--- a/examples/worlds/linear_battery_demo.sdf
+++ b/examples/worlds/linear_battery_demo.sdf
@@ -28,7 +28,7 @@
   Stop recharging the battery using a topic (optional if <recharge_by_topic> is true):
       ign topic -t /model/vehicle_blue/battery/linear_battery/recharge/stop -m ignition.msgs.Boolean -p 'data:true'
 
-  The blue vehicle should stop when it runs out of battery.
+  After the battery runs out, no force is applied to the joints in the blue vehicle. It would keep on moving as there is no friction to stop it.
   The green vehicle will not stop with recharge function.
 
 -->

--- a/examples/worlds/linear_battery_demo.sdf
+++ b/examples/worlds/linear_battery_demo.sdf
@@ -28,7 +28,9 @@
   Stop recharging the battery using a topic (optional if <recharge_by_topic> is true):
       ign topic -t /model/vehicle_blue/battery/linear_battery/recharge/stop -m ignition.msgs.Boolean -p 'data:true'
 
-  After the battery runs out, no force is applied to the joints in the blue vehicle. It would keep on moving as there is no friction to stop it.
+  After the battery runs out, no force is applied to the joints in the blue vehicle.
+  It eventually comes to a stop due to friction in its joints. Had there been no joint friction,
+  the vehicle would have kept on moving as Gazebo currently does not support rolling friction.
   The green vehicle will not stop with recharge function.
 
 -->
@@ -434,6 +436,9 @@
         <child>left_wheel_blue</child>
         <axis>
           <xyz>0 0 1</xyz>
+          <dynamics>
+            <friction>0.2</friction>
+          </dynamics>
           <limit>
             <lower>-1.79769e+308</lower>
             <upper>1.79769e+308</upper>
@@ -446,6 +451,9 @@
         <child>right_wheel_blue</child>
         <axis>
           <xyz>0 0 1</xyz>
+          <dynamics>
+            <friction>0.2</friction>
+          </dynamics>
           <limit>
             <lower>-1.79769e+308</lower>
             <upper>1.79769e+308</upper>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/1494

## Summary
The blue vehicle does not stop moving when the battery runs out, its just that the forces applied at the joints become zero. The line "vehicle stops moving" in the sdf file is a bit misleading. The update explains the reason for the behavior. 

Detailed discussion here : https://github.com/gazebosim/gz-sim/issues/1494

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸