### PR TITLE
Enable use of ign gazebo -s on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-gazebo6 VERSION 6.11.0)
+project(ignition-gazebo6 VERSION 6.12.0)
 set (GZ_DISTRIBUTION "Fortress")
 
 #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,19 @@
 ## Ignition Gazebo 6.x
 
+### Gazebo Sim 6.12.0 (2022-08-30)
+
+1. Add topic parameter to thrust plugin
+    * [Pull request #1681](https://github.com/gazebosim/gz-sim/pull/1681)
+
+1. Add information about `<topic>` system parameter
+    * [Pull request #1671](https://github.com/gazebosim/gz-sim/pull/1671)
+
+1. Adding tests for hydrodynamics
+    * [Pull request #1617](https://github.com/gazebosim/gz-sim/pull/1617)
+
+1. Fix Windows and Doxygen
+    * [Pull request #1643](https://github.com/gazebosim/gz-sim/pull/1643)
+
 ### Gazebo Sim 6.11.0 (2022-08-17)
 
 1. Add support for specifying log record period

--- a/Migration.md
+++ b/Migration.md
@@ -5,6 +5,12 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Ignition Gazebo 6.11.X to 6.12.X
+
+ * **Modified**:
+   + In the Hydrodynamics plugin, inverted the added mass contribution to make it
+     act in the correct direction.
+
 ## Ignition Gazebo 6.1 to 6.2
 
 * If no `<namespace>` is given to the `Thruster` plugin, the namespace now

--- a/examples/worlds/triggered_publisher.sdf
+++ b/examples/worlds/triggered_publisher.sdf
@@ -387,13 +387,17 @@ start falling.
         <time>0.001</time>
         <enabled>true</enabled>
       </plugin>
-      <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
+      <plugin
+        filename="ignition-gazebo-detachable-joint-system"
+        name="ignition::gazebo::systems::DetachableJoint">
         <parent_link>body</parent_link>
         <child_model>box1</child_model>
         <child_link>box_body</child_link>
         <topic>/box1/detach</topic>
       </plugin>
-      <plugin filename="ignition-gazebo-detachable-joint-system" name="ignition::gazebo::systems::DetachableJoint">
+      <plugin
+        filename="ignition-gazebo-detachable-joint-system"
+        name="ignition::gazebo::systems::DetachableJoint">
         <parent_link>body</parent_link>
         <child_model>box2</child_model>
         <child_link>box_body</child_link>
@@ -448,19 +452,40 @@ start falling.
       </link>
     </model>
 
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Empty" topic="/start"/>
       <output type="ignition.msgs.Twist" topic="/cmd_vel">
           linear: {x: 3}
       </output>
     </plugin>
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
+      <input type="ignition.msgs.Empty" topic="/reset_robot"/>
+      <output type="ignition.msgs.Twist" topic="/cmd_vel">
+          linear: {x: 0}
+      </output>
+      <service
+        name="/world/triggered_publisher/set_pose"
+        reqType="ignition.msgs.Pose"
+        repType="ignition.msgs.Boolean"
+        timeout="3000"
+        reqMsg="name: 'blue_vehicle', position: {x: -3, z: 0.325}">
+      </service>
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Boolean" topic="/trigger/touched">
         <match>data: true</match>
       </input>
       <output type="ignition.msgs.Empty" topic="/box1/detach"/>
     </plugin>
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Altimeter" topic="/altimeter">
         <match field="vertical_position" tol="0.2">-7.5</match>
       </input>

--- a/include/ignition/gazebo/rendering/RenderUtil.hh
+++ b/include/ignition/gazebo/rendering/RenderUtil.hh
@@ -201,6 +201,10 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     /// \brief Clears the set of selected entities and lowlights all of them.
     public: void DeselectAllEntities();
 
+    /// \brief Init render engine plugins paths. This lets gz-rendering know
+    /// paths to find render engine plugins
+    public: void InitRenderEnginePluginPaths();
+
     /// \brief Helper function to get all child links of a model entity.
     /// \param[in] _entity Entity to find child links
     /// \return Vector of child links found for the parent entity

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -236,9 +236,9 @@ foreach(CMD_TEST
   # in build directory in necessary. For regular tests, the trick is to place all libraries
   # and executables in a common CMAKE_RUNTIME_OUTPUT_DIRECTORY, so that the .dll are found
   # as they are in the same directory where the executable is loaded. For tests that are
-  # launched via ruby, this does not work, so we need to manually add CMAKE_RUNTIME_OUTPUT_DIRECTORY
+  # launched via Ruby, this does not work, so we need to manually add CMAKE_RUNTIME_OUTPUT_DIRECTORY
   # to the PATH. This is done via the ENVIRONMENT_MODIFICATION that is only available
-  # since CMake 3.22 . However, if an older CMake is used another trick to install the libraries
+  # since CMake 3.22. However, if an older CMake is used another trick to install the libraries
   # beforehand
   if (WIN32 AND CMAKE_VERSION STRGREATER "3.22")
     set_tests_properties(${CMD_TEST} PROPERTIES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,7 +92,6 @@ set (gtest_sources
   TestFixture_TEST.cc
   Util_TEST.cc
   World_TEST.cc
-  ign_TEST.cc
   comms/Broker_TEST.cc
   comms/MsgManager_TEST.cc
   network/NetworkConfig_TEST.cc
@@ -100,10 +99,21 @@ set (gtest_sources
   network/NetworkManager_TEST.cc
 )
 
+# ign_TEST and ModelCommandAPI_TEST are not supported with multi config
+# CMake generators, see also cmd/CMakeLists.txt
+get_property(GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(NOT GENERATOR_IS_MULTI_CONFIG)
+  list(APPEND gtest_sources ign_TEST.cc)
+endif()
+
+
 # Tests that require a valid display
 set(tests_needing_display
-  ModelCommandAPI_TEST.cc
 )
+
+if(NOT GENERATOR_IS_MULTI_CONFIG)
+  list(APPEND tests_needing_display ModelCommandAPI_TEST.cc)
+endif()
 
 # Add systems that need a valid display here.
 # \todo(anyone) Find a way to run these tests with a virtual display such Xvfb
@@ -222,9 +232,19 @@ foreach(CMD_TEST
   set_tests_properties(${CMD_TEST} PROPERTIES
     ENVIRONMENT "${_env_vars}")
 
+  # On Windows there is no RPATH, so an alternative way for tests for finding .dll libraries
+  # in build directory in necessary. For regular tests, the trick is to place all libraries
+  # and executables in a common CMAKE_RUNTIME_OUTPUT_DIRECTORY, so that the .dll are found
+  # as they are in the same directory where the executable is loaded. For tests that are
+  # launched via ruby, this does not work, so we need to manually add CMAKE_RUNTIME_OUTPUT_DIRECTORY
+  # to the PATH. This is done via the ENVIRONMENT_MODIFICATION that is only available
+  # since CMake 3.22 . However, if an older CMake is used another trick to install the libraries
+  # beforehand
+  if (WIN32 AND CMAKE_VERSION STRGREATER "3.22")
+    set_tests_properties(${CMD_TEST} PROPERTIES
+      ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+  endif()
+
 endforeach()
 
-if(NOT WIN32)
-  add_subdirectory(cmd)
-endif()
-
+add_subdirectory(cmd)

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -49,7 +49,7 @@ install( FILES
 # Note that the major version of the library is included in the name.
 set(cmd_model_script_name "cmdmodel${PROJECT_VERSION_MAJOR}.rb")
 set(cmd_model_script_generated "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>_${cmd_model_script_name}")
-set(cmd_model_script_configured "${CMAKE_CURRENT_BINARY_DIR}/${cmd_script_name}.configured")
+set(cmd_model_script_configured "${CMAKE_CURRENT_BINARY_DIR}/${cmd_model_script_name}.configured")
 
 configure_file(
   "cmdmodel.rb.in"

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -2,12 +2,19 @@
 # Generate the ruby script.
 # Note that the major version of the library is included in the name.
 # Ex: cmdgazebo0.rb
-set(cmd_script_generated "${CMAKE_CURRENT_BINARY_DIR}/cmd${IGN_DESIGNATION}${PROJECT_VERSION_MAJOR}.rb")
-set(cmd_script_configured "${cmd_script_generated}.configured")
+set(cmd_script_name "cmd${IGN_DESIGNATION}${PROJECT_VERSION_MAJOR}.rb")
+set(cmd_script_generated "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>_${cmd_script_name}")
+set(cmd_script_configured "${CMAKE_CURRENT_BINARY_DIR}/${cmd_script_name}.configured")
 
 # Set the library_location variable to the relative path to the library file
 # within the install directory structure.
-set(library_location "../../../${CMAKE_INSTALL_LIBDIR}/$<TARGET_FILE_NAME:${ign_lib_target}>")
+if(WIN32)
+  set(plugin_location ${CMAKE_INSTALL_BINDIR})
+else()
+  set(plugin_location ${CMAKE_INSTALL_LIBDIR})
+endif()
+
+set(library_location "../../../${plugin_location}/$<TARGET_FILE_NAME:${ign_lib_target}>")
 
 configure_file(
   "cmd${IGN_DESIGNATION}.rb.in"
@@ -19,7 +26,7 @@ file(GENERATE
   INPUT  "${cmd_script_configured}")
 
 # Install the ruby command line library in an unversioned location.
-install(FILES ${cmd_script_generated} DESTINATION lib/ruby/ignition)
+install(FILES ${cmd_script_generated} DESTINATION lib/ruby/ignition RENAME ${cmd_script_name})
 
 set(ign_library_path "${CMAKE_INSTALL_PREFIX}/lib/ruby/ignition/cmd${IGN_DESIGNATION}${PROJECT_VERSION_MAJOR}")
 
@@ -40,8 +47,9 @@ install( FILES
 # Used for the installed model command version.
 # Generate the ruby script that gets installed.
 # Note that the major version of the library is included in the name.
-set(cmd_model_script_generated "${CMAKE_CURRENT_BINARY_DIR}/cmdmodel${PROJECT_VERSION_MAJOR}.rb")
-set(cmd_model_script_configured "${cmd_model_script_generated}.configured")
+set(cmd_model_script_name "cmdmodel${PROJECT_VERSION_MAJOR}.rb")
+set(cmd_model_script_generated "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>_${cmd_model_script_name}")
+set(cmd_model_script_configured "${CMAKE_CURRENT_BINARY_DIR}/${cmd_script_name}.configured")
 
 configure_file(
   "cmdmodel.rb.in"
@@ -51,7 +59,7 @@ file(GENERATE
   OUTPUT "${cmd_model_script_generated}"
   INPUT  "${cmd_model_script_configured}")
 
-install(FILES ${cmd_model_script_generated} DESTINATION lib/ruby/ignition)
+install(FILES ${cmd_model_script_generated} DESTINATION lib/ruby/ignition RENAME ${cmd_model_script_name})
 
 # Used for the installed version.
 set(ign_model_ruby_path "${CMAKE_INSTALL_PREFIX}/lib/ruby/ignition/cmdmodel${PROJECT_VERSION_MAJOR}")
@@ -68,55 +76,64 @@ install(FILES ${model_configured} DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_IN
 # Generate the ruby script for internal testing.
 # Note that the major version of the library is included in the name.
 # Ex: cmdgazebo0.rb
-set(cmd_script_generated_test "${CMAKE_BINARY_DIR}/test/lib/ruby/ignition/cmd${IGN_DESIGNATION}${PROJECT_VERSION_MAJOR}.rb")
-set(cmd_script_configured_test "${cmd_script_generated_test}.configured")
+# The logic is valid only for single-config CMake generators, so no script is
+# generated if a multiple-config CMake geneator is used
+get_property(GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(NOT GENERATOR_IS_MULTI_CONFIG)
+  set(cmd_script_generated_test "${CMAKE_BINARY_DIR}/test/lib/ruby/ignition/cmd${IGN_DESIGNATION}${PROJECT_VERSION_MAJOR}.rb")
+  set(cmd_script_configured_test "${cmd_script_generated_test}.configured")
 
-# Set the library_location variable to the relative path to the library file
-# within the install directory structure.
-set(library_location "$<TARGET_FILE:${ign_lib_target}>")
+  # Set the library_location variable to the relative path to the library file
+  # within the install directory structure.
+  set(library_location "$<TARGET_FILE:${ign_lib_target}>")
 
-configure_file(
-  "cmd${IGN_DESIGNATION}.rb.in"
-  "${cmd_script_configured_test}"
-  @ONLY)
+  configure_file(
+    "cmd${IGN_DESIGNATION}.rb.in"
+    "${cmd_script_configured_test}"
+    @ONLY)
 
-file(GENERATE
-  OUTPUT "${cmd_script_generated_test}"
-  INPUT  "${cmd_script_configured_test}")
+  file(GENERATE
+    OUTPUT "${cmd_script_generated_test}"
+    INPUT  "${cmd_script_configured_test}")
 
-# Used only for internal testing.
-set(ign_library_path
-  "${CMAKE_BINARY_DIR}/test/lib/ruby/ignition/cmd${IGN_DESIGNATION}${PROJECT_VERSION_MAJOR}")
+  # Used only for internal testing.
+  set(ign_library_path
+    "${CMAKE_BINARY_DIR}/test/lib/ruby/ignition/cmd${IGN_DESIGNATION}${PROJECT_VERSION_MAJOR}")
 
-# Generate a configuration file for internal testing.
-# Note that the major version of the library is included in the name.
-# Ex: gazebo0.yaml
-configure_file(
-  "${IGN_DESIGNATION}.yaml.in"
-  "${CMAKE_BINARY_DIR}/test/conf/${IGN_DESIGNATION}${PROJECT_VERSION_MAJOR}.yaml" @ONLY)
+  # Generate a configuration file for internal testing.
+  # Note that the major version of the library is included in the name.
+  # Ex: gazebo0.yaml
+  configure_file(
+    "${IGN_DESIGNATION}.yaml.in"
+    "${CMAKE_BINARY_DIR}/test/conf/${IGN_DESIGNATION}${PROJECT_VERSION_MAJOR}.yaml" @ONLY)
+endif()
 
 #===============================================================================
 # Generate the ruby script for internal testing.
 # Note that the major version of the library is included in the name.
-set(cmd_model_ruby_test_dir "${CMAKE_BINARY_DIR}/test/lib/ruby/ignition")
-set(cmd_model_script_generated_test "${cmd_model_ruby_test_dir}/cmdmodel${PROJECT_VERSION_MAJOR}.rb")
-set(cmd_model_script_configured_test "${cmd_model_script_generated_test}.configured")
+# The logic is valid only for single-config CMake generators, so no script is
+# generated if a multiple-config CMake geneator is used
+if(NOT GENERATOR_IS_MULTI_CONFIG)
+  set(cmd_model_ruby_test_dir "${CMAKE_BINARY_DIR}/test/lib/ruby/ignition")
+  set(cmd_model_script_generated_test "${cmd_model_ruby_test_dir}/cmdmodel${PROJECT_VERSION_MAJOR}.rb")
+  set(cmd_model_script_configured_test "${cmd_model_script_generated_test}.configured")
 
-configure_file(
-  "cmdmodel.rb.in"
-  "${cmd_model_script_configured_test}"
-  @ONLY)
+  configure_file(
+    "cmdmodel.rb.in"
+    "${cmd_model_script_configured_test}"
+    @ONLY)
 
-file(GENERATE
-  OUTPUT "${cmd_model_script_generated_test}"
-  INPUT  "${cmd_model_script_configured_test}")
+  file(GENERATE
+    OUTPUT "${cmd_model_script_generated_test}"
+    INPUT  "${cmd_model_script_configured_test}")
 
-# Used for internal testing.
-set(ign_model_ruby_path "${cmd_model_script_generated_test}")
+  # Used for internal testing.
+  set(ign_model_ruby_path "${cmd_model_script_generated_test}")
 
-configure_file(
-  "model.yaml.in"
-  "${CMAKE_BINARY_DIR}/test/conf/model${PROJECT_VERSION_MAJOR}.yaml" @ONLY)
+  configure_file(
+    "model.yaml.in"
+    "${CMAKE_BINARY_DIR}/test/conf/model${PROJECT_VERSION_MAJOR}.yaml" @ONLY)
+endif()
 
 #===============================================================================
 # Bash completion

--- a/src/cmd/ModelCommandAPI.hh
+++ b/src/cmd/ModelCommandAPI.hh
@@ -15,8 +15,10 @@
  *
 */
 
+#include "ignition/gazebo/Export.hh"
+
 /// \brief External hook to get a list of available models.
-extern "C" void cmdModelList();
+extern "C" IGNITION_GAZEBO_VISIBLE void cmdModelList();
 
 /// \brief External hook to dump model information.
 /// \param[in] _modelName Model name.
@@ -24,7 +26,7 @@ extern "C" void cmdModelList();
 /// \param[in] _linkName Link name.
 /// \param[in] _jointName Joint name.
 /// \param[in] _sensorName Sensor name.
-extern "C" void cmdModelInfo(
+extern "C" IGNITION_GAZEBO_VISIBLE void cmdModelInfo(
     const char *_modelName, int _pose, const char *_linkName,
     const char *_jointName,
     const char *_sensorName);

--- a/src/cmd/cmdgazebo.rb.in
+++ b/src/cmd/cmdgazebo.rb.in
@@ -27,6 +27,7 @@ end
 
 require 'optparse'
 require 'erb'
+require 'pathname'
 
 # Constants.
 LIBRARY_NAME = '@library_location@'
@@ -337,7 +338,8 @@ class Cmd
   def execute(args)
     options = parse(args)
 
-    if LIBRARY_NAME[0] == '/'
+    library_name_path = Pathname.new(LIBRARY_NAME)
+    if library_name_path.absolute?
       # If the first character is a slash, we'll assume that we've been given an
       # absolute path to the library. This is only used during test mode.
       plugin = LIBRARY_NAME
@@ -467,6 +469,12 @@ See https://github.com/ignitionrobotics/ign-gazebo/issues/44 for more info."
           exit(-1)
         end
 
+        if plugin.end_with? ".dll"
+          puts "`ign gazebo` currently only works with the -s argument on Windows.
+See https://github.com/gazebosim/gz-sim/issues/168 for more info."
+          exit(-1)
+        end
+
         serverPid = Process.fork do
           ENV['RMT_PORT'] = '1500'
           Process.setpgid(0, 0)
@@ -523,6 +531,12 @@ See https://github.com/ignitionrobotics/ign-gazebo/issues/44 for more info."
         if plugin.end_with? ".dylib"
           puts "`ign gazebo` currently only works with the -s argument on macOS.
 See https://github.com/ignitionrobotics/ign-gazebo/issues/44 for more info."
+          exit(-1)
+        end
+
+        if plugin.end_with? ".dll"
+          puts "`ign gazebo` currently only works with the -s argument on Windows.
+See https://github.com/gazebosim/gz-sim/issues/168 for more info."
           exit(-1)
         end
 

--- a/src/cmd/cmdmodel.rb.in
+++ b/src/cmd/cmdmodel.rb.in
@@ -26,6 +26,7 @@ else
 end
 
 require 'optparse'
+require 'pathname'
 
 # Constants.
 LIBRARY_NAME = '@library_location@'
@@ -157,7 +158,8 @@ class Cmd
     options = parse(args)
 
     # Read the plugin that handles the command.
-    if LIBRARY_NAME[0] == '/'
+    library_name_path = Pathname.new(LIBRARY_NAME)
+    if library_name_path.absolute?
       # If the first character is a slash, we'll assume that we've been given an
       # absolute path to the library. This is only used during test mode.
       plugin = LIBRARY_NAME

--- a/src/gui/plugins/scene_manager/GzSceneManager.cc
+++ b/src/gui/plugins/scene_manager/GzSceneManager.cc
@@ -59,6 +59,9 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     /// \brief Rendering utility
     public: RenderUtil renderUtil;
 
+    /// \brief True if render engine plugins paths are initialized
+    public: bool renderEnginePluginPathsInit{false};
+
     /// \brief List of new entities from a gui event
     public: std::set<Entity> newEntities;
 
@@ -122,6 +125,12 @@ void GzSceneManager::Update(const UpdateInfo &_info,
     return;
 
   IGN_PROFILE("GzSceneManager::Update");
+
+  if (!this->dataPtr->renderEnginePluginPathsInit)
+  {
+    this->dataPtr->renderUtil.InitRenderEnginePluginPaths();
+    this->dataPtr->renderEnginePluginPathsInit = true;
+  }
 
   this->dataPtr->renderUtil.UpdateECM(_info, _ecm);
 

--- a/src/ign.hh
+++ b/src/ign.hh
@@ -21,18 +21,18 @@
 
 /// \brief External hook to read the library version.
 /// \return C-string representing the version. Ex.: 0.1.2
-extern "C" char *ignitionGazeboVersion();
+extern "C" IGNITION_GAZEBO_VISIBLE char *ignitionGazeboVersion();
 
 /// \brief Get the Gazebo version header.
 /// \return C-string containing the Gazebo version information.
-extern "C" char *gazeboVersionHeader();
+extern "C" IGNITION_GAZEBO_VISIBLE char *gazeboVersionHeader();
 
 /// \brief Set verbosity level
 /// \param[in] _verbosity 0 to 4
-extern "C" void cmdVerbosity(
+extern "C" IGNITION_GAZEBO_VISIBLE void cmdVerbosity(
     const char *_verbosity);
 
-extern "C" const char *worldInstallDir();
+extern "C" IGNITION_GAZEBO_VISIBLE const char *worldInstallDir();
 
 /// \brief External hook to run simulation server.
 /// \param[in] _sdfString SDF file to run, as a string.
@@ -59,7 +59,7 @@ extern "C" const char *worldInstallDir();
 /// \param[in] _headless True if server rendering should run headless
 /// \param[in] _recordPeriod --record-period option
 /// \return 0 if successful, 1 if not.
-extern "C" int runServer(const char *_sdfString,
+extern "C" IGNITION_GAZEBO_VISIBLE int runServer(const char *_sdfString,
     int _iterations, int _run, float _hz, int _levels,
     const char *_networkRole, int _networkSecondaries, int _record,
     const char *_recordPath, int _recordResources, int _logOverwrite,
@@ -77,14 +77,14 @@ extern "C" int runServer(const char *_sdfString,
 /// it receives a world path from GUI.
 /// \param[in] _renderEngine --render-engine-gui option
 /// \return 0 if successful, 1 if not.
-extern "C" int runGui(const char *_guiConfig, const char *_file, int _waitGui,
-    const char *_renderEngine);
+extern "C" IGNITION_GAZEBO_VISIBLE int runGui(const char *_guiConfig,
+    const char *_file, int _waitGui, const char *_renderEngine);
 
 /// \brief External hook to find or download a fuel world provided a URL.
 /// \param[in] _pathToResource Path to the fuel world resource, ie,
 /// https://staging-fuel.ignitionrobotics.org/1.0/gmas/worlds/ShapesClone
 /// \return C-string containing the path to the local world sdf file
-extern "C" const char *findFuelResource(
+extern "C" IGNITION_GAZEBO_VISIBLE const char *findFuelResource(
     char *_pathToResource);
 
 #endif

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -59,8 +59,7 @@ std::string customExecStr(std::string _cmd)
 }
 
 /////////////////////////////////////////////////
-// See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
-TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_WIN32(Server))
+TEST(CmdLine, Server)
 {
   std::string cmd = kIgnCommand + " -r -v 4 --iterations 5 " +
     std::string(PROJECT_SOURCE_PATH) + "/test/worlds/plugins.sdf";
@@ -75,6 +74,9 @@ TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_WIN32(Server))
         << output;
   }
 
+// Disable on WIN32 as on Windows it is not support to prepend
+// a command with the env variable to set
+#ifndef _WIN32
   // Use IGN_GAZEBO_RESOURCE_PATH instead of specifying the complete path
   cmd = std::string("IGN_GAZEBO_RESOURCE_PATH=") +
     PROJECT_SOURCE_PATH + "/test/worlds " + kIgnCommand +
@@ -89,10 +91,11 @@ TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_WIN32(Server))
     EXPECT_NE(output.find("iteration " + std::to_string(i)), std::string::npos)
         << output;
   }
+#endif
 }
 
 /////////////////////////////////////////////////
-TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_WIN32(CachedFuelWorld))
+TEST(CmdLine, CachedFuelWorld)
 {
   std::string projectPath = std::string(PROJECT_SOURCE_PATH) + "/test/worlds";
   ignition::common::setenv("IGN_FUEL_CACHE_PATH", projectPath.c_str());
@@ -106,7 +109,7 @@ TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_WIN32(CachedFuelWorld))
 }
 
 /////////////////////////////////////////////////
-TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_WIN32(GazeboServer))
+TEST(CmdLine, GazeboServer)
 {
   std::string cmd = kIgnCommand + " -r -v 4 --iterations 5 " +
     std::string(PROJECT_SOURCE_PATH) + "/test/worlds/plugins.sdf";
@@ -123,7 +126,7 @@ TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_WIN32(GazeboServer))
 }
 
 /////////////////////////////////////////////////
-TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_WIN32(Gazebo))
+TEST(CmdLine, Gazebo)
 {
   std::string cmd = kIgnCommand + " -r -v 4 --iterations 5 " +
     std::string(PROJECT_SOURCE_PATH) + "/test/worlds/plugins.sdf";

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -2497,15 +2497,21 @@ bool RenderUtil::HeadlessRendering() const
 }
 
 /////////////////////////////////////////////////
+void RenderUtil::InitRenderEnginePluginPaths()
+{
+  ignition::common::SystemPaths pluginPath;
+  pluginPath.SetPluginPathEnv(kRenderPluginPathEnv);
+  rendering::setPluginPaths(pluginPath.PluginPaths());
+}
+
+/////////////////////////////////////////////////
 void RenderUtil::Init()
 {
   // Already initialized
   if (nullptr != this->dataPtr->scene)
     return;
 
-  ignition::common::SystemPaths pluginPath;
-  pluginPath.SetPluginPathEnv(kRenderPluginPathEnv);
-  rendering::setPluginPaths(pluginPath.PluginPaths());
+  this->InitRenderEnginePluginPaths();
 
   std::map<std::string, std::string> params;
   if (this->dataPtr->useCurrentGLContext)

--- a/src/systems/CMakeLists.txt
+++ b/src/systems/CMakeLists.txt
@@ -82,10 +82,9 @@ function(gz_add_system system_name)
   set(unversioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_NO_VERSION_LOWER}-${system_name}${CMAKE_SHARED_LIBRARY_SUFFIX})
   if(WIN32)
     # symlinks on Windows require admin priviledges, fallback to copy
-    ADD_CUSTOM_COMMAND(TARGET ${system_target} POST_BUILD
-      COMMAND "${CMAKE_COMMAND}" -E copy
-        "$<TARGET_FILE:${system_target}>"
-        "$<TARGET_FILE_DIR:${system_target}>/${unversioned}")
+    INSTALL(CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy
+      ${IGNITION_GAZEBO_PLUGIN_INSTALL_DIR}\/${versioned}
+      ${IGNITION_GAZEBO_PLUGIN_INSTALL_DIR}\/${unversioned})")
   else()
     file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
     EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned} WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/lib")

--- a/src/systems/ackermann_steering/AckermannSteering.hh
+++ b/src/systems/ackermann_steering/AckermannSteering.hh
@@ -111,7 +111,7 @@ namespace systems
   /// right_steering_joint
   ///
   /// References:
-  /// https://github.com/ignitionrobotics/ign-gazebo/tree/main/src/systems/diff_drive
+  /// https://github.com/gazebosim/gz-sim/tree/main/src/systems/ackermann_steering
   /// https://www.auto.tuwien.ac.at/bib/pdf_TR/TR0183.pdf
   /// https://github.com/froohoo/ackermansteer/blob/master/ackermansteer/
 

--- a/src/systems/joint_state_publisher/JointStatePublisher.hh
+++ b/src/systems/joint_state_publisher/JointStatePublisher.hh
@@ -35,7 +35,7 @@ namespace systems
 {
   /// \brief The JointStatePub system publishes state information for
   /// a model. The published message type is ignition::msgs::Model, and the
-  /// publication topic is "/world/<world_name>/model/<model_name>/state".
+  /// publication topic is determined by the `<topic>` parameter.
   ///
   /// By default the JointStatePublisher will publish all joints for
   /// a model. Use the `<joint_name>` system parameter, described below, to
@@ -43,6 +43,9 @@ namespace systems
   ///
   /// # System Parameters
   ///
+  /// `<topic>`: Name of the topic to publish to. This parameter is optional,
+  /// and if not provided, the joint state will be published to
+  /// "/world/<world_name>/model/<model_name>/state".
   /// `<joint_name>`: Name of a joint to publish. This parameter can be
   /// specified multiple times, and is optional. All joints in a model will
   /// be published if joint names are not specified.

--- a/src/systems/thruster/Thruster.cc
+++ b/src/systems/thruster/Thruster.cc
@@ -104,6 +104,9 @@ class ignition::gazebo::systems::ThrusterPrivateData
   /// \brief Diameter of propeller in m, default: 0.02
   public: double propellerDiameter = 0.02;
 
+  /// \brief Topic name used to control thrust.
+  public: std::string topic = "";
+
   /// \brief Callback for handling thrust update
   public: void OnCmdThrust(const msgs::Double &_msg);
 
@@ -171,6 +174,13 @@ void Thruster::Configure(
     this->dataPtr->fluidDensity = _sdf->Get<double>("fluid_density");
   }
 
+  // Get a custom topic.
+  if (_sdf->HasElement("topic"))
+  {
+    this->dataPtr->topic = transport::TopicUtils::AsValidTopic(
+      _sdf->Get<std::string>("topic"));
+  }
+
   this->dataPtr->jointEntity = model.JointByName(_ecm, jointName);
   if (kNullEntity == this->dataPtr->jointEntity)
   {
@@ -191,14 +201,21 @@ void Thruster::Configure(
   std::string thrusterTopicOld = ignition::transport::TopicUtils::AsValidTopic(
     "/model/" + ns + "/joint/" + jointName + "/cmd_pos");
 
+  ignwarn << thrusterTopicOld << " topic is deprecated" << std::endl;
+
   this->dataPtr->node.Subscribe(
     thrusterTopicOld,
     &ThrusterPrivateData::OnCmdThrust,
     this->dataPtr.get());
 
   // Subscribe to force commands
-  std::string thrusterTopic = ignition::transport::TopicUtils::AsValidTopic(
-    "/model/" + ns + "/joint/" + jointName + "/cmd_thrust");
+  std::string thrusterTopic =
+    "/model/" + ns + "/joint/" + jointName + "/cmd_thrust";
+
+  if (!this->dataPtr->topic.empty())
+    thrusterTopic = ns + "/" + this->dataPtr->topic;
+
+  thrusterTopic = transport::TopicUtils::AsValidTopic(thrusterTopic);
 
   this->dataPtr->node.Subscribe(
     thrusterTopic,

--- a/src/systems/thruster/Thruster.hh
+++ b/src/systems/thruster/Thruster.hh
@@ -40,8 +40,10 @@ namespace systems
   ///
   /// ## System Parameters
   /// - <namespace> - The namespace in which the robot exists. The plugin will
-  ///   listen on the topic `/model/{namespace}/joint/{joint_name}/cmd_thrust`.
+  ///   listen on the topic `/model/{namespace}/joint/{joint_name}/cmd_thrust`
+  ///   or on {namespace}/{topic} if {topic} is set.
   ///   [Optional]
+  /// - <topic> - The topic for receiving thrust commands. [Optional]
   /// - <joint_name> - This is the joint in the model which corresponds to the
   ///   propeller. [Required]
   /// - <fluid_density> - The fluid density of the liquid in which the thruster

--- a/test/integration/thruster.cc
+++ b/test/integration/thruster.cc
@@ -43,19 +43,20 @@ class ThrusterTest : public InternalFixture<::testing::Test>
   /// \brief Test a world file
   /// \param[in] _world Path to world file
   /// \param[in] _namespace Namespace for topic
+  /// \param[in] _topic Thrust topic
   /// \param[in] _coefficient Thrust coefficient
   /// \param[in] _density Fluid density
   /// \param[in] _diameter Propeller diameter
   /// \param[in] _baseTol Base tolerance for most quantities
   public: void TestWorld(const std::string &_world,
-      const std::string &_namespace, double _coefficient, double _density,
-      double _diameter, double _baseTol);
+      const std::string &_namespace, const std::string &_topic,
+      double _coefficient, double _density, double _diameter, double _baseTol);
 };
 
 //////////////////////////////////////////////////
 void ThrusterTest::TestWorld(const std::string &_world,
-    const std::string &_namespace, double _coefficient, double _density,
-    double _diameter, double _baseTol)
+    const std::string &_namespace, const std::string &_topic,
+    double _coefficient, double _density, double _diameter, double _baseTol)
 {
   // Start server
   ServerConfig serverConfig;
@@ -122,8 +123,7 @@ void ThrusterTest::TestWorld(const std::string &_world,
 
   // Publish command and check that vehicle moved
   transport::Node node;
-  auto pub = node.Advertise<msgs::Double>(
-      "/model/" + _namespace + "/joint/propeller_joint/cmd_thrust");
+  auto pub = node.Advertise<msgs::Double>(_topic);
 
   int sleep{0};
   int maxSleep{30};
@@ -234,31 +234,39 @@ void ThrusterTest::TestWorld(const std::string &_world,
 // See https://github.com/ignitionrobotics/ign-gazebo/issues/1175
 TEST_F(ThrusterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(PIDControl))
 {
+  const std::string ns{"sub"};
+  const std::string topic = "/model/" + ns +
+      "/joint/propeller_joint/cmd_thrust";
   auto world = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
       "test", "worlds", "thruster_pid.sdf");
 
   // Tolerance could be lower (1e-6) if the joint pose had a precise 180
   // rotation
-  this->TestWorld(world, "sub", 0.004, 1000, 0.2, 1e-4);
+  this->TestWorld(world, ns, topic, 0.004, 1000, 0.2, 1e-4);
 }
 
 /////////////////////////////////////////////////
 TEST_F(ThrusterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(VelocityControl))
 {
+  const std::string ns = "custom";
+  const std::string topic = "/model/" + ns +
+      "/joint/propeller_joint/cmd_thrust";
   auto world = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
       "test", "worlds", "thruster_vel_cmd.sdf");
 
   // Tolerance is high because the joint command disturbs the vehicle body
-  this->TestWorld(world, "custom", 0.005, 950, 0.25, 1e-2);
+  this->TestWorld(world, ns, topic, 0.005, 950, 0.25, 1e-2);
 }
 
 /////////////////////////////////////////////////
 TEST_F(ThrusterTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(BatteryIntegration))
 {
+  const std::string ns = "lowbattery";
+  const std::string topic =  ns + "/thrust";
   auto world = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
       "test", "worlds", "thruster_battery.sdf");
 
   // Tolerance is high because the joint command disturbs the vehicle body
-  this->TestWorld(world, "lowbattery", 0.005, 950, 0.25, 1e-2);
+  this->TestWorld(world, ns, topic, 0.005, 950, 0.25, 1e-2);
 }
 

--- a/test/worlds/thruster_battery.sdf
+++ b/test/worlds/thruster_battery.sdf
@@ -105,6 +105,7 @@
         <velocity_control>true</velocity_control>
         <max_thrust_cmd>300</max_thrust_cmd>
         <min_thrust_cmd>0</min_thrust_cmd>
+        <topic>thrust</topic>
       </plugin>
 
       <plugin filename="ignition-gazebo-linearbatteryplugin-system"

--- a/test/worlds/triggered_publisher.sdf
+++ b/test/worlds/triggered_publisher.sdf
@@ -5,19 +5,25 @@
       <real_time_factor>0</real_time_factor>
     </physics>
 
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Empty" topic="/in_0"/>
       <output type="ignition.msgs.Empty" topic="/out_0"/>
     </plugin>
 
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Empty" topic="/in_1"/>
       <output type="ignition.msgs.Boolean" topic="/out_1">
           data: true
       </output>
     </plugin>
 
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Empty" topic="/in_2"/>
       <output type="ignition.msgs.Boolean" topic="/out_2_0">
           data: false
@@ -27,7 +33,9 @@
       </output>
     </plugin>
 
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Boolean" topic="/in_3">
         <match>
             data: true
@@ -36,7 +44,9 @@
       <output type="ignition.msgs.Empty" topic="/out_3"/>
     </plugin>
 
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Int32" topic="/in_4">
         <match logic_type="negative">
             data: 0
@@ -45,7 +55,9 @@
       <output type="ignition.msgs.Empty" topic="/out_4_0"/>
     </plugin>
 
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Int32" topic="/in_4">
         <match logic_type="positive">
             data: 0
@@ -54,7 +66,9 @@
       <output type="ignition.msgs.Empty" topic="/out_4_1"/>
     </plugin>
 
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Int32" topic="/in_5">
         <match logic_type="negative">
             data: -5
@@ -75,7 +89,9 @@
       <output type="ignition.msgs.Empty" topic="/out_5"/>
     </plugin>
 
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Vector2d" topic="/in_6">
         <match field="x">1.0</match>
         <match field="y">2.0</match>
@@ -83,7 +99,9 @@
       <output type="ignition.msgs.Empty" topic="/out_6_0"/>
     </plugin>
 
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Vector2d" topic="/in_6">
         <match field="x">1.0</match>
         <match logic_type="negative" field="y">2.0</match>
@@ -91,7 +109,9 @@
       <output type="ignition.msgs.Empty" topic="/out_6_1"/>
     </plugin>
 
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Pose" topic="/in_7">
         <match field="header.data">
             {
@@ -102,7 +122,9 @@
       </input>
       <output type="ignition.msgs.Empty" topic="/out_7"/>
     </plugin>
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Pose" topic="/in_8">
         <match field="header">
           {
@@ -120,53 +142,152 @@
       <output type="ignition.msgs.Empty" topic="/out_8"/>
     </plugin>
 
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Int32_V" topic="/in_9">
         <match>data: 0, data: 1</match>
       </input>
       <output type="ignition.msgs.Empty" topic="/out_9"/>
     </plugin>
 
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Float" topic="/in_10">
         <match tol="0.15">data: 0.5</match>
       </input>
       <output type="ignition.msgs.Empty" topic="/out_10"/>
     </plugin>
 
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Pose" topic="/in_11">
         <match field="position.z" tol="0.15">0.5</match>
       </input>
       <output type="ignition.msgs.Empty" topic="/out_11"/>
     </plugin>
 
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Header" topic="/in_12">
         <match field="data.value">"value1"</match>
       </input>
       <output type="ignition.msgs.Empty" topic="/out_12"/>
     </plugin>
 
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Empty" topic="/in_13"/>
       <output type="ignition.msgs.Empty" topic="/out_13"/>
       <delay_ms>1000</delay_ms>
     </plugin>
 
-    <!-- The following systems are used for testing invalid configuration. They don't have actual tests -->
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <!-- The following systems are used for testing invalid configuration.
+         They don't have actual tests -->
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.NonExtentType" topic="/invalid_input_0">
         <match>data: 0, data: 1</match>
       </input>
       <output type="ignition.msgs.Empty" topic="/invalid_output_0"/>
     </plugin>
 
-    <plugin filename="ignition-gazebo-triggered-publisher-system" name="ignition::gazebo::systems::TriggeredPublisher">
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
       <input type="ignition.msgs.Empty" topic="/invalid_input_1"/>
     </plugin>
     <!-- End invalid configuration -->
+
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
+      <input type="ignition.msgs.Empty" topic="/in_14"/>
+      <service
+        name="/srv-test"
+        reqType="ignition.msgs.StringMsg"
+        repType="ignition.msgs.StringMsg"
+        timeout="100"
+        reqMsg="data: 'test'">
+      </service>
+    </plugin>
+
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
+      <input type="ignition.msgs.Empty" topic="/in_15"/>
+      <service
+        name="/srv-test-0"
+        reqType="ignition.msgs.Boolean"
+        repType="ignition.msgs.Boolean"
+        timeout="100"
+        reqMsg="data: true">
+      </service>
+      <service
+        name="/srv-test-1"
+        reqType="ignition.msgs.Boolean"
+        repType="ignition.msgs.Boolean"
+        timeout="100"
+        reqMsg="data: true">
+      </service>
+    </plugin>
+
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
+      <input type="ignition.msgs.Empty" topic="/in_16"/>
+      <service
+        name="/srv-test"
+        reqType="ignition.msgs.InvalidReqType"
+        repType="ignition.msgs.StringMsg"
+        timeout="100"
+        reqMsg="data: 'test'">
+      </service>
+    </plugin>
+
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
+      <input type="ignition.msgs.Empty" topic="/in_16"/>
+      <service
+        name="/srv-test"
+        reqType="ignition.msgs.StringMsg"
+        repType="ignition.msgs.InvalidRepType"
+        timeout="100"
+        reqMsg="data: 'test'">
+      </service>
+    </plugin>
+
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
+      <input type="ignition.msgs.Empty" topic="/in_18"/>
+      <service
+        name="/srv-diff-type-0"
+        reqType="ignition.msgs.Boolean"
+        repType="ignition.msgs.StringMsg"
+        timeout="100"
+        reqMsg="data: true">
+      </service>
+    </plugin>
+
+    <plugin
+      filename="ignition-gazebo-triggered-publisher-system"
+      name="ignition::gazebo::systems::TriggeredPublisher">
+      <input type="ignition.msgs.Empty" topic="/in_19"/>
+      <service
+        name="/srv-diff-type-1"
+        reqType="ignition.msgs.StringMsg"
+        repType="ignition.msgs.Boolean"
+        timeout="100"
+        reqMsg="data: 'test'">
+      </service>
+    </plugin>
   </world>
 </sdf>
-
 

--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -61,7 +61,7 @@ feature which hasn't been released yet.
 
 1. Install tools
   ```
-  sudo apt install -y build-essential cmake g++-8 git gnupg lsb-release wget
+  sudo apt install -y build-essential cmake git gnupg lsb-release wget
   ```
 
 2. Enable the Ignition software repositories:

--- a/tutorials/triggered_publisher.md
+++ b/tutorials/triggered_publisher.md
@@ -1,17 +1,20 @@
 \page triggeredpublisher Triggered Publisher
 
 The `TriggeredPublisher` system publishes a user specified message on an output
-topic in response to an input message that matches user specified criteria. The
-system works by checking the input against a set of Matchers. Matchers
-contain string representations of protobuf messages which are compared for
-equality or containment with the input message. Matchers can match the whole
-input message or only a specific field inside the message.
+topic in response to an input message that matches user specified criteria. It
+can also call a user specified service in response to an input
+message. The system works by checking the input against a set of Matchers.
+Matchers contain string representations of protobuf messages which are compared
+for equality or containment with the input message. Matchers can match the
+whole input message or only a specific field inside the message.
+
 
 This tutorial describes how the Triggered Publisher system can be used to
 cause a box to fall from its initial position by detaching a detachable joint
 in response to the motion of a vehicle. The tutorial also covers how Triggered
 Publisher systems can be chained together by showing how the falling of the box
-can trigger another box to fall. The finished world SDFormat file for this
+can trigger another box to fall. Last, it covers how a service call can be
+triggered to reset the robot pose. The finished world SDFormat file for this
 tutorial can be found in
 [examples/worlds/triggered_publisher.sdf](https://github.com/ignitionrobotics/ign-gazebo/blob/ign-gazebo2/examples/worlds/triggered_publisher.sdf)
 
@@ -262,4 +265,28 @@ and publish the start message
 
 ```
 ign topic -t "/start" -m ignition.msgs.Empty -p " "
+```
+
+Once both boxes have fallen, we can publish a message to invoke a service call
+to reset the robot position as well as set the speed to 0. As shown below, the
+`<output>` sets the linear x speed to 0, and the `<service>` tag contains
+metadata to invoke a service call to `/world/triggered_publisher/set_pose`. The
+`reqMsg` is expressed in the human-readable form of Google Protobuf meesages.
+Multiple `<service>` tags can be used as well as with the `<output>` tag.
+
+```xml
+<plugin filename="ignition-gazebo-triggered-publisher-system"
+  name="ignition::gazebo::systems::TriggeredPublisher">
+  <input type="ignition.msgs.Empty" topic="/reset_robot"/>
+  <output type="ignition.msgs.Twist" topic="/cmd_vel">
+      linear: {x: 0}
+  </output>
+  <service
+    name="/world/triggered_publisher/set_pose"
+    reqType="ignition.msgs.Pose"
+    repType="ignition.msgs.Boolean"
+    timeout="3000"
+    reqMsg="name: 'blue_vehicle', id: 8, position: {x: -3, z: 1}">
+  </service>
+</plugin>
 ```


### PR DESCRIPTION
# 🎉 New feature

This PR enable the use of `ign gazebo -s` on Windows. Similarly to what is done in macOS, as `ign gazebo` and `ign gazebo -g` are not supported, those options are explicitly disabled to give a nice error to the users.

## Summary

Summary of changes:
* Add `src/cmd` directory also on Windows
* Correctly mark export visibility in `ign.hh` and `ModelCommandAPI.hh`
* Ensure that the correct directory if used in `cmdgazebo.rb.in` to load the gazebo plugin
* Fix the logic to copy the unversion versions of the plugins
* Fix `UNIT_ign_TEST` to work correctly on Windows
* Disable generation of test-only ruby scripts for `ign-tools` when using multiple config CMake generators, and consequently disable `UNIT_ign_TEST and `UNIT_ModelCommandAPI_TEST` when using multiple config CMake generators.
* As only `ign gazebo -s` is working, explicitly disable `ign gazebo -g` and `ign gazebo` as done on macOS .

## Test it

**Note, the following instructions are not complete as a version of libignition-common4 with https://github.com/gazebosim/gz-common/pull/389 needs to be released before the tests work again.**

Personally, I tested it with conda-forge provided depedencies. I created an environment with:
~~~
mamba create -n igngaz vs2019_win-64 cmake ninja pkg-config libignition-cmake2 libsdformat12 libignition-plugin1 libignition-transport11 libignition-msgs8 libignition-common4 libignition-fuel-tools7 libignition-gui6 libignition-physics5 libignition-sensors6 libignition-rendering6 libignition-math6 libignition-tools1 libprotobuf qt-main tinyxml2
~~~

Then, I compiled `ign-gazebo` with:
~~~
mamba activate igngaz
git clone https://github.com/traversaro/ign-gazebo
cd ign-gazebo
git checkout fixigngazeboserveronwin
mkdir build
cd build
cmake -GNinja -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP:BOOL=ON ..
~~~

After that, I was able to run correctly the server:
~~~
mamba activate igngaz
ign gazebo --verbose -s shapes.sdf
~~~

To verify the server was running correctly, I run in another terminal:
~~~
(igngaz) C:\Users\STraversaro>ign model --list

Requesting state for world [shapes]...

Available models:
    - ground_plane
    - box
    - cylinder
    - sphere
    - capsule
    - ellipsoid
~~~

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
