### PR TITLE
Expose the ability to stop a server

### DIFF
--- a/include/ignition/gazebo/Server.hh
+++ b/include/ignition/gazebo/Server.hh
@@ -285,6 +285,9 @@ namespace ignition
                                       bool _recursive = true,
                                       const unsigned int _worldIndex = 0);
 
+      /// \brief Stop the server. This will stop all running simulations.
+      public: void Stop();
+
       /// \brief Private data
       private: std::unique_ptr<ServerPrivate> dataPtr;
     };

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -377,3 +377,9 @@ bool Server::RequestRemoveEntity(const Entity _entity,
 
   return false;
 }
+
+//////////////////////////////////////////////////
+void Server::Stop()
+{
+  this->dataPtr->Stop();
+}

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -339,7 +339,7 @@ TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(SdfServerConfig))
 
   // Setting the SDF file should override the string.
   serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
-      "/test/worlds/shapes.sdf"));
+      "test", "worlds", "shapes.sdf"));
   EXPECT_FALSE(serverConfig.SdfFile().empty());
   EXPECT_TRUE(serverConfig.SdfString().empty());
 
@@ -479,7 +479,7 @@ TEST_P(ServerFixture, SdfStringServerConfig)
   ignition::gazebo::ServerConfig serverConfig;
 
   serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
-      "/test/worlds/shapes.sdf"));
+      "test", "worlds", "shapes.sdf"));
   EXPECT_FALSE(serverConfig.SdfFile().empty());
   EXPECT_TRUE(serverConfig.SdfString().empty());
 
@@ -795,7 +795,7 @@ TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(AddSystemWhileRunning))
   ignition::gazebo::ServerConfig serverConfig;
 
   serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
-      "/test/worlds/shapes.sdf"));
+      "test", "worlds", "shapes.sdf"));
 
   gazebo::Server server(serverConfig);
   EXPECT_FALSE(server.Running());
@@ -843,7 +843,7 @@ TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(AddSystemAfterLoad))
   ignition::gazebo::ServerConfig serverConfig;
 
   serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
-      "/test/worlds/shapes.sdf"));
+      "test", "worlds", "shapes.sdf"));
 
   gazebo::Server server(serverConfig);
   EXPECT_FALSE(server.Running());
@@ -915,8 +915,9 @@ TEST_P(ServerFixture, Seed)
 TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ResourcePath))
 {
   ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
-      (common::joinPaths(PROJECT_SOURCE_PATH, "/test/worlds:") +
-       common::joinPaths(PROJECT_SOURCE_PATH, "/test/worlds/models")).c_str());
+      (common::joinPaths(PROJECT_SOURCE_PATH, "test", "worlds:") +
+       common::joinPaths(PROJECT_SOURCE_PATH,
+           "test", "worlds", "models")).c_str());
 
   ServerConfig serverConfig;
   serverConfig.SetSdfFile("resource_paths.sdf");
@@ -1177,7 +1178,7 @@ TEST_P(ServerFixture, Stop)
   ServerConfig serverConfig;
   serverConfig.SetUpdateRate(10000);
   serverConfig.SetSdfFile(common::joinPaths((PROJECT_SOURCE_PATH),
-      "/test/worlds/shapes.sdf"));
+      "test", "worlds", "shapes.sdf"));
 
   gazebo::Server server(serverConfig);
 

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -231,8 +231,8 @@ TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigRealPlugin))
   // Start server
   ServerConfig serverConfig;
   serverConfig.SetUpdateRate(10000);
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/shapes.sdf");
+  serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
+      "/test/worlds/shapes.sdf"));
 
   sdf::ElementPtr sdf(new sdf::Element);
   sdf->SetName("plugin");
@@ -338,8 +338,8 @@ TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(SdfServerConfig))
   EXPECT_FALSE(serverConfig.SdfString().empty());
 
   // Setting the SDF file should override the string.
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/shapes.sdf");
+  serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
+      "/test/worlds/shapes.sdf"));
   EXPECT_FALSE(serverConfig.SdfFile().empty());
   EXPECT_TRUE(serverConfig.SdfString().empty());
 
@@ -407,8 +407,7 @@ TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(SdfRootServerConfig))
 /////////////////////////////////////////////////
 TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigLogRecord))
 {
-  auto logPath = common::joinPaths(
-      std::string(PROJECT_BINARY_PATH), "test_log_path");
+  auto logPath = common::joinPaths(PROJECT_BINARY_PATH, "test_log_path");
   auto logFile = common::joinPaths(logPath, "state.tlog");
   auto compressedFile = logPath + ".zip";
 
@@ -447,8 +446,7 @@ TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigLogRecord))
 TEST_P(ServerFixture,
        IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigLogRecordCompress))
 {
-  auto logPath = common::joinPaths(
-      std::string(PROJECT_BINARY_PATH), "test_log_path");
+  auto logPath = common::joinPaths(PROJECT_BINARY_PATH, "test_log_path");
   auto logFile = common::joinPaths(logPath, "state.tlog");
   auto compressedFile = logPath + ".zip";
 
@@ -480,8 +478,8 @@ TEST_P(ServerFixture, SdfStringServerConfig)
 {
   ignition::gazebo::ServerConfig serverConfig;
 
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/shapes.sdf");
+  serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
+      "/test/worlds/shapes.sdf"));
   EXPECT_FALSE(serverConfig.SdfFile().empty());
   EXPECT_TRUE(serverConfig.SdfString().empty());
 
@@ -796,8 +794,8 @@ TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(AddSystemWhileRunning))
 {
   ignition::gazebo::ServerConfig serverConfig;
 
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/shapes.sdf");
+  serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
+      "/test/worlds/shapes.sdf"));
 
   gazebo::Server server(serverConfig);
   EXPECT_FALSE(server.Running());
@@ -844,8 +842,8 @@ TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(AddSystemAfterLoad))
 {
   ignition::gazebo::ServerConfig serverConfig;
 
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/shapes.sdf");
+  serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
+      "/test/worlds/shapes.sdf"));
 
   gazebo::Server server(serverConfig);
   EXPECT_FALSE(server.Running());
@@ -917,8 +915,8 @@ TEST_P(ServerFixture, Seed)
 TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ResourcePath))
 {
   ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
-         (std::string(PROJECT_SOURCE_PATH) + "/test/worlds:" +
-          std::string(PROJECT_SOURCE_PATH) + "/test/worlds/models").c_str());
+      (common::joinPaths(PROJECT_SOURCE_PATH, "/test/worlds:") +
+       common::joinPaths(PROJECT_SOURCE_PATH, "/test/worlds/models")).c_str());
 
   ServerConfig serverConfig;
   serverConfig.SetSdfFile("resource_paths.sdf");
@@ -1178,8 +1176,8 @@ TEST_P(ServerFixture, Stop)
   // Start server
   ServerConfig serverConfig;
   serverConfig.SetUpdateRate(10000);
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/shapes.sdf");
+  serverConfig.SetSdfFile(common::joinPaths((PROJECT_SOURCE_PATH),
+      "/test/worlds/shapes.sdf"));
 
   gazebo::Server server(serverConfig);
 

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -232,7 +232,7 @@ TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigRealPlugin))
   ServerConfig serverConfig;
   serverConfig.SetUpdateRate(10000);
   serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
-      "/test/worlds/shapes.sdf"));
+      "test", "worlds", "shapes.sdf"));
 
   sdf::ElementPtr sdf(new sdf::Element);
   sdf->SetName("plugin");

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -1172,6 +1172,32 @@ TEST_P(ServerFixture, ResolveResourcePaths)
         "include_nested", "model.sdf"), true);
 }
 
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, Stop)
+{
+  // Start server
+  ServerConfig serverConfig;
+  serverConfig.SetUpdateRate(10000);
+  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
+      "/test/worlds/shapes.sdf");
+
+  gazebo::Server server(serverConfig);
+
+  // The simulation runner should not be running.
+  EXPECT_FALSE(*server.Running(0));
+  EXPECT_FALSE(server.Running());
+
+  // Run the server.
+  EXPECT_TRUE(server.Run(false, 0, false));
+  EXPECT_TRUE(*server.Running(0));
+  EXPECT_TRUE(server.Running());
+
+  // Stop the server
+  server.Stop();
+  EXPECT_FALSE(*server.Running(0));
+  EXPECT_FALSE(server.Running());
+}
+
 // Run multiple times. We want to make sure that static globals don't cause
 // problems.
 INSTANTIATE_TEST_SUITE_P(ServerRepeat, ServerFixture, ::testing::Range(1, 2));


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

Exposes `ServerPrivate::Stop` through a new `Server::Stop` function. This is useful when using Gazebo as a library.
 

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.