### PR TITLE
Scene update resource finder

### DIFF
--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -356,6 +356,8 @@ void ServerPrivate::SetupTransport()
            << "]" << std::endl;
   }
 
+  // Advertise a service that returns the full path, on the Gazebo server's
+  // host machine, based on a provided URI.
   std::string resolvePathService{"/gazebo/resource_paths/resolve"};
   if (this->node.Advertise(resolvePathService,
       &ServerPrivate::ResourcePathsResolveService, this))
@@ -368,7 +370,6 @@ void ServerPrivate::SetupTransport()
     ignerr << "Something went wrong, failed to advertise [" << getPathService
            << "]" << std::endl;
   }
-
 
   std::string pathTopic{"/gazebo/resource_paths"};
   this->pathPub = this->node.Advertise<msgs::StringMsg_V>(pathTopic);
@@ -507,14 +508,14 @@ bool ServerPrivate::ResourcePathsResolveService(
   // Get the request
   std::string req = _req.data();
 
-  // Handle the case where the request is already valid
+  // Handle the case where the request is already a valid path
   if (common::exists(req))
   {
     _res.set_data(req);
     return true;
   }
 
-  // Try Fuel first.
+  // Try Fuel
   std::string path =
       fuel_tools::fetchResourceWithClient(req, *this->fuelClient.get());
   if (!path.empty() && common::exists(path))
@@ -553,6 +554,7 @@ bool ServerPrivate::ResourcePathsResolveService(
     }
   }
 
+  // Otherwise the resource could not be found
   return false;
 }
 

--- a/src/ServerPrivate.hh
+++ b/src/ServerPrivate.hh
@@ -117,18 +117,20 @@ namespace ignition
       /// \return True if successful.
       private: bool ResourcePathsService(ignition::msgs::StringMsg_V &_res);
 
-      /// \brief Callback for resource paths resolve service. This service
+      /// \brief Callback for a resource path resolve service. This service
       /// will return the full path to a provided resource's URI. An empty
       /// string and return value of false will be used if the resource could
       /// not be found.
       ///
       /// Fuel will be checked and then the GZ_GAZEBO_RESOURCE_PATH environment
-      /// variable paths.
+      /// variable paths. This service will not check for files relative to
+      /// working directory of the Gazebo server.
+      ///
       /// \param[in] _req Request filled with a rsource URI to resolve.
       /// Example values could be:
       ///   * https://URI_TO_A_FUEL_RESOURCE
       ///   * model://MODLE_NAME/meshes/MESH_NAME
-      ///   * file:///PATH/TO/FILE
+      ///   * file://PATH/TO/FILE
       ///
       /// \param[out] _res Response filled with the resovled path, or empty
       /// if the resource could not be found.

--- a/src/ServerPrivate.hh
+++ b/src/ServerPrivate.hh
@@ -117,10 +117,22 @@ namespace ignition
       /// \return True if successful.
       private: bool ResourcePathsService(ignition::msgs::StringMsg_V &_res);
 
-      /// \brief Callback for resource paths resolve service.
-      /// \param[in] _req Request filled with a path to resolve.
-      /// \param[out] _res Response filled with the resovled path.
-      /// \return True if successful.
+      /// \brief Callback for resource paths resolve service. This service
+      /// will return the full path to a provided resource's URI. An empty
+      /// string and return value of false will be used if the resource could
+      /// not be found.
+      ///
+      /// Fuel will be checked and then the GZ_GAZEBO_RESOURCE_PATH environment
+      /// variable paths.
+      /// \param[in] _req Request filled with a rsource URI to resolve.
+      /// Example values could be:
+      ///   * https://URI_TO_A_FUEL_RESOURCE
+      ///   * model://MODLE_NAME/meshes/MESH_NAME
+      ///   * file:///PATH/TO/FILE
+      ///
+      /// \param[out] _res Response filled with the resovled path, or empty
+      /// if the resource could not be found.
+      /// \return True if successful, false otherwise.
       private: bool ResourcePathsResolveService(
                    const ignition::msgs::StringMsg &_req,
                    ignition::msgs::StringMsg &_res);

--- a/src/ServerPrivate.hh
+++ b/src/ServerPrivate.hh
@@ -117,6 +117,14 @@ namespace ignition
       /// \return True if successful.
       private: bool ResourcePathsService(ignition::msgs::StringMsg_V &_res);
 
+      /// \brief Callback for resource paths resolve service.
+      /// \param[in] _req Request filled with a path to resolve.
+      /// \param[out] _res Response filled with the resovled path.
+      /// \return True if successful.
+      private: bool ResourcePathsResolveService(
+                   const ignition::msgs::StringMsg &_req,
+                   ignition::msgs::StringMsg &_res);
+
       /// \brief Callback for server control service.
       /// \param[out] _req The control request.
       /// \param[out] _res Whether the request was successfully fullfilled.

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -50,988 +50,988 @@ class ServerFixture : public InternalFixture<::testing::TestWithParam<int>>
 {
 };
 
-///////////////////////////////////////////////////
-//// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
-//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(DefaultServerConfig))
-//{
-//  ignition::gazebo::ServerConfig serverConfig;
-//  EXPECT_TRUE(serverConfig.SdfFile().empty());
-//  EXPECT_TRUE(serverConfig.SdfString().empty());
-//  EXPECT_FALSE(serverConfig.UpdateRate());
-//  EXPECT_FALSE(serverConfig.UseLevels());
-//  EXPECT_FALSE(serverConfig.UseDistributedSimulation());
-//  EXPECT_EQ(0u, serverConfig.NetworkSecondaries());
-//  EXPECT_TRUE(serverConfig.NetworkRole().empty());
-//  EXPECT_FALSE(serverConfig.UseLogRecord());
-//  EXPECT_FALSE(serverConfig.LogRecordPath().empty());
-//  EXPECT_TRUE(serverConfig.LogPlaybackPath().empty());
-//  EXPECT_FALSE(serverConfig.LogRecordResources());
-//  EXPECT_TRUE(serverConfig.LogRecordCompressPath().empty());
-//  EXPECT_EQ(0u, serverConfig.Seed());
-//  EXPECT_EQ(123ms, serverConfig.UpdatePeriod().value_or(123ms));
-//  EXPECT_TRUE(serverConfig.ResourceCache().empty());
-//  EXPECT_TRUE(serverConfig.PhysicsEngine().empty());
-//  EXPECT_TRUE(serverConfig.Plugins().empty());
-//  EXPECT_TRUE(serverConfig.LogRecordTopics().empty());
-//
-//  gazebo::Server server(serverConfig);
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//  EXPECT_EQ(std::nullopt, server.Running(1));
-//  EXPECT_TRUE(*server.Paused());
-//  EXPECT_EQ(0u, *server.IterationCount());
-//
-//  EXPECT_EQ(3u, *server.EntityCount());
-//  EXPECT_TRUE(server.HasEntity("default"));
-//
-//  EXPECT_EQ(3u, *server.SystemCount());
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, UpdateRate)
-//{
-//  gazebo::ServerConfig serverConfig;
-//  serverConfig.SetUpdateRate(1000.0);
-//  EXPECT_DOUBLE_EQ(1000.0, *serverConfig.UpdateRate());
-//  serverConfig.SetUpdateRate(-1000.0);
-//  EXPECT_DOUBLE_EQ(1000.0, *serverConfig.UpdateRate());
-//  serverConfig.SetUpdateRate(0.0);
-//  EXPECT_DOUBLE_EQ(1000.0, *serverConfig.UpdateRate());
-//  EXPECT_EQ(1ms, serverConfig.UpdatePeriod());
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, ServerConfigPluginInfo)
-//{
-//  ServerConfig::PluginInfo pluginInfo;
-//  pluginInfo.SetEntityName("an_entity");
-//  pluginInfo.SetEntityType("model");
-//  pluginInfo.SetFilename("filename");
-//  pluginInfo.SetName("interface");
-//  pluginInfo.SetSdf(nullptr);
-//
-//  ignition::gazebo::ServerConfig serverConfig;
-//  serverConfig.AddPlugin(pluginInfo);
-//
-//  const std::list<ServerConfig::PluginInfo> &plugins = serverConfig.Plugins();
-//  ASSERT_FALSE(plugins.empty());
-//
-//  EXPECT_EQ("an_entity", plugins.front().EntityName());
-//  EXPECT_EQ("model", plugins.front().EntityType());
-//  EXPECT_EQ("filename", plugins.front().Filename());
-//  EXPECT_EQ("interface", plugins.front().Name());
-//  EXPECT_EQ(nullptr, plugins.front().Sdf());
-//
-//  // Test operator=
-//  {
-//    ServerConfig::PluginInfo info;
-//    info = plugins.front();
-//
-//    EXPECT_EQ(info.EntityName(), plugins.front().EntityName());
-//    EXPECT_EQ(info.EntityType(), plugins.front().EntityType());
-//    EXPECT_EQ(info.Filename(), plugins.front().Filename());
-//    EXPECT_EQ(info.Name(), plugins.front().Name());
-//    EXPECT_EQ(info.Sdf(), plugins.front().Sdf());
-//  }
-//
-//  // Test copy constructor
-//  {
-//    ServerConfig::PluginInfo info(plugins.front());
-//
-//    EXPECT_EQ(info.EntityName(), plugins.front().EntityName());
-//    EXPECT_EQ(info.EntityType(), plugins.front().EntityType());
-//    EXPECT_EQ(info.Filename(), plugins.front().Filename());
-//    EXPECT_EQ(info.Name(), plugins.front().Name());
-//    EXPECT_EQ(info.Sdf(), plugins.front().Sdf());
-//  }
-//
-//  // Test server config copy constructor
-//  {
-//    const ServerConfig &cfg(serverConfig);
-//    const std::list<ServerConfig::PluginInfo> &cfgPlugins = cfg.Plugins();
-//    ASSERT_FALSE(cfgPlugins.empty());
-//
-//    EXPECT_EQ(cfgPlugins.front().EntityName(), plugins.front().EntityName());
-//    EXPECT_EQ(cfgPlugins.front().EntityType(), plugins.front().EntityType());
-//    EXPECT_EQ(cfgPlugins.front().Filename(), plugins.front().Filename());
-//    EXPECT_EQ(cfgPlugins.front().Name(), plugins.front().Name());
-//    EXPECT_EQ(cfgPlugins.front().Sdf(), plugins.front().Sdf());
-//  }
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigRealPlugin))
-//{
-//  // Start server
-//  ServerConfig serverConfig;
-//  serverConfig.SetUpdateRate(10000);
-//  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-//      "/test/worlds/shapes.sdf");
-//
-//  sdf::ElementPtr sdf(new sdf::Element);
-//  sdf->SetName("plugin");
-//  sdf->AddAttribute("name", "string",
-//      "ignition::gazebo::TestModelSystem", true);
-//  sdf->AddAttribute("filename", "string", "libTestModelSystem.so", true);
-//
-//  sdf::ElementPtr child(new sdf::Element);
-//  child->SetParent(sdf);
-//  child->SetName("model_key");
-//  child->AddValue("string", "987", "1");
-//
-//  serverConfig.AddPlugin({"box", "model",
-//      "libTestModelSystem.so", "ignition::gazebo::TestModelSystem", sdf});
-//
-//  gazebo::Server server(serverConfig);
-//
-//  // The simulation runner should not be running.
-//  EXPECT_FALSE(*server.Running(0));
-//
-//  // Run the server
-//  EXPECT_TRUE(server.Run(false, 0, false));
-//  EXPECT_FALSE(*server.Paused());
-//
-//  // The TestModelSystem should have created a service. Call the service to
-//  // make sure the TestModelSystem was successfully loaded.
-//  transport::Node node;
-//  msgs::StringMsg rep;
-//  bool result{false};
-//  bool executed{false};
-//  int sleep{0};
-//  int maxSleep{30};
-//  while (!executed && sleep < maxSleep)
-//  {
-//    igndbg << "Requesting /test/service" << std::endl;
-//    executed = node.Request("/test/service", 100, rep, result);
-//    sleep++;
-//  }
-//  EXPECT_TRUE(executed);
-//  EXPECT_TRUE(result);
-//  EXPECT_EQ("TestModelSystem", rep.data());
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture,
-//       IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigSensorPlugin))
-//{
-//  // Start server
-//  ServerConfig serverConfig;
-//  serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
-//      "test", "worlds", "air_pressure.sdf"));
-//
-//  sdf::ElementPtr sdf(new sdf::Element);
-//  sdf->SetName("plugin");
-//  sdf->AddAttribute("name", "string",
-//      "ignition::gazebo::TestSensorSystem", true);
-//  sdf->AddAttribute("filename", "string", "libTestSensorSystem.so", true);
-//
-//  serverConfig.AddPlugin({
-//      "air_pressure_sensor::air_pressure_model::link::air_pressure_sensor",
-//      "sensor", "libTestSensorSystem.so", "ignition::gazebo::TestSensorSystem",
-//      sdf});
-//
-//  igndbg << "Create server" << std::endl;
-//  gazebo::Server server(serverConfig);
-//
-//  // The simulation runner should not be running.
-//  EXPECT_FALSE(*server.Running(0));
-//  EXPECT_EQ(3u, *server.SystemCount());
-//
-//  // Run the server
-//  igndbg << "Run server" << std::endl;
-//  EXPECT_TRUE(server.Run(false, 0, false));
-//  EXPECT_FALSE(*server.Paused());
-//
-//  // The TestSensorSystem should have created a service. Call the service to
-//  // make sure the TestSensorSystem was successfully loaded.
-//  igndbg << "Request service" << std::endl;
-//  transport::Node node;
-//  msgs::StringMsg rep;
-//  bool result{false};
-//  bool executed{false};
-//  int sleep{0};
-//  int maxSleep{30};
-//  while (!executed && sleep < maxSleep)
-//  {
-//    igndbg << "Requesting /test/service/sensor" << std::endl;
-//    executed = node.Request("/test/service/sensor", 100, rep, result);
-//    sleep++;
-//  }
-//  EXPECT_TRUE(executed);
-//  EXPECT_TRUE(result);
-//  EXPECT_EQ("TestSensorSystem", rep.data());
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(SdfServerConfig))
-//{
-//  ignition::gazebo::ServerConfig serverConfig;
-//
-//  serverConfig.SetSdfString(TestWorldSansPhysics::World());
-//  EXPECT_TRUE(serverConfig.SdfFile().empty());
-//  EXPECT_FALSE(serverConfig.SdfString().empty());
-//
-//  // Setting the SDF file should override the string.
-//  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-//      "/test/worlds/shapes.sdf");
-//  EXPECT_FALSE(serverConfig.SdfFile().empty());
-//  EXPECT_TRUE(serverConfig.SdfString().empty());
-//
-//  gazebo::Server server(serverConfig);
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//  EXPECT_TRUE(*server.Paused());
-//  EXPECT_EQ(0u, *server.IterationCount());
-//  EXPECT_EQ(24u, *server.EntityCount());
-//  EXPECT_EQ(3u, *server.SystemCount());
-//
-//  EXPECT_TRUE(server.HasEntity("box"));
-//  EXPECT_FALSE(server.HasEntity("box", 1));
-//  EXPECT_TRUE(server.HasEntity("sphere"));
-//  EXPECT_TRUE(server.HasEntity("cylinder"));
-//  EXPECT_TRUE(server.HasEntity("capsule"));
-//  EXPECT_TRUE(server.HasEntity("ellipsoid"));
-//  EXPECT_FALSE(server.HasEntity("bad", 0));
-//  EXPECT_FALSE(server.HasEntity("bad", 1));
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(SdfRootServerConfig))
-//{
-//  ignition::gazebo::ServerConfig serverConfig;
-//
-//  serverConfig.SetSdfString(TestWorldSansPhysics::World());
-//  EXPECT_TRUE(serverConfig.SdfFile().empty());
-//  EXPECT_FALSE(serverConfig.SdfString().empty());
-//
-//  serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
-//      "test", "worlds", "air_pressure.sdf"));
-//  EXPECT_FALSE(serverConfig.SdfFile().empty());
-//  EXPECT_TRUE(serverConfig.SdfString().empty());
-//
-//  sdf::Root root;
-//  root.Load(common::joinPaths(PROJECT_SOURCE_PATH,
-//      "test", "worlds", "shapes.sdf"));
-//
-//  // Setting the SDF Root should override the string and file.
-//  serverConfig.SetSdfRoot(root);
-//
-//  EXPECT_TRUE(serverConfig.SdfRoot());
-//  EXPECT_TRUE(serverConfig.SdfFile().empty());
-//  EXPECT_TRUE(serverConfig.SdfString().empty());
-//
-//  gazebo::Server server(serverConfig);
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//  EXPECT_TRUE(*server.Paused());
-//  EXPECT_EQ(0u, *server.IterationCount());
-//  EXPECT_EQ(24u, *server.EntityCount());
-//  EXPECT_EQ(3u, *server.SystemCount());
-//
-//  EXPECT_TRUE(server.HasEntity("box"));
-//  EXPECT_FALSE(server.HasEntity("box", 1));
-//  EXPECT_TRUE(server.HasEntity("sphere"));
-//  EXPECT_TRUE(server.HasEntity("cylinder"));
-//  EXPECT_TRUE(server.HasEntity("capsule"));
-//  EXPECT_TRUE(server.HasEntity("ellipsoid"));
-//  EXPECT_FALSE(server.HasEntity("bad", 0));
-//  EXPECT_FALSE(server.HasEntity("bad", 1));
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigLogRecord))
-//{
-//  auto logPath = common::joinPaths(
-//      std::string(PROJECT_BINARY_PATH), "test_log_path");
-//  auto logFile = common::joinPaths(logPath, "state.tlog");
-//  auto compressedFile = logPath + ".zip";
-//
-//  igndbg << "Log path [" << logPath << "]" << std::endl;
-//
-//  common::removeAll(logPath);
-//  common::removeAll(compressedFile);
-//  EXPECT_FALSE(common::exists(logFile));
-//  EXPECT_FALSE(common::exists(compressedFile));
-//
-//  {
-//    gazebo::ServerConfig serverConfig;
-//    serverConfig.SetUseLogRecord(true);
-//    serverConfig.SetLogRecordPath(logPath);
-//
-//    gazebo::Server server(serverConfig);
-//
-//    EXPECT_EQ(0u, *server.IterationCount());
-//    EXPECT_EQ(3u, *server.EntityCount());
-//    EXPECT_EQ(4u, *server.SystemCount());
-//
-//    EXPECT_TRUE(serverConfig.LogRecordTopics().empty());
-//    serverConfig.AddLogRecordTopic("test_topic1");
-//    EXPECT_EQ(1u, serverConfig.LogRecordTopics().size());
-//    serverConfig.AddLogRecordTopic("test_topic2");
-//    EXPECT_EQ(2u, serverConfig.LogRecordTopics().size());
-//    serverConfig.ClearLogRecordTopics();
-//    EXPECT_TRUE(serverConfig.LogRecordTopics().empty());
-//  }
-//
-//  EXPECT_TRUE(common::exists(logFile));
-//  EXPECT_FALSE(common::exists(compressedFile));
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture,
-//       IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigLogRecordCompress))
-//{
-//  auto logPath = common::joinPaths(
-//      std::string(PROJECT_BINARY_PATH), "test_log_path");
-//  auto logFile = common::joinPaths(logPath, "state.tlog");
-//  auto compressedFile = logPath + ".zip";
-//
-//  igndbg << "Log path [" << logPath << "]" << std::endl;
-//
-//  common::removeAll(logPath);
-//  common::removeAll(compressedFile);
-//  EXPECT_FALSE(common::exists(logFile));
-//  EXPECT_FALSE(common::exists(compressedFile));
-//
-//  {
-//    gazebo::ServerConfig serverConfig;
-//    serverConfig.SetUseLogRecord(true);
-//    serverConfig.SetLogRecordPath(logPath);
-//    serverConfig.SetLogRecordCompressPath(compressedFile);
-//
-//    gazebo::Server server(serverConfig);
-//    EXPECT_EQ(0u, *server.IterationCount());
-//    EXPECT_EQ(3u, *server.EntityCount());
-//    EXPECT_EQ(4u, *server.SystemCount());
-//  }
-//
-//  EXPECT_FALSE(common::exists(logFile));
-//  EXPECT_TRUE(common::exists(compressedFile));
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, SdfStringServerConfig)
-//{
-//  ignition::gazebo::ServerConfig serverConfig;
-//
-//  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-//      "/test/worlds/shapes.sdf");
-//  EXPECT_FALSE(serverConfig.SdfFile().empty());
-//  EXPECT_TRUE(serverConfig.SdfString().empty());
-//
-//  // Setting the string should override the file.
-//  serverConfig.SetSdfString(TestWorldSansPhysics::World());
-//  EXPECT_TRUE(serverConfig.SdfFile().empty());
-//  EXPECT_FALSE(serverConfig.SdfString().empty());
-//
-//  gazebo::Server server(serverConfig);
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//  EXPECT_TRUE(*server.Paused());
-//  EXPECT_EQ(0u, *server.IterationCount());
-//  EXPECT_EQ(3u, *server.EntityCount());
-//  EXPECT_EQ(2u, *server.SystemCount());
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, RunBlocking)
-//{
-//  gazebo::Server server;
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//  EXPECT_TRUE(*server.Paused());
-//  EXPECT_EQ(0u, server.IterationCount());
-//
-//  // Make the server run fast.
-//  server.SetUpdatePeriod(1ns);
-//
-//  uint64_t expectedIters = 0;
-//  for (uint64_t i = 1; i < 10; ++i)
-//  {
-//    EXPECT_FALSE(server.Running());
-//    EXPECT_FALSE(*server.Running(0));
-//    server.Run(true, i, false);
-//    EXPECT_FALSE(server.Running());
-//    EXPECT_FALSE(*server.Running(0));
-//
-//    expectedIters += i;
-//    EXPECT_EQ(expectedIters, *server.IterationCount());
-//  }
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, RunNonBlockingPaused)
-//{
-//  gazebo::Server server;
-//
-//  // The server should not be running.
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//
-//  // The simulation runner should not be running.
-//  EXPECT_FALSE(*server.Running(0));
-//
-//  // Invalid world index.
-//  EXPECT_EQ(std::nullopt, server.Running(1));
-//
-//  EXPECT_TRUE(*server.Paused());
-//  EXPECT_EQ(0u, *server.IterationCount());
-//
-//  // Make the server run fast.
-//  server.SetUpdatePeriod(1ns);
-//
-//  EXPECT_TRUE(server.Run(false, 100, true));
-//  EXPECT_TRUE(*server.Paused());
-//
-//  EXPECT_TRUE(server.Running());
-//
-//  // Add a small sleep because the non-blocking Run call causes the
-//  // simulation runner to start asynchronously.
-//  IGN_SLEEP_MS(500);
-//  EXPECT_TRUE(*server.Running(0));
-//
-//  EXPECT_EQ(0u, server.IterationCount());
-//
-//  // Attempt to unpause an invalid world
-//  EXPECT_FALSE(server.SetPaused(false, 1));
-//
-//  // Unpause the existing world
-//  EXPECT_TRUE(server.SetPaused(false, 0));
-//
-//  EXPECT_FALSE(*server.Paused());
-//  EXPECT_TRUE(server.Running());
-//
-//  while (*server.IterationCount() < 100)
-//    IGN_SLEEP_MS(100);
-//
-//  EXPECT_EQ(100u, *server.IterationCount());
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, RunNonBlocking)
-//{
-//  gazebo::Server server;
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//  EXPECT_EQ(0u, *server.IterationCount());
-//
-//  // Make the server run fast.
-//  server.SetUpdatePeriod(1ns);
-//
-//  server.Run(false, 100, false);
-//  while (*server.IterationCount() < 100)
-//    IGN_SLEEP_MS(100);
-//
-//  EXPECT_EQ(100u, *server.IterationCount());
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(RunOnceUnpaused))
-//{
-//  gazebo::Server server;
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//  EXPECT_EQ(0u, *server.IterationCount());
-//
-//  // Load a system
-//  gazebo::SystemLoader systemLoader;
-//  auto mockSystemPlugin = systemLoader.LoadPlugin(
-//      "libMockSystem.so", "ignition::gazebo::MockSystem", nullptr);
-//  ASSERT_TRUE(mockSystemPlugin.has_value());
-//
-//  // Check that it was loaded
-//  const size_t systemCount = *server.SystemCount();
-//  EXPECT_TRUE(*server.AddSystem(mockSystemPlugin.value()));
-//  EXPECT_EQ(systemCount + 1, *server.SystemCount());
-//
-//  // Query the interface from the plugin
-//  auto system = mockSystemPlugin.value()->QueryInterface<gazebo::System>();
-//  EXPECT_NE(system, nullptr);
-//  auto mockSystem = dynamic_cast<gazebo::MockSystem*>(system);
-//  EXPECT_NE(mockSystem, nullptr);
-//
-//  // No steps should have been executed
-//  EXPECT_EQ(0u, mockSystem->preUpdateCallCount);
-//  EXPECT_EQ(0u, mockSystem->updateCallCount);
-//  EXPECT_EQ(0u, mockSystem->postUpdateCallCount);
-//
-//  // Make the server run fast
-//  server.SetUpdatePeriod(1ns);
-//
-//  while (*server.IterationCount() < 100)
-//    server.RunOnce(false);
-//
-//  // Check that the server provides the correct information
-//  EXPECT_EQ(*server.IterationCount(), 100u);
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//
-//  // Check that the system has been called correctly
-//  EXPECT_EQ(100u, mockSystem->preUpdateCallCount);
-//  EXPECT_EQ(100u, mockSystem->updateCallCount);
-//  EXPECT_EQ(100u, mockSystem->postUpdateCallCount);
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(RunOncePaused))
-//{
-//  gazebo::Server server;
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//  EXPECT_EQ(0u, *server.IterationCount());
-//
-//  // Load a system
-//  gazebo::SystemLoader systemLoader;
-//  auto mockSystemPlugin = systemLoader.LoadPlugin(
-//      "libMockSystem.so", "ignition::gazebo::MockSystem", nullptr);
-//  ASSERT_TRUE(mockSystemPlugin.has_value());
-//
-//  // Check that it was loaded
-//  const size_t systemCount = *server.SystemCount();
-//  EXPECT_TRUE(*server.AddSystem(mockSystemPlugin.value()));
-//  EXPECT_EQ(systemCount + 1, *server.SystemCount());
-//
-//  // Query the interface from the plugin
-//  auto system = mockSystemPlugin.value()->QueryInterface<gazebo::System>();
-//  EXPECT_NE(system, nullptr);
-//  auto mockSystem = dynamic_cast<gazebo::MockSystem*>(system);
-//  EXPECT_NE(mockSystem, nullptr);
-//
-//  // No steps should have been executed
-//  EXPECT_EQ(0u, mockSystem->preUpdateCallCount);
-//  EXPECT_EQ(0u, mockSystem->updateCallCount);
-//  EXPECT_EQ(0u, mockSystem->postUpdateCallCount);
-//
-//  // Make the server run fast
-//  server.SetUpdatePeriod(1ns);
-//
-//  while (*server.IterationCount() < 100)
-//    server.RunOnce(true);
-//
-//  // Check that the server provides the correct information
-//  EXPECT_EQ(*server.IterationCount(), 100u);
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//
-//  // Check that the system has been called correctly
-//  EXPECT_EQ(100u, mockSystem->preUpdateCallCount);
-//  EXPECT_EQ(100u, mockSystem->updateCallCount);
-//  EXPECT_EQ(100u, mockSystem->postUpdateCallCount);
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, RunNonBlockingMultiple)
-//{
-//  ignition::gazebo::ServerConfig serverConfig;
-//  serverConfig.SetSdfString(TestWorldSansPhysics::World());
-//  gazebo::Server server(serverConfig);
-//
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//  EXPECT_EQ(0u, *server.IterationCount());
-//
-//  EXPECT_TRUE(server.Run(false, 100, false));
-//  EXPECT_FALSE(server.Run(false, 100, false));
-//
-//  while (*server.IterationCount() < 100)
-//    IGN_SLEEP_MS(100);
-//
-//  EXPECT_EQ(100u, *server.IterationCount());
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, SigInt)
-//{
-//  gazebo::Server server;
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//
-//  // Run forever, non-blocking.
-//  server.Run(false, 0, false);
-//
-//  IGN_SLEEP_MS(500);
-//
-//  EXPECT_TRUE(server.Running());
-//  EXPECT_TRUE(*server.Running(0));
-//
-//  std::raise(SIGTERM);
-//
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, ServerControlStop)
-//{
-//  // Test that the server correctly reacts to requests on /server_control
-//  // service with `stop` set to either false or true.
-//
-//  gazebo::Server server;
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//
-//  // Run forever, non-blocking.
-//  server.Run(false, 0, false);
-//
-//  IGN_SLEEP_MS(500);
-//
-//  EXPECT_TRUE(server.Running());
-//  EXPECT_TRUE(*server.Running(0));
-//
-//  transport::Node node;
-//  msgs::ServerControl req;
-//  msgs::Boolean res;
-//  bool result{false};
-//  bool executed{false};
-//  int sleep{0};
-//  int maxSleep{30};
-//
-//  // first, call with stop = false; the server should keep running
-//  while (!executed && sleep < maxSleep)
-//  {
-//    igndbg << "Requesting /server_control" << std::endl;
-//    executed = node.Request("/server_control", req, 100, res, result);
-//    sleep++;
-//  }
-//  EXPECT_TRUE(executed);
-//  EXPECT_TRUE(result);
-//  EXPECT_FALSE(res.data());
-//
-//  IGN_SLEEP_MS(500);
-//
-//  EXPECT_TRUE(server.Running());
-//  EXPECT_TRUE(*server.Running(0));
-//
-//  // now call with stop = true; the server should stop
-//  req.set_stop(true);
-//
-//  igndbg << "Requesting /server_control" << std::endl;
-//  executed = node.Request("/server_control", req, 100, res, result);
-//
-//  EXPECT_TRUE(executed);
-//  EXPECT_TRUE(result);
-//  EXPECT_TRUE(res.data());
-//
-//  IGN_SLEEP_MS(500);
-//
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(AddSystemWhileRunning))
-//{
-//  ignition::gazebo::ServerConfig serverConfig;
-//
-//  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-//      "/test/worlds/shapes.sdf");
-//
-//  gazebo::Server server(serverConfig);
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//  server.SetUpdatePeriod(1us);
-//
-//  // Run the server to test whether we can add systems while system is running
-//  server.Run(false, 0, false);
-//
-//  IGN_SLEEP_MS(500);
-//
-//  EXPECT_TRUE(server.Running());
-//  EXPECT_TRUE(*server.Running(0));
-//
-//  EXPECT_EQ(3u, *server.SystemCount());
-//
-//  // Add system from plugin
-//  gazebo::SystemLoader systemLoader;
-//  auto mockSystemPlugin = systemLoader.LoadPlugin("libMockSystem.so",
-//      "ignition::gazebo::MockSystem", nullptr);
-//  ASSERT_TRUE(mockSystemPlugin.has_value());
-//
-//  auto result = server.AddSystem(mockSystemPlugin.value());
-//  ASSERT_TRUE(result.has_value());
-//  EXPECT_FALSE(result.value());
-//  EXPECT_EQ(3u, *server.SystemCount());
-//
-//  // Add system pointer
-//  auto mockSystem = std::make_shared<MockSystem>();
-//  result = server.AddSystem(mockSystem);
-//  ASSERT_TRUE(result.has_value());
-//  EXPECT_FALSE(result.value());
-//  EXPECT_EQ(3u, *server.SystemCount());
-//
-//  // Stop the server
-//  std::raise(SIGTERM);
-//
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(AddSystemAfterLoad))
-//{
-//  ignition::gazebo::ServerConfig serverConfig;
-//
-//  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-//      "/test/worlds/shapes.sdf");
-//
-//  gazebo::Server server(serverConfig);
-//  EXPECT_FALSE(server.Running());
-//  EXPECT_FALSE(*server.Running(0));
-//
-//  // Add system from plugin
-//  gazebo::SystemLoader systemLoader;
-//  auto mockSystemPlugin = systemLoader.LoadPlugin("libMockSystem.so",
-//      "ignition::gazebo::MockSystem", nullptr);
-//  ASSERT_TRUE(mockSystemPlugin.has_value());
-//
-//  auto system = mockSystemPlugin.value()->QueryInterface<gazebo::System>();
-//  EXPECT_NE(system, nullptr);
-//  auto mockSystem = dynamic_cast<gazebo::MockSystem*>(system);
-//  ASSERT_NE(mockSystem, nullptr);
-//
-//  EXPECT_EQ(3u, *server.SystemCount());
-//  EXPECT_EQ(0u, mockSystem->configureCallCount);
-//
-//  EXPECT_TRUE(*server.AddSystem(mockSystemPlugin.value()));
-//
-//  EXPECT_EQ(4u, *server.SystemCount());
-//  EXPECT_EQ(1u, mockSystem->configureCallCount);
-//
-//  // Add system pointer
-//  auto mockSystemLocal = std::make_shared<MockSystem>();
-//  EXPECT_EQ(0u, mockSystemLocal->configureCallCount);
-//
-//  EXPECT_TRUE(server.AddSystem(mockSystemLocal));
-//  EXPECT_EQ(5u, *server.SystemCount());
-//  EXPECT_EQ(1u, mockSystemLocal->configureCallCount);
-//
-//  // Check that update callbacks are called
-//  server.SetUpdatePeriod(1us);
-//  EXPECT_EQ(0u, mockSystem->preUpdateCallCount);
-//  EXPECT_EQ(0u, mockSystem->updateCallCount);
-//  EXPECT_EQ(0u, mockSystem->postUpdateCallCount);
-//  EXPECT_EQ(0u, mockSystemLocal->preUpdateCallCount);
-//  EXPECT_EQ(0u, mockSystemLocal->updateCallCount);
-//  EXPECT_EQ(0u, mockSystemLocal->postUpdateCallCount);
-//  server.Run(true, 1, false);
-//  EXPECT_EQ(1u, mockSystem->preUpdateCallCount);
-//  EXPECT_EQ(1u, mockSystem->updateCallCount);
-//  EXPECT_EQ(1u, mockSystem->postUpdateCallCount);
-//  EXPECT_EQ(1u, mockSystemLocal->preUpdateCallCount);
-//  EXPECT_EQ(1u, mockSystemLocal->updateCallCount);
-//  EXPECT_EQ(1u, mockSystemLocal->postUpdateCallCount);
-//
-//  // Add to inexistent world
-//  auto result = server.AddSystem(mockSystemPlugin.value(), 100);
-//  EXPECT_FALSE(result.has_value());
-//
-//  result = server.AddSystem(mockSystemLocal, 100);
-//  EXPECT_FALSE(result.has_value());
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, Seed)
-//{
-//  ignition::gazebo::ServerConfig serverConfig;
-//  EXPECT_EQ(0u, serverConfig.Seed());
-//  unsigned int mySeed = 12345u;
-//  serverConfig.SetSeed(mySeed);
-//  EXPECT_EQ(mySeed, serverConfig.Seed());
-//  EXPECT_EQ(mySeed, ignition::math::Rand::Seed());
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ResourcePath))
-//{
-//  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
-//         (std::string(PROJECT_SOURCE_PATH) + "/test/worlds:" +
-//          std::string(PROJECT_SOURCE_PATH) + "/test/worlds/models").c_str());
-//
-//  ServerConfig serverConfig;
-//  serverConfig.SetSdfFile("resource_paths.sdf");
-//  gazebo::Server server(serverConfig);
-//
-//  test::Relay testSystem;
-//  unsigned int preUpdates{0};
-//  testSystem.OnPreUpdate(
-//    [&preUpdates](const gazebo::UpdateInfo &,
-//    gazebo::EntityComponentManager &_ecm)
-//    {
-//      // Create AABB so it is populated
-//      unsigned int eachCount{0};
-//      _ecm.Each<components::Model>(
-//        [&](const Entity &_entity, components::Model *) -> bool
-//        {
-//          auto bboxComp = _ecm.Component<components::AxisAlignedBox>(_entity);
-//          EXPECT_EQ(bboxComp, nullptr);
-//          _ecm.CreateComponent(_entity, components::AxisAlignedBox());
-//          eachCount++;
-//          return true;
-//        });
-//      EXPECT_EQ(1u, eachCount);
-//      preUpdates++;
-//    });
-//
-//  unsigned int postUpdates{0};
-//  testSystem.OnPostUpdate([&postUpdates](const gazebo::UpdateInfo &,
-//    const gazebo::EntityComponentManager &_ecm)
-//    {
-//      // Check geometry components
-//      unsigned int eachCount{0};
-//      _ecm.Each<components::Geometry>(
-//        [&eachCount](const Entity &, const components::Geometry *_geom)
-//        -> bool
-//        {
-//          auto mesh = _geom->Data().MeshShape();
-//
-//          // ASSERT would fail at compile with
-//          // "void value not ignored as it ought to be"
-//          EXPECT_NE(nullptr, mesh);
-//
-//          if (mesh)
-//          {
-//            EXPECT_EQ("model://scheme_resource_uri/meshes/box.dae",
-//                mesh->Uri());
-//          }
-//
-//          eachCount++;
-//          return true;
-//        });
-//      EXPECT_EQ(2u, eachCount);
-//
-//      // Check physics system loaded meshes and got their BB correct
-//      eachCount = 0;
-//      _ecm.Each<components::AxisAlignedBox>(
-//        [&](const ignition::gazebo::Entity &,
-//            const components::AxisAlignedBox *_box)->bool
-//        {
-//          auto box = _box->Data();
-//          EXPECT_EQ(box, math::AxisAlignedBox(-0.4, -0.4, 0.6, 0.4, 0.4, 1.4));
-//          eachCount++;
-//          return true;
-//        });
-//      EXPECT_EQ(1u, eachCount);
-//
-//      postUpdates++;
-//    });
-//  server.AddSystem(testSystem.systemPtr);
-//
-//  EXPECT_FALSE(*server.Running(0));
-//
-//  EXPECT_TRUE(server.Run(true /*blocking*/, 1, false /*paused*/));
-//  EXPECT_EQ(1u, preUpdates);
-//  EXPECT_EQ(1u, postUpdates);
-//
-//  EXPECT_EQ(7u, *server.EntityCount());
-//  EXPECT_TRUE(server.HasEntity("scheme_resource_uri"));
-//  EXPECT_TRUE(server.HasEntity("the_link"));
-//  EXPECT_TRUE(server.HasEntity("the_visual"));
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, GetResourcePaths)
-//{
-//  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
-//      "/tmp/some/path:/home/user/another_path");
-//
-//  ServerConfig serverConfig;
-//  gazebo::Server server(serverConfig);
-//
-//  EXPECT_FALSE(*server.Running(0));
-//
-//  transport::Node node;
-//  msgs::StringMsg_V res;
-//  bool result{false};
-//  bool executed{false};
-//  int sleep{0};
-//  int maxSleep{30};
-//  while (!executed && sleep < maxSleep)
-//  {
-//    igndbg << "Requesting /gazebo/resource_paths/get" << std::endl;
-//    executed = node.Request("/gazebo/resource_paths/get", 100, res, result);
-//    sleep++;
-//  }
-//  EXPECT_TRUE(executed);
-//  EXPECT_TRUE(result);
-//  EXPECT_EQ(2, res.data_size());
-//  EXPECT_EQ("/tmp/some/path", res.data(0));
-//  EXPECT_EQ("/home/user/another_path", res.data(1));
-//}
-//
-///////////////////////////////////////////////////
-//TEST_P(ServerFixture, AddResourcePaths)
-//{
-//  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
-//      "/tmp/some/path:/home/user/another_path");
-//  ignition::common::setenv("SDF_PATH", "");
-//  ignition::common::setenv("IGN_FILE_PATH", "");
-//
-//  ServerConfig serverConfig;
-//  gazebo::Server server(serverConfig);
-//
-//  EXPECT_FALSE(*server.Running(0));
-//
-//  transport::Node node;
-//
-//  // Subscribe to path updates
-//  bool receivedMsg{false};
-//  auto resourceCb = std::function<void(const msgs::StringMsg_V &)>(
-//      [&receivedMsg](const auto &_msg)
-//      {
-//        receivedMsg = true;
-//        EXPECT_EQ(5, _msg.data_size());
-//        EXPECT_EQ("/tmp/some/path", _msg.data(0));
-//        EXPECT_EQ("/home/user/another_path", _msg.data(1));
-//        EXPECT_EQ("/tmp/new_path", _msg.data(2));
-//        EXPECT_EQ("/tmp/more", _msg.data(3));
-//        EXPECT_EQ("/tmp/even_more", _msg.data(4));
-//      });
-//  node.Subscribe("/gazebo/resource_paths", resourceCb);
-//
-//  // Add path
-//  msgs::StringMsg_V req;
-//  req.add_data("/tmp/new_path");
-//  req.add_data("/tmp/more:/tmp/even_more");
-//  req.add_data("/tmp/some/path");
-//  bool executed = node.Request("/gazebo/resource_paths/add", req);
-//  EXPECT_TRUE(executed);
-//
-//  int sleep{0};
-//  int maxSleep{30};
-//  while (!receivedMsg && sleep < maxSleep)
-//  {
-//    IGN_SLEEP_MS(50);
-//    sleep++;
-//  }
-//  EXPECT_TRUE(receivedMsg);
-//
-//  // Check environment variables
-//  for (auto env : {"IGN_GAZEBO_RESOURCE_PATH", "SDF_PATH", "IGN_FILE_PATH"})
-//  {
-//    char *pathCStr = std::getenv(env);
-//
-//    auto paths = common::Split(pathCStr, ':');
-//    paths.erase(std::remove_if(paths.begin(), paths.end(),
-//        [](std::string const &_path)
-//        {
-//          return _path.empty();
-//        }),
-//        paths.end());
-//
-//    EXPECT_EQ(5u, paths.size());
-//    EXPECT_EQ("/tmp/some/path", paths[0]);
-//    EXPECT_EQ("/home/user/another_path", paths[1]);
-//    EXPECT_EQ("/tmp/new_path", paths[2]);
-//    EXPECT_EQ("/tmp/more", paths[3]);
-//    EXPECT_EQ("/tmp/even_more", paths[4]);
-//  }
-//}
+/////////////////////////////////////////////////
+// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(DefaultServerConfig))
+{
+  ignition::gazebo::ServerConfig serverConfig;
+  EXPECT_TRUE(serverConfig.SdfFile().empty());
+  EXPECT_TRUE(serverConfig.SdfString().empty());
+  EXPECT_FALSE(serverConfig.UpdateRate());
+  EXPECT_FALSE(serverConfig.UseLevels());
+  EXPECT_FALSE(serverConfig.UseDistributedSimulation());
+  EXPECT_EQ(0u, serverConfig.NetworkSecondaries());
+  EXPECT_TRUE(serverConfig.NetworkRole().empty());
+  EXPECT_FALSE(serverConfig.UseLogRecord());
+  EXPECT_FALSE(serverConfig.LogRecordPath().empty());
+  EXPECT_TRUE(serverConfig.LogPlaybackPath().empty());
+  EXPECT_FALSE(serverConfig.LogRecordResources());
+  EXPECT_TRUE(serverConfig.LogRecordCompressPath().empty());
+  EXPECT_EQ(0u, serverConfig.Seed());
+  EXPECT_EQ(123ms, serverConfig.UpdatePeriod().value_or(123ms));
+  EXPECT_TRUE(serverConfig.ResourceCache().empty());
+  EXPECT_TRUE(serverConfig.PhysicsEngine().empty());
+  EXPECT_TRUE(serverConfig.Plugins().empty());
+  EXPECT_TRUE(serverConfig.LogRecordTopics().empty());
+
+  gazebo::Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+  EXPECT_EQ(std::nullopt, server.Running(1));
+  EXPECT_TRUE(*server.Paused());
+  EXPECT_EQ(0u, *server.IterationCount());
+
+  EXPECT_EQ(3u, *server.EntityCount());
+  EXPECT_TRUE(server.HasEntity("default"));
+
+  EXPECT_EQ(3u, *server.SystemCount());
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, UpdateRate)
+{
+  gazebo::ServerConfig serverConfig;
+  serverConfig.SetUpdateRate(1000.0);
+  EXPECT_DOUBLE_EQ(1000.0, *serverConfig.UpdateRate());
+  serverConfig.SetUpdateRate(-1000.0);
+  EXPECT_DOUBLE_EQ(1000.0, *serverConfig.UpdateRate());
+  serverConfig.SetUpdateRate(0.0);
+  EXPECT_DOUBLE_EQ(1000.0, *serverConfig.UpdateRate());
+  EXPECT_EQ(1ms, serverConfig.UpdatePeriod());
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, ServerConfigPluginInfo)
+{
+  ServerConfig::PluginInfo pluginInfo;
+  pluginInfo.SetEntityName("an_entity");
+  pluginInfo.SetEntityType("model");
+  pluginInfo.SetFilename("filename");
+  pluginInfo.SetName("interface");
+  pluginInfo.SetSdf(nullptr);
+
+  ignition::gazebo::ServerConfig serverConfig;
+  serverConfig.AddPlugin(pluginInfo);
+
+  const std::list<ServerConfig::PluginInfo> &plugins = serverConfig.Plugins();
+  ASSERT_FALSE(plugins.empty());
+
+  EXPECT_EQ("an_entity", plugins.front().EntityName());
+  EXPECT_EQ("model", plugins.front().EntityType());
+  EXPECT_EQ("filename", plugins.front().Filename());
+  EXPECT_EQ("interface", plugins.front().Name());
+  EXPECT_EQ(nullptr, plugins.front().Sdf());
+
+  // Test operator=
+  {
+    ServerConfig::PluginInfo info;
+    info = plugins.front();
+
+    EXPECT_EQ(info.EntityName(), plugins.front().EntityName());
+    EXPECT_EQ(info.EntityType(), plugins.front().EntityType());
+    EXPECT_EQ(info.Filename(), plugins.front().Filename());
+    EXPECT_EQ(info.Name(), plugins.front().Name());
+    EXPECT_EQ(info.Sdf(), plugins.front().Sdf());
+  }
+
+  // Test copy constructor
+  {
+    ServerConfig::PluginInfo info(plugins.front());
+
+    EXPECT_EQ(info.EntityName(), plugins.front().EntityName());
+    EXPECT_EQ(info.EntityType(), plugins.front().EntityType());
+    EXPECT_EQ(info.Filename(), plugins.front().Filename());
+    EXPECT_EQ(info.Name(), plugins.front().Name());
+    EXPECT_EQ(info.Sdf(), plugins.front().Sdf());
+  }
+
+  // Test server config copy constructor
+  {
+    const ServerConfig &cfg(serverConfig);
+    const std::list<ServerConfig::PluginInfo> &cfgPlugins = cfg.Plugins();
+    ASSERT_FALSE(cfgPlugins.empty());
+
+    EXPECT_EQ(cfgPlugins.front().EntityName(), plugins.front().EntityName());
+    EXPECT_EQ(cfgPlugins.front().EntityType(), plugins.front().EntityType());
+    EXPECT_EQ(cfgPlugins.front().Filename(), plugins.front().Filename());
+    EXPECT_EQ(cfgPlugins.front().Name(), plugins.front().Name());
+    EXPECT_EQ(cfgPlugins.front().Sdf(), plugins.front().Sdf());
+  }
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigRealPlugin))
+{
+  // Start server
+  ServerConfig serverConfig;
+  serverConfig.SetUpdateRate(10000);
+  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
+      "/test/worlds/shapes.sdf");
+
+  sdf::ElementPtr sdf(new sdf::Element);
+  sdf->SetName("plugin");
+  sdf->AddAttribute("name", "string",
+      "ignition::gazebo::TestModelSystem", true);
+  sdf->AddAttribute("filename", "string", "libTestModelSystem.so", true);
+
+  sdf::ElementPtr child(new sdf::Element);
+  child->SetParent(sdf);
+  child->SetName("model_key");
+  child->AddValue("string", "987", "1");
+
+  serverConfig.AddPlugin({"box", "model",
+      "libTestModelSystem.so", "ignition::gazebo::TestModelSystem", sdf});
+
+  gazebo::Server server(serverConfig);
+
+  // The simulation runner should not be running.
+  EXPECT_FALSE(*server.Running(0));
+
+  // Run the server
+  EXPECT_TRUE(server.Run(false, 0, false));
+  EXPECT_FALSE(*server.Paused());
+
+  // The TestModelSystem should have created a service. Call the service to
+  // make sure the TestModelSystem was successfully loaded.
+  transport::Node node;
+  msgs::StringMsg rep;
+  bool result{false};
+  bool executed{false};
+  int sleep{0};
+  int maxSleep{30};
+  while (!executed && sleep < maxSleep)
+  {
+    igndbg << "Requesting /test/service" << std::endl;
+    executed = node.Request("/test/service", 100, rep, result);
+    sleep++;
+  }
+  EXPECT_TRUE(executed);
+  EXPECT_TRUE(result);
+  EXPECT_EQ("TestModelSystem", rep.data());
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigSensorPlugin))
+{
+  // Start server
+  ServerConfig serverConfig;
+  serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
+      "test", "worlds", "air_pressure.sdf"));
+
+  sdf::ElementPtr sdf(new sdf::Element);
+  sdf->SetName("plugin");
+  sdf->AddAttribute("name", "string",
+      "ignition::gazebo::TestSensorSystem", true);
+  sdf->AddAttribute("filename", "string", "libTestSensorSystem.so", true);
+
+  serverConfig.AddPlugin({
+      "air_pressure_sensor::air_pressure_model::link::air_pressure_sensor",
+      "sensor", "libTestSensorSystem.so", "ignition::gazebo::TestSensorSystem",
+      sdf});
+
+  igndbg << "Create server" << std::endl;
+  gazebo::Server server(serverConfig);
+
+  // The simulation runner should not be running.
+  EXPECT_FALSE(*server.Running(0));
+  EXPECT_EQ(3u, *server.SystemCount());
+
+  // Run the server
+  igndbg << "Run server" << std::endl;
+  EXPECT_TRUE(server.Run(false, 0, false));
+  EXPECT_FALSE(*server.Paused());
+
+  // The TestSensorSystem should have created a service. Call the service to
+  // make sure the TestSensorSystem was successfully loaded.
+  igndbg << "Request service" << std::endl;
+  transport::Node node;
+  msgs::StringMsg rep;
+  bool result{false};
+  bool executed{false};
+  int sleep{0};
+  int maxSleep{30};
+  while (!executed && sleep < maxSleep)
+  {
+    igndbg << "Requesting /test/service/sensor" << std::endl;
+    executed = node.Request("/test/service/sensor", 100, rep, result);
+    sleep++;
+  }
+  EXPECT_TRUE(executed);
+  EXPECT_TRUE(result);
+  EXPECT_EQ("TestSensorSystem", rep.data());
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(SdfServerConfig))
+{
+  ignition::gazebo::ServerConfig serverConfig;
+
+  serverConfig.SetSdfString(TestWorldSansPhysics::World());
+  EXPECT_TRUE(serverConfig.SdfFile().empty());
+  EXPECT_FALSE(serverConfig.SdfString().empty());
+
+  // Setting the SDF file should override the string.
+  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
+      "/test/worlds/shapes.sdf");
+  EXPECT_FALSE(serverConfig.SdfFile().empty());
+  EXPECT_TRUE(serverConfig.SdfString().empty());
+
+  gazebo::Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+  EXPECT_TRUE(*server.Paused());
+  EXPECT_EQ(0u, *server.IterationCount());
+  EXPECT_EQ(24u, *server.EntityCount());
+  EXPECT_EQ(3u, *server.SystemCount());
+
+  EXPECT_TRUE(server.HasEntity("box"));
+  EXPECT_FALSE(server.HasEntity("box", 1));
+  EXPECT_TRUE(server.HasEntity("sphere"));
+  EXPECT_TRUE(server.HasEntity("cylinder"));
+  EXPECT_TRUE(server.HasEntity("capsule"));
+  EXPECT_TRUE(server.HasEntity("ellipsoid"));
+  EXPECT_FALSE(server.HasEntity("bad", 0));
+  EXPECT_FALSE(server.HasEntity("bad", 1));
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(SdfRootServerConfig))
+{
+  ignition::gazebo::ServerConfig serverConfig;
+
+  serverConfig.SetSdfString(TestWorldSansPhysics::World());
+  EXPECT_TRUE(serverConfig.SdfFile().empty());
+  EXPECT_FALSE(serverConfig.SdfString().empty());
+
+  serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
+      "test", "worlds", "air_pressure.sdf"));
+  EXPECT_FALSE(serverConfig.SdfFile().empty());
+  EXPECT_TRUE(serverConfig.SdfString().empty());
+
+  sdf::Root root;
+  root.Load(common::joinPaths(PROJECT_SOURCE_PATH,
+      "test", "worlds", "shapes.sdf"));
+
+  // Setting the SDF Root should override the string and file.
+  serverConfig.SetSdfRoot(root);
+
+  EXPECT_TRUE(serverConfig.SdfRoot());
+  EXPECT_TRUE(serverConfig.SdfFile().empty());
+  EXPECT_TRUE(serverConfig.SdfString().empty());
+
+  gazebo::Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+  EXPECT_TRUE(*server.Paused());
+  EXPECT_EQ(0u, *server.IterationCount());
+  EXPECT_EQ(24u, *server.EntityCount());
+  EXPECT_EQ(3u, *server.SystemCount());
+
+  EXPECT_TRUE(server.HasEntity("box"));
+  EXPECT_FALSE(server.HasEntity("box", 1));
+  EXPECT_TRUE(server.HasEntity("sphere"));
+  EXPECT_TRUE(server.HasEntity("cylinder"));
+  EXPECT_TRUE(server.HasEntity("capsule"));
+  EXPECT_TRUE(server.HasEntity("ellipsoid"));
+  EXPECT_FALSE(server.HasEntity("bad", 0));
+  EXPECT_FALSE(server.HasEntity("bad", 1));
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigLogRecord))
+{
+  auto logPath = common::joinPaths(
+      std::string(PROJECT_BINARY_PATH), "test_log_path");
+  auto logFile = common::joinPaths(logPath, "state.tlog");
+  auto compressedFile = logPath + ".zip";
+
+  igndbg << "Log path [" << logPath << "]" << std::endl;
+
+  common::removeAll(logPath);
+  common::removeAll(compressedFile);
+  EXPECT_FALSE(common::exists(logFile));
+  EXPECT_FALSE(common::exists(compressedFile));
+
+  {
+    gazebo::ServerConfig serverConfig;
+    serverConfig.SetUseLogRecord(true);
+    serverConfig.SetLogRecordPath(logPath);
+
+    gazebo::Server server(serverConfig);
+
+    EXPECT_EQ(0u, *server.IterationCount());
+    EXPECT_EQ(3u, *server.EntityCount());
+    EXPECT_EQ(4u, *server.SystemCount());
+
+    EXPECT_TRUE(serverConfig.LogRecordTopics().empty());
+    serverConfig.AddLogRecordTopic("test_topic1");
+    EXPECT_EQ(1u, serverConfig.LogRecordTopics().size());
+    serverConfig.AddLogRecordTopic("test_topic2");
+    EXPECT_EQ(2u, serverConfig.LogRecordTopics().size());
+    serverConfig.ClearLogRecordTopics();
+    EXPECT_TRUE(serverConfig.LogRecordTopics().empty());
+  }
+
+  EXPECT_TRUE(common::exists(logFile));
+  EXPECT_FALSE(common::exists(compressedFile));
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigLogRecordCompress))
+{
+  auto logPath = common::joinPaths(
+      std::string(PROJECT_BINARY_PATH), "test_log_path");
+  auto logFile = common::joinPaths(logPath, "state.tlog");
+  auto compressedFile = logPath + ".zip";
+
+  igndbg << "Log path [" << logPath << "]" << std::endl;
+
+  common::removeAll(logPath);
+  common::removeAll(compressedFile);
+  EXPECT_FALSE(common::exists(logFile));
+  EXPECT_FALSE(common::exists(compressedFile));
+
+  {
+    gazebo::ServerConfig serverConfig;
+    serverConfig.SetUseLogRecord(true);
+    serverConfig.SetLogRecordPath(logPath);
+    serverConfig.SetLogRecordCompressPath(compressedFile);
+
+    gazebo::Server server(serverConfig);
+    EXPECT_EQ(0u, *server.IterationCount());
+    EXPECT_EQ(3u, *server.EntityCount());
+    EXPECT_EQ(4u, *server.SystemCount());
+  }
+
+  EXPECT_FALSE(common::exists(logFile));
+  EXPECT_TRUE(common::exists(compressedFile));
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, SdfStringServerConfig)
+{
+  ignition::gazebo::ServerConfig serverConfig;
+
+  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
+      "/test/worlds/shapes.sdf");
+  EXPECT_FALSE(serverConfig.SdfFile().empty());
+  EXPECT_TRUE(serverConfig.SdfString().empty());
+
+  // Setting the string should override the file.
+  serverConfig.SetSdfString(TestWorldSansPhysics::World());
+  EXPECT_TRUE(serverConfig.SdfFile().empty());
+  EXPECT_FALSE(serverConfig.SdfString().empty());
+
+  gazebo::Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+  EXPECT_TRUE(*server.Paused());
+  EXPECT_EQ(0u, *server.IterationCount());
+  EXPECT_EQ(3u, *server.EntityCount());
+  EXPECT_EQ(2u, *server.SystemCount());
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, RunBlocking)
+{
+  gazebo::Server server;
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+  EXPECT_TRUE(*server.Paused());
+  EXPECT_EQ(0u, server.IterationCount());
+
+  // Make the server run fast.
+  server.SetUpdatePeriod(1ns);
+
+  uint64_t expectedIters = 0;
+  for (uint64_t i = 1; i < 10; ++i)
+  {
+    EXPECT_FALSE(server.Running());
+    EXPECT_FALSE(*server.Running(0));
+    server.Run(true, i, false);
+    EXPECT_FALSE(server.Running());
+    EXPECT_FALSE(*server.Running(0));
+
+    expectedIters += i;
+    EXPECT_EQ(expectedIters, *server.IterationCount());
+  }
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, RunNonBlockingPaused)
+{
+  gazebo::Server server;
+
+  // The server should not be running.
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  // The simulation runner should not be running.
+  EXPECT_FALSE(*server.Running(0));
+
+  // Invalid world index.
+  EXPECT_EQ(std::nullopt, server.Running(1));
+
+  EXPECT_TRUE(*server.Paused());
+  EXPECT_EQ(0u, *server.IterationCount());
+
+  // Make the server run fast.
+  server.SetUpdatePeriod(1ns);
+
+  EXPECT_TRUE(server.Run(false, 100, true));
+  EXPECT_TRUE(*server.Paused());
+
+  EXPECT_TRUE(server.Running());
+
+  // Add a small sleep because the non-blocking Run call causes the
+  // simulation runner to start asynchronously.
+  IGN_SLEEP_MS(500);
+  EXPECT_TRUE(*server.Running(0));
+
+  EXPECT_EQ(0u, server.IterationCount());
+
+  // Attempt to unpause an invalid world
+  EXPECT_FALSE(server.SetPaused(false, 1));
+
+  // Unpause the existing world
+  EXPECT_TRUE(server.SetPaused(false, 0));
+
+  EXPECT_FALSE(*server.Paused());
+  EXPECT_TRUE(server.Running());
+
+  while (*server.IterationCount() < 100)
+    IGN_SLEEP_MS(100);
+
+  EXPECT_EQ(100u, *server.IterationCount());
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, RunNonBlocking)
+{
+  gazebo::Server server;
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+  EXPECT_EQ(0u, *server.IterationCount());
+
+  // Make the server run fast.
+  server.SetUpdatePeriod(1ns);
+
+  server.Run(false, 100, false);
+  while (*server.IterationCount() < 100)
+    IGN_SLEEP_MS(100);
+
+  EXPECT_EQ(100u, *server.IterationCount());
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(RunOnceUnpaused))
+{
+  gazebo::Server server;
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+  EXPECT_EQ(0u, *server.IterationCount());
+
+  // Load a system
+  gazebo::SystemLoader systemLoader;
+  auto mockSystemPlugin = systemLoader.LoadPlugin(
+      "libMockSystem.so", "ignition::gazebo::MockSystem", nullptr);
+  ASSERT_TRUE(mockSystemPlugin.has_value());
+
+  // Check that it was loaded
+  const size_t systemCount = *server.SystemCount();
+  EXPECT_TRUE(*server.AddSystem(mockSystemPlugin.value()));
+  EXPECT_EQ(systemCount + 1, *server.SystemCount());
+
+  // Query the interface from the plugin
+  auto system = mockSystemPlugin.value()->QueryInterface<gazebo::System>();
+  EXPECT_NE(system, nullptr);
+  auto mockSystem = dynamic_cast<gazebo::MockSystem*>(system);
+  EXPECT_NE(mockSystem, nullptr);
+
+  // No steps should have been executed
+  EXPECT_EQ(0u, mockSystem->preUpdateCallCount);
+  EXPECT_EQ(0u, mockSystem->updateCallCount);
+  EXPECT_EQ(0u, mockSystem->postUpdateCallCount);
+
+  // Make the server run fast
+  server.SetUpdatePeriod(1ns);
+
+  while (*server.IterationCount() < 100)
+    server.RunOnce(false);
+
+  // Check that the server provides the correct information
+  EXPECT_EQ(*server.IterationCount(), 100u);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  // Check that the system has been called correctly
+  EXPECT_EQ(100u, mockSystem->preUpdateCallCount);
+  EXPECT_EQ(100u, mockSystem->updateCallCount);
+  EXPECT_EQ(100u, mockSystem->postUpdateCallCount);
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(RunOncePaused))
+{
+  gazebo::Server server;
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+  EXPECT_EQ(0u, *server.IterationCount());
+
+  // Load a system
+  gazebo::SystemLoader systemLoader;
+  auto mockSystemPlugin = systemLoader.LoadPlugin(
+      "libMockSystem.so", "ignition::gazebo::MockSystem", nullptr);
+  ASSERT_TRUE(mockSystemPlugin.has_value());
+
+  // Check that it was loaded
+  const size_t systemCount = *server.SystemCount();
+  EXPECT_TRUE(*server.AddSystem(mockSystemPlugin.value()));
+  EXPECT_EQ(systemCount + 1, *server.SystemCount());
+
+  // Query the interface from the plugin
+  auto system = mockSystemPlugin.value()->QueryInterface<gazebo::System>();
+  EXPECT_NE(system, nullptr);
+  auto mockSystem = dynamic_cast<gazebo::MockSystem*>(system);
+  EXPECT_NE(mockSystem, nullptr);
+
+  // No steps should have been executed
+  EXPECT_EQ(0u, mockSystem->preUpdateCallCount);
+  EXPECT_EQ(0u, mockSystem->updateCallCount);
+  EXPECT_EQ(0u, mockSystem->postUpdateCallCount);
+
+  // Make the server run fast
+  server.SetUpdatePeriod(1ns);
+
+  while (*server.IterationCount() < 100)
+    server.RunOnce(true);
+
+  // Check that the server provides the correct information
+  EXPECT_EQ(*server.IterationCount(), 100u);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  // Check that the system has been called correctly
+  EXPECT_EQ(100u, mockSystem->preUpdateCallCount);
+  EXPECT_EQ(100u, mockSystem->updateCallCount);
+  EXPECT_EQ(100u, mockSystem->postUpdateCallCount);
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, RunNonBlockingMultiple)
+{
+  ignition::gazebo::ServerConfig serverConfig;
+  serverConfig.SetSdfString(TestWorldSansPhysics::World());
+  gazebo::Server server(serverConfig);
+
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+  EXPECT_EQ(0u, *server.IterationCount());
+
+  EXPECT_TRUE(server.Run(false, 100, false));
+  EXPECT_FALSE(server.Run(false, 100, false));
+
+  while (*server.IterationCount() < 100)
+    IGN_SLEEP_MS(100);
+
+  EXPECT_EQ(100u, *server.IterationCount());
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, SigInt)
+{
+  gazebo::Server server;
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  // Run forever, non-blocking.
+  server.Run(false, 0, false);
+
+  IGN_SLEEP_MS(500);
+
+  EXPECT_TRUE(server.Running());
+  EXPECT_TRUE(*server.Running(0));
+
+  std::raise(SIGTERM);
+
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, ServerControlStop)
+{
+  // Test that the server correctly reacts to requests on /server_control
+  // service with `stop` set to either false or true.
+
+  gazebo::Server server;
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  // Run forever, non-blocking.
+  server.Run(false, 0, false);
+
+  IGN_SLEEP_MS(500);
+
+  EXPECT_TRUE(server.Running());
+  EXPECT_TRUE(*server.Running(0));
+
+  transport::Node node;
+  msgs::ServerControl req;
+  msgs::Boolean res;
+  bool result{false};
+  bool executed{false};
+  int sleep{0};
+  int maxSleep{30};
+
+  // first, call with stop = false; the server should keep running
+  while (!executed && sleep < maxSleep)
+  {
+    igndbg << "Requesting /server_control" << std::endl;
+    executed = node.Request("/server_control", req, 100, res, result);
+    sleep++;
+  }
+  EXPECT_TRUE(executed);
+  EXPECT_TRUE(result);
+  EXPECT_FALSE(res.data());
+
+  IGN_SLEEP_MS(500);
+
+  EXPECT_TRUE(server.Running());
+  EXPECT_TRUE(*server.Running(0));
+
+  // now call with stop = true; the server should stop
+  req.set_stop(true);
+
+  igndbg << "Requesting /server_control" << std::endl;
+  executed = node.Request("/server_control", req, 100, res, result);
+
+  EXPECT_TRUE(executed);
+  EXPECT_TRUE(result);
+  EXPECT_TRUE(res.data());
+
+  IGN_SLEEP_MS(500);
+
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(AddSystemWhileRunning))
+{
+  ignition::gazebo::ServerConfig serverConfig;
+
+  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
+      "/test/worlds/shapes.sdf");
+
+  gazebo::Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+  server.SetUpdatePeriod(1us);
+
+  // Run the server to test whether we can add systems while system is running
+  server.Run(false, 0, false);
+
+  IGN_SLEEP_MS(500);
+
+  EXPECT_TRUE(server.Running());
+  EXPECT_TRUE(*server.Running(0));
+
+  EXPECT_EQ(3u, *server.SystemCount());
+
+  // Add system from plugin
+  gazebo::SystemLoader systemLoader;
+  auto mockSystemPlugin = systemLoader.LoadPlugin("libMockSystem.so",
+      "ignition::gazebo::MockSystem", nullptr);
+  ASSERT_TRUE(mockSystemPlugin.has_value());
+
+  auto result = server.AddSystem(mockSystemPlugin.value());
+  ASSERT_TRUE(result.has_value());
+  EXPECT_FALSE(result.value());
+  EXPECT_EQ(3u, *server.SystemCount());
+
+  // Add system pointer
+  auto mockSystem = std::make_shared<MockSystem>();
+  result = server.AddSystem(mockSystem);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_FALSE(result.value());
+  EXPECT_EQ(3u, *server.SystemCount());
+
+  // Stop the server
+  std::raise(SIGTERM);
+
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(AddSystemAfterLoad))
+{
+  ignition::gazebo::ServerConfig serverConfig;
+
+  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
+      "/test/worlds/shapes.sdf");
+
+  gazebo::Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  // Add system from plugin
+  gazebo::SystemLoader systemLoader;
+  auto mockSystemPlugin = systemLoader.LoadPlugin("libMockSystem.so",
+      "ignition::gazebo::MockSystem", nullptr);
+  ASSERT_TRUE(mockSystemPlugin.has_value());
+
+  auto system = mockSystemPlugin.value()->QueryInterface<gazebo::System>();
+  EXPECT_NE(system, nullptr);
+  auto mockSystem = dynamic_cast<gazebo::MockSystem*>(system);
+  ASSERT_NE(mockSystem, nullptr);
+
+  EXPECT_EQ(3u, *server.SystemCount());
+  EXPECT_EQ(0u, mockSystem->configureCallCount);
+
+  EXPECT_TRUE(*server.AddSystem(mockSystemPlugin.value()));
+
+  EXPECT_EQ(4u, *server.SystemCount());
+  EXPECT_EQ(1u, mockSystem->configureCallCount);
+
+  // Add system pointer
+  auto mockSystemLocal = std::make_shared<MockSystem>();
+  EXPECT_EQ(0u, mockSystemLocal->configureCallCount);
+
+  EXPECT_TRUE(server.AddSystem(mockSystemLocal));
+  EXPECT_EQ(5u, *server.SystemCount());
+  EXPECT_EQ(1u, mockSystemLocal->configureCallCount);
+
+  // Check that update callbacks are called
+  server.SetUpdatePeriod(1us);
+  EXPECT_EQ(0u, mockSystem->preUpdateCallCount);
+  EXPECT_EQ(0u, mockSystem->updateCallCount);
+  EXPECT_EQ(0u, mockSystem->postUpdateCallCount);
+  EXPECT_EQ(0u, mockSystemLocal->preUpdateCallCount);
+  EXPECT_EQ(0u, mockSystemLocal->updateCallCount);
+  EXPECT_EQ(0u, mockSystemLocal->postUpdateCallCount);
+  server.Run(true, 1, false);
+  EXPECT_EQ(1u, mockSystem->preUpdateCallCount);
+  EXPECT_EQ(1u, mockSystem->updateCallCount);
+  EXPECT_EQ(1u, mockSystem->postUpdateCallCount);
+  EXPECT_EQ(1u, mockSystemLocal->preUpdateCallCount);
+  EXPECT_EQ(1u, mockSystemLocal->updateCallCount);
+  EXPECT_EQ(1u, mockSystemLocal->postUpdateCallCount);
+
+  // Add to inexistent world
+  auto result = server.AddSystem(mockSystemPlugin.value(), 100);
+  EXPECT_FALSE(result.has_value());
+
+  result = server.AddSystem(mockSystemLocal, 100);
+  EXPECT_FALSE(result.has_value());
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, Seed)
+{
+  ignition::gazebo::ServerConfig serverConfig;
+  EXPECT_EQ(0u, serverConfig.Seed());
+  unsigned int mySeed = 12345u;
+  serverConfig.SetSeed(mySeed);
+  EXPECT_EQ(mySeed, serverConfig.Seed());
+  EXPECT_EQ(mySeed, ignition::math::Rand::Seed());
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ResourcePath))
+{
+  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
+         (std::string(PROJECT_SOURCE_PATH) + "/test/worlds:" +
+          std::string(PROJECT_SOURCE_PATH) + "/test/worlds/models").c_str());
+
+  ServerConfig serverConfig;
+  serverConfig.SetSdfFile("resource_paths.sdf");
+  gazebo::Server server(serverConfig);
+
+  test::Relay testSystem;
+  unsigned int preUpdates{0};
+  testSystem.OnPreUpdate(
+    [&preUpdates](const gazebo::UpdateInfo &,
+    gazebo::EntityComponentManager &_ecm)
+    {
+      // Create AABB so it is populated
+      unsigned int eachCount{0};
+      _ecm.Each<components::Model>(
+        [&](const Entity &_entity, components::Model *) -> bool
+        {
+          auto bboxComp = _ecm.Component<components::AxisAlignedBox>(_entity);
+          EXPECT_EQ(bboxComp, nullptr);
+          _ecm.CreateComponent(_entity, components::AxisAlignedBox());
+          eachCount++;
+          return true;
+        });
+      EXPECT_EQ(1u, eachCount);
+      preUpdates++;
+    });
+
+  unsigned int postUpdates{0};
+  testSystem.OnPostUpdate([&postUpdates](const gazebo::UpdateInfo &,
+    const gazebo::EntityComponentManager &_ecm)
+    {
+      // Check geometry components
+      unsigned int eachCount{0};
+      _ecm.Each<components::Geometry>(
+        [&eachCount](const Entity &, const components::Geometry *_geom)
+        -> bool
+        {
+          auto mesh = _geom->Data().MeshShape();
+
+          // ASSERT would fail at compile with
+          // "void value not ignored as it ought to be"
+          EXPECT_NE(nullptr, mesh);
+
+          if (mesh)
+          {
+            EXPECT_EQ("model://scheme_resource_uri/meshes/box.dae",
+                mesh->Uri());
+          }
+
+          eachCount++;
+          return true;
+        });
+      EXPECT_EQ(2u, eachCount);
+
+      // Check physics system loaded meshes and got their BB correct
+      eachCount = 0;
+      _ecm.Each<components::AxisAlignedBox>(
+        [&](const ignition::gazebo::Entity &,
+            const components::AxisAlignedBox *_box)->bool
+        {
+          auto box = _box->Data();
+          EXPECT_EQ(box, math::AxisAlignedBox(-0.4, -0.4, 0.6, 0.4, 0.4, 1.4));
+          eachCount++;
+          return true;
+        });
+      EXPECT_EQ(1u, eachCount);
+
+      postUpdates++;
+    });
+  server.AddSystem(testSystem.systemPtr);
+
+  EXPECT_FALSE(*server.Running(0));
+
+  EXPECT_TRUE(server.Run(true /*blocking*/, 1, false /*paused*/));
+  EXPECT_EQ(1u, preUpdates);
+  EXPECT_EQ(1u, postUpdates);
+
+  EXPECT_EQ(7u, *server.EntityCount());
+  EXPECT_TRUE(server.HasEntity("scheme_resource_uri"));
+  EXPECT_TRUE(server.HasEntity("the_link"));
+  EXPECT_TRUE(server.HasEntity("the_visual"));
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, GetResourcePaths)
+{
+  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
+      "/tmp/some/path:/home/user/another_path");
+
+  ServerConfig serverConfig;
+  gazebo::Server server(serverConfig);
+
+  EXPECT_FALSE(*server.Running(0));
+
+  transport::Node node;
+  msgs::StringMsg_V res;
+  bool result{false};
+  bool executed{false};
+  int sleep{0};
+  int maxSleep{30};
+  while (!executed && sleep < maxSleep)
+  {
+    igndbg << "Requesting /gazebo/resource_paths/get" << std::endl;
+    executed = node.Request("/gazebo/resource_paths/get", 100, res, result);
+    sleep++;
+  }
+  EXPECT_TRUE(executed);
+  EXPECT_TRUE(result);
+  EXPECT_EQ(2, res.data_size());
+  EXPECT_EQ("/tmp/some/path", res.data(0));
+  EXPECT_EQ("/home/user/another_path", res.data(1));
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, AddResourcePaths)
+{
+  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
+      "/tmp/some/path:/home/user/another_path");
+  ignition::common::setenv("SDF_PATH", "");
+  ignition::common::setenv("IGN_FILE_PATH", "");
+
+  ServerConfig serverConfig;
+  gazebo::Server server(serverConfig);
+
+  EXPECT_FALSE(*server.Running(0));
+
+  transport::Node node;
+
+  // Subscribe to path updates
+  bool receivedMsg{false};
+  auto resourceCb = std::function<void(const msgs::StringMsg_V &)>(
+      [&receivedMsg](const auto &_msg)
+      {
+        receivedMsg = true;
+        EXPECT_EQ(5, _msg.data_size());
+        EXPECT_EQ("/tmp/some/path", _msg.data(0));
+        EXPECT_EQ("/home/user/another_path", _msg.data(1));
+        EXPECT_EQ("/tmp/new_path", _msg.data(2));
+        EXPECT_EQ("/tmp/more", _msg.data(3));
+        EXPECT_EQ("/tmp/even_more", _msg.data(4));
+      });
+  node.Subscribe("/gazebo/resource_paths", resourceCb);
+
+  // Add path
+  msgs::StringMsg_V req;
+  req.add_data("/tmp/new_path");
+  req.add_data("/tmp/more:/tmp/even_more");
+  req.add_data("/tmp/some/path");
+  bool executed = node.Request("/gazebo/resource_paths/add", req);
+  EXPECT_TRUE(executed);
+
+  int sleep{0};
+  int maxSleep{30};
+  while (!receivedMsg && sleep < maxSleep)
+  {
+    IGN_SLEEP_MS(50);
+    sleep++;
+  }
+  EXPECT_TRUE(receivedMsg);
+
+  // Check environment variables
+  for (auto env : {"IGN_GAZEBO_RESOURCE_PATH", "SDF_PATH", "IGN_FILE_PATH"})
+  {
+    char *pathCStr = std::getenv(env);
+
+    auto paths = common::Split(pathCStr, ':');
+    paths.erase(std::remove_if(paths.begin(), paths.end(),
+        [](std::string const &_path)
+        {
+          return _path.empty();
+        }),
+        paths.end());
+
+    EXPECT_EQ(5u, paths.size());
+    EXPECT_EQ("/tmp/some/path", paths[0]);
+    EXPECT_EQ("/home/user/another_path", paths[1]);
+    EXPECT_EQ("/tmp/new_path", paths[2]);
+    EXPECT_EQ("/tmp/more", paths[3]);
+    EXPECT_EQ("/tmp/even_more", paths[4]);
+  }
+}
 
 /////////////////////////////////////////////////
 TEST_P(ServerFixture, ResolveResourcePaths)

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -50,922 +50,991 @@ class ServerFixture : public InternalFixture<::testing::TestWithParam<int>>
 {
 };
 
+///////////////////////////////////////////////////
+//// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
+//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(DefaultServerConfig))
+//{
+//  ignition::gazebo::ServerConfig serverConfig;
+//  EXPECT_TRUE(serverConfig.SdfFile().empty());
+//  EXPECT_TRUE(serverConfig.SdfString().empty());
+//  EXPECT_FALSE(serverConfig.UpdateRate());
+//  EXPECT_FALSE(serverConfig.UseLevels());
+//  EXPECT_FALSE(serverConfig.UseDistributedSimulation());
+//  EXPECT_EQ(0u, serverConfig.NetworkSecondaries());
+//  EXPECT_TRUE(serverConfig.NetworkRole().empty());
+//  EXPECT_FALSE(serverConfig.UseLogRecord());
+//  EXPECT_FALSE(serverConfig.LogRecordPath().empty());
+//  EXPECT_TRUE(serverConfig.LogPlaybackPath().empty());
+//  EXPECT_FALSE(serverConfig.LogRecordResources());
+//  EXPECT_TRUE(serverConfig.LogRecordCompressPath().empty());
+//  EXPECT_EQ(0u, serverConfig.Seed());
+//  EXPECT_EQ(123ms, serverConfig.UpdatePeriod().value_or(123ms));
+//  EXPECT_TRUE(serverConfig.ResourceCache().empty());
+//  EXPECT_TRUE(serverConfig.PhysicsEngine().empty());
+//  EXPECT_TRUE(serverConfig.Plugins().empty());
+//  EXPECT_TRUE(serverConfig.LogRecordTopics().empty());
+//
+//  gazebo::Server server(serverConfig);
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//  EXPECT_EQ(std::nullopt, server.Running(1));
+//  EXPECT_TRUE(*server.Paused());
+//  EXPECT_EQ(0u, *server.IterationCount());
+//
+//  EXPECT_EQ(3u, *server.EntityCount());
+//  EXPECT_TRUE(server.HasEntity("default"));
+//
+//  EXPECT_EQ(3u, *server.SystemCount());
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, UpdateRate)
+//{
+//  gazebo::ServerConfig serverConfig;
+//  serverConfig.SetUpdateRate(1000.0);
+//  EXPECT_DOUBLE_EQ(1000.0, *serverConfig.UpdateRate());
+//  serverConfig.SetUpdateRate(-1000.0);
+//  EXPECT_DOUBLE_EQ(1000.0, *serverConfig.UpdateRate());
+//  serverConfig.SetUpdateRate(0.0);
+//  EXPECT_DOUBLE_EQ(1000.0, *serverConfig.UpdateRate());
+//  EXPECT_EQ(1ms, serverConfig.UpdatePeriod());
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, ServerConfigPluginInfo)
+//{
+//  ServerConfig::PluginInfo pluginInfo;
+//  pluginInfo.SetEntityName("an_entity");
+//  pluginInfo.SetEntityType("model");
+//  pluginInfo.SetFilename("filename");
+//  pluginInfo.SetName("interface");
+//  pluginInfo.SetSdf(nullptr);
+//
+//  ignition::gazebo::ServerConfig serverConfig;
+//  serverConfig.AddPlugin(pluginInfo);
+//
+//  const std::list<ServerConfig::PluginInfo> &plugins = serverConfig.Plugins();
+//  ASSERT_FALSE(plugins.empty());
+//
+//  EXPECT_EQ("an_entity", plugins.front().EntityName());
+//  EXPECT_EQ("model", plugins.front().EntityType());
+//  EXPECT_EQ("filename", plugins.front().Filename());
+//  EXPECT_EQ("interface", plugins.front().Name());
+//  EXPECT_EQ(nullptr, plugins.front().Sdf());
+//
+//  // Test operator=
+//  {
+//    ServerConfig::PluginInfo info;
+//    info = plugins.front();
+//
+//    EXPECT_EQ(info.EntityName(), plugins.front().EntityName());
+//    EXPECT_EQ(info.EntityType(), plugins.front().EntityType());
+//    EXPECT_EQ(info.Filename(), plugins.front().Filename());
+//    EXPECT_EQ(info.Name(), plugins.front().Name());
+//    EXPECT_EQ(info.Sdf(), plugins.front().Sdf());
+//  }
+//
+//  // Test copy constructor
+//  {
+//    ServerConfig::PluginInfo info(plugins.front());
+//
+//    EXPECT_EQ(info.EntityName(), plugins.front().EntityName());
+//    EXPECT_EQ(info.EntityType(), plugins.front().EntityType());
+//    EXPECT_EQ(info.Filename(), plugins.front().Filename());
+//    EXPECT_EQ(info.Name(), plugins.front().Name());
+//    EXPECT_EQ(info.Sdf(), plugins.front().Sdf());
+//  }
+//
+//  // Test server config copy constructor
+//  {
+//    const ServerConfig &cfg(serverConfig);
+//    const std::list<ServerConfig::PluginInfo> &cfgPlugins = cfg.Plugins();
+//    ASSERT_FALSE(cfgPlugins.empty());
+//
+//    EXPECT_EQ(cfgPlugins.front().EntityName(), plugins.front().EntityName());
+//    EXPECT_EQ(cfgPlugins.front().EntityType(), plugins.front().EntityType());
+//    EXPECT_EQ(cfgPlugins.front().Filename(), plugins.front().Filename());
+//    EXPECT_EQ(cfgPlugins.front().Name(), plugins.front().Name());
+//    EXPECT_EQ(cfgPlugins.front().Sdf(), plugins.front().Sdf());
+//  }
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigRealPlugin))
+//{
+//  // Start server
+//  ServerConfig serverConfig;
+//  serverConfig.SetUpdateRate(10000);
+//  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
+//      "/test/worlds/shapes.sdf");
+//
+//  sdf::ElementPtr sdf(new sdf::Element);
+//  sdf->SetName("plugin");
+//  sdf->AddAttribute("name", "string",
+//      "ignition::gazebo::TestModelSystem", true);
+//  sdf->AddAttribute("filename", "string", "libTestModelSystem.so", true);
+//
+//  sdf::ElementPtr child(new sdf::Element);
+//  child->SetParent(sdf);
+//  child->SetName("model_key");
+//  child->AddValue("string", "987", "1");
+//
+//  serverConfig.AddPlugin({"box", "model",
+//      "libTestModelSystem.so", "ignition::gazebo::TestModelSystem", sdf});
+//
+//  gazebo::Server server(serverConfig);
+//
+//  // The simulation runner should not be running.
+//  EXPECT_FALSE(*server.Running(0));
+//
+//  // Run the server
+//  EXPECT_TRUE(server.Run(false, 0, false));
+//  EXPECT_FALSE(*server.Paused());
+//
+//  // The TestModelSystem should have created a service. Call the service to
+//  // make sure the TestModelSystem was successfully loaded.
+//  transport::Node node;
+//  msgs::StringMsg rep;
+//  bool result{false};
+//  bool executed{false};
+//  int sleep{0};
+//  int maxSleep{30};
+//  while (!executed && sleep < maxSleep)
+//  {
+//    igndbg << "Requesting /test/service" << std::endl;
+//    executed = node.Request("/test/service", 100, rep, result);
+//    sleep++;
+//  }
+//  EXPECT_TRUE(executed);
+//  EXPECT_TRUE(result);
+//  EXPECT_EQ("TestModelSystem", rep.data());
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture,
+//       IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigSensorPlugin))
+//{
+//  // Start server
+//  ServerConfig serverConfig;
+//  serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
+//      "test", "worlds", "air_pressure.sdf"));
+//
+//  sdf::ElementPtr sdf(new sdf::Element);
+//  sdf->SetName("plugin");
+//  sdf->AddAttribute("name", "string",
+//      "ignition::gazebo::TestSensorSystem", true);
+//  sdf->AddAttribute("filename", "string", "libTestSensorSystem.so", true);
+//
+//  serverConfig.AddPlugin({
+//      "air_pressure_sensor::air_pressure_model::link::air_pressure_sensor",
+//      "sensor", "libTestSensorSystem.so", "ignition::gazebo::TestSensorSystem",
+//      sdf});
+//
+//  igndbg << "Create server" << std::endl;
+//  gazebo::Server server(serverConfig);
+//
+//  // The simulation runner should not be running.
+//  EXPECT_FALSE(*server.Running(0));
+//  EXPECT_EQ(3u, *server.SystemCount());
+//
+//  // Run the server
+//  igndbg << "Run server" << std::endl;
+//  EXPECT_TRUE(server.Run(false, 0, false));
+//  EXPECT_FALSE(*server.Paused());
+//
+//  // The TestSensorSystem should have created a service. Call the service to
+//  // make sure the TestSensorSystem was successfully loaded.
+//  igndbg << "Request service" << std::endl;
+//  transport::Node node;
+//  msgs::StringMsg rep;
+//  bool result{false};
+//  bool executed{false};
+//  int sleep{0};
+//  int maxSleep{30};
+//  while (!executed && sleep < maxSleep)
+//  {
+//    igndbg << "Requesting /test/service/sensor" << std::endl;
+//    executed = node.Request("/test/service/sensor", 100, rep, result);
+//    sleep++;
+//  }
+//  EXPECT_TRUE(executed);
+//  EXPECT_TRUE(result);
+//  EXPECT_EQ("TestSensorSystem", rep.data());
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(SdfServerConfig))
+//{
+//  ignition::gazebo::ServerConfig serverConfig;
+//
+//  serverConfig.SetSdfString(TestWorldSansPhysics::World());
+//  EXPECT_TRUE(serverConfig.SdfFile().empty());
+//  EXPECT_FALSE(serverConfig.SdfString().empty());
+//
+//  // Setting the SDF file should override the string.
+//  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
+//      "/test/worlds/shapes.sdf");
+//  EXPECT_FALSE(serverConfig.SdfFile().empty());
+//  EXPECT_TRUE(serverConfig.SdfString().empty());
+//
+//  gazebo::Server server(serverConfig);
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//  EXPECT_TRUE(*server.Paused());
+//  EXPECT_EQ(0u, *server.IterationCount());
+//  EXPECT_EQ(24u, *server.EntityCount());
+//  EXPECT_EQ(3u, *server.SystemCount());
+//
+//  EXPECT_TRUE(server.HasEntity("box"));
+//  EXPECT_FALSE(server.HasEntity("box", 1));
+//  EXPECT_TRUE(server.HasEntity("sphere"));
+//  EXPECT_TRUE(server.HasEntity("cylinder"));
+//  EXPECT_TRUE(server.HasEntity("capsule"));
+//  EXPECT_TRUE(server.HasEntity("ellipsoid"));
+//  EXPECT_FALSE(server.HasEntity("bad", 0));
+//  EXPECT_FALSE(server.HasEntity("bad", 1));
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(SdfRootServerConfig))
+//{
+//  ignition::gazebo::ServerConfig serverConfig;
+//
+//  serverConfig.SetSdfString(TestWorldSansPhysics::World());
+//  EXPECT_TRUE(serverConfig.SdfFile().empty());
+//  EXPECT_FALSE(serverConfig.SdfString().empty());
+//
+//  serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
+//      "test", "worlds", "air_pressure.sdf"));
+//  EXPECT_FALSE(serverConfig.SdfFile().empty());
+//  EXPECT_TRUE(serverConfig.SdfString().empty());
+//
+//  sdf::Root root;
+//  root.Load(common::joinPaths(PROJECT_SOURCE_PATH,
+//      "test", "worlds", "shapes.sdf"));
+//
+//  // Setting the SDF Root should override the string and file.
+//  serverConfig.SetSdfRoot(root);
+//
+//  EXPECT_TRUE(serverConfig.SdfRoot());
+//  EXPECT_TRUE(serverConfig.SdfFile().empty());
+//  EXPECT_TRUE(serverConfig.SdfString().empty());
+//
+//  gazebo::Server server(serverConfig);
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//  EXPECT_TRUE(*server.Paused());
+//  EXPECT_EQ(0u, *server.IterationCount());
+//  EXPECT_EQ(24u, *server.EntityCount());
+//  EXPECT_EQ(3u, *server.SystemCount());
+//
+//  EXPECT_TRUE(server.HasEntity("box"));
+//  EXPECT_FALSE(server.HasEntity("box", 1));
+//  EXPECT_TRUE(server.HasEntity("sphere"));
+//  EXPECT_TRUE(server.HasEntity("cylinder"));
+//  EXPECT_TRUE(server.HasEntity("capsule"));
+//  EXPECT_TRUE(server.HasEntity("ellipsoid"));
+//  EXPECT_FALSE(server.HasEntity("bad", 0));
+//  EXPECT_FALSE(server.HasEntity("bad", 1));
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigLogRecord))
+//{
+//  auto logPath = common::joinPaths(
+//      std::string(PROJECT_BINARY_PATH), "test_log_path");
+//  auto logFile = common::joinPaths(logPath, "state.tlog");
+//  auto compressedFile = logPath + ".zip";
+//
+//  igndbg << "Log path [" << logPath << "]" << std::endl;
+//
+//  common::removeAll(logPath);
+//  common::removeAll(compressedFile);
+//  EXPECT_FALSE(common::exists(logFile));
+//  EXPECT_FALSE(common::exists(compressedFile));
+//
+//  {
+//    gazebo::ServerConfig serverConfig;
+//    serverConfig.SetUseLogRecord(true);
+//    serverConfig.SetLogRecordPath(logPath);
+//
+//    gazebo::Server server(serverConfig);
+//
+//    EXPECT_EQ(0u, *server.IterationCount());
+//    EXPECT_EQ(3u, *server.EntityCount());
+//    EXPECT_EQ(4u, *server.SystemCount());
+//
+//    EXPECT_TRUE(serverConfig.LogRecordTopics().empty());
+//    serverConfig.AddLogRecordTopic("test_topic1");
+//    EXPECT_EQ(1u, serverConfig.LogRecordTopics().size());
+//    serverConfig.AddLogRecordTopic("test_topic2");
+//    EXPECT_EQ(2u, serverConfig.LogRecordTopics().size());
+//    serverConfig.ClearLogRecordTopics();
+//    EXPECT_TRUE(serverConfig.LogRecordTopics().empty());
+//  }
+//
+//  EXPECT_TRUE(common::exists(logFile));
+//  EXPECT_FALSE(common::exists(compressedFile));
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture,
+//       IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigLogRecordCompress))
+//{
+//  auto logPath = common::joinPaths(
+//      std::string(PROJECT_BINARY_PATH), "test_log_path");
+//  auto logFile = common::joinPaths(logPath, "state.tlog");
+//  auto compressedFile = logPath + ".zip";
+//
+//  igndbg << "Log path [" << logPath << "]" << std::endl;
+//
+//  common::removeAll(logPath);
+//  common::removeAll(compressedFile);
+//  EXPECT_FALSE(common::exists(logFile));
+//  EXPECT_FALSE(common::exists(compressedFile));
+//
+//  {
+//    gazebo::ServerConfig serverConfig;
+//    serverConfig.SetUseLogRecord(true);
+//    serverConfig.SetLogRecordPath(logPath);
+//    serverConfig.SetLogRecordCompressPath(compressedFile);
+//
+//    gazebo::Server server(serverConfig);
+//    EXPECT_EQ(0u, *server.IterationCount());
+//    EXPECT_EQ(3u, *server.EntityCount());
+//    EXPECT_EQ(4u, *server.SystemCount());
+//  }
+//
+//  EXPECT_FALSE(common::exists(logFile));
+//  EXPECT_TRUE(common::exists(compressedFile));
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, SdfStringServerConfig)
+//{
+//  ignition::gazebo::ServerConfig serverConfig;
+//
+//  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
+//      "/test/worlds/shapes.sdf");
+//  EXPECT_FALSE(serverConfig.SdfFile().empty());
+//  EXPECT_TRUE(serverConfig.SdfString().empty());
+//
+//  // Setting the string should override the file.
+//  serverConfig.SetSdfString(TestWorldSansPhysics::World());
+//  EXPECT_TRUE(serverConfig.SdfFile().empty());
+//  EXPECT_FALSE(serverConfig.SdfString().empty());
+//
+//  gazebo::Server server(serverConfig);
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//  EXPECT_TRUE(*server.Paused());
+//  EXPECT_EQ(0u, *server.IterationCount());
+//  EXPECT_EQ(3u, *server.EntityCount());
+//  EXPECT_EQ(2u, *server.SystemCount());
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, RunBlocking)
+//{
+//  gazebo::Server server;
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//  EXPECT_TRUE(*server.Paused());
+//  EXPECT_EQ(0u, server.IterationCount());
+//
+//  // Make the server run fast.
+//  server.SetUpdatePeriod(1ns);
+//
+//  uint64_t expectedIters = 0;
+//  for (uint64_t i = 1; i < 10; ++i)
+//  {
+//    EXPECT_FALSE(server.Running());
+//    EXPECT_FALSE(*server.Running(0));
+//    server.Run(true, i, false);
+//    EXPECT_FALSE(server.Running());
+//    EXPECT_FALSE(*server.Running(0));
+//
+//    expectedIters += i;
+//    EXPECT_EQ(expectedIters, *server.IterationCount());
+//  }
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, RunNonBlockingPaused)
+//{
+//  gazebo::Server server;
+//
+//  // The server should not be running.
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//
+//  // The simulation runner should not be running.
+//  EXPECT_FALSE(*server.Running(0));
+//
+//  // Invalid world index.
+//  EXPECT_EQ(std::nullopt, server.Running(1));
+//
+//  EXPECT_TRUE(*server.Paused());
+//  EXPECT_EQ(0u, *server.IterationCount());
+//
+//  // Make the server run fast.
+//  server.SetUpdatePeriod(1ns);
+//
+//  EXPECT_TRUE(server.Run(false, 100, true));
+//  EXPECT_TRUE(*server.Paused());
+//
+//  EXPECT_TRUE(server.Running());
+//
+//  // Add a small sleep because the non-blocking Run call causes the
+//  // simulation runner to start asynchronously.
+//  IGN_SLEEP_MS(500);
+//  EXPECT_TRUE(*server.Running(0));
+//
+//  EXPECT_EQ(0u, server.IterationCount());
+//
+//  // Attempt to unpause an invalid world
+//  EXPECT_FALSE(server.SetPaused(false, 1));
+//
+//  // Unpause the existing world
+//  EXPECT_TRUE(server.SetPaused(false, 0));
+//
+//  EXPECT_FALSE(*server.Paused());
+//  EXPECT_TRUE(server.Running());
+//
+//  while (*server.IterationCount() < 100)
+//    IGN_SLEEP_MS(100);
+//
+//  EXPECT_EQ(100u, *server.IterationCount());
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, RunNonBlocking)
+//{
+//  gazebo::Server server;
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//  EXPECT_EQ(0u, *server.IterationCount());
+//
+//  // Make the server run fast.
+//  server.SetUpdatePeriod(1ns);
+//
+//  server.Run(false, 100, false);
+//  while (*server.IterationCount() < 100)
+//    IGN_SLEEP_MS(100);
+//
+//  EXPECT_EQ(100u, *server.IterationCount());
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(RunOnceUnpaused))
+//{
+//  gazebo::Server server;
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//  EXPECT_EQ(0u, *server.IterationCount());
+//
+//  // Load a system
+//  gazebo::SystemLoader systemLoader;
+//  auto mockSystemPlugin = systemLoader.LoadPlugin(
+//      "libMockSystem.so", "ignition::gazebo::MockSystem", nullptr);
+//  ASSERT_TRUE(mockSystemPlugin.has_value());
+//
+//  // Check that it was loaded
+//  const size_t systemCount = *server.SystemCount();
+//  EXPECT_TRUE(*server.AddSystem(mockSystemPlugin.value()));
+//  EXPECT_EQ(systemCount + 1, *server.SystemCount());
+//
+//  // Query the interface from the plugin
+//  auto system = mockSystemPlugin.value()->QueryInterface<gazebo::System>();
+//  EXPECT_NE(system, nullptr);
+//  auto mockSystem = dynamic_cast<gazebo::MockSystem*>(system);
+//  EXPECT_NE(mockSystem, nullptr);
+//
+//  // No steps should have been executed
+//  EXPECT_EQ(0u, mockSystem->preUpdateCallCount);
+//  EXPECT_EQ(0u, mockSystem->updateCallCount);
+//  EXPECT_EQ(0u, mockSystem->postUpdateCallCount);
+//
+//  // Make the server run fast
+//  server.SetUpdatePeriod(1ns);
+//
+//  while (*server.IterationCount() < 100)
+//    server.RunOnce(false);
+//
+//  // Check that the server provides the correct information
+//  EXPECT_EQ(*server.IterationCount(), 100u);
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//
+//  // Check that the system has been called correctly
+//  EXPECT_EQ(100u, mockSystem->preUpdateCallCount);
+//  EXPECT_EQ(100u, mockSystem->updateCallCount);
+//  EXPECT_EQ(100u, mockSystem->postUpdateCallCount);
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(RunOncePaused))
+//{
+//  gazebo::Server server;
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//  EXPECT_EQ(0u, *server.IterationCount());
+//
+//  // Load a system
+//  gazebo::SystemLoader systemLoader;
+//  auto mockSystemPlugin = systemLoader.LoadPlugin(
+//      "libMockSystem.so", "ignition::gazebo::MockSystem", nullptr);
+//  ASSERT_TRUE(mockSystemPlugin.has_value());
+//
+//  // Check that it was loaded
+//  const size_t systemCount = *server.SystemCount();
+//  EXPECT_TRUE(*server.AddSystem(mockSystemPlugin.value()));
+//  EXPECT_EQ(systemCount + 1, *server.SystemCount());
+//
+//  // Query the interface from the plugin
+//  auto system = mockSystemPlugin.value()->QueryInterface<gazebo::System>();
+//  EXPECT_NE(system, nullptr);
+//  auto mockSystem = dynamic_cast<gazebo::MockSystem*>(system);
+//  EXPECT_NE(mockSystem, nullptr);
+//
+//  // No steps should have been executed
+//  EXPECT_EQ(0u, mockSystem->preUpdateCallCount);
+//  EXPECT_EQ(0u, mockSystem->updateCallCount);
+//  EXPECT_EQ(0u, mockSystem->postUpdateCallCount);
+//
+//  // Make the server run fast
+//  server.SetUpdatePeriod(1ns);
+//
+//  while (*server.IterationCount() < 100)
+//    server.RunOnce(true);
+//
+//  // Check that the server provides the correct information
+//  EXPECT_EQ(*server.IterationCount(), 100u);
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//
+//  // Check that the system has been called correctly
+//  EXPECT_EQ(100u, mockSystem->preUpdateCallCount);
+//  EXPECT_EQ(100u, mockSystem->updateCallCount);
+//  EXPECT_EQ(100u, mockSystem->postUpdateCallCount);
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, RunNonBlockingMultiple)
+//{
+//  ignition::gazebo::ServerConfig serverConfig;
+//  serverConfig.SetSdfString(TestWorldSansPhysics::World());
+//  gazebo::Server server(serverConfig);
+//
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//  EXPECT_EQ(0u, *server.IterationCount());
+//
+//  EXPECT_TRUE(server.Run(false, 100, false));
+//  EXPECT_FALSE(server.Run(false, 100, false));
+//
+//  while (*server.IterationCount() < 100)
+//    IGN_SLEEP_MS(100);
+//
+//  EXPECT_EQ(100u, *server.IterationCount());
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, SigInt)
+//{
+//  gazebo::Server server;
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//
+//  // Run forever, non-blocking.
+//  server.Run(false, 0, false);
+//
+//  IGN_SLEEP_MS(500);
+//
+//  EXPECT_TRUE(server.Running());
+//  EXPECT_TRUE(*server.Running(0));
+//
+//  std::raise(SIGTERM);
+//
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, ServerControlStop)
+//{
+//  // Test that the server correctly reacts to requests on /server_control
+//  // service with `stop` set to either false or true.
+//
+//  gazebo::Server server;
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//
+//  // Run forever, non-blocking.
+//  server.Run(false, 0, false);
+//
+//  IGN_SLEEP_MS(500);
+//
+//  EXPECT_TRUE(server.Running());
+//  EXPECT_TRUE(*server.Running(0));
+//
+//  transport::Node node;
+//  msgs::ServerControl req;
+//  msgs::Boolean res;
+//  bool result{false};
+//  bool executed{false};
+//  int sleep{0};
+//  int maxSleep{30};
+//
+//  // first, call with stop = false; the server should keep running
+//  while (!executed && sleep < maxSleep)
+//  {
+//    igndbg << "Requesting /server_control" << std::endl;
+//    executed = node.Request("/server_control", req, 100, res, result);
+//    sleep++;
+//  }
+//  EXPECT_TRUE(executed);
+//  EXPECT_TRUE(result);
+//  EXPECT_FALSE(res.data());
+//
+//  IGN_SLEEP_MS(500);
+//
+//  EXPECT_TRUE(server.Running());
+//  EXPECT_TRUE(*server.Running(0));
+//
+//  // now call with stop = true; the server should stop
+//  req.set_stop(true);
+//
+//  igndbg << "Requesting /server_control" << std::endl;
+//  executed = node.Request("/server_control", req, 100, res, result);
+//
+//  EXPECT_TRUE(executed);
+//  EXPECT_TRUE(result);
+//  EXPECT_TRUE(res.data());
+//
+//  IGN_SLEEP_MS(500);
+//
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(AddSystemWhileRunning))
+//{
+//  ignition::gazebo::ServerConfig serverConfig;
+//
+//  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
+//      "/test/worlds/shapes.sdf");
+//
+//  gazebo::Server server(serverConfig);
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//  server.SetUpdatePeriod(1us);
+//
+//  // Run the server to test whether we can add systems while system is running
+//  server.Run(false, 0, false);
+//
+//  IGN_SLEEP_MS(500);
+//
+//  EXPECT_TRUE(server.Running());
+//  EXPECT_TRUE(*server.Running(0));
+//
+//  EXPECT_EQ(3u, *server.SystemCount());
+//
+//  // Add system from plugin
+//  gazebo::SystemLoader systemLoader;
+//  auto mockSystemPlugin = systemLoader.LoadPlugin("libMockSystem.so",
+//      "ignition::gazebo::MockSystem", nullptr);
+//  ASSERT_TRUE(mockSystemPlugin.has_value());
+//
+//  auto result = server.AddSystem(mockSystemPlugin.value());
+//  ASSERT_TRUE(result.has_value());
+//  EXPECT_FALSE(result.value());
+//  EXPECT_EQ(3u, *server.SystemCount());
+//
+//  // Add system pointer
+//  auto mockSystem = std::make_shared<MockSystem>();
+//  result = server.AddSystem(mockSystem);
+//  ASSERT_TRUE(result.has_value());
+//  EXPECT_FALSE(result.value());
+//  EXPECT_EQ(3u, *server.SystemCount());
+//
+//  // Stop the server
+//  std::raise(SIGTERM);
+//
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(AddSystemAfterLoad))
+//{
+//  ignition::gazebo::ServerConfig serverConfig;
+//
+//  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
+//      "/test/worlds/shapes.sdf");
+//
+//  gazebo::Server server(serverConfig);
+//  EXPECT_FALSE(server.Running());
+//  EXPECT_FALSE(*server.Running(0));
+//
+//  // Add system from plugin
+//  gazebo::SystemLoader systemLoader;
+//  auto mockSystemPlugin = systemLoader.LoadPlugin("libMockSystem.so",
+//      "ignition::gazebo::MockSystem", nullptr);
+//  ASSERT_TRUE(mockSystemPlugin.has_value());
+//
+//  auto system = mockSystemPlugin.value()->QueryInterface<gazebo::System>();
+//  EXPECT_NE(system, nullptr);
+//  auto mockSystem = dynamic_cast<gazebo::MockSystem*>(system);
+//  ASSERT_NE(mockSystem, nullptr);
+//
+//  EXPECT_EQ(3u, *server.SystemCount());
+//  EXPECT_EQ(0u, mockSystem->configureCallCount);
+//
+//  EXPECT_TRUE(*server.AddSystem(mockSystemPlugin.value()));
+//
+//  EXPECT_EQ(4u, *server.SystemCount());
+//  EXPECT_EQ(1u, mockSystem->configureCallCount);
+//
+//  // Add system pointer
+//  auto mockSystemLocal = std::make_shared<MockSystem>();
+//  EXPECT_EQ(0u, mockSystemLocal->configureCallCount);
+//
+//  EXPECT_TRUE(server.AddSystem(mockSystemLocal));
+//  EXPECT_EQ(5u, *server.SystemCount());
+//  EXPECT_EQ(1u, mockSystemLocal->configureCallCount);
+//
+//  // Check that update callbacks are called
+//  server.SetUpdatePeriod(1us);
+//  EXPECT_EQ(0u, mockSystem->preUpdateCallCount);
+//  EXPECT_EQ(0u, mockSystem->updateCallCount);
+//  EXPECT_EQ(0u, mockSystem->postUpdateCallCount);
+//  EXPECT_EQ(0u, mockSystemLocal->preUpdateCallCount);
+//  EXPECT_EQ(0u, mockSystemLocal->updateCallCount);
+//  EXPECT_EQ(0u, mockSystemLocal->postUpdateCallCount);
+//  server.Run(true, 1, false);
+//  EXPECT_EQ(1u, mockSystem->preUpdateCallCount);
+//  EXPECT_EQ(1u, mockSystem->updateCallCount);
+//  EXPECT_EQ(1u, mockSystem->postUpdateCallCount);
+//  EXPECT_EQ(1u, mockSystemLocal->preUpdateCallCount);
+//  EXPECT_EQ(1u, mockSystemLocal->updateCallCount);
+//  EXPECT_EQ(1u, mockSystemLocal->postUpdateCallCount);
+//
+//  // Add to inexistent world
+//  auto result = server.AddSystem(mockSystemPlugin.value(), 100);
+//  EXPECT_FALSE(result.has_value());
+//
+//  result = server.AddSystem(mockSystemLocal, 100);
+//  EXPECT_FALSE(result.has_value());
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, Seed)
+//{
+//  ignition::gazebo::ServerConfig serverConfig;
+//  EXPECT_EQ(0u, serverConfig.Seed());
+//  unsigned int mySeed = 12345u;
+//  serverConfig.SetSeed(mySeed);
+//  EXPECT_EQ(mySeed, serverConfig.Seed());
+//  EXPECT_EQ(mySeed, ignition::math::Rand::Seed());
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ResourcePath))
+//{
+//  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
+//         (std::string(PROJECT_SOURCE_PATH) + "/test/worlds:" +
+//          std::string(PROJECT_SOURCE_PATH) + "/test/worlds/models").c_str());
+//
+//  ServerConfig serverConfig;
+//  serverConfig.SetSdfFile("resource_paths.sdf");
+//  gazebo::Server server(serverConfig);
+//
+//  test::Relay testSystem;
+//  unsigned int preUpdates{0};
+//  testSystem.OnPreUpdate(
+//    [&preUpdates](const gazebo::UpdateInfo &,
+//    gazebo::EntityComponentManager &_ecm)
+//    {
+//      // Create AABB so it is populated
+//      unsigned int eachCount{0};
+//      _ecm.Each<components::Model>(
+//        [&](const Entity &_entity, components::Model *) -> bool
+//        {
+//          auto bboxComp = _ecm.Component<components::AxisAlignedBox>(_entity);
+//          EXPECT_EQ(bboxComp, nullptr);
+//          _ecm.CreateComponent(_entity, components::AxisAlignedBox());
+//          eachCount++;
+//          return true;
+//        });
+//      EXPECT_EQ(1u, eachCount);
+//      preUpdates++;
+//    });
+//
+//  unsigned int postUpdates{0};
+//  testSystem.OnPostUpdate([&postUpdates](const gazebo::UpdateInfo &,
+//    const gazebo::EntityComponentManager &_ecm)
+//    {
+//      // Check geometry components
+//      unsigned int eachCount{0};
+//      _ecm.Each<components::Geometry>(
+//        [&eachCount](const Entity &, const components::Geometry *_geom)
+//        -> bool
+//        {
+//          auto mesh = _geom->Data().MeshShape();
+//
+//          // ASSERT would fail at compile with
+//          // "void value not ignored as it ought to be"
+//          EXPECT_NE(nullptr, mesh);
+//
+//          if (mesh)
+//          {
+//            EXPECT_EQ("model://scheme_resource_uri/meshes/box.dae",
+//                mesh->Uri());
+//          }
+//
+//          eachCount++;
+//          return true;
+//        });
+//      EXPECT_EQ(2u, eachCount);
+//
+//      // Check physics system loaded meshes and got their BB correct
+//      eachCount = 0;
+//      _ecm.Each<components::AxisAlignedBox>(
+//        [&](const ignition::gazebo::Entity &,
+//            const components::AxisAlignedBox *_box)->bool
+//        {
+//          auto box = _box->Data();
+//          EXPECT_EQ(box, math::AxisAlignedBox(-0.4, -0.4, 0.6, 0.4, 0.4, 1.4));
+//          eachCount++;
+//          return true;
+//        });
+//      EXPECT_EQ(1u, eachCount);
+//
+//      postUpdates++;
+//    });
+//  server.AddSystem(testSystem.systemPtr);
+//
+//  EXPECT_FALSE(*server.Running(0));
+//
+//  EXPECT_TRUE(server.Run(true /*blocking*/, 1, false /*paused*/));
+//  EXPECT_EQ(1u, preUpdates);
+//  EXPECT_EQ(1u, postUpdates);
+//
+//  EXPECT_EQ(7u, *server.EntityCount());
+//  EXPECT_TRUE(server.HasEntity("scheme_resource_uri"));
+//  EXPECT_TRUE(server.HasEntity("the_link"));
+//  EXPECT_TRUE(server.HasEntity("the_visual"));
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, GetResourcePaths)
+//{
+//  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
+//      "/tmp/some/path:/home/user/another_path");
+//
+//  ServerConfig serverConfig;
+//  gazebo::Server server(serverConfig);
+//
+//  EXPECT_FALSE(*server.Running(0));
+//
+//  transport::Node node;
+//  msgs::StringMsg_V res;
+//  bool result{false};
+//  bool executed{false};
+//  int sleep{0};
+//  int maxSleep{30};
+//  while (!executed && sleep < maxSleep)
+//  {
+//    igndbg << "Requesting /gazebo/resource_paths/get" << std::endl;
+//    executed = node.Request("/gazebo/resource_paths/get", 100, res, result);
+//    sleep++;
+//  }
+//  EXPECT_TRUE(executed);
+//  EXPECT_TRUE(result);
+//  EXPECT_EQ(2, res.data_size());
+//  EXPECT_EQ("/tmp/some/path", res.data(0));
+//  EXPECT_EQ("/home/user/another_path", res.data(1));
+//}
+//
+///////////////////////////////////////////////////
+//TEST_P(ServerFixture, AddResourcePaths)
+//{
+//  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
+//      "/tmp/some/path:/home/user/another_path");
+//  ignition::common::setenv("SDF_PATH", "");
+//  ignition::common::setenv("IGN_FILE_PATH", "");
+//
+//  ServerConfig serverConfig;
+//  gazebo::Server server(serverConfig);
+//
+//  EXPECT_FALSE(*server.Running(0));
+//
+//  transport::Node node;
+//
+//  // Subscribe to path updates
+//  bool receivedMsg{false};
+//  auto resourceCb = std::function<void(const msgs::StringMsg_V &)>(
+//      [&receivedMsg](const auto &_msg)
+//      {
+//        receivedMsg = true;
+//        EXPECT_EQ(5, _msg.data_size());
+//        EXPECT_EQ("/tmp/some/path", _msg.data(0));
+//        EXPECT_EQ("/home/user/another_path", _msg.data(1));
+//        EXPECT_EQ("/tmp/new_path", _msg.data(2));
+//        EXPECT_EQ("/tmp/more", _msg.data(3));
+//        EXPECT_EQ("/tmp/even_more", _msg.data(4));
+//      });
+//  node.Subscribe("/gazebo/resource_paths", resourceCb);
+//
+//  // Add path
+//  msgs::StringMsg_V req;
+//  req.add_data("/tmp/new_path");
+//  req.add_data("/tmp/more:/tmp/even_more");
+//  req.add_data("/tmp/some/path");
+//  bool executed = node.Request("/gazebo/resource_paths/add", req);
+//  EXPECT_TRUE(executed);
+//
+//  int sleep{0};
+//  int maxSleep{30};
+//  while (!receivedMsg && sleep < maxSleep)
+//  {
+//    IGN_SLEEP_MS(50);
+//    sleep++;
+//  }
+//  EXPECT_TRUE(receivedMsg);
+//
+//  // Check environment variables
+//  for (auto env : {"IGN_GAZEBO_RESOURCE_PATH", "SDF_PATH", "IGN_FILE_PATH"})
+//  {
+//    char *pathCStr = std::getenv(env);
+//
+//    auto paths = common::Split(pathCStr, ':');
+//    paths.erase(std::remove_if(paths.begin(), paths.end(),
+//        [](std::string const &_path)
+//        {
+//          return _path.empty();
+//        }),
+//        paths.end());
+//
+//    EXPECT_EQ(5u, paths.size());
+//    EXPECT_EQ("/tmp/some/path", paths[0]);
+//    EXPECT_EQ("/home/user/another_path", paths[1]);
+//    EXPECT_EQ("/tmp/new_path", paths[2]);
+//    EXPECT_EQ("/tmp/more", paths[3]);
+//    EXPECT_EQ("/tmp/even_more", paths[4]);
+//  }
+//}
+
 /////////////////////////////////////////////////
-// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
-TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(DefaultServerConfig))
-{
-  ignition::gazebo::ServerConfig serverConfig;
-  EXPECT_TRUE(serverConfig.SdfFile().empty());
-  EXPECT_TRUE(serverConfig.SdfString().empty());
-  EXPECT_FALSE(serverConfig.UpdateRate());
-  EXPECT_FALSE(serverConfig.UseLevels());
-  EXPECT_FALSE(serverConfig.UseDistributedSimulation());
-  EXPECT_EQ(0u, serverConfig.NetworkSecondaries());
-  EXPECT_TRUE(serverConfig.NetworkRole().empty());
-  EXPECT_FALSE(serverConfig.UseLogRecord());
-  EXPECT_FALSE(serverConfig.LogRecordPath().empty());
-  EXPECT_TRUE(serverConfig.LogPlaybackPath().empty());
-  EXPECT_FALSE(serverConfig.LogRecordResources());
-  EXPECT_TRUE(serverConfig.LogRecordCompressPath().empty());
-  EXPECT_EQ(0u, serverConfig.Seed());
-  EXPECT_EQ(123ms, serverConfig.UpdatePeriod().value_or(123ms));
-  EXPECT_TRUE(serverConfig.ResourceCache().empty());
-  EXPECT_TRUE(serverConfig.PhysicsEngine().empty());
-  EXPECT_TRUE(serverConfig.Plugins().empty());
-  EXPECT_TRUE(serverConfig.LogRecordTopics().empty());
-
-  gazebo::Server server(serverConfig);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-  EXPECT_EQ(std::nullopt, server.Running(1));
-  EXPECT_TRUE(*server.Paused());
-  EXPECT_EQ(0u, *server.IterationCount());
-
-  EXPECT_EQ(3u, *server.EntityCount());
-  EXPECT_TRUE(server.HasEntity("default"));
-
-  EXPECT_EQ(3u, *server.SystemCount());
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, UpdateRate)
-{
-  gazebo::ServerConfig serverConfig;
-  serverConfig.SetUpdateRate(1000.0);
-  EXPECT_DOUBLE_EQ(1000.0, *serverConfig.UpdateRate());
-  serverConfig.SetUpdateRate(-1000.0);
-  EXPECT_DOUBLE_EQ(1000.0, *serverConfig.UpdateRate());
-  serverConfig.SetUpdateRate(0.0);
-  EXPECT_DOUBLE_EQ(1000.0, *serverConfig.UpdateRate());
-  EXPECT_EQ(1ms, serverConfig.UpdatePeriod());
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, ServerConfigPluginInfo)
-{
-  ServerConfig::PluginInfo pluginInfo;
-  pluginInfo.SetEntityName("an_entity");
-  pluginInfo.SetEntityType("model");
-  pluginInfo.SetFilename("filename");
-  pluginInfo.SetName("interface");
-  pluginInfo.SetSdf(nullptr);
-
-  ignition::gazebo::ServerConfig serverConfig;
-  serverConfig.AddPlugin(pluginInfo);
-
-  const std::list<ServerConfig::PluginInfo> &plugins = serverConfig.Plugins();
-  ASSERT_FALSE(plugins.empty());
-
-  EXPECT_EQ("an_entity", plugins.front().EntityName());
-  EXPECT_EQ("model", plugins.front().EntityType());
-  EXPECT_EQ("filename", plugins.front().Filename());
-  EXPECT_EQ("interface", plugins.front().Name());
-  EXPECT_EQ(nullptr, plugins.front().Sdf());
-
-  // Test operator=
-  {
-    ServerConfig::PluginInfo info;
-    info = plugins.front();
-
-    EXPECT_EQ(info.EntityName(), plugins.front().EntityName());
-    EXPECT_EQ(info.EntityType(), plugins.front().EntityType());
-    EXPECT_EQ(info.Filename(), plugins.front().Filename());
-    EXPECT_EQ(info.Name(), plugins.front().Name());
-    EXPECT_EQ(info.Sdf(), plugins.front().Sdf());
-  }
-
-  // Test copy constructor
-  {
-    ServerConfig::PluginInfo info(plugins.front());
-
-    EXPECT_EQ(info.EntityName(), plugins.front().EntityName());
-    EXPECT_EQ(info.EntityType(), plugins.front().EntityType());
-    EXPECT_EQ(info.Filename(), plugins.front().Filename());
-    EXPECT_EQ(info.Name(), plugins.front().Name());
-    EXPECT_EQ(info.Sdf(), plugins.front().Sdf());
-  }
-
-  // Test server config copy constructor
-  {
-    const ServerConfig &cfg(serverConfig);
-    const std::list<ServerConfig::PluginInfo> &cfgPlugins = cfg.Plugins();
-    ASSERT_FALSE(cfgPlugins.empty());
-
-    EXPECT_EQ(cfgPlugins.front().EntityName(), plugins.front().EntityName());
-    EXPECT_EQ(cfgPlugins.front().EntityType(), plugins.front().EntityType());
-    EXPECT_EQ(cfgPlugins.front().Filename(), plugins.front().Filename());
-    EXPECT_EQ(cfgPlugins.front().Name(), plugins.front().Name());
-    EXPECT_EQ(cfgPlugins.front().Sdf(), plugins.front().Sdf());
-  }
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigRealPlugin))
-{
-  // Start server
-  ServerConfig serverConfig;
-  serverConfig.SetUpdateRate(10000);
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/shapes.sdf");
-
-  sdf::ElementPtr sdf(new sdf::Element);
-  sdf->SetName("plugin");
-  sdf->AddAttribute("name", "string",
-      "ignition::gazebo::TestModelSystem", true);
-  sdf->AddAttribute("filename", "string", "libTestModelSystem.so", true);
-
-  sdf::ElementPtr child(new sdf::Element);
-  child->SetParent(sdf);
-  child->SetName("model_key");
-  child->AddValue("string", "987", "1");
-
-  serverConfig.AddPlugin({"box", "model",
-      "libTestModelSystem.so", "ignition::gazebo::TestModelSystem", sdf});
-
-  gazebo::Server server(serverConfig);
-
-  // The simulation runner should not be running.
-  EXPECT_FALSE(*server.Running(0));
-
-  // Run the server
-  EXPECT_TRUE(server.Run(false, 0, false));
-  EXPECT_FALSE(*server.Paused());
-
-  // The TestModelSystem should have created a service. Call the service to
-  // make sure the TestModelSystem was successfully loaded.
-  transport::Node node;
-  msgs::StringMsg rep;
-  bool result{false};
-  bool executed{false};
-  int sleep{0};
-  int maxSleep{30};
-  while (!executed && sleep < maxSleep)
-  {
-    igndbg << "Requesting /test/service" << std::endl;
-    executed = node.Request("/test/service", 100, rep, result);
-    sleep++;
-  }
-  EXPECT_TRUE(executed);
-  EXPECT_TRUE(result);
-  EXPECT_EQ("TestModelSystem", rep.data());
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture,
-       IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigSensorPlugin))
-{
-  // Start server
-  ServerConfig serverConfig;
-  serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
-      "test", "worlds", "air_pressure.sdf"));
-
-  sdf::ElementPtr sdf(new sdf::Element);
-  sdf->SetName("plugin");
-  sdf->AddAttribute("name", "string",
-      "ignition::gazebo::TestSensorSystem", true);
-  sdf->AddAttribute("filename", "string", "libTestSensorSystem.so", true);
-
-  serverConfig.AddPlugin({
-      "air_pressure_sensor::air_pressure_model::link::air_pressure_sensor",
-      "sensor", "libTestSensorSystem.so", "ignition::gazebo::TestSensorSystem",
-      sdf});
-
-  igndbg << "Create server" << std::endl;
-  gazebo::Server server(serverConfig);
-
-  // The simulation runner should not be running.
-  EXPECT_FALSE(*server.Running(0));
-  EXPECT_EQ(3u, *server.SystemCount());
-
-  // Run the server
-  igndbg << "Run server" << std::endl;
-  EXPECT_TRUE(server.Run(false, 0, false));
-  EXPECT_FALSE(*server.Paused());
-
-  // The TestSensorSystem should have created a service. Call the service to
-  // make sure the TestSensorSystem was successfully loaded.
-  igndbg << "Request service" << std::endl;
-  transport::Node node;
-  msgs::StringMsg rep;
-  bool result{false};
-  bool executed{false};
-  int sleep{0};
-  int maxSleep{30};
-  while (!executed && sleep < maxSleep)
-  {
-    igndbg << "Requesting /test/service/sensor" << std::endl;
-    executed = node.Request("/test/service/sensor", 100, rep, result);
-    sleep++;
-  }
-  EXPECT_TRUE(executed);
-  EXPECT_TRUE(result);
-  EXPECT_EQ("TestSensorSystem", rep.data());
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(SdfServerConfig))
-{
-  ignition::gazebo::ServerConfig serverConfig;
-
-  serverConfig.SetSdfString(TestWorldSansPhysics::World());
-  EXPECT_TRUE(serverConfig.SdfFile().empty());
-  EXPECT_FALSE(serverConfig.SdfString().empty());
-
-  // Setting the SDF file should override the string.
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/shapes.sdf");
-  EXPECT_FALSE(serverConfig.SdfFile().empty());
-  EXPECT_TRUE(serverConfig.SdfString().empty());
-
-  gazebo::Server server(serverConfig);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-  EXPECT_TRUE(*server.Paused());
-  EXPECT_EQ(0u, *server.IterationCount());
-  EXPECT_EQ(24u, *server.EntityCount());
-  EXPECT_EQ(3u, *server.SystemCount());
-
-  EXPECT_TRUE(server.HasEntity("box"));
-  EXPECT_FALSE(server.HasEntity("box", 1));
-  EXPECT_TRUE(server.HasEntity("sphere"));
-  EXPECT_TRUE(server.HasEntity("cylinder"));
-  EXPECT_TRUE(server.HasEntity("capsule"));
-  EXPECT_TRUE(server.HasEntity("ellipsoid"));
-  EXPECT_FALSE(server.HasEntity("bad", 0));
-  EXPECT_FALSE(server.HasEntity("bad", 1));
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(SdfRootServerConfig))
-{
-  ignition::gazebo::ServerConfig serverConfig;
-
-  serverConfig.SetSdfString(TestWorldSansPhysics::World());
-  EXPECT_TRUE(serverConfig.SdfFile().empty());
-  EXPECT_FALSE(serverConfig.SdfString().empty());
-
-  serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
-      "test", "worlds", "air_pressure.sdf"));
-  EXPECT_FALSE(serverConfig.SdfFile().empty());
-  EXPECT_TRUE(serverConfig.SdfString().empty());
-
-  sdf::Root root;
-  root.Load(common::joinPaths(PROJECT_SOURCE_PATH,
-      "test", "worlds", "shapes.sdf"));
-
-  // Setting the SDF Root should override the string and file.
-  serverConfig.SetSdfRoot(root);
-
-  EXPECT_TRUE(serverConfig.SdfRoot());
-  EXPECT_TRUE(serverConfig.SdfFile().empty());
-  EXPECT_TRUE(serverConfig.SdfString().empty());
-
-  gazebo::Server server(serverConfig);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-  EXPECT_TRUE(*server.Paused());
-  EXPECT_EQ(0u, *server.IterationCount());
-  EXPECT_EQ(24u, *server.EntityCount());
-  EXPECT_EQ(3u, *server.SystemCount());
-
-  EXPECT_TRUE(server.HasEntity("box"));
-  EXPECT_FALSE(server.HasEntity("box", 1));
-  EXPECT_TRUE(server.HasEntity("sphere"));
-  EXPECT_TRUE(server.HasEntity("cylinder"));
-  EXPECT_TRUE(server.HasEntity("capsule"));
-  EXPECT_TRUE(server.HasEntity("ellipsoid"));
-  EXPECT_FALSE(server.HasEntity("bad", 0));
-  EXPECT_FALSE(server.HasEntity("bad", 1));
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigLogRecord))
-{
-  auto logPath = common::joinPaths(
-      std::string(PROJECT_BINARY_PATH), "test_log_path");
-  auto logFile = common::joinPaths(logPath, "state.tlog");
-  auto compressedFile = logPath + ".zip";
-
-  igndbg << "Log path [" << logPath << "]" << std::endl;
-
-  common::removeAll(logPath);
-  common::removeAll(compressedFile);
-  EXPECT_FALSE(common::exists(logFile));
-  EXPECT_FALSE(common::exists(compressedFile));
-
-  {
-    gazebo::ServerConfig serverConfig;
-    serverConfig.SetUseLogRecord(true);
-    serverConfig.SetLogRecordPath(logPath);
-
-    gazebo::Server server(serverConfig);
-
-    EXPECT_EQ(0u, *server.IterationCount());
-    EXPECT_EQ(3u, *server.EntityCount());
-    EXPECT_EQ(4u, *server.SystemCount());
-
-    EXPECT_TRUE(serverConfig.LogRecordTopics().empty());
-    serverConfig.AddLogRecordTopic("test_topic1");
-    EXPECT_EQ(1u, serverConfig.LogRecordTopics().size());
-    serverConfig.AddLogRecordTopic("test_topic2");
-    EXPECT_EQ(2u, serverConfig.LogRecordTopics().size());
-    serverConfig.ClearLogRecordTopics();
-    EXPECT_TRUE(serverConfig.LogRecordTopics().empty());
-  }
-
-  EXPECT_TRUE(common::exists(logFile));
-  EXPECT_FALSE(common::exists(compressedFile));
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture,
-       IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigLogRecordCompress))
-{
-  auto logPath = common::joinPaths(
-      std::string(PROJECT_BINARY_PATH), "test_log_path");
-  auto logFile = common::joinPaths(logPath, "state.tlog");
-  auto compressedFile = logPath + ".zip";
-
-  igndbg << "Log path [" << logPath << "]" << std::endl;
-
-  common::removeAll(logPath);
-  common::removeAll(compressedFile);
-  EXPECT_FALSE(common::exists(logFile));
-  EXPECT_FALSE(common::exists(compressedFile));
-
-  {
-    gazebo::ServerConfig serverConfig;
-    serverConfig.SetUseLogRecord(true);
-    serverConfig.SetLogRecordPath(logPath);
-    serverConfig.SetLogRecordCompressPath(compressedFile);
-
-    gazebo::Server server(serverConfig);
-    EXPECT_EQ(0u, *server.IterationCount());
-    EXPECT_EQ(3u, *server.EntityCount());
-    EXPECT_EQ(4u, *server.SystemCount());
-  }
-
-  EXPECT_FALSE(common::exists(logFile));
-  EXPECT_TRUE(common::exists(compressedFile));
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, SdfStringServerConfig)
-{
-  ignition::gazebo::ServerConfig serverConfig;
-
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/shapes.sdf");
-  EXPECT_FALSE(serverConfig.SdfFile().empty());
-  EXPECT_TRUE(serverConfig.SdfString().empty());
-
-  // Setting the string should override the file.
-  serverConfig.SetSdfString(TestWorldSansPhysics::World());
-  EXPECT_TRUE(serverConfig.SdfFile().empty());
-  EXPECT_FALSE(serverConfig.SdfString().empty());
-
-  gazebo::Server server(serverConfig);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-  EXPECT_TRUE(*server.Paused());
-  EXPECT_EQ(0u, *server.IterationCount());
-  EXPECT_EQ(3u, *server.EntityCount());
-  EXPECT_EQ(2u, *server.SystemCount());
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, RunBlocking)
-{
-  gazebo::Server server;
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-  EXPECT_TRUE(*server.Paused());
-  EXPECT_EQ(0u, server.IterationCount());
-
-  // Make the server run fast.
-  server.SetUpdatePeriod(1ns);
-
-  uint64_t expectedIters = 0;
-  for (uint64_t i = 1; i < 10; ++i)
-  {
-    EXPECT_FALSE(server.Running());
-    EXPECT_FALSE(*server.Running(0));
-    server.Run(true, i, false);
-    EXPECT_FALSE(server.Running());
-    EXPECT_FALSE(*server.Running(0));
-
-    expectedIters += i;
-    EXPECT_EQ(expectedIters, *server.IterationCount());
-  }
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, RunNonBlockingPaused)
-{
-  gazebo::Server server;
-
-  // The server should not be running.
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-
-  // The simulation runner should not be running.
-  EXPECT_FALSE(*server.Running(0));
-
-  // Invalid world index.
-  EXPECT_EQ(std::nullopt, server.Running(1));
-
-  EXPECT_TRUE(*server.Paused());
-  EXPECT_EQ(0u, *server.IterationCount());
-
-  // Make the server run fast.
-  server.SetUpdatePeriod(1ns);
-
-  EXPECT_TRUE(server.Run(false, 100, true));
-  EXPECT_TRUE(*server.Paused());
-
-  EXPECT_TRUE(server.Running());
-
-  // Add a small sleep because the non-blocking Run call causes the
-  // simulation runner to start asynchronously.
-  IGN_SLEEP_MS(500);
-  EXPECT_TRUE(*server.Running(0));
-
-  EXPECT_EQ(0u, server.IterationCount());
-
-  // Attempt to unpause an invalid world
-  EXPECT_FALSE(server.SetPaused(false, 1));
-
-  // Unpause the existing world
-  EXPECT_TRUE(server.SetPaused(false, 0));
-
-  EXPECT_FALSE(*server.Paused());
-  EXPECT_TRUE(server.Running());
-
-  while (*server.IterationCount() < 100)
-    IGN_SLEEP_MS(100);
-
-  EXPECT_EQ(100u, *server.IterationCount());
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, RunNonBlocking)
-{
-  gazebo::Server server;
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-  EXPECT_EQ(0u, *server.IterationCount());
-
-  // Make the server run fast.
-  server.SetUpdatePeriod(1ns);
-
-  server.Run(false, 100, false);
-  while (*server.IterationCount() < 100)
-    IGN_SLEEP_MS(100);
-
-  EXPECT_EQ(100u, *server.IterationCount());
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(RunOnceUnpaused))
-{
-  gazebo::Server server;
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-  EXPECT_EQ(0u, *server.IterationCount());
-
-  // Load a system
-  gazebo::SystemLoader systemLoader;
-  auto mockSystemPlugin = systemLoader.LoadPlugin(
-      "libMockSystem.so", "ignition::gazebo::MockSystem", nullptr);
-  ASSERT_TRUE(mockSystemPlugin.has_value());
-
-  // Check that it was loaded
-  const size_t systemCount = *server.SystemCount();
-  EXPECT_TRUE(*server.AddSystem(mockSystemPlugin.value()));
-  EXPECT_EQ(systemCount + 1, *server.SystemCount());
-
-  // Query the interface from the plugin
-  auto system = mockSystemPlugin.value()->QueryInterface<gazebo::System>();
-  EXPECT_NE(system, nullptr);
-  auto mockSystem = dynamic_cast<gazebo::MockSystem*>(system);
-  EXPECT_NE(mockSystem, nullptr);
-
-  // No steps should have been executed
-  EXPECT_EQ(0u, mockSystem->preUpdateCallCount);
-  EXPECT_EQ(0u, mockSystem->updateCallCount);
-  EXPECT_EQ(0u, mockSystem->postUpdateCallCount);
-
-  // Make the server run fast
-  server.SetUpdatePeriod(1ns);
-
-  while (*server.IterationCount() < 100)
-    server.RunOnce(false);
-
-  // Check that the server provides the correct information
-  EXPECT_EQ(*server.IterationCount(), 100u);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-
-  // Check that the system has been called correctly
-  EXPECT_EQ(100u, mockSystem->preUpdateCallCount);
-  EXPECT_EQ(100u, mockSystem->updateCallCount);
-  EXPECT_EQ(100u, mockSystem->postUpdateCallCount);
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(RunOncePaused))
-{
-  gazebo::Server server;
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-  EXPECT_EQ(0u, *server.IterationCount());
-
-  // Load a system
-  gazebo::SystemLoader systemLoader;
-  auto mockSystemPlugin = systemLoader.LoadPlugin(
-      "libMockSystem.so", "ignition::gazebo::MockSystem", nullptr);
-  ASSERT_TRUE(mockSystemPlugin.has_value());
-
-  // Check that it was loaded
-  const size_t systemCount = *server.SystemCount();
-  EXPECT_TRUE(*server.AddSystem(mockSystemPlugin.value()));
-  EXPECT_EQ(systemCount + 1, *server.SystemCount());
-
-  // Query the interface from the plugin
-  auto system = mockSystemPlugin.value()->QueryInterface<gazebo::System>();
-  EXPECT_NE(system, nullptr);
-  auto mockSystem = dynamic_cast<gazebo::MockSystem*>(system);
-  EXPECT_NE(mockSystem, nullptr);
-
-  // No steps should have been executed
-  EXPECT_EQ(0u, mockSystem->preUpdateCallCount);
-  EXPECT_EQ(0u, mockSystem->updateCallCount);
-  EXPECT_EQ(0u, mockSystem->postUpdateCallCount);
-
-  // Make the server run fast
-  server.SetUpdatePeriod(1ns);
-
-  while (*server.IterationCount() < 100)
-    server.RunOnce(true);
-
-  // Check that the server provides the correct information
-  EXPECT_EQ(*server.IterationCount(), 100u);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-
-  // Check that the system has been called correctly
-  EXPECT_EQ(100u, mockSystem->preUpdateCallCount);
-  EXPECT_EQ(100u, mockSystem->updateCallCount);
-  EXPECT_EQ(100u, mockSystem->postUpdateCallCount);
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, RunNonBlockingMultiple)
-{
-  ignition::gazebo::ServerConfig serverConfig;
-  serverConfig.SetSdfString(TestWorldSansPhysics::World());
-  gazebo::Server server(serverConfig);
-
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-  EXPECT_EQ(0u, *server.IterationCount());
-
-  EXPECT_TRUE(server.Run(false, 100, false));
-  EXPECT_FALSE(server.Run(false, 100, false));
-
-  while (*server.IterationCount() < 100)
-    IGN_SLEEP_MS(100);
-
-  EXPECT_EQ(100u, *server.IterationCount());
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, SigInt)
-{
-  gazebo::Server server;
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-
-  // Run forever, non-blocking.
-  server.Run(false, 0, false);
-
-  IGN_SLEEP_MS(500);
-
-  EXPECT_TRUE(server.Running());
-  EXPECT_TRUE(*server.Running(0));
-
-  std::raise(SIGTERM);
-
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, ServerControlStop)
-{
-  // Test that the server correctly reacts to requests on /server_control
-  // service with `stop` set to either false or true.
-
-  gazebo::Server server;
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-
-  // Run forever, non-blocking.
-  server.Run(false, 0, false);
-
-  IGN_SLEEP_MS(500);
-
-  EXPECT_TRUE(server.Running());
-  EXPECT_TRUE(*server.Running(0));
-
-  transport::Node node;
-  msgs::ServerControl req;
-  msgs::Boolean res;
-  bool result{false};
-  bool executed{false};
-  int sleep{0};
-  int maxSleep{30};
-
-  // first, call with stop = false; the server should keep running
-  while (!executed && sleep < maxSleep)
-  {
-    igndbg << "Requesting /server_control" << std::endl;
-    executed = node.Request("/server_control", req, 100, res, result);
-    sleep++;
-  }
-  EXPECT_TRUE(executed);
-  EXPECT_TRUE(result);
-  EXPECT_FALSE(res.data());
-
-  IGN_SLEEP_MS(500);
-
-  EXPECT_TRUE(server.Running());
-  EXPECT_TRUE(*server.Running(0));
-
-  // now call with stop = true; the server should stop
-  req.set_stop(true);
-
-  igndbg << "Requesting /server_control" << std::endl;
-  executed = node.Request("/server_control", req, 100, res, result);
-
-  EXPECT_TRUE(executed);
-  EXPECT_TRUE(result);
-  EXPECT_TRUE(res.data());
-
-  IGN_SLEEP_MS(500);
-
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(AddSystemWhileRunning))
-{
-  ignition::gazebo::ServerConfig serverConfig;
-
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/shapes.sdf");
-
-  gazebo::Server server(serverConfig);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-  server.SetUpdatePeriod(1us);
-
-  // Run the server to test whether we can add systems while system is running
-  server.Run(false, 0, false);
-
-  IGN_SLEEP_MS(500);
-
-  EXPECT_TRUE(server.Running());
-  EXPECT_TRUE(*server.Running(0));
-
-  EXPECT_EQ(3u, *server.SystemCount());
-
-  // Add system from plugin
-  gazebo::SystemLoader systemLoader;
-  auto mockSystemPlugin = systemLoader.LoadPlugin("libMockSystem.so",
-      "ignition::gazebo::MockSystem", nullptr);
-  ASSERT_TRUE(mockSystemPlugin.has_value());
-
-  auto result = server.AddSystem(mockSystemPlugin.value());
-  ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value());
-  EXPECT_EQ(3u, *server.SystemCount());
-
-  // Add system pointer
-  auto mockSystem = std::make_shared<MockSystem>();
-  result = server.AddSystem(mockSystem);
-  ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value());
-  EXPECT_EQ(3u, *server.SystemCount());
-
-  // Stop the server
-  std::raise(SIGTERM);
-
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(AddSystemAfterLoad))
-{
-  ignition::gazebo::ServerConfig serverConfig;
-
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/shapes.sdf");
-
-  gazebo::Server server(serverConfig);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-
-  // Add system from plugin
-  gazebo::SystemLoader systemLoader;
-  auto mockSystemPlugin = systemLoader.LoadPlugin("libMockSystem.so",
-      "ignition::gazebo::MockSystem", nullptr);
-  ASSERT_TRUE(mockSystemPlugin.has_value());
-
-  auto system = mockSystemPlugin.value()->QueryInterface<gazebo::System>();
-  EXPECT_NE(system, nullptr);
-  auto mockSystem = dynamic_cast<gazebo::MockSystem*>(system);
-  ASSERT_NE(mockSystem, nullptr);
-
-  EXPECT_EQ(3u, *server.SystemCount());
-  EXPECT_EQ(0u, mockSystem->configureCallCount);
-
-  EXPECT_TRUE(*server.AddSystem(mockSystemPlugin.value()));
-
-  EXPECT_EQ(4u, *server.SystemCount());
-  EXPECT_EQ(1u, mockSystem->configureCallCount);
-
-  // Add system pointer
-  auto mockSystemLocal = std::make_shared<MockSystem>();
-  EXPECT_EQ(0u, mockSystemLocal->configureCallCount);
-
-  EXPECT_TRUE(server.AddSystem(mockSystemLocal));
-  EXPECT_EQ(5u, *server.SystemCount());
-  EXPECT_EQ(1u, mockSystemLocal->configureCallCount);
-
-  // Check that update callbacks are called
-  server.SetUpdatePeriod(1us);
-  EXPECT_EQ(0u, mockSystem->preUpdateCallCount);
-  EXPECT_EQ(0u, mockSystem->updateCallCount);
-  EXPECT_EQ(0u, mockSystem->postUpdateCallCount);
-  EXPECT_EQ(0u, mockSystemLocal->preUpdateCallCount);
-  EXPECT_EQ(0u, mockSystemLocal->updateCallCount);
-  EXPECT_EQ(0u, mockSystemLocal->postUpdateCallCount);
-  server.Run(true, 1, false);
-  EXPECT_EQ(1u, mockSystem->preUpdateCallCount);
-  EXPECT_EQ(1u, mockSystem->updateCallCount);
-  EXPECT_EQ(1u, mockSystem->postUpdateCallCount);
-  EXPECT_EQ(1u, mockSystemLocal->preUpdateCallCount);
-  EXPECT_EQ(1u, mockSystemLocal->updateCallCount);
-  EXPECT_EQ(1u, mockSystemLocal->postUpdateCallCount);
-
-  // Add to inexistent world
-  auto result = server.AddSystem(mockSystemPlugin.value(), 100);
-  EXPECT_FALSE(result.has_value());
-
-  result = server.AddSystem(mockSystemLocal, 100);
-  EXPECT_FALSE(result.has_value());
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, Seed)
-{
-  ignition::gazebo::ServerConfig serverConfig;
-  EXPECT_EQ(0u, serverConfig.Seed());
-  unsigned int mySeed = 12345u;
-  serverConfig.SetSeed(mySeed);
-  EXPECT_EQ(mySeed, serverConfig.Seed());
-  EXPECT_EQ(mySeed, ignition::math::Rand::Seed());
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ResourcePath))
-{
-  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
-         (std::string(PROJECT_SOURCE_PATH) + "/test/worlds:" +
-          std::string(PROJECT_SOURCE_PATH) + "/test/worlds/models").c_str());
-
-  ServerConfig serverConfig;
-  serverConfig.SetSdfFile("resource_paths.sdf");
-  gazebo::Server server(serverConfig);
-
-  test::Relay testSystem;
-  unsigned int preUpdates{0};
-  testSystem.OnPreUpdate(
-    [&preUpdates](const gazebo::UpdateInfo &,
-    gazebo::EntityComponentManager &_ecm)
-    {
-      // Create AABB so it is populated
-      unsigned int eachCount{0};
-      _ecm.Each<components::Model>(
-        [&](const Entity &_entity, components::Model *) -> bool
-        {
-          auto bboxComp = _ecm.Component<components::AxisAlignedBox>(_entity);
-          EXPECT_EQ(bboxComp, nullptr);
-          _ecm.CreateComponent(_entity, components::AxisAlignedBox());
-          eachCount++;
-          return true;
-        });
-      EXPECT_EQ(1u, eachCount);
-      preUpdates++;
-    });
-
-  unsigned int postUpdates{0};
-  testSystem.OnPostUpdate([&postUpdates](const gazebo::UpdateInfo &,
-    const gazebo::EntityComponentManager &_ecm)
-    {
-      // Check geometry components
-      unsigned int eachCount{0};
-      _ecm.Each<components::Geometry>(
-        [&eachCount](const Entity &, const components::Geometry *_geom)
-        -> bool
-        {
-          auto mesh = _geom->Data().MeshShape();
-
-          // ASSERT would fail at compile with
-          // "void value not ignored as it ought to be"
-          EXPECT_NE(nullptr, mesh);
-
-          if (mesh)
-          {
-            EXPECT_EQ("model://scheme_resource_uri/meshes/box.dae",
-                mesh->Uri());
-          }
-
-          eachCount++;
-          return true;
-        });
-      EXPECT_EQ(2u, eachCount);
-
-      // Check physics system loaded meshes and got their BB correct
-      eachCount = 0;
-      _ecm.Each<components::AxisAlignedBox>(
-        [&](const ignition::gazebo::Entity &,
-            const components::AxisAlignedBox *_box)->bool
-        {
-          auto box = _box->Data();
-          EXPECT_EQ(box, math::AxisAlignedBox(-0.4, -0.4, 0.6, 0.4, 0.4, 1.4));
-          eachCount++;
-          return true;
-        });
-      EXPECT_EQ(1u, eachCount);
-
-      postUpdates++;
-    });
-  server.AddSystem(testSystem.systemPtr);
-
-  EXPECT_FALSE(*server.Running(0));
-
-  EXPECT_TRUE(server.Run(true /*blocking*/, 1, false /*paused*/));
-  EXPECT_EQ(1u, preUpdates);
-  EXPECT_EQ(1u, postUpdates);
-
-  EXPECT_EQ(7u, *server.EntityCount());
-  EXPECT_TRUE(server.HasEntity("scheme_resource_uri"));
-  EXPECT_TRUE(server.HasEntity("the_link"));
-  EXPECT_TRUE(server.HasEntity("the_visual"));
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, GetResourcePaths)
-{
-  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
-      "/tmp/some/path:/home/user/another_path");
-
-  ServerConfig serverConfig;
-  gazebo::Server server(serverConfig);
-
-  EXPECT_FALSE(*server.Running(0));
-
-  transport::Node node;
-  msgs::StringMsg_V res;
-  bool result{false};
-  bool executed{false};
-  int sleep{0};
-  int maxSleep{30};
-  while (!executed && sleep < maxSleep)
-  {
-    igndbg << "Requesting /gazebo/resource_paths/get" << std::endl;
-    executed = node.Request("/gazebo/resource_paths/get", 100, res, result);
-    sleep++;
-  }
-  EXPECT_TRUE(executed);
-  EXPECT_TRUE(result);
-  EXPECT_EQ(2, res.data_size());
-  EXPECT_EQ("/tmp/some/path", res.data(0));
-  EXPECT_EQ("/home/user/another_path", res.data(1));
-}
-
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, AddResourcePaths)
+TEST_P(ServerFixture, ResolveResourcePaths)
 {
   ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
       "/tmp/some/path:/home/user/another_path");
@@ -977,60 +1046,64 @@ TEST_P(ServerFixture, AddResourcePaths)
 
   EXPECT_FALSE(*server.Running(0));
 
-  transport::Node node;
-
-  // Subscribe to path updates
-  bool receivedMsg{false};
-  auto resourceCb = std::function<void(const msgs::StringMsg_V &)>(
-      [&receivedMsg](const auto &_msg)
-      {
-        receivedMsg = true;
-        EXPECT_EQ(5, _msg.data_size());
-        EXPECT_EQ("/tmp/some/path", _msg.data(0));
-        EXPECT_EQ("/home/user/another_path", _msg.data(1));
-        EXPECT_EQ("/tmp/new_path", _msg.data(2));
-        EXPECT_EQ("/tmp/more", _msg.data(3));
-        EXPECT_EQ("/tmp/even_more", _msg.data(4));
-      });
-  node.Subscribe("/gazebo/resource_paths", resourceCb);
-
-  // Add path
-  msgs::StringMsg_V req;
-  req.add_data("/tmp/new_path");
-  req.add_data("/tmp/more:/tmp/even_more");
-  req.add_data("/tmp/some/path");
-  bool executed = node.Request("/gazebo/resource_paths/add", req);
-  EXPECT_TRUE(executed);
-
-  int sleep{0};
-  int maxSleep{30};
-  while (!receivedMsg && sleep < maxSleep)
-  {
-    IGN_SLEEP_MS(50);
-    sleep++;
-  }
-  EXPECT_TRUE(receivedMsg);
-
-  // Check environment variables
-  for (auto env : {"IGN_GAZEBO_RESOURCE_PATH", "SDF_PATH", "IGN_FILE_PATH"})
-  {
-    char *pathCStr = std::getenv(env);
-
-    auto paths = common::Split(pathCStr, ':');
-    paths.erase(std::remove_if(paths.begin(), paths.end(),
-        [](std::string const &_path)
+  auto test = std::function<void(const std::string _uri,
+      const std::string &_expected, bool _found)>(
+        [&](const std::string &_uri, const std::string &_expected, bool _found)
         {
-          return _path.empty();
-        }),
-        paths.end());
+          transport::Node node;
+          msgs::StringMsg req, res;
+          bool result{false};
+          bool executed{false};
+          int sleep{0};
+          int maxSleep{30};
 
-    EXPECT_EQ(5u, paths.size());
-    EXPECT_EQ("/tmp/some/path", paths[0]);
-    EXPECT_EQ("/home/user/another_path", paths[1]);
-    EXPECT_EQ("/tmp/new_path", paths[2]);
-    EXPECT_EQ("/tmp/more", paths[3]);
-    EXPECT_EQ("/tmp/even_more", paths[4]);
-  }
+          req.set_data(_uri);
+          while (!executed && sleep < maxSleep)
+          {
+            igndbg << "Requesting /gazebo/resource_paths/resolve" << std::endl;
+            executed = node.Request("/gazebo/resource_paths/resolve", req, 100,
+                res, result);
+            sleep++;
+          }
+          EXPECT_TRUE(executed);
+          EXPECT_EQ(_found, result);
+          EXPECT_EQ(_expected, res.data()) << "Expected[" << _expected
+            << "] Received[" << res.data() << "]";
+        });
+
+  // Make sure the resource path is clear
+  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH", "");
+
+  // An absolute path should return the same absolute path
+  test(PROJECT_SOURCE_PATH, PROJECT_SOURCE_PATH, true);
+
+  // An absolute path, with the file:// prefix, should return the absolute path
+  test(std::string("file://") +
+      PROJECT_SOURCE_PATH, PROJECT_SOURCE_PATH, true);
+
+  // A non-absolute path with no RESOURCE_PATH should not find the resource
+  test(common::joinPaths("test", "worlds", "plugins.sdf"), "", false);
+
+  // Try again, this time with a RESOURCE_PATH
+  common::setenv("IGN_GAZEBO_RESOURCE_PATH", PROJECT_SOURCE_PATH);
+  test(common::joinPaths("test", "worlds", "plugins.sdf"),
+      common::joinPaths(PROJECT_SOURCE_PATH, "test", "worlds", "plugins.sdf"),
+      true);
+  // With the file:// prefix should also work
+  test(std::string("file://") +
+      common::joinPaths("test", "worlds", "plugins.sdf"),
+      common::joinPaths(PROJECT_SOURCE_PATH, "test", "worlds", "plugins.sdf"),
+      true);
+
+  // The model:// URI should not resolve
+  test("model://include_nested/model.sdf", "", false);
+  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
+      common::joinPaths(PROJECT_SOURCE_PATH, "test", "worlds", "models"));
+  // The model:// URI should now resolve because the RESOURCE_PATH has been
+  // updated.
+  test("model://include_nested/model.sdf",
+      common::joinPaths(PROJECT_SOURCE_PATH, "test", "worlds", "models",
+        "include_nested", "model.sdf"), true);
 }
 
 // Run multiple times. We want to make sure that static globals don't cause

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -1036,8 +1036,7 @@ TEST_P(ServerFixture, AddResourcePaths)
 /////////////////////////////////////////////////
 TEST_P(ServerFixture, ResolveResourcePaths)
 {
-  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
-      "/tmp/some/path:/home/user/another_path");
+  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH", "");
   ignition::common::setenv("SDF_PATH", "");
   ignition::common::setenv("IGN_FILE_PATH", "");
 

--- a/src/systems/scene_broadcaster/SceneBroadcaster.cc
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.cc
@@ -308,8 +308,12 @@ void SceneBroadcaster::PostUpdate(const UpdateInfo &_info,
   if (_manager.HasNewEntities())
     this->dataPtr->SceneGraphAddEntities(_manager);
 
-  // Populate pose message
-  // TODO(louise) Get <scene> from SDF
+  // Store the Scene component data, which holds sdf::Scene so that we can
+  // populate the scene info messages.
+  auto sceneComp =
+    _manager.Component<components::Scene>(this->dataPtr->worldEntity);
+  if (sceneComp)
+    this->dataPtr->sdfScene = sceneComp->Data();
 
   // Create and send pose update if transport connections exist.
   if (this->dataPtr->dyPosePub.HasConnections() ||
@@ -687,9 +691,6 @@ void SceneBroadcasterPrivate::SceneGraphAddEntities(
 
   // Populate a graph with latest information from all entities
 
-  auto sceneComp = _manager.Component<components::Scene>(this->worldEntity);
-  this->sdfScene = sceneComp->Data();
-
   // Scene graph for new entities. This will be used later to create a scene msg
   // to publish.
   SceneGraphType newGraph;
@@ -1023,7 +1024,7 @@ void SceneBroadcasterPrivate::SceneGraphAddEntities(
 
     msgs::Scene sceneMsg;
     // Populate scene message
-    _res.CopyFrom(convert<msgs::Scene>(this->sdfScene));
+    sceneMsg.CopyFrom(convert<msgs::Scene>(this->sdfScene));
 
     AddModels(&sceneMsg, this->worldEntity, newGraph);
 

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -915,7 +915,8 @@ TEST_P(SceneBroadcasterTest,
 }
 
 /////////////////////////////////////////////////
-TEST_P(SceneBroadcasterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(SceneInfoHasSceneSdf))
+TEST_P(SceneBroadcasterTest,
+    IGN_UTILS_TEST_DISABLED_ON_WIN32(SceneInfoHasSceneSdf))
 {
   // Start server
   ignition::gazebo::ServerConfig serverConfig;

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -914,6 +914,43 @@ TEST_P(SceneBroadcasterTest,
   server.Run(true, 1, false);
 }
 
+/////////////////////////////////////////////////
+TEST_P(SceneBroadcasterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(SceneInfoHasSceneSdf))
+{
+  // Start server
+  ignition::gazebo::ServerConfig serverConfig;
+  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
+      "/test/worlds/conveyor.sdf");
+
+  gazebo::Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  // Run server
+  server.Run(true, 1, false);
+
+  // Create requester
+  transport::Node node;
+
+  bool result{false};
+  unsigned int timeout{5000};
+  ignition::msgs::Scene res;
+
+  EXPECT_TRUE(node.Request("/world/default/scene/info", timeout, res, result));
+  EXPECT_TRUE(result);
+
+  ASSERT_TRUE(res.has_ambient());
+  EXPECT_EQ(math::Color(1.0, 1.0, 1.0, 1.0), msgs::Convert(res.ambient()));
+
+  ASSERT_TRUE(res.has_background());
+  EXPECT_EQ(math::Color(0.8, 0.8, 0.8, 1.0), msgs::Convert(res.background()));
+
+  EXPECT_TRUE(res.shadows());
+  EXPECT_FALSE(res.grid());
+  EXPECT_FALSE(res.has_fog());
+  EXPECT_FALSE(res.has_sky());
+}
+
 // Run multiple times
 INSTANTIATE_TEST_SUITE_P(ServerRepeat, SceneBroadcasterTest,
     ::testing::Range(1, 2));

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -921,7 +921,7 @@ TEST_P(SceneBroadcasterTest,
   // Start server
   ignition::gazebo::ServerConfig serverConfig;
   serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/conveyor.sdf");
+      common::joinPaths("/", "test", "worlds", "conveyor.sdf"));
 
   gazebo::Server server(serverConfig);
   EXPECT_FALSE(server.Running());

--- a/test/worlds/conveyor.sdf
+++ b/test/worlds/conveyor.sdf
@@ -24,6 +24,8 @@
         <scene>
             <ambient>1.0 1.0 1.0</ambient>
             <background>0.8 0.8 0.8</background>
+            <shadows>true</shadows>
+            <grid>false</grid>
         </scene>
 
         <light type="directional" name="sun">


### PR DESCRIPTION
# 🎉 New feature

## Summary

This adds a `/gazebo/resource_paths/resolve` service that will return the full path to a file on disk when provided with a URI. Only Fuel and IGN_GAZEBO_RESOURCE_PATH are checked.

This also stores the `<scene>` information the SceneBroadcaster so that the `scene/info` service can send over `<scene>` information.

## Test

Path resolver
```
ign service -s /gazebo/resource_paths/resolve --reqtype ignition.msgs.StringMsg --reptype ignition.msgs.StringMsg --timeout 2000 --req "data:'/tmp'"
```


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.