### PR TITLE
Trivial issue with Documentation heading in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ export IGN_CONFIG_PATH=$HOME/.ignition/tools/configs
 
 This issue is tracked [here](https://github.com/ignitionrobotics/ign-tools/issues/8).
 
-# Documentation
+# Documentation
 
 See the [installation tutorial](https://ignitionrobotics.org/api/gazebo/6.0/install.html).
 


### PR DESCRIPTION
# 🦟 Bug fix

Currently the Documentation heading (and link) is broken in our readme. Probably due to some weird unicode issue where the space character is an impostor. This PR fixes it.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
