### PR TITLE
[BACKPORT] Fix faulty assumption in INTEGRATION_log_system (#1426)

### DIFF
--- a/test/integration/log_system.cc
+++ b/test/integration/log_system.cc
@@ -334,9 +334,8 @@ TEST_F(LogSystemTest, LogDefaults)
   EXPECT_TRUE(ignition::common::setenv(IGN_HOMEDIR, homeFake.c_str()));
 
   // Test case 1:
-  // No path specified, on both command line and SDF. This does not go through
-  // ign.cc, so ignLogDirectory() is not initialized (empty string). Recording
-  // should not take place.
+  // No path specified on command line. This does not go through
+  // ign.cc, recording should take place in the `.ignition` directory
   {
     // Change log path in SDF to empty
     sdf::Root recordSdfRoot;
@@ -356,8 +355,12 @@ TEST_F(LogSystemTest, LogDefaults)
     recordServer.Run(true, 200, false);
   }
 
-  // Check ignLogDirectory is empty
-  EXPECT_TRUE(ignLogDirectory().empty());
+  // We should expect to see "auto_default.log"  and "state.tlog"
+  EXPECT_FALSE(ignLogDirectory().empty());
+  EXPECT_TRUE(common::exists(
+        common::joinPaths(ignLogDirectory(), "auto_default.log")));
+  EXPECT_TRUE(common::exists(
+        common::joinPaths(ignLogDirectory(), "state.tlog")));
 
   // Remove artifacts. Recreate new directory
   this->RemoveLogsDir();


### PR DESCRIPTION
Signed-off-by: Michael Carroll <michael@openrobotics.org>

# 🦟 Bug fix

## Summary
Backports #1426 to Citadel, should fix this test regression:
https://build.osrfoundation.org/job/ignition_gazebo-ci-ign-gazebo3-focal-amd64/19/testReport/(root)/LogSystemTest/LogDefaults/

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests -> Not added, but fixed (some of) them
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers
