### PR TITLE
Fix locks in Visualize Lidar GUI plugin

### DIFF
--- a/src/gui/plugins/visualize_lidar/VisualizeLidar.cc
+++ b/src/gui/plugins/visualize_lidar/VisualizeLidar.cc
@@ -379,7 +379,6 @@ void VisualizeLidar::UpdateSize(int _size)
 //////////////////////////////////////////////////
 void VisualizeLidar::OnTopic(const QString &_topicName)
 {
-  std::lock_guard<std::mutex>(this->dataPtr->serviceMutex);
   if (!this->dataPtr->topicName.empty() &&
       !this->dataPtr->node.Unsubscribe(this->dataPtr->topicName))
   {
@@ -388,6 +387,7 @@ void VisualizeLidar::OnTopic(const QString &_topicName)
   }
   this->dataPtr->topicName = _topicName.toStdString();
 
+  std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
   // Reset visualization
   this->dataPtr->resetVisual = true;
 
@@ -406,14 +406,14 @@ void VisualizeLidar::OnTopic(const QString &_topicName)
 //////////////////////////////////////////////////
 void VisualizeLidar::UpdateNonHitting(bool _value)
 {
-  std::lock_guard<std::mutex>(this->dataPtr->serviceMutex);
+  std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
   this->dataPtr->lidar->SetDisplayNonHitting(_value);
 }
 
 //////////////////////////////////////////////////
 void VisualizeLidar::DisplayVisual(bool _value)
 {
-  std::lock_guard<std::mutex>(this->dataPtr->serviceMutex);
+  std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
   this->dataPtr->lidar->SetVisible(_value);
   ignmsg << "Lidar Visual Display " << ((_value) ? "ON." : "OFF.")
          << std::endl;
@@ -422,7 +422,6 @@ void VisualizeLidar::DisplayVisual(bool _value)
 /////////////////////////////////////////////////
 void VisualizeLidar::OnRefresh()
 {
-  std::lock_guard<std::mutex>(this->dataPtr->serviceMutex);
   ignmsg << "Refreshing topic list for LaserScan messages." << std::endl;
 
   // Clear
@@ -468,7 +467,7 @@ void VisualizeLidar::SetTopicList(const QStringList &_topicList)
 //////////////////////////////////////////////////
 void VisualizeLidar::OnScan(const msgs::LaserScan &_msg)
 {
-  std::lock_guard<std::mutex>(this->dataPtr->serviceMutex);
+  std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
   if (this->dataPtr->initialized)
   {
     this->dataPtr->msg = std::move(_msg);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #1487

## Summary

I ran into segfaults using the `Visualize Lidar` GUI plugin before. It happens when closing the plugin for me. A crash that could be related to this was reported downstream in https://github.com/osrf/mbzirc/issues/150. This PR fixes obvious locking syntax errors in Visualize Lidar GUI plugin. I also removed the one in `OnRefresh` as that causes a deadlock.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

