### PR TITLE
Implement Pose3d with common widget pose

### DIFF
--- a/src/gui/plugins/component_inspector/Pose3d.qml
+++ b/src/gui/plugins/component_inspector/Pose3d.qml
@@ -25,7 +25,7 @@ import "qrc:/qml"
 
 // Item displaying 3D pose information.
 Rectangle {
-  height: header.height + gzPose.height
+  height: header.height + gzPoseContent.height
   width: componentInspector.width
   color: index % 2 == 0 ? lightGrey : darkGrey
 
@@ -39,13 +39,21 @@ Rectangle {
   function sendPose() {
     // TODO(anyone) There's a loss of precision when these values get to C++
     Pose3dImpl.OnPose(
-      gzPose.xItem.value,
-      gzPose.yItem.value,
-      gzPose.zItem.value,
-      gzPose.rollItem.value,
-      gzPose.pitchItem.value,
-      gzPose.yawItem.value
+      gzPoseContent.xItem.value,
+      gzPoseContent.yItem.value,
+      gzPoseContent.zItem.value,
+      gzPoseContent.rollItem.value,
+      gzPoseContent.pitchItem.value,
+      gzPoseContent.yawItem.value
     );
+    console.log(
+      gzPoseContent.xItem.value,
+      gzPoseContent.yItem.value,
+      gzPoseContent.zItem.value,
+      gzPoseContent.rollItem.value,
+      gzPoseContent.pitchItem.value,
+      gzPoseContent.yawItem.value
+    )
   }
 
   Column {
@@ -69,7 +77,7 @@ Rectangle {
           sourceSize.width: indentation
           fillMode: Image.Pad
           Layout.alignment : Qt.AlignVCenter
-          source: gzPose.show ?
+          source: gzPoseContent.show ?
               "qrc:/Gazebo/images/minus.png" : "qrc:/Gazebo/images/plus.png"
         }
         TypeHeader {
@@ -84,9 +92,7 @@ Rectangle {
         hoverEnabled: true
         cursorShape: Qt.PointingHandCursor
         onClicked: {
-          gzPose.show = !gzPose.show
-          // console.log(model.data[0], model.data[1], model.data[2], model.data[3], model.data[4], model.data[5])
-          // console.log(gzPose.xItem, gzPose.yItem, gzPose.zItem, gzPose.rollItem, gzPose.pitchItem, gzPose.yawItem)
+          gzPoseContent.show = !gzPoseContent.show
         }
         onEntered: {
           header.color = highlightColor
@@ -99,7 +105,7 @@ Rectangle {
 
     // Content
     GzPose {
-      id: gzPose
+      id: gzPoseContent
       width: parent.width
 
       readOnly: {
@@ -114,9 +120,13 @@ Rectangle {
       pitchModelValue: model.data[4]
       yawModelValue: model.data[5]
 
-      onPoseSet: {
+      onGzPoseSet: {
         sendPose()
       }
-    } // end gzPose
+
+      onShowChanged: {
+        console.log("bool var show changed")
+      }
+    } // end gzPoseContent
   } // end Column
 } // end Rectangle

--- a/src/gui/plugins/component_inspector/Pose3d.qml
+++ b/src/gui/plugins/component_inspector/Pose3d.qml
@@ -15,7 +15,6 @@
  *
 */
 import QtQuick 2.9
-import QtQuick.Controls 1.4
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.1
 import QtQuick.Layouts 1.3
@@ -36,24 +35,9 @@ Rectangle {
   property int margin: 5
 
   // Send new pose to C++
-  function sendPose() {
+  function sendPose(x, y, z, roll, pitch, yaw) {
     // TODO(anyone) There's a loss of precision when these values get to C++
-    Pose3dImpl.OnPose(
-      gzPoseContent.xItem.value,
-      gzPoseContent.yItem.value,
-      gzPoseContent.zItem.value,
-      gzPoseContent.rollItem.value,
-      gzPoseContent.pitchItem.value,
-      gzPoseContent.yawItem.value
-    );
-    console.log(
-      gzPoseContent.xItem.value,
-      gzPoseContent.yItem.value,
-      gzPoseContent.zItem.value,
-      gzPoseContent.rollItem.value,
-      gzPoseContent.pitchItem.value,
-      gzPoseContent.yawItem.value
-    )
+    Pose3dImpl.OnPose(x, y, z, roll, pitch, yaw);
   }
 
   Column {
@@ -120,8 +104,8 @@ Rectangle {
       pitchModelValue: model.data[4]
       yawModelValue: model.data[5]
 
-      onGzPoseSet: {
-        sendPose()
+      onGzPoseSet: (x, y, z, roll, pitch, yaw) => {
+        sendPose(x, y, z, roll, pitch, yaw)
       }
 
       onShowChanged: {

--- a/src/gui/plugins/component_inspector/Pose3d.qml
+++ b/src/gui/plugins/component_inspector/Pose3d.qml
@@ -104,7 +104,7 @@ Rectangle {
       pitchModelValue: model.data[4]
       yawModelValue: model.data[5]
 
-      onGzPoseSet: (x, y, z, roll, pitch, yaw) => {
+      onGzPoseSet: {
         sendPose(x, y, z, roll, pitch, yaw)
       }
 

--- a/src/gui/plugins/component_inspector/Pose3d.qml
+++ b/src/gui/plugins/component_inspector/Pose3d.qml
@@ -97,20 +97,21 @@ Rectangle {
         return !(isModel) || nestedModel
       }
 
-      xModelValue: model.data[0]
-      yModelValue: model.data[1]
-      zModelValue: model.data[2]
-      rollModelValue: model.data[3]
-      pitchModelValue: model.data[4]
-      yawModelValue: model.data[5]
+      xValue: model.data[0]
+      yValue: model.data[1]
+      zValue: model.data[2]
+      rollValue: model.data[3]
+      pitchValue: model.data[4]
+      yawValue: model.data[5]
 
       onGzPoseSet: {
-        sendPose(x, y, z, roll, pitch, yaw)
+        // _x, _y, _z, _roll, _pitch, _yaw are parameters of signal gzPoseSet
+        sendPose(_x, _y, _z, _roll, _pitch, _yaw)
       }
 
-      onShowChanged: {
-        console.log("bool var show changed")
-      }
+      // By default it is closed
+      show: false
+
     } // end gzPoseContent
   } // end Column
 } // end Rectangle

--- a/src/gui/plugins/component_inspector/Pose3d.qml
+++ b/src/gui/plugins/component_inspector/Pose3d.qml
@@ -86,32 +86,52 @@ Rectangle {
         }
       }
     }
-
-    // Content
-    GzPose {
-      id: gzPoseContent
+    Rectangle {
+      id: content
+      color: "transparent"
       width: parent.width
+      height: gzPoseContent.height
+      RowLayout {
+        id: gzPoseRow
+        width: parent.width
 
-      readOnly: {
-        var isModel = entityType == "model"
-        return !(isModel) || nestedModel
-      }
+        // Left spacer
+        Item {
+          Layout.preferredWidth: margin + indentation
+        }
 
-      xValue: model.data[0]
-      yValue: model.data[1]
-      zValue: model.data[2]
-      rollValue: model.data[3]
-      pitchValue: model.data[4]
-      yawValue: model.data[5]
+        // Content
+        GzPose {
+          id: gzPoseContent
+          Layout.fillWidth: true
 
-      onGzPoseSet: {
-        // _x, _y, _z, _roll, _pitch, _yaw are parameters of signal gzPoseSet
-        sendPose(_x, _y, _z, _roll, _pitch, _yaw)
-      }
+          readOnly: {
+            var isModel = entityType == "model"
+            return !(isModel) || nestedModel
+          }
 
-      // By default it is closed
-      show: false
+          xValue: model.data[0]
+          yValue: model.data[1]
+          zValue: model.data[2]
+          rollValue: model.data[3]
+          pitchValue: model.data[4]
+          yawValue: model.data[5]
 
-    } // end gzPoseContent
+          onGzPoseSet: {
+            // _x, _y, _z, _roll, _pitch, _yaw are parameters of signal gzPoseSet
+            sendPose(_x, _y, _z, _roll, _pitch, _yaw)
+          }
+
+          // By default it is closed
+          show: false
+
+        } // end gzPoseContent
+
+        // Right spacer
+        Item {
+          Layout.preferredWidth: margin
+        }
+      } // end RowLayout
+    } // end Rectangle
   } // end Column
 } // end Rectangle

--- a/src/gui/plugins/component_inspector/Pose3d.qml
+++ b/src/gui/plugins/component_inspector/Pose3d.qml
@@ -61,7 +61,7 @@ Rectangle {
           sourceSize.width: indentation
           fillMode: Image.Pad
           Layout.alignment : Qt.AlignVCenter
-          source: gzPoseContent.show ?
+          source: gzPoseContent.expand ?
               "qrc:/Gazebo/images/minus.png" : "qrc:/Gazebo/images/plus.png"
         }
         TypeHeader {
@@ -76,7 +76,7 @@ Rectangle {
         hoverEnabled: true
         cursorShape: Qt.PointingHandCursor
         onClicked: {
-          gzPoseContent.show = !gzPoseContent.show
+          gzPoseContent.expand = !gzPoseContent.expand
         }
         onEntered: {
           header.color = highlightColor
@@ -87,7 +87,6 @@ Rectangle {
       }
     }
     Rectangle {
-      id: content
       color: "transparent"
       width: parent.width
       height: gzPoseContent.height
@@ -123,7 +122,7 @@ Rectangle {
           }
 
           // By default it is closed
-          show: false
+          expand: false
 
         } // end gzPoseContent
 

--- a/src/gui/plugins/component_inspector/Pose3d.qml
+++ b/src/gui/plugins/component_inspector/Pose3d.qml
@@ -24,7 +24,7 @@ import "qrc:/qml"
 
 // Item displaying 3D pose information.
 Rectangle {
-  height: header.height + gzPoseContent.height
+  height: header.height + gzPoseInstance.height
   width: componentInspector.width
   color: index % 2 == 0 ? lightGrey : darkGrey
 
@@ -61,7 +61,7 @@ Rectangle {
           sourceSize.width: indentation
           fillMode: Image.Pad
           Layout.alignment : Qt.AlignVCenter
-          source: gzPoseContent.expand ?
+          source: gzPoseInstance.expand ?
               "qrc:/Gazebo/images/minus.png" : "qrc:/Gazebo/images/plus.png"
         }
         TypeHeader {
@@ -76,7 +76,7 @@ Rectangle {
         hoverEnabled: true
         cursorShape: Qt.PointingHandCursor
         onClicked: {
-          gzPoseContent.expand = !gzPoseContent.expand
+          gzPoseInstance.expand = !gzPoseInstance.expand
         }
         onEntered: {
           header.color = highlightColor
@@ -89,7 +89,7 @@ Rectangle {
     Rectangle {
       color: "transparent"
       width: parent.width
-      height: gzPoseContent.height
+      height: gzPoseInstance.height
       RowLayout {
         id: gzPoseRow
         width: parent.width
@@ -101,7 +101,7 @@ Rectangle {
 
         // Content
         GzPose {
-          id: gzPoseContent
+          id: gzPoseInstance
           Layout.fillWidth: true
 
           readOnly: {
@@ -124,7 +124,7 @@ Rectangle {
           // By default it is closed
           expand: false
 
-        } // end gzPoseContent
+        } // end gzPoseInstance
 
         // Right spacer
         Item {


### PR DESCRIPTION
<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

* Part of https://github.com/gazebosim/gz-gui/issues/310

# New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Implement `Pose` in Component Inspector with common widget GzPose introduced in gz-gui#424. 

Behavior should be exactly the same as before.

![image](https://user-images.githubusercontent.com/50132891/176924702-68f927b7-54ce-49f2-8284-d0d8d7e0b1ab.png)


## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
