### PR TITLE
Use base RenderingSensor::HasConnections function in sensors system

### DIFF
--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -198,11 +198,6 @@ class gz::sim::systems::SensorsPrivate
   /// \param[in] _ecm Entity component manager
   public: void UpdateBatteryState(const EntityComponentManager &_ecm);
 
-  /// \brief Check if sensor has subscribers
-  /// \param[in] _sensor Sensor to check
-  /// \return True if the sensor has subscribers, false otherwise
-  public: bool HasConnections(sensors::RenderingSensor *_sensor) const;
-
   /// \brief Use to optionally set the background color.
   public: std::optional<math::Color> backgroundColor;
 
@@ -342,7 +337,7 @@ void SensorsPrivate::RunOnce()
     {
       sensors::Sensor *s = this->sensorManager.Sensor(id);
       auto rs = dynamic_cast<sensors::RenderingSensor *>(s);
-      if (rs->IsActive() && !this->HasConnections(rs))
+      if (rs->IsActive() && !rs->HasConnections())
       {
         rs->SetActive(false);
         tmpDisabledSensors.insert(rs);
@@ -893,49 +888,6 @@ std::string Sensors::CreateSensor(const Entity &_entity,
   }
 
   return sensor->Name();
-}
-
-//////////////////////////////////////////////////
-bool SensorsPrivate::HasConnections(sensors::RenderingSensor *_sensor) const
-{
-  if (!_sensor)
-    return true;
-
-  // \todo(iche033) Remove this function once a virtual
-  // sensors::RenderingSensor::HasConnections function is available
-  {
-    auto s = dynamic_cast<sensors::RgbdCameraSensor *>(_sensor);
-    if (s)
-      return s->HasConnections();
-  }
-  {
-    auto s = dynamic_cast<sensors::DepthCameraSensor *>(_sensor);
-    if (s)
-      return s->HasConnections();
-  }
-  {
-    auto s = dynamic_cast<sensors::GpuLidarSensor *>(_sensor);
-    if (s)
-      return s->HasConnections();
-  }
-  {
-    auto s = dynamic_cast<sensors::SegmentationCameraSensor *>(_sensor);
-    if (s)
-      return s->HasConnections();
-  }
-  {
-    auto s = dynamic_cast<sensors::ThermalCameraSensor *>(_sensor);
-    if (s)
-      return s->HasConnections();
-  }
-  {
-    auto s = dynamic_cast<sensors::CameraSensor *>(_sensor);
-    if (s)
-      return s->HasConnections();
-  }
-  gzwarn << "Unable to check connection count for sensor: " << _sensor->Name()
-          << ". Unknown sensor type." << std::endl;
-  return true;
 }
 
 GZ_ADD_PLUGIN(Sensors, System,


### PR DESCRIPTION
# 🦟 Bug fix

Depends on https://github.com/gazebosim/gz-sensors/pull/234

## Summary
Use the new `RenderingSensor::HasConnections` function introduced in https://github.com/gazebosim/gz-sensors/pull/234. This avoids checking the sensor type by doing explicit casts which was previously done for ABI compatibility.

This should also fix the WideAngleCamera integration test.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

