### PR TITLE
Detect gz program instead of using CMake module to check for gz-tools

### DIFF
--- a/.github/ci/after_make.sh
+++ b/.github/ci/after_make.sh
@@ -8,7 +8,7 @@ make install
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
 
 # For ign-tools
-export GZ_CONFIG_PATH=/usr/local/share/gz
+export GZ_CONFIG_PATH=/usr/local/share/ignition
 
 # For rendering / window tests
 Xvfb :1 -screen 0 1280x1024x24 &

--- a/.github/ci/after_make.sh
+++ b/.github/ci/after_make.sh
@@ -7,7 +7,7 @@ set -e
 make install
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
 
-# For ign-tools
+# For gz-tools
 export GZ_CONFIG_PATH=/usr/local/share/ignition
 
 # For rendering / window tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,10 +159,13 @@ gz_find_package(ignition-math7 REQUIRED COMPONENTS eigen3)
 set(IGN_MATH_VER ${ignition-math7_VERSION_MAJOR})
 
 #--------------------------------------
-# Find ignition-tools
-gz_find_package(ignition-tools2
-                 REQUIRED
-                 PKGCONFIG "ignition-tools2")
+# Find if gz command is available
+find_program(GZ_TOOLS_PROGRAM gz)
+if (GZ_TOOLS_PROGRAM)
+  message (STATUS "Searching for gz program - found. CLI tests can be built.")
+else()
+  message (STATUS "Searching for gz program - not found. CLI tests are skipped.")
+endif()
 
 #--------------------------------------
 # Find ignition-utils

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,6 +114,11 @@ set(tests_needing_display
   ModelCommandAPI_TEST.cc
 )
 
+# Disable tests that need CLI if gz-tools is not found
+if (MSVC OR NOT GZ_TOOLS_PROGRAM)
+  list(REMOVE_ITEM gtest_sources gz_TEST.cc ModelCommandAPI_TEST.cc)
+endif()
+
 # Add systems that need a valid display here.
 # \todo(anyone) Find a way to run these tests with a virtual display such Xvfb
 # or Xdummy instead of skipping them

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -214,7 +214,7 @@ foreach(CMD_TEST
       "BREW_RUBY=\"${BREW_RUBY} \"")
 
   target_compile_definitions(${CMD_TEST} PRIVATE
-      "GZ_PATH=\"${IGNITION-TOOLS2_BINARY_DIRS}\"")
+      "GZ_PATH=\"${GZ_TOOLS_PROGRAM}\"")
 
   set(_env_vars)
   list(APPEND _env_vars "GZ_CONFIG_PATH=${CMAKE_BINARY_DIR}/test/conf")

--- a/src/ModelCommandAPI_TEST.cc
+++ b/src/ModelCommandAPI_TEST.cc
@@ -26,8 +26,7 @@
 #include "gz/sim/test_config.hh"  // NOLINT(build/include)
 
 static const std::string kIgnModelCommand(
-    std::string(BREW_RUBY) + std::string(GZ_PATH) + "/gz model ");
-
+    std::string(BREW_RUBY) + std::string(GZ_PATH) + " model ");
 
 /////////////////////////////////////////////////
 /// \brief Used to avoid the cases where the zero is

--- a/src/gz_TEST.cc
+++ b/src/gz_TEST.cc
@@ -28,7 +28,7 @@
 static const std::string kBinPath(PROJECT_BINARY_PATH);
 
 static const std::string kIgnCommand(
-    std::string(BREW_RUBY) + std::string(GZ_PATH) + "/gz sim -s ");
+    std::string(BREW_RUBY) + std::string(GZ_PATH) + " sim -s ");
 
 /////////////////////////////////////////////////
 std::string customExecStr(std::string _cmd)

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -94,6 +94,11 @@ set(tests_needing_display
   wide_angle_camera.cc
 )
 
+# Disable tests that need CLI if gz-tools is not found
+if (MSVC OR NOT GZ_TOOLS_PROGRAM)
+  list(REMOVE_ITEM tests log_system.cc)
+endif()
+
 # Add systems that need a valid display here.
 # \todo(anyone) Find a way to run these tests with a virtual display such Xvfb
 # or Xdummy instead of skipping them


### PR DESCRIPTION
# 🦟 Bug fix

* Part of https://github.com/gazebo-tooling/release-tools/issues/472

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This branch was broken when https://github.com/gazebosim/gz-tools/pull/96 was merged. This PR fixes the build by addressing https://github.com/gazebo-tooling/release-tools/issues/472 like other libraries did.

Sorry for the disruption, I should have built the entire stack with the `gz-tools` PR instead of just a few libs.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
