### PR TITLE
Fix SensorsBatteryState test

### DIFF
--- a/test/integration/sensors_system_battery.cc
+++ b/test/integration/sensors_system_battery.cc
@@ -192,8 +192,8 @@ TEST_F(SensorsFixture, IGN_UTILS_TEST_DISABLED_ON_MAC(SensorsBatteryState))
   // verify image count
   {
     std::lock_guard<std::mutex> lock(mutex);
-    EXPECT_EQ(expectedImgCount, imgCount);
-    EXPECT_EQ(expectedImgCount, depthImgCount);
+    EXPECT_NEAR(expectedImgCount, imgCount, 1);
+    EXPECT_NEAR(expectedImgCount, depthImgCount, 1);
     imgCount = 0u;
     depthImgCount = 0u;
   }


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

This should fix the test failure when running `INTEGRATION_sensors_system_battery`. The expected image count is updated to allow for one extra image received.

More info: 

https://github.com/gazebosim/gz-sim/pull/1480 broke this test. The side effect of that PR is that there is a change in timing of the rendering thread in sensors system - the rendering loop is now running faster before any subscribers and created. When the subscribers are created, the first camera / depth camera images are now rendered at an earlier timestep (because they do not need to wait for previous updates to finish). Because of this slight change in timing, they publish one extra image with the given time period.

Here are sample debug outputs showing the timestamp of the camera image, in `sec  nsec`:

before:
```
0 124000000
0 154000000
0 184000000
0 214000000
0 244000000
0 274000000
0 304000000
```

after:
```
0 132000000
0 165000000
0 198000000
0 231000000
0 264000000
0 297000000
```


The above output shows that the update rates are still correct and the rest of the integration test ensures no images are published after the battery is drained.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
