### PR TITLE
Expose rendering teardown event

### DIFF
--- a/include/gz/sim/rendering/Events.hh
+++ b/include/gz/sim/rendering/Events.hh
@@ -78,9 +78,9 @@ namespace gz
           struct PostRenderTag>;
 
       /// \brief The render teardown event is emitted right before the
-      /// rendering thread is torn down. The veven is emitted in the
+      /// rendering thread is torn down. The event is emitted in the
       /// rendering thread so last minute, cleanup rendering calls can
-      /// be made in this event callback
+      /// be made in this event callback.
       ///
       /// For example:
       /// \code

--- a/include/gz/sim/rendering/Events.hh
+++ b/include/gz/sim/rendering/Events.hh
@@ -77,6 +77,18 @@ namespace gz
       using PostRender = gz::common::EventT<void(void),
           struct PostRenderTag>;
 
+      /// \brief The render teardown event is emitted right before the
+      /// rendering thread is torn down. The veven is emitted in the
+      /// rendering thread so last minute, cleanup rendering calls can
+      /// be made in this event callback
+      ///
+      /// For example:
+      /// \code
+      /// eventManager.Emit<gz::sim::events::RenderTeardown>();
+      /// \endcode
+      using RenderTeardown = gz::common::EventT<void(void),
+          struct RenderTeardownTag>;
+
       /// \brief The force render event may be emitted outside the
       /// rendering thread to force rendering calls ie. to ensure
       /// rendering occurs even if it wasn't seemingly necessary.

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -396,6 +396,8 @@ void SensorsPrivate::RenderThread()
     this->RunOnce();
   }
 
+  this->eventManager->Emit<events::RenderTeardown>();
+
   // clean up before exiting
   for (const auto id : this->sensorIds)
     this->sensorManager.Remove(id);


### PR DESCRIPTION
# 🎉 New feature

Follow-up after #1475. Turns out rendering sensor destruction must also occur in the rendering thread.

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->
This patch adds a `rendering::RenderTeardown` event for downstream users to perform cleanup upon the rendering thread stopping. 

## Test it
<!--Explain how reviewers can test this new feature manually.-->
...
## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
