### PR TITLE
Bash completion for flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ set(IGN_MATH_VER ${ignition-math6_VERSION_MAJOR})
 ign_find_package(ignition-tools
                  REQUIRED
                  PKGCONFIG "ignition-tools")
+set(IGN_TOOLS_VER 1)
 
 #--------------------------------------
 # Find protobuf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,8 @@ set(IGN_MATH_VER ${ignition-math6_VERSION_MAJOR})
 ign_find_package(ignition-tools
                  REQUIRED
                  PKGCONFIG "ignition-tools")
+# Note that CLI files are installed regardless of whether the dependency is
+# available during build time
 set(IGN_TOOLS_VER 1)
 
 #--------------------------------------

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -118,7 +118,6 @@ configure_file(
   "model.yaml.in"
   "${CMAKE_BINARY_DIR}/test/conf/model${PROJECT_VERSION_MAJOR}.yaml" @ONLY)
 
-
 #===============================================================================
 # Bash completion
 

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -131,3 +131,12 @@ install(
     ${CMAKE_CURRENT_BINARY_DIR}/gazebo${PROJECT_VERSION_MAJOR}.bash_completion.sh
   DESTINATION
     ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/gz/gz${IGN_TOOLS_VER}.completion.d)
+
+configure_file(
+  "model.bash_completion.sh"
+    "${CMAKE_CURRENT_BINARY_DIR}/model${PROJECT_VERSION_MAJOR}.bash_completion.sh" @ONLY)
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/model${PROJECT_VERSION_MAJOR}.bash_completion.sh
+  DESTINATION
+    ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/gz/gz${IGN_TOOLS_VER}.completion.d)

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -117,3 +117,19 @@ set(ign_model_ruby_path "${cmd_model_script_generated_test}")
 configure_file(
   "model.yaml.in"
   "${CMAKE_BINARY_DIR}/test/conf/model${PROJECT_VERSION_MAJOR}.yaml" @ONLY)
+
+
+#===============================================================================
+# Bash completion
+
+# Tack version onto and install the bash completion script
+configure_file(
+  "gazebo.bash_completion.sh"
+    "${CMAKE_CURRENT_BINARY_DIR}/gazebo${PROJECT_VERSION_MAJOR}.bash_completion.sh" @ONLY)
+if (HAVE_IGN_TOOLS)
+  install(
+    FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/gazebo${PROJECT_VERSION_MAJOR}.bash_completion.sh
+    DESTINATION
+      ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/gz/gz${IGN_TOOLS_VER}.completion.d)
+endif()

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -126,10 +126,8 @@ configure_file(
 configure_file(
   "gazebo.bash_completion.sh"
     "${CMAKE_CURRENT_BINARY_DIR}/gazebo${PROJECT_VERSION_MAJOR}.bash_completion.sh" @ONLY)
-if (HAVE_IGN_TOOLS)
-  install(
-    FILES
-      ${CMAKE_CURRENT_BINARY_DIR}/gazebo${PROJECT_VERSION_MAJOR}.bash_completion.sh
-    DESTINATION
-      ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/gz/gz${IGN_TOOLS_VER}.completion.d)
-endif()
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/gazebo${PROJECT_VERSION_MAJOR}.bash_completion.sh
+  DESTINATION
+    ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/gz/gz${IGN_TOOLS_VER}.completion.d)

