### PR TITLE
Utilizes function to sequence trajectories

### DIFF
--- a/include/ignition/gazebo/rendering/SceneManager.hh
+++ b/include/ignition/gazebo/rendering/SceneManager.hh
@@ -203,7 +203,8 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     /// \brief Sequences Trajectories
     /// \param[in] _trajectories Actor trajectories
     /// \param[in] _time Actor trajectory delay start time (miliseconds)
-    public: void SequenceTrajectories(std::vector<common::TrajectoryInfo>& _trajectories,
+    public: void SequenceTrajectories(
+        std::vector<common::TrajectoryInfo>& _trajectories,
         std::chrono::steady_clock::time_point _time);
 
     /// \brief Create an actor

--- a/include/ignition/gazebo/rendering/SceneManager.hh
+++ b/include/ignition/gazebo/rendering/SceneManager.hh
@@ -200,6 +200,12 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     /// \return Pointer to requested visual
     public: rendering::VisualPtr VisualById(Entity _id);
 
+    /// \brief Sequences Trajectories
+    /// \param[in] _trajectories Actor trajectories
+    /// \param[in] _delayStartTime Actor trajectory delay start time (miliseconds)
+    public: void SequenceTrajectories(std::vector<common::TrajectoryInfo>& _trajectories,
+        std::chrono::steady_clock::time_point _time);
+
     /// \brief Create an actor
     /// \param[in] _id Unique actor id
     /// \param[in] _actor Actor sdf dom

--- a/include/ignition/gazebo/rendering/SceneManager.hh
+++ b/include/ignition/gazebo/rendering/SceneManager.hh
@@ -202,7 +202,7 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
 
     /// \brief Sequences Trajectories
     /// \param[in] _trajectories Actor trajectories
-    /// \param[in] _delayStartTime Actor trajectory delay start time (miliseconds)
+    /// \param[in] _time Actor trajectory delay start time (miliseconds)
     public: void SequenceTrajectories(std::vector<common::TrajectoryInfo>& _trajectories,
         std::chrono::steady_clock::time_point _time);
 

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -910,6 +910,19 @@ rendering::MaterialPtr SceneManager::LoadMaterial(
   return material;
 }
 
+void SceneManager::SequenceTrajectories(std::vector<common::TrajectoryInfo>& _trajectories,
+   TP _time)
+{
+  // sequencing all trajectories
+  for (auto &trajectory : _trajectories)
+  {
+    auto duration = trajectory.Duration();
+    trajectory.SetStartTime(_time);
+    _time += duration;
+    trajectory.SetEndTime(_time);
+  }
+}
+
 /////////////////////////////////////////////////
 rendering::VisualPtr SceneManager::CreateActor(Entity _id,
     const sdf::Actor &_actor, const std::string &_name, Entity _parentId)
@@ -1164,13 +1177,8 @@ rendering::VisualPtr SceneManager::CreateActor(Entity _id,
   auto delayStartTime = std::chrono::milliseconds(
               static_cast<int>(_actor.ScriptDelayStart() * 1000));
   TP time(delayStartTime);
-  for (auto &trajectory : trajectories)
-  {
-    auto dura = trajectory.Duration();
-    trajectory.SetStartTime(time);
-    time += dura;
-    trajectory.SetEndTime(time);
-  }
+  this->SequenceTrajectories(trajectories, time);
+
 
   // loop flag: add a placeholder trajectory to indicate no loop
   if (!_actor.ScriptLoop())

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -910,8 +910,9 @@ rendering::MaterialPtr SceneManager::LoadMaterial(
   return material;
 }
 
-void SceneManager::SequenceTrajectories(std::vector<common::TrajectoryInfo>& _trajectories,
-   TP _time)
+void SceneManager::SequenceTrajectories(
+    std::vector<common::TrajectoryInfo>& _trajectories,
+    TP _time)
 {
   // sequencing all trajectories
   for (auto &trajectory : _trajectories)


### PR DESCRIPTION
Utilizes new SequenceTrajectories function to sequence trajectories during 
actor creation.

Part of three PR for the [meta-ticket](https://github.com/gazebosim/gz-sim/issues/1564#issue-1290407501) for slimming down the CreateActor function.