### PR TITLE
More missing math includes and math::clock fixes

### DIFF
--- a/include/gz/sim/Conversions.hh
+++ b/include/gz/sim/Conversions.hh
@@ -41,6 +41,7 @@
 #include <gz/common/Console.hh>
 #include <gz/math/AxisAlignedBox.hh>
 #include <gz/math/Inertial.hh>
+#include <gz/math/Pose3.hh>
 #include <sdf/Actor.hh>
 #include <sdf/Atmosphere.hh>
 #include <sdf/Collision.hh>

--- a/include/gz/sim/Link.hh
+++ b/include/gz/sim/Link.hh
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 
+#include <gz/math/Matrix3.hh>
 #include <gz/math/Pose3.hh>
 #include <gz/math/Quaternion.hh>
 #include <gz/math/Vector3.hh>

--- a/include/gz/sim/rendering/SceneManager.hh
+++ b/include/gz/sim/rendering/SceneManager.hh
@@ -37,7 +37,10 @@
 #include <gz/common/Animation.hh>
 #include <gz/common/graphics/Types.hh>
 
+#include <gz/math/Inertial.hh>
 #include <gz/math/Matrix4.hh>
+#include <gz/math/Pose3.hh>
+#include <gz/math/Vector3.hh>
 
 #include <gz/msgs/particle_emitter.pb.h>
 

--- a/src/Link.cc
+++ b/src/Link.cc
@@ -15,6 +15,11 @@
  *
  */
 
+#include <gz/math/Inertial.hh>
+#include <gz/math/Matrix3.hh>
+#include <gz/math/Pose3.hh>
+#include <gz/math/Vector3.hh>
+
 #include <gz/msgs/Utility.hh>
 
 #include "gz/sim/components/AngularAcceleration.hh"

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -1354,13 +1354,14 @@ SimulationRunner::UpdatePeriod() const
 }
 
 /////////////////////////////////////////////////
-const gz::math::clock::duration &SimulationRunner::StepSize() const
+const std::chrono::steady_clock::duration &SimulationRunner::StepSize() const
 {
   return this->stepSize;
 }
 
 /////////////////////////////////////////////////
-void SimulationRunner::SetStepSize(const gz::math::clock::duration &_step)
+void SimulationRunner::SetStepSize(
+    const std::chrono::steady_clock::duration &_step)
 {
   this->stepSize = _step;
 }

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -280,11 +280,12 @@ namespace gz
 
       /// \brief Get the step size;
       /// \return Step size.
-      public: const gz::math::clock::duration &StepSize() const;
+      public: const std::chrono::steady_clock::duration &StepSize() const;
 
       /// \brief Set the step size;
       /// \param[in] _step Step size.
-      public: void SetStepSize(const gz::math::clock::duration &_step);
+      public: void SetStepSize(
+          const std::chrono::steady_clock::duration &_step);
 
       /// \brief World control service callback. This function stores the
       /// the request which will then be processed by the ProcessMessages
@@ -456,7 +457,7 @@ namespace gz
       private: gz::math::Stopwatch realTimeWatch;
 
       /// \brief Step size
-      private: gz::math::clock::duration stepSize{10ms};
+      private: std::chrono::steady_clock::duration stepSize{10ms};
 
       /// \brief Desired real time factor
       private: double desiredRtf{1.0};

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -18,6 +18,10 @@
 #include <gz/common/Filesystem.hh>
 #include <gz/common/StringUtils.hh>
 #include <gz/common/Util.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/Pose3.hh>
+#include <gz/math/SphericalCoordinates.hh>
+#include <gz/math/Vector3.hh>
 #include <gz/transport/TopicUtils.hh>
 #include <sdf/Types.hh>
 

--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -23,6 +23,9 @@
 #include <gz/common/Profiler.hh>
 #include <gz/gui/Application.hh>
 #include <gz/gui/MainWindow.hh>
