### PR TITLE
Disable MacOS flakies Citadel

### DIFF
--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -678,7 +678,8 @@ TEST_P(ServerFixture, ServerControlStop)
 }
 
 /////////////////////////////////////////////////
-TEST_P(ServerFixture, TwoServersNonBlocking)
+// See: https://github.com/gazebosim/gz-sim/issues/1544
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_MAC(TwoServersNonBlocking))
 {
   ignition::gazebo::ServerConfig serverConfig;
   serverConfig.SetSdfString(TestWorldSansPhysics::World());
@@ -718,7 +719,8 @@ TEST_P(ServerFixture, TwoServersNonBlocking)
 }
 
 /////////////////////////////////////////////////
-TEST_P(ServerFixture, TwoServersMixedBlocking)
+// See: https://github.com/gazebosim/gz-sim/issues/1544
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_MAC(TwoServersMixedBlocking))
 {
   ignition::gazebo::ServerConfig serverConfig;
   serverConfig.SetSdfString(TestWorldSansPhysics::World());

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -23,6 +23,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Rand.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 #include <sdf/Mesh.hh>
 
 #include "ignition/gazebo/components/AxisAlignedBox.hh"

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -23,7 +23,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Rand.hh>
 #include <ignition/transport/Node.hh>
-#include <ignition/utils/ExtraTestMacros.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 #include <sdf/Mesh.hh>
 
 #include "ignition/gazebo/components/AxisAlignedBox.hh"

--- a/src/network/PeerTracker_TEST.cc
+++ b/src/network/PeerTracker_TEST.cc
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include "PeerTracker.hh"
 #include "ignition/gazebo/EventManager.hh"
@@ -143,7 +144,7 @@ TEST(PeerTracker, PeerTracker)
 }
 
 //////////////////////////////////////////////////
-TEST(PeerTracker, PeerTrackerStale)
+TEST(PeerTracker, IGN_UTILS_TEST_DISABLED_ON_MAC(PeerTrackerStale))
 {
   ignition::common::Console::SetVerbosity(4);
   EventManager eventMgr;

--- a/src/network/PeerTracker_TEST.cc
+++ b/src/network/PeerTracker_TEST.cc
@@ -20,7 +20,7 @@
 #include <cstdlib>
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
-#include <ignition/utils/ExtraTestMacros.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "PeerTracker.hh"
 #include "ignition/gazebo/EventManager.hh"

--- a/test/integration/altimeter_system.cc
+++ b/test/integration/altimeter_system.cc
@@ -24,6 +24,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Altimeter.hh"
 #include "ignition/gazebo/components/LinearVelocity.hh"

--- a/test/integration/altimeter_system.cc
+++ b/test/integration/altimeter_system.cc
@@ -59,7 +59,8 @@ void altimeterCb(const msgs::Altimeter &_msg)
 
 /////////////////////////////////////////////////
 // The test checks the world pose and sensor readings of a falling altimeter
-TEST_F(AltimeterTest, ModelFalling)
+// See: https://github.com/gazebosim/gz-sim/issues/630
+TEST_F(AltimeterTest, IGN_UTILS_TEST_DISABLED_ON_MAC(ModelFalling))
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/altimeter_system.cc
+++ b/test/integration/altimeter_system.cc
@@ -24,7 +24,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
-#include <ignition/utils/ExtraTestMacros.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Altimeter.hh"
 #include "ignition/gazebo/components/LinearVelocity.hh"

--- a/test/integration/diff_drive_system.cc
+++ b/test/integration/diff_drive_system.cc
@@ -20,6 +20,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/Model.hh"

--- a/test/integration/diff_drive_system.cc
+++ b/test/integration/diff_drive_system.cc
@@ -210,7 +210,8 @@ class DiffDriveTest : public InternalFixture<::testing::TestWithParam<int>>
 };
 
 /////////////////////////////////////////////////