--- a/src/cmd/gazebo.bash_completion.sh
+++ b/src/cmd/gazebo.bash_completion.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# bash tab-completion
+
+# This is a per-library function definition, used in conjunction with the
+# top-level entry point in ign-tools.
+
+# NOTE: In Garden+, replace `gazebo` in function name to align with subcommand,
+# for ign-tools/etc/ign.bash_completion.sh to find this function.
+function _gz_gazebo
+{
+  if [[ ${COMP_WORDS[COMP_CWORD]} == -* ]]; then
+    # Specify options (-*) word list for this subcommand
+    COMPREPLY=($(compgen -W "
+      -g
+      --iterations
+      --levels
+      --network-role
+      --network-secondaries
+      --record
+      --record-path
+      --record-resources
+      --record-topic
+      --log-overwrite
+      --log-compress
+      --playback
+      -r
+      -s
+      -v --verbose
+      --gui-config
+      --physics-engine
+      --render-engine
+      --render-engine-gui
+      --render-engine-server
+      --version
+      -z
+      -h --help
+      --force-version
+      --versions
+      " -- "${COMP_WORDS[COMP_CWORD]}" ))
+    return
+  else
+    # Just use bash default auto-complete, because we never have two
+    # subcommands in the same line. If that is ever needed, change here to
+    # detect subsequent subcommands
+    COMPREPLY=($(compgen -o default -- "${COMP_WORDS[COMP_CWORD]}"))
+    return
+  fi
+}

--- a/src/cmd/gazebo.bash_completion.sh
+++ b/src/cmd/gazebo.bash_completion.sh
@@ -1,4 +1,19 @@
 #!/usr/bin/env bash
+#
+# Copyright (C) 2022 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # bash tab-completion
 
@@ -11,6 +26,8 @@ function _gz_gazebo
 {
   if [[ ${COMP_WORDS[COMP_CWORD]} == -* ]]; then
     # Specify options (-*) word list for this subcommand
+    # NOTE: In Fortress+, add --headless-rendering.
+    # Update ../ign_TEST.cc accordingly.
     COMPREPLY=($(compgen -W "
       -g
       --iterations

--- a/src/cmd/gazebo.bash_completion.sh
+++ b/src/cmd/gazebo.bash_completion.sh
@@ -20,6 +20,34 @@
 # This is a per-library function definition, used in conjunction with the
 # top-level entry point in ign-tools.
 
+GZ_SIM_COMPLETION_LIST="
+  -g
+  --iterations
+  --levels
+  --network-role
+  --network-secondaries
+  --record
+  --record-path
+  --record-resources
+  --record-topic
+  --log-overwrite
+  --log-compress
+  --playback
+  -r
+  -s
+  -v --verbose
+  --gui-config
+  --physics-engine
+  --render-engine
+  --render-engine-gui
+  --render-engine-server
+  --version
+  -z
+  -h --help
+  --force-version
+  --versions
+"
+
 # TODO(anyone): In Garden+, replace `gazebo` in function name to align with
 # subcommand, for ign-tools/etc/ign.bash_completion.sh to find this function.
 function _gz_gazebo
@@ -28,33 +56,8 @@ function _gz_gazebo
     # Specify options (-*) word list for this subcommand
     # NOTE: In Fortress+, add --headless-rendering.
     # Update ../ign_TEST.cc accordingly.
-    COMPREPLY=($(compgen -W "
-      -g
-      --iterations
-      --levels
-      --network-role
-      --network-secondaries
-      --record
-      --record-path
-      --record-resources
-      --record-topic
-      --log-overwrite
-      --log-compress
-      --playback
-      -r
-      -s
-      -v --verbose
-      --gui-config
-      --physics-engine
-      --render-engine
-      --render-engine-gui
-      --render-engine-server
-      --version
-      -z
-      -h --help
-      --force-version
-      --versions
-      " -- "${COMP_WORDS[COMP_CWORD]}" ))
+    COMPREPLY=($(compgen -W "$GZ_SIM_COMPLETION_LIST" \
+      -- "${COMP_WORDS[COMP_CWORD]}" ))
     return
   else
     # Just use bash default auto-complete, because we never have two
@@ -63,4 +66,11 @@ function _gz_gazebo
     COMPREPLY=($(compgen -o default -- "${COMP_WORDS[COMP_CWORD]}"))
     return
   fi
+}
+
+function _gz_sim_flags
+{
+  for word in $GZ_SIM_COMPLETION_LIST; do
+    echo "$word"
+  done
 }

--- a/src/cmd/gazebo.bash_completion.sh
+++ b/src/cmd/gazebo.bash_completion.sh
@@ -54,7 +54,7 @@ function _gz_gazebo
 {
   if [[ ${COMP_WORDS[COMP_CWORD]} == -* ]]; then
     # Specify options (-*) word list for this subcommand
-    # NOTE: In Fortress+, add --headless-rendering.
+    # TODO(anyone): In Fortress+, add --headless-rendering.
     # Update ../ign_TEST.cc accordingly.
     COMPREPLY=($(compgen -W "$GZ_SIM_COMPLETION_LIST" \
       -- "${COMP_WORDS[COMP_CWORD]}" ))

--- a/src/cmd/model.bash_completion.sh
+++ b/src/cmd/model.bash_completion.sh
@@ -35,8 +35,6 @@ function _gz_model
 {
   if [[ ${COMP_WORDS[COMP_CWORD]} == -* ]]; then
     # Specify options (-*) word list for this subcommand
-    # NOTE: In Fortress+, add --headless-rendering.
-    # Update ../ign_TEST.cc accordingly.
     COMPREPLY=($(compgen -W "$GZ_MODEL_COMPLETION_LIST" \
       -- "${COMP_WORDS[COMP_CWORD]}" ))
     return

--- a/src/cmd/model.bash_completion.sh
+++ b/src/cmd/model.bash_completion.sh
@@ -20,7 +20,7 @@
 # This is a per-library function definition, used in conjunction with the
 # top-level entry point in ign-tools.
 
-GZ_MODEL_WORDLIST="
+GZ_MODEL_COMPLETION_LIST="
   --list
   -m --model
   -p --pose
@@ -37,7 +37,7 @@ function _gz_model
     # Specify options (-*) word list for this subcommand
     # NOTE: In Fortress+, add --headless-rendering.
     # Update ../ign_TEST.cc accordingly.
-    COMPREPLY=($(compgen -W "$GZ_MODEL_WORDLIST" \
+    COMPREPLY=($(compgen -W "$GZ_MODEL_COMPLETION_LIST" \
       -- "${COMP_WORDS[COMP_CWORD]}" ))
     return
   else
@@ -51,7 +51,7 @@ function _gz_model
 
 function _gz_model_flags
 {
-  for word in $GZ_MODEL_WORDLIST; do
+  for word in $GZ_MODEL_COMPLETION_LIST; do
     echo "$word"
   done
 }

--- a/src/cmd/model.bash_completion.sh
+++ b/src/cmd/model.bash_completion.sh
@@ -20,41 +20,25 @@
 # This is a per-library function definition, used in conjunction with the
 # top-level entry point in ign-tools.
 
-# TODO(anyone): In Garden+, replace `gazebo` in function name to align with
-# subcommand, for ign-tools/etc/ign.bash_completion.sh to find this function.
-function _gz_gazebo
+GZ_MODEL_WORDLIST="
+  --list
+  -m --model
+  -p --pose
+  -l --link
+  -j --joint
+  -h --help
+  --force-version
+  --versions
+"
+
+function _gz_model
 {
   if [[ ${COMP_WORDS[COMP_CWORD]} == -* ]]; then
     # Specify options (-*) word list for this subcommand
     # NOTE: In Fortress+, add --headless-rendering.
     # Update ../ign_TEST.cc accordingly.
-    COMPREPLY=($(compgen -W "
-      -g
-      --iterations
-      --levels
-      --network-role
-      --network-secondaries
-      --record
-      --record-path
-      --record-resources
-      --record-topic
-      --log-overwrite
-      --log-compress
-      --playback
-      -r
-      -s
-      -v --verbose
-      --gui-config
-      --physics-engine
-      --render-engine
-      --render-engine-gui
-      --render-engine-server
-      --version
-      -z
-      -h --help
-      --force-version
-      --versions
-      " -- "${COMP_WORDS[COMP_CWORD]}" ))
+    COMPREPLY=($(compgen -W "$GZ_MODEL_WORDLIST" \
+      -- "${COMP_WORDS[COMP_CWORD]}" ))
     return
   else
     # Just use bash default auto-complete, because we never have two
@@ -63,4 +47,11 @@ function _gz_gazebo
     COMPREPLY=($(compgen -o default -- "${COMP_WORDS[COMP_CWORD]}"))
     return
   fi
+}
+
+function _gz_model_flags
+{
+  for word in $GZ_MODEL_WORDLIST; do
+    echo "$word"
+  done
 }

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -164,7 +164,7 @@ TEST(CmdLine, ResourcePath)
 
 //////////////////////////////////////////////////
 /// \brief Check --help message and bash completion script for consistent flags
-TEST(CmdLine, HelpVsCompletionFlags)
+TEST(CmdLine, GazeboHelpVsCompletionFlags)
 {
   // Flags in help message
   std::string output = customExecStr(kIgnCommand + " gazebo --help");

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -170,66 +170,31 @@ TEST(CmdLine, ResourcePath)
 TEST(CmdLine, GazeboHelpVsCompletionFlags)
 {
   // Flags in help message
-  std::string output = customExecStr(kIgnCommand + " gazebo --help");
-  EXPECT_NE(std::string::npos, output.find("-g")) << output;
-  EXPECT_NE(std::string::npos, output.find("--iterations")) << output;
-  EXPECT_NE(std::string::npos, output.find("--levels")) << output;
-  EXPECT_NE(std::string::npos, output.find("--network-role")) << output;
-  EXPECT_NE(std::string::npos, output.find("--network-secondaries")) << output;
-  EXPECT_NE(std::string::npos, output.find("--record")) << output;
-  EXPECT_NE(std::string::npos, output.find("--record-path")) << output;
-  EXPECT_NE(std::string::npos, output.find("--record-resources")) << output;
-  EXPECT_NE(std::string::npos, output.find("--record-topic")) << output;
-  EXPECT_NE(std::string::npos, output.find("--log-overwrite")) << output;
-  EXPECT_NE(std::string::npos, output.find("--log-compress")) << output;
-  EXPECT_NE(std::string::npos, output.find("--playback")) << output;
-  EXPECT_NE(std::string::npos, output.find("-r")) << output;
-  EXPECT_NE(std::string::npos, output.find("-s")) << output;
-  EXPECT_NE(std::string::npos, output.find("--verbose")) << output;
-  EXPECT_NE(std::string::npos, output.find("--gui-config")) << output;
-  EXPECT_NE(std::string::npos, output.find("--physics-engine")) << output;
-  EXPECT_NE(std::string::npos, output.find("--render-engine")) << output;
-  EXPECT_NE(std::string::npos, output.find("--render-engine-gui")) << output;
-  EXPECT_NE(std::string::npos, output.find("--render-engine-server")) << output;
-  EXPECT_NE(std::string::npos, output.find("--version")) << output;
-  EXPECT_NE(std::string::npos, output.find("-z")) << output;
-  EXPECT_NE(std::string::npos, output.find("--help")) << output;
-  EXPECT_NE(std::string::npos, output.find("--force-version")) << output;
-  EXPECT_NE(std::string::npos, output.find("--versions")) << output;
+  std::string helpOutput = customExecStr(kIgnCommand + " gazebo --help");
 
-  // Flags in bash completion
+  // Call the output function in the bash completion script
   std::string scriptPath = ignition::common::joinPaths(
     std::string(PROJECT_SOURCE_PATH),
     "src", "cmd", "gazebo.bash_completion.sh");
-  std::ifstream scriptFile(scriptPath);
-  std::string script((std::istreambuf_iterator<char>(scriptFile)),
-      std::istreambuf_iterator<char>());
 
-  EXPECT_NE(std::string::npos, script.find("-g")) << script;
-  EXPECT_NE(std::string::npos, script.find("--iterations")) << script;
-  EXPECT_NE(std::string::npos, script.find("--levels")) << script;
-  EXPECT_NE(std::string::npos, script.find("--network-role")) << script;
-  EXPECT_NE(std::string::npos, script.find("--network-secondaries")) << script;
-  EXPECT_NE(std::string::npos, script.find("--record")) << script;
-  EXPECT_NE(std::string::npos, script.find("--record-path")) << script;
-  EXPECT_NE(std::string::npos, script.find("--record-resources")) << script;
-  EXPECT_NE(std::string::npos, script.find("--record-topic")) << script;
-  EXPECT_NE(std::string::npos, script.find("--log-overwrite")) << script;
-  EXPECT_NE(std::string::npos, script.find("--log-compress")) << script;
-  EXPECT_NE(std::string::npos, script.find("--playback")) << script;
-  EXPECT_NE(std::string::npos, script.find("-r")) << script;
-  EXPECT_NE(std::string::npos, script.find("-s")) << script;
-  EXPECT_NE(std::string::npos, script.find("--verbose")) << script;
-  EXPECT_NE(std::string::npos, script.find("--gui-config")) << script;
-  EXPECT_NE(std::string::npos, script.find("--physics-engine")) << script;
-  EXPECT_NE(std::string::npos, script.find("--render-engine")) << script;
-  EXPECT_NE(std::string::npos, script.find("--render-engine-gui")) << script;
-  EXPECT_NE(std::string::npos, script.find("--render-engine-server")) << script;
-  EXPECT_NE(std::string::npos, script.find("--version")) << script;
-  EXPECT_NE(std::string::npos, script.find("-z")) << script;
-  EXPECT_NE(std::string::npos, script.find("--help")) << script;
-  EXPECT_NE(std::string::npos, script.find("--force-version")) << script;
-  EXPECT_NE(std::string::npos, script.find("--versions")) << script;
+  // Equivalent to:
+  // sh -c "bash -c \". /path/to/gazebo.bash_completion.sh; _gz_sim_flags\""
+  std::string cmd = "bash -c \". " + scriptPath + "; _gz_sim_flags\"";
+  std::cout << "Running command [" << cmd << "]" << std::endl;
+  std::string scriptOutput = customExecStr(cmd);
+
+  // Tokenize script output
+  std::istringstream iss(scriptOutput);
+  std::vector<std::string> flags((std::istream_iterator<std::string>(iss)),
+    std::istream_iterator<std::string>());
+
+  EXPECT_GT(flags.size(), 0u);
+
+  // Match each flag in script output with help message
+  for (std::string flag : flags)
+  {
+    EXPECT_NE(std::string::npos, helpOutput.find(flag)) << helpOutput;
+  }
 }
 
 //////////////////////////////////////////////////

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -19,6 +19,7 @@
 #include <cstdio>
 #include <cstdlib>
 
+#include <fstream>
 #include <string>
 #include <ignition/common/Util.hh>
 #include <ignition/utilities/ExtraTestMacros.hh>
@@ -159,4 +160,69 @@ TEST(CmdLine, ResourcePath)
   output = customExecStr(path + cmd);
   EXPECT_EQ(output.find("Unable to find file plugins.sdf"), std::string::npos)
       << output;
+}
+
+//////////////////////////////////////////////////
+/// \brief Check --help message and bash completion script for consistent flags
+TEST(CmdLine, HelpVsCompletionFlags)
+{
+  // Flags in help message
+  std::string output = customExecStr(kIgnCommand + " gazebo --help");
+  EXPECT_NE(std::string::npos, output.find("-g")) << output;
+  EXPECT_NE(std::string::npos, output.find("--iterations")) << output;
+  EXPECT_NE(std::string::npos, output.find("--levels")) << output;
+  EXPECT_NE(std::string::npos, output.find("--network-role")) << output;
+  EXPECT_NE(std::string::npos, output.find("--network-secondaries")) << output;
+  EXPECT_NE(std::string::npos, output.find("--record")) << output;
+  EXPECT_NE(std::string::npos, output.find("--record-path")) << output;
+  EXPECT_NE(std::string::npos, output.find("--record-resources")) << output;
+  EXPECT_NE(std::string::npos, output.find("--record-topic")) << output;
+  EXPECT_NE(std::string::npos, output.find("--log-overwrite")) << output;
+  EXPECT_NE(std::string::npos, output.find("--log-compress")) << output;
+  EXPECT_NE(std::string::npos, output.find("--playback")) << output;
+  EXPECT_NE(std::string::npos, output.find("-r")) << output;
+  EXPECT_NE(std::string::npos, output.find("-s")) << output;
+  EXPECT_NE(std::string::npos, output.find("--verbose")) << output;
+  EXPECT_NE(std::string::npos, output.find("--gui-config")) << output;
+  EXPECT_NE(std::string::npos, output.find("--physics-engine")) << output;
+  EXPECT_NE(std::string::npos, output.find("--render-engine")) << output;
+  EXPECT_NE(std::string::npos, output.find("--render-engine-gui")) << output;
+  EXPECT_NE(std::string::npos, output.find("--render-engine-server")) << output;
+  EXPECT_NE(std::string::npos, output.find("--version")) << output;
+  EXPECT_NE(std::string::npos, output.find("-z")) << output;
+  EXPECT_NE(std::string::npos, output.find("--help")) << output;
+  EXPECT_NE(std::string::npos, output.find("--force-version")) << output;
+  EXPECT_NE(std::string::npos, output.find("--versions")) << output;
+
+  // Flags in bash completion
+  std::ifstream scriptFile(std::string(PROJECT_SOURCE_PATH) +
+    "/src/cmd/gazebo.bash_completion.sh");
+  std::string script((std::istreambuf_iterator<char>(scriptFile)),
+      std::istreambuf_iterator<char>());
+
+  EXPECT_NE(std::string::npos, script.find("-g")) << script;
+  EXPECT_NE(std::string::npos, script.find("--iterations")) << script;
+  EXPECT_NE(std::string::npos, script.find("--levels")) << script;
+  EXPECT_NE(std::string::npos, script.find("--network-role")) << script;
+  EXPECT_NE(std::string::npos, script.find("--network-secondaries")) << script;
+  EXPECT_NE(std::string::npos, script.find("--record")) << script;
+  EXPECT_NE(std::string::npos, script.find("--record-path")) << script;
+  EXPECT_NE(std::string::npos, script.find("--record-resources")) << script;
+  EXPECT_NE(std::string::npos, script.find("--record-topic")) << script;
+  EXPECT_NE(std::string::npos, script.find("--log-overwrite")) << script;
+  EXPECT_NE(std::string::npos, script.find("--log-compress")) << script;
+  EXPECT_NE(std::string::npos, script.find("--playback")) << script;
+  EXPECT_NE(std::string::npos, script.find("-r")) << script;
+  EXPECT_NE(std::string::npos, script.find("-s")) << script;
+  EXPECT_NE(std::string::npos, script.find("--verbose")) << script;
+  EXPECT_NE(std::string::npos, script.find("--gui-config")) << script;
+  EXPECT_NE(std::string::npos, script.find("--physics-engine")) << script;
+  EXPECT_NE(std::string::npos, script.find("--render-engine")) << script;
+  EXPECT_NE(std::string::npos, script.find("--render-engine-gui")) << script;
+  EXPECT_NE(std::string::npos, script.find("--render-engine-server")) << script;
+  EXPECT_NE(std::string::npos, script.find("--version")) << script;
+  EXPECT_NE(std::string::npos, script.find("-z")) << script;
+  EXPECT_NE(std::string::npos, script.find("--help")) << script;
+  EXPECT_NE(std::string::npos, script.find("--force-version")) << script;
+  EXPECT_NE(std::string::npos, script.find("--versions")) << script;
 }

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -196,7 +196,8 @@ TEST(CmdLine, GazeboHelpVsCompletionFlags)
   EXPECT_NE(std::string::npos, output.find("--versions")) << output;
 
   // Flags in bash completion
-  std::string scriptPath = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+  std::string scriptPath = ignition::common::joinPaths(
+    std::string(PROJECT_SOURCE_PATH),
     "src", "cmd", "gazebo.bash_completion.sh");
   std::ifstream scriptFile(scriptPath);
   std::string script((std::istreambuf_iterator<char>(scriptFile)),

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -190,7 +190,7 @@ TEST(CmdLine, GazeboHelpVsCompletionFlags)
   EXPECT_GT(flags.size(), 0u);
 
   // Match each flag in script output with help message
-  for (std::string flag : flags)
+  for (const auto &flag : flags)
   {
     EXPECT_NE(std::string::npos, helpOutput.find(flag)) << helpOutput;
   }
@@ -221,7 +221,7 @@ TEST(CmdLine, ModelHelpVsCompletionFlags)
   EXPECT_GT(flags.size(), 0u);
 
   // Match each flag in script output with help message
-  for (std::string flag : flags)
+  for (const auto &flag : flags)
   {
     EXPECT_NE(std::string::npos, helpOutput.find(flag)) << helpOutput;
   }

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -180,7 +180,6 @@ TEST(CmdLine, GazeboHelpVsCompletionFlags)
   // Equivalent to:
   // sh -c "bash -c \". /path/to/gazebo.bash_completion.sh; _gz_sim_flags\""
   std::string cmd = "bash -c \". " + scriptPath + "; _gz_sim_flags\"";
-  std::cout << "Running command [" << cmd << "]" << std::endl;
   std::string scriptOutput = customExecStr(cmd);
 
   // Tokenize script output
@@ -212,7 +211,6 @@ TEST(CmdLine, ModelHelpVsCompletionFlags)
   // Equivalent to:
   // sh -c "bash -c \". /path/to/model.bash_completion.sh; _gz_model_flags\""
   std::string cmd = "bash -c \". " + scriptPath + "; _gz_model_flags\"";
-  std::cout << "Running command [" << cmd << "]" << std::endl;
   std::string scriptOutput = customExecStr(cmd);
 
   // Tokenize script output

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -21,6 +21,7 @@
 
 #include <fstream>
 #include <string>
+#include <ignition/common/Filesystem.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/utilities/ExtraTestMacros.hh>
 
@@ -195,8 +196,9 @@ TEST(CmdLine, GazeboHelpVsCompletionFlags)
   EXPECT_NE(std::string::npos, output.find("--versions")) << output;
 
   // Flags in bash completion
-  std::ifstream scriptFile(std::string(PROJECT_SOURCE_PATH) +
-    "/src/cmd/gazebo.bash_completion.sh");
+  std::string scriptPath = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+    "src", "cmd", "gazebo.bash_completion.sh");
+  std::ifstream scriptFile(scriptPath);
   std::string script((std::istreambuf_iterator<char>(scriptFile)),
       std::istreambuf_iterator<char>());
 


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebosim/gz-tools/issues/1
Used together with https://github.com/gazebosim/gz-tools/pull/87

## Summary

Bash completion, installation, tests.

## Test it

```
$ . install/share/gz/gz.completion

$ ign gazebo -
--force-version         --physics-engine        --verbose
--gui-config            --playback              --version
--help                  --record                --versions
--iterations            --record-path           -g
--levels                --record-resources      -h
--log-compress          --record-topic          -r
--log-overwrite         --render-engine         -s
--network-role          --render-engine-gui     -v
--network-secondaries   --render-engine-server  -z

$ ign model -
--force-version  --list           -h               -p
--help           --model          -j               
--joint          --pose           -l               
--link           --versions       -m
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.