### PR TITLE
Check RGBD camera sensor connection

### DIFF
--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -842,6 +842,11 @@ bool SensorsPrivate::HasConnections(sensors::RenderingSensor *_sensor) const
   // \todo(iche033) Remove this function once a virtual
   // sensors::RenderingSensor::HasConnections function is available
   {
+    auto s = dynamic_cast<sensors::RgbdCameraSensor *>(_sensor);
+    if (s)
+      return s->HasConnections();
+  }
+  {
     auto s = dynamic_cast<sensors::DepthCameraSensor *>(_sensor);
     if (s)
       return s->HasConnections();


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary
Follow up to pull request #1480. RGBD camera was missing from the list of sensors. We added a warning to catch sensors missing from the list but unfortunately it didn't catch this because the RGBD camera was cast to a `CameraSensor` and the incorrect `HasConnection` call was invoked. This should not happen once the todo note is addressed in Garden.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
