### PR TITLE
Add missing gz-math includes

### DIFF
--- a/examples/standalone/light_control/light_control.cc
+++ b/examples/standalone/light_control/light_control.cc
@@ -17,6 +17,7 @@
 
 #include <chrono>
 #include <iostream>
+#include <random>
 
 #include <gz/sim/components/Light.hh>
 #include <gz/sim/components/LightCmd.hh>

--- a/include/gz/sim/Conversions.hh
+++ b/include/gz/sim/Conversions.hh
@@ -40,6 +40,7 @@
 
 #include <gz/common/Console.hh>
 #include <gz/math/Inertial.hh>
+#include <gz/math/AxisAlignedBox.hh>
 #include <sdf/Actor.hh>
 #include <sdf/Atmosphere.hh>
 #include <sdf/Collision.hh>

--- a/include/gz/sim/Conversions.hh
+++ b/include/gz/sim/Conversions.hh
@@ -39,8 +39,8 @@
 #include <string>
 
 #include <gz/common/Console.hh>
-#include <gz/math/Inertial.hh>
 #include <gz/math/AxisAlignedBox.hh>
+#include <gz/math/Inertial.hh>
 #include <sdf/Actor.hh>
 #include <sdf/Atmosphere.hh>
 #include <sdf/Collision.hh>

--- a/include/gz/sim/rendering/SceneManager.hh
+++ b/include/gz/sim/rendering/SceneManager.hh
@@ -37,6 +37,8 @@
 #include <gz/common/Animation.hh>
 #include <gz/common/graphics/Types.hh>
 
+#include <gz/math/Matrix4.hh>
+
 #include <gz/msgs/particle_emitter.pb.h>
 
 #include <gz/rendering/RenderTypes.hh>

--- a/src/gui/plugins/component_inspector_editor/ComponentInspectorEditor.hh
+++ b/src/gui/plugins/component_inspector_editor/ComponentInspectorEditor.hh
@@ -26,8 +26,8 @@
 #include <sdf/Physics.hh>
 #include <sdf/Joint.hh>
 
-#include <gz/math/Vector3.hh>
 #include <gz/math/SphericalCoordinates.hh>
+#include <gz/math/Vector3.hh>
 
 #include <gz/sim/components/Component.hh>
 #include <gz/sim/gui/GuiSystem.hh>

--- a/src/gui/plugins/component_inspector_editor/ComponentInspectorEditor.hh
+++ b/src/gui/plugins/component_inspector_editor/ComponentInspectorEditor.hh
@@ -27,6 +27,7 @@
 #include <sdf/Joint.hh>
 
 #include <gz/math/Vector3.hh>
+#include <gz/math/SphericalCoordinates.hh>
 
 #include <gz/sim/components/Component.hh>
 #include <gz/sim/gui/GuiSystem.hh>

--- a/src/rendering/MarkerManager.cc
+++ b/src/rendering/MarkerManager.cc
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <string>
 
+#include <gz/math/Rand.hh>
 #include <gz/msgs.hh>
 #include <gz/transport/Node.hh>
 

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -19,6 +19,7 @@
 #include <map>
 #include <memory>
 #include <unordered_map>
+#include <queue>
 
 #include <sdf/Box.hh>
 #include <sdf/Capsule.hh>

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -18,8 +18,8 @@
 
 #include <map>
 #include <memory>
-#include <unordered_map>
 #include <queue>
+#include <unordered_map>
 
 #include <sdf/Box.hh>
 #include <sdf/Capsule.hh>

--- a/src/systems/multicopter_control/Common.cc
+++ b/src/systems/multicopter_control/Common.cc
@@ -20,6 +20,7 @@
 #include <string>
 
 #include <gz/common/Console.hh>
+#include <gz/math/Rand.hh>
 #include <gz/math/eigen3/Conversions.hh>
 
 #include <gz/sim/components/ChildLinkName.hh>

--- a/src/systems/odometry_publisher/OdometryPublisher.cc
+++ b/src/systems/odometry_publisher/OdometryPublisher.cc
@@ -30,6 +30,7 @@
 #include <gz/math/Helpers.hh>
 #include <gz/math/Pose3.hh>
 #include <gz/math/Quaternion.hh>
+#include <gz/math/Rand.hh>
 #include <gz/math/RollingMean.hh>
 #include <gz/plugin/Register.hh>
 #include <gz/transport/Node.hh>
@@ -95,7 +96,7 @@ class gz::sim::systems::OdometryPublisherPrivate
   public: math::Pose3d lastUpdatePose{0, 0, 0, 0, 0, 0};
 
   /// \brief Current timestamp.
-  public: math::clock::time_point lastUpdateTime;
+  public: std::chrono::steady_clock::time_point lastUpdateTime;
 
   /// \brief Allow specifying constant xyz and rpy offsets
   public: gz::math::Pose3d offset = {0, 0, 0, 0, 0, 0};

--- a/src/systems/thruster/Thruster.cc
+++ b/src/systems/thruster/Thruster.cc
@@ -21,6 +21,7 @@
 #include <gz/msgs/double.pb.h>
 
 #include <gz/math/Helpers.hh>
+#include <gz/math/PID.hh>
 
 #include <gz/plugin/Register.hh>
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Some libsdformat headers used to include `gz/math.hh`, but that is no longer the case since https://github.com/gazebosim/sdformat/pull/1043. As a result, gz-sim has to be updated to include the necessary headers.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