-TEST_P(DiffDriveTest, PublishCmd)
+// See: https://github.com/gazebosim/gz-sim/issues/630
+TEST_P(DiffDriveTest, IGN_UTILS_TEST_DISABLED_ON_MAC(PublishCmd))
 {
   TestPublishCmd(
       std::string(PROJECT_SOURCE_PATH) + "/test/worlds/diff_drive.sdf",
@@ -218,7 +219,8 @@ TEST_P(DiffDriveTest, PublishCmd)
 }
 
 /////////////////////////////////////////////////
-TEST_P(DiffDriveTest, PublishCmdCustomTopics)
+// See: https://github.com/gazebosim/gz-sim/issues/630
+TEST_P(DiffDriveTest, IGN_UTILS_TEST_DISABLED_ON_MAC(PublishCmdCustomTopics))
 {
   TestPublishCmd(
       std::string(PROJECT_SOURCE_PATH) +

--- a/test/integration/diff_drive_system.cc
+++ b/test/integration/diff_drive_system.cc
@@ -20,7 +20,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
-#include <ignition/utils/ExtraTestMacros.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/Model.hh"

--- a/test/integration/level_manager.cc
+++ b/test/integration/level_manager.cc
@@ -23,6 +23,7 @@
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 #include <sdf/Box.hh>
 #include <sdf/Cylinder.hh>
 #include <sdf/Joint.hh>

--- a/test/integration/level_manager.cc
+++ b/test/integration/level_manager.cc
@@ -431,7 +431,8 @@ TEST_F(LevelManagerFixture, LevelsWithMultiplePerformers)
 ///////////////////////////////////////////////
 /// Check that buffers work properly with multiple performers
 // See: https://github.com/gazebosim/gz-sim/issues/630
-TEST_F(LevelManagerFixture, IGN_UTILS_TEST_DISABLED_ON_MAC(LevelBuffersWithMultiplePerformers))
+TEST_F(LevelManagerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_MAC(LevelBuffersWithMultiplePerformers))
 {
   ModelMover perf1(*this->server->EntityByName("sphere"));
   ModelMover perf2(*this->server->EntityByName("box"));

--- a/test/integration/level_manager.cc
+++ b/test/integration/level_manager.cc
@@ -23,7 +23,7 @@
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
-#include <ignition/utils/ExtraTestMacros.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 #include <sdf/Box.hh>
 #include <sdf/Cylinder.hh>
 #include <sdf/Joint.hh>

--- a/test/integration/level_manager.cc
+++ b/test/integration/level_manager.cc
@@ -178,7 +178,8 @@ class LevelManagerFixture : public InternalFixture<::testing::Test>
 
 /////////////////////////////////////////////////
 /// Check default level includes entities not included by other levels
-TEST_F(LevelManagerFixture, DefaultLevel)
+// See: https://github.com/gazebosim/gz-sim/issues/630
+TEST_F(LevelManagerFixture, IGN_UTILS_TEST_DISABLED_ON_MAC(DefaultLevel))
 {
   std::vector<std::set<std::string>> levelEntityNamesList;
 
@@ -429,7 +430,8 @@ TEST_F(LevelManagerFixture, LevelsWithMultiplePerformers)
 
 ///////////////////////////////////////////////
 /// Check that buffers work properly with multiple performers
-TEST_F(LevelManagerFixture, LevelBuffersWithMultiplePerformers)
+// See: https://github.com/gazebosim/gz-sim/issues/630
+TEST_F(LevelManagerFixture, IGN_UTILS_TEST_DISABLED_ON_MAC(LevelBuffersWithMultiplePerformers))
 {
   ModelMover perf1(*this->server->EntityByName("sphere"));
   ModelMover perf2(*this->server->EntityByName("box"));

--- a/test/integration/logical_audio_sensor_plugin.cc
+++ b/test/integration/logical_audio_sensor_plugin.cc
@@ -204,7 +204,8 @@ TEST_F(LogicalAudioTest, LogicalAudioDetections)
       "world/logical_audio_sensor/model/source_model/sensor/source_1");
 }
 
-TEST_F(LogicalAudioTest, LogicalAudioServices)
+// See: https://github.com/gazebosim/gz-sim/issues/630
+TEST_F(LogicalAudioTest, IGN_UTILS_TEST_DISABLED_ON_MAC(LogicalAudioServices))
 {
   ServerConfig serverConfig;
   const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +

--- a/test/integration/logical_audio_sensor_plugin.cc
+++ b/test/integration/logical_audio_sensor_plugin.cc
@@ -28,7 +28,7 @@
 #include <ignition/math/Pose3.hh>
 #include <ignition/msgs.hh>
 #include <ignition/transport.hh>
-#include <ignition/utils/ExtraTestMacros.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/LogicalAudio.hh"
 #include "ignition/gazebo/components/Pose.hh"

--- a/test/integration/logical_audio_sensor_plugin.cc
+++ b/test/integration/logical_audio_sensor_plugin.cc
@@ -28,6 +28,7 @@
 #include <ignition/math/Pose3.hh>
 #include <ignition/msgs.hh>
 #include <ignition/transport.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/LogicalAudio.hh"
 #include "ignition/gazebo/components/Pose.hh"

--- a/test/integration/network_handshake.cc
+++ b/test/integration/network_handshake.cc
@@ -122,7 +122,8 @@ TEST_F(NetworkHandshake, Handshake)
 }
 
 /////////////////////////////////////////////////
-TEST_F(NetworkHandshake, Updates)
+// See: https://github.com/gazebosim/gz-sim/issues/630
+TEST_F(NetworkHandshake, IGN_UTILS_TEST_DISABLED_ON_MAC(Updates))
 {
   auto pluginElem = std::make_shared<sdf::Element>();
   pluginElem->SetName("plugin");

--- a/test/integration/network_handshake.cc
+++ b/test/integration/network_handshake.cc
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include <chrono>
 #include <condition_variable>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include "ignition/msgs/world_control.pb.h"
 #include "ignition/msgs/world_stats.pb.h"

--- a/test/integration/network_handshake.cc
+++ b/test/integration/network_handshake.cc
@@ -18,7 +18,7 @@
 #include <gtest/gtest.h>
 #include <chrono>
 #include <condition_variable>
-#include <ignition/utils/ExtraTestMacros.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/msgs/world_control.pb.h"
 #include "ignition/msgs/world_stats.pb.h"

--- a/test/integration/performer_detector.cc
+++ b/test/integration/performer_detector.cc
@@ -19,7 +19,7 @@
 #include <ignition/msgs/pose.pb.h>
 
 #include <ignition/transport/Node.hh>
-#include <ignition/utils/ExtraTestMacros.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/SystemLoader.hh"

--- a/test/integration/performer_detector.cc
+++ b/test/integration/performer_detector.cc
@@ -60,7 +60,8 @@ class PerformerDetectorTest : public InternalFixture<::testing::Test>
 
 /////////////////////////////////////////////////
 // Test that commanded motor speed is applied
-TEST_F(PerformerDetectorTest, MovingPerformer)
+// See: https://github.com/gazebosim/gz-sim/issues/630
+TEST_F(PerformerDetectorTest, IGN_UTILS_TEST_DISABLED_ON_MAC(MovingPerformer))
 {
   auto server = this->StartServer("/test/worlds/performer_detector.sdf");
 

--- a/test/integration/performer_detector.cc
+++ b/test/integration/performer_detector.cc
@@ -19,6 +19,7 @@
 #include <ignition/msgs/pose.pb.h>
 
 #include <ignition/transport/Node.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/SystemLoader.hh"

--- a/test/integration/pose_publisher_system.cc
+++ b/test/integration/pose_publisher_system.cc
@@ -309,7 +309,8 @@ TEST_F(PosePublisherTest, PublishCmd)
 }
 
 /////////////////////////////////////////////////
-TEST_F(PosePublisherTest, UpdateFrequency)
+// See: https://github.com/gazebosim/gz-sim/issues/630
+TEST_F(PosePublisherTest, IGN_UTILS_TEST_DISABLED_ON_MAC(UpdateFrequency))
 {
   // Start server
   ServerConfig serverConfig;
@@ -626,7 +627,8 @@ TEST_F(PosePublisherTest, StaticPosePublisher)
 }
 
 /////////////////////////////////////////////////
-TEST_F(PosePublisherTest, StaticPoseUpdateFrequency)
+// See: https://github.com/gazebosim/gz-sim/issues/630
+TEST_F(PosePublisherTest, IGN_UTILS_TEST_DISABLED_ON_MAC(StaticPoseUpdateFrequency))
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/pose_publisher_system.cc
+++ b/test/integration/pose_publisher_system.cc
@@ -22,6 +22,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/Model.hh"

--- a/test/integration/pose_publisher_system.cc
+++ b/test/integration/pose_publisher_system.cc
@@ -628,7 +628,8 @@ TEST_F(PosePublisherTest, StaticPosePublisher)
 
 /////////////////////////////////////////////////
 // See: https://github.com/gazebosim/gz-sim/issues/630
-TEST_F(PosePublisherTest, IGN_UTILS_TEST_DISABLED_ON_MAC(StaticPoseUpdateFrequency))
+TEST_F(PosePublisherTest,
+       IGN_UTILS_TEST_DISABLED_ON_MAC(StaticPoseUpdateFrequency))
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/pose_publisher_system.cc
+++ b/test/integration/pose_publisher_system.cc
@@ -22,7 +22,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
-#include <ignition/utils/ExtraTestMacros.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/Model.hh"

--- a/test/integration/touch_plugin.cc
+++ b/test/integration/touch_plugin.cc
@@ -19,7 +19,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
-#include <ignition/utils/ExtraTestMacros.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/test_config.hh"

--- a/test/integration/touch_plugin.cc
+++ b/test/integration/touch_plugin.cc
@@ -185,7 +185,8 @@ TEST_F(TouchPluginTest, StartDisabled)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TouchPluginTest, RemovalOfParentModel)
+// See: https://github.com/gazebosim/gz-sim/issues/630
+TEST_F(TouchPluginTest, IGN_UTILS_TEST_DISABLED_ON_MAC(RemovalOfParentModel))
 {
   this->StartServer("/test/worlds/touch_plugin.sdf");
 

--- a/test/integration/touch_plugin.cc
+++ b/test/integration/touch_plugin.cc
@@ -19,6 +19,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/Server.hh"
 #include "ignition/gazebo/test_config.hh"

--- a/test/integration/velocity_control_system.cc
+++ b/test/integration/velocity_control_system.cc
@@ -230,7 +230,8 @@ class VelocityControlTest
 };
 
 /////////////////////////////////////////////////
-TEST_P(VelocityControlTest, PublishCmd)
+// See: https://github.com/gazebosim/gz-sim/issues/630
+TEST_P(VelocityControlTest, IGN_UTILS_TEST_DISABLED_ON_MAC(PublishCmd))
 {
   TestPublishCmd(
       std::string(PROJECT_SOURCE_PATH) + "/test/worlds/velocity_control.sdf",

--- a/test/integration/velocity_control_system.cc
+++ b/test/integration/velocity_control_system.cc
@@ -20,6 +20,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Link.hh"
 #include "ignition/gazebo/components/Name.hh"

--- a/test/integration/velocity_control_system.cc
+++ b/test/integration/velocity_control_system.cc
@@ -20,7 +20,7 @@
 #include <ignition/common/Util.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/transport/Node.hh>
-#include <ignition/utils/ExtraTestMacros.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/gazebo/components/Link.hh"
 #include "ignition/gazebo/components/Name.hh"


### PR DESCRIPTION
Backport of #1398 to Citadel and temporary disabled tests for #630 #154

## Summary
Disabling flaky tests on MacOS to help with https://github.com/gazebo-tooling/release-tools/issues/398

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests -> actually disabling tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