+#include <gz/math/Color.hh>
+#include <gz/math/SphericalCoordinates.hh>
+#include <gz/math/Vector3.hh>
 #include <gz/plugin/Register.hh>
 
 #include "gz/sim/components/Actor.hh"

--- a/src/gui/plugins/component_inspector/ComponentInspector.hh
+++ b/src/gui/plugins/component_inspector/ComponentInspector.hh
@@ -25,6 +25,7 @@
 #include <sdf/Material.hh>
 #include <sdf/Physics.hh>
 
+#include <gz/math/SphericalCoordinates.hh>
 #include <gz/math/Vector3.hh>
 #include <gz/transport/Node.hh>
 

--- a/src/gui/plugins/component_inspector_editor/ComponentInspectorEditor.cc
+++ b/src/gui/plugins/component_inspector_editor/ComponentInspectorEditor.cc
@@ -27,6 +27,9 @@
 #include <gz/common/Profiler.hh>
 #include <gz/gui/Application.hh>
 #include <gz/gui/MainWindow.hh>
+#include <gz/math/Color.hh>
+#include <gz/math/SphericalCoordinates.hh>
+#include <gz/math/Vector3.hh>
 #include <gz/plugin/Register.hh>
 #include <gz/transport/Node.hh>
 

--- a/src/gui/plugins/plotting/Plotting.cc
+++ b/src/gui/plugins/plotting/Plotting.cc
@@ -17,6 +17,9 @@
 
 #include "Plotting.hh"
 
+#include <gz/math/Pose3.hh>
+#include <gz/math/SphericalCoordinates.hh>
+#include <gz/math/Vector3.hh>
 #include <gz/plugin/Register.hh>
 
 #include "gz/sim/components/AngularAcceleration.hh"

--- a/src/rendering/MarkerManager.cc
+++ b/src/rendering/MarkerManager.cc
@@ -21,7 +21,11 @@
 #include <mutex>
 #include <string>
 
+#include <gz/math/Color.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/Pose3.hh>
 #include <gz/math/Rand.hh>
+#include <gz/math/Vector3.hh>
 #include <gz/msgs.hh>
 #include <gz/transport/Node.hh>
 

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -45,6 +45,15 @@
 #include <gz/common/StringUtils.hh>
 #include <gz/common/Uuid.hh>
 
+#include <gz/math/Color.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/Inertial.hh>
+#include <gz/math/Matrix4.hh>
+#include <gz/math/Pose3.hh>
+#include <gz/math/Quaternion.hh>
+#include <gz/math/Vector2.hh>
+#include <gz/math/Vector3.hh>
+
 #include <gz/msgs/Utility.hh>
 
 #include "gz/rendering/Capsule.hh"

--- a/src/systems/thruster/Thruster.cc
+++ b/src/systems/thruster/Thruster.cc
@@ -22,6 +22,8 @@
 
 #include <gz/math/Helpers.hh>
 #include <gz/math/PID.hh>
+#include <gz/math/Pose3.hh>
+#include <gz/math/Vector3.hh>
 
 #include <gz/plugin/Register.hh>
 

--- a/test/integration/link.cc
+++ b/test/integration/link.cc
@@ -19,6 +19,11 @@
 
 #include <gz/common/Console.hh>
 #include <gz/common/Util.hh>
+#include <gz/math/Inertial.hh>
+#include <gz/math/MassMatrix3.hh>
+#include <gz/math/Matrix3.hh>
+#include <gz/math/Pose3.hh>
+#include <gz/math/Vector3.hh>
 
 #include <gz/sim/components/AngularAcceleration.hh>
 #include <gz/sim/components/AngularVelocity.hh>


### PR DESCRIPTION
# 🦟 Bug fix

Follow up to #1525

## Summary

I noticed the build failures today due to https://github.com/gazebosim/sdformat/pull/1043 and started on a fix but was slower than @azeey who already fixed the build with #1525. I did find a few extra missing includes and `gz::math::clock` references that I've replaced with `std::chrono::steady_clock`, so I'll submit this as well.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
