### PR TITLE
Fix clang warning from Thruster plugin

### DIFF
--- a/src/systems/thruster/Thruster.hh
+++ b/src/systems/thruster/Thruster.hh
@@ -111,7 +111,7 @@ namespace systems
 
     /// Documentation inherited
     public: void PostUpdate(const UpdateInfo &_info,
-        const EntityComponentManager &_ecm);
+        const EntityComponentManager &_ecm) override;
 
     /// \brief Private data pointer
     private: std::unique_ptr<ThrusterPrivateData> dataPtr;


### PR DESCRIPTION
# 🦟 Bug fix

* Follow up to https://github.com/gazebosim/gz-sim/pull/1495

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Just fixing a small warning that was introduced in https://github.com/gazebosim/gz-sim/pull/1495.

See https://build.osrfoundation.org/job/ignition_gazebo-ci-ign-gazebo6-homebrew-amd64/100/clang/

```
'PostUpdate' overrides a member function but is not marked 'override'
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
