### PR TITLE
Fix to modelphotoshoot test

### DIFF
--- a/test/integration/ModelPhotoShootTest.hh
+++ b/test/integration/ModelPhotoShootTest.hh
@@ -95,7 +95,7 @@ void testImages(const std::string &_imageFile,
   EXPECT_EQ(image.PixelFormat(), testImage.PixelFormat());
   // Images should be almost equal (They might have
   // minimal color differences on a few pixels)
-  unsigned int equal_pixels = 0;
+  unsigned int equalPixels = 0;
   unsigned int total_pixels = testImage.Width() * testImage.Height();
   for (unsigned int x = 0; x < image.Width(); x++)
   {

--- a/test/integration/ModelPhotoShootTest.hh
+++ b/test/integration/ModelPhotoShootTest.hh
@@ -103,11 +103,11 @@ void testImages(const std::string &_imageFile,
     {
       if (image.Pixel(x, y) == testImage.Pixel(x, y))
       {
-        equal_pixels++;
+        equalPixels++;
       }
     }
   }
-  ASSERT_GT((float)equal_pixels/(float)total_pixels, 0.99);
+  ASSERT_GT((float)equalPixels/(float)totalPixels, 0.99);
 
   // Deleting files so they do not affect future tests
   EXPECT_EQ(remove(imageFilePath.c_str()), 0);

--- a/test/integration/ModelPhotoShootTest.hh
+++ b/test/integration/ModelPhotoShootTest.hh
@@ -96,7 +96,7 @@ void testImages(const std::string &_imageFile,
   // Images should be almost equal (They might have
   // minimal color differences on a few pixels)
   unsigned int equalPixels = 0;
-  unsigned int total_pixels = testImage.Width() * testImage.Height();
+  unsigned int totalPixels = testImage.Width() * testImage.Height();
   for (unsigned int x = 0; x < image.Width(); x++)
   {
     for (unsigned int y = 0; y < image.Height(); y++)

--- a/test/integration/ModelPhotoShootTest.hh
+++ b/test/integration/ModelPhotoShootTest.hh
@@ -93,14 +93,21 @@ void testImages(const std::string &_imageFile,
   EXPECT_EQ(image.Width(), testImage.Width());
   EXPECT_EQ(image.Height(), testImage.Height());
   EXPECT_EQ(image.PixelFormat(), testImage.PixelFormat());
-  unsigned int dataLength;
-  unsigned char *imageData = nullptr;
-  image.Data(&imageData, dataLength);
-  unsigned int testDataLenght;
-  unsigned char *testImageData = nullptr;
-  image.Data(&testImageData, testDataLenght);
-  ASSERT_EQ(dataLength, testDataLenght);
-  ASSERT_EQ(memcmp(imageData, testImageData, dataLength), 0);
+  // Images should be almost equal (They might have
+  // minimal color differences on a few pixels)
+  unsigned int equal_pixels = 0;
+  unsigned int total_pixels = testImage.Width() * testImage.Height();
+  for (unsigned int x = 0; x < image.Width(); x++)
+  {
+    for (unsigned int y = 0; y < image.Height(); y++)
+    {
+      if (image.Pixel(x, y) == testImage.Pixel(x, y))
+      {
+        equal_pixels++;
+      }
+    }
+  }
+  ASSERT_GT((float)equal_pixels/(float)total_pixels, 0.99);
 
   // Deleting files so they do not affect future tests
   EXPECT_EQ(remove(imageFilePath.c_str()), 0);


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

# 🦟 Bug fix

This PR fixes the test for Model Photo Shoot system. Apparently the image generation contains some differences in color for a few pixels that would make it fail when comparing the exact content of the two images data. For now it will compare that most of the pixels are the same.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
