### PR TITLE
Fix UNIT_Server_TEST on Windows

### DIFF
--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -1004,7 +1004,9 @@ TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ResourcePath))
 TEST_P(ServerFixture, GetResourcePaths)
 {
   ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
-      "/tmp/some/path:/home/user/another_path");
+      std::string("/tmp/some/path") +
+      common::SystemPaths::Delimiter() +
+      std::string("/home/user/another_path"));
 
   ServerConfig serverConfig;
   gazebo::Server server(serverConfig);
@@ -1034,7 +1036,9 @@ TEST_P(ServerFixture, GetResourcePaths)
 TEST_P(ServerFixture, AddResourcePaths)
 {
   ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
-      "/tmp/some/path:/home/user/another_path");
+      std::string("/tmp/some/path") +
+      common::SystemPaths::Delimiter() +
+      std::string("/home/user/another_path"));
   ignition::common::setenv("SDF_PATH", "");
   ignition::common::setenv("IGN_FILE_PATH", "");
 
@@ -1063,7 +1067,9 @@ TEST_P(ServerFixture, AddResourcePaths)
   // Add path
   msgs::StringMsg_V req;
   req.add_data("/tmp/new_path");
-  req.add_data("/tmp/more:/tmp/even_more");
+  req.add_data(std::string("/tmp/more") +
+               common::SystemPaths::Delimiter() +
+               std::string("/tmp/even_more"));
   req.add_data("/tmp/some/path");
   bool executed = node.Request("/gazebo/resource_paths/add", req);
   EXPECT_TRUE(executed);
@@ -1082,7 +1088,7 @@ TEST_P(ServerFixture, AddResourcePaths)
   {
     char *pathCStr = std::getenv(env);
 
-    auto paths = common::Split(pathCStr, ':');
+    auto paths = common::Split(pathCStr, common::SystemPaths::Delimiter());
     paths.erase(std::remove_if(paths.begin(), paths.end(),
         [](std::string const &_path)
         {

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -408,7 +408,7 @@ std::vector<std::string> resourcePaths()
   char *gzPathCStr = std::getenv(kResourcePathEnv.c_str());
   if (gzPathCStr && *gzPathCStr != '\0')
   {
-    gzPaths = common::Split(gzPathCStr, ':');
+    gzPaths = common::Split(gzPathCStr, common::SystemPaths::Delimiter());
   }
 
   gzPaths.erase(std::remove_if(gzPaths.begin(), gzPaths.end(),
@@ -428,7 +428,7 @@ void addResourcePaths(const std::vector<std::string> &_paths)
   char *sdfPathCStr = std::getenv(kSdfPathEnv.c_str());
   if (sdfPathCStr && *sdfPathCStr != '\0')
   {
-    sdfPaths = common::Split(sdfPathCStr, ':');
+    sdfPaths = common::Split(sdfPathCStr, common::SystemPaths::Delimiter());
   }
 
   // Ignition file paths (for <uri>s)
@@ -437,7 +437,7 @@ void addResourcePaths(const std::vector<std::string> &_paths)
   char *ignPathCStr = std::getenv(systemPaths->FilePathEnv().c_str());
   if (ignPathCStr && *ignPathCStr != '\0')
   {
-    ignPaths = common::Split(ignPathCStr, ':');
+    ignPaths = common::Split(ignPathCStr, common::SystemPaths::Delimiter());
   }
 
   // Gazebo resource paths
@@ -445,7 +445,7 @@ void addResourcePaths(const std::vector<std::string> &_paths)
   char *gzPathCStr = std::getenv(kResourcePathEnv.c_str());
   if (gzPathCStr && *gzPathCStr != '\0')
   {
-    gzPaths = common::Split(gzPathCStr, ':');
+    gzPaths = common::Split(gzPathCStr, common::SystemPaths::Delimiter());
   }
 
   // Add new paths to gzPaths
@@ -474,20 +474,20 @@ void addResourcePaths(const std::vector<std::string> &_paths)
   // Update the vars
   std::string sdfPathsStr;
   for (const auto &path : sdfPaths)
-    sdfPathsStr += ':' + path;
+    sdfPathsStr += common::SystemPaths::Delimiter() + path;
 
   ignition::common::setenv(kSdfPathEnv.c_str(), sdfPathsStr.c_str());
 
   std::string ignPathsStr;
   for (const auto &path : ignPaths)
-    ignPathsStr += ':' + path;
+    ignPathsStr += common::SystemPaths::Delimiter() + path;
 
   ignition::common::setenv(
     systemPaths->FilePathEnv().c_str(), ignPathsStr.c_str());
 
   std::string gzPathsStr;
   for (const auto &path : gzPaths)
-    gzPathsStr += ':' + path;
+    gzPathsStr += common::SystemPaths::Delimiter() + path;
 
   ignition::common::setenv(kResourcePathEnv.c_str(), gzPathsStr.c_str());
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This PR fixes the execution of `UNIT_Server_TEST` on Windows, by using the `;` environment variables path separator instead of hardcoding the using of the `:` separator.

Before this patch, on my system the `UNIT_Server_TEST` was failing with error:
~~~
27: C:\src\ign-gazebo\src\Server_TEST.cc(1135): error: Expected equality of these values:
27:   _expected
27:     Which is: "C:\\src\\ign-gazebo\\test\\worlds\\plugins.sdf"
27:   res.data()
27:     Which is: "\\src\\ign-gazebo\\test\\worlds\\plugins.sdf"
27: Expected[C:\src\ign-gazebo\test\worlds\plugins.sdf] Received[\src\ign-gazebo\test\worlds\plugins.sdf]
27: [Dbg] [C:\src\ign-gazebo\src\Server_TEST.cc:1128] Requesting /gazebo/resource_paths/resolve
27: C:\src\ign-gazebo\src\Server_TEST.cc(1135): error: Expected equality of these values:
27:   _expected
27:     Which is: "C:\\src\\ign-gazebo\\test\\worlds\\plugins.sdf"
27:   res.data()
27:     Which is: "\\src\\ign-gazebo\\test\\worlds\\plugins.sdf"
27: Expected[C:\src\ign-gazebo\test\worlds\plugins.sdf] Received[\src\ign-gazebo\test\worlds\plugins.sdf]
27: [Dbg] [C:\src\ign-gazebo\src\Server_TEST.cc:1128] Requesting /gazebo/resource_paths/resolve
27: [Dbg] [C:\src\ign-gazebo\src\Server_TEST.cc:1128] Requesting /gazebo/resource_paths/resolve
27: C:\src\ign-gazebo\src\Server_TEST.cc(1135): error: Expected equality of these values:
27:   _expected
27:     Which is: "C:\\src\\ign-gazebo\\test\\worlds\\models\\include_nested\\model.sdf"
27:   res.data()
27:     Which is: "\\src\\ign-gazebo\\test\\worlds\\models\\include_nested\\model.sdf"
27: Expected[C:\src\ign-gazebo\test\worlds\models\include_nested\model.sdf] Received[\src\ign-gazebo\test\worlds\models\include_nested\model.sdf]
27: [  FAILED  ] ServerRepeat/ServerFixture.ResolveResourcePaths/0, where GetParam() = 1 (142 ms)
27: [ RUN      ] ServerRepeat/ServerFixture.Stop/0
27: [Msg] Loading SDF world file[C:\src\ign-gazebo\test\worlds\shapes.sdf].
27: [Msg] Serving entity system service on [/entity/system/add]
27: [Msg] Loaded level [3]
27: [Msg] No systems loaded from SDF, loading defaults
27: [Wrn] [D:\bld\libignition-common4_1656525324646\work\src\Util.cc:368] Reading environment variable with _allowEmpty==true is unsupported on Windows.
27: [Dbg] [C:\src\ign-gazebo\src\ServerConfig.cc:999] Loaded (3) plugins from file [C:\src\ign-gazebo\build\test\fake_home\.ignition\gazebo\6\server.config]
27: [Dbg] [C:\src\ign-gazebo\src\systems\physics\Physics.cc:803] Loaded [ignition::physics::dartsim::Plugin] from library [C:\Users\STraversaro\AppData\Local\mambaforge\envs\igngaz\Library\lib\ign-physics-5\engine-plugins\ignition-physics-dartsim-plugin.dll]
27: [Dbg] [C:\src\ign-gazebo\src\SystemManager.cc:58] Loaded system [ignition::gazebo::systems::Physics] for entity [1]
27: [Msg] Create service on [/world/default/create]
27: [Msg] Remove service on [/world/default/remove]
27: [Msg] Pose service on [/world/default/set_pose]
27: [Msg] Pose service on [/world/default/set_pose_vector]
27: [Msg] Light configuration service on [/world/default/light_config]
27: [Msg] Physics service on [/world/default/set_physics]
27: [Msg] SphericalCoordinates service on [/world/default/set_spherical_coordinates]
27: [Msg] Enable collision service on [/world/default/enable_collision]
27: [Msg] Disable collision service on [/world/default/disable_collision]
27: [Msg] Material service on [/world/default/visual_config]
27: [Msg] Material service on [/world/default/wheel_slip]
27: [Dbg] [C:\src\ign-gazebo\src\SystemManager.cc:58] Loaded system [ignition::gazebo::systems::UserCommands] for entity [1]
27: [Dbg] [C:\src\ign-gazebo\src\SystemManager.cc:58] Loaded system [ignition::gazebo::systems::SceneBroadcaster] for entity [1]
27: [Msg] Serving world controls on [/world/default/control], [/world/default/control/state] and [/world/default/playback/control]
27: [Msg] Serving GUI information on [/world/default/gui/info]
27: [Msg] World [default] initialized with [1ms] physics profile.
27: [Msg] Serving world SDF generation service on [/world/default/generate_world_sdf]
27: [Msg] Serving world names on [/gazebo/worlds]
27: [Msg] Resource path add service on [/gazebo/resource_paths/add].
27: [Msg] Resource path get service on [/gazebo/resource_paths/get].
27: [Msg] Resource path resolve service on [/gazebo/resource_paths/resolve].
27: [Msg] Resource paths published on [/gazebo/resource_paths].
27: [Msg] Server control service on [/server_control].
27: [Msg] Found no publishers on /stats, adding root stats topic
27: [Msg] Found no publishers on /clock, adding root clock topic
27: [       OK ] ServerRepeat/ServerFixture.Stop/0 (180 ms)
27: [----------] 15 tests from ServerRepeat/ServerFixture (5506 ms total)
27:
27: [----------] Global test environment tear-down
27: [==========] 15 tests from 1 test suite ran. (5506 ms total)
27: [  PASSED  ] 14 tests.
27: [  FAILED  ] 1 test, listed below:
27: [  FAILED  ] ServerRepeat/ServerFixture.ResolveResourcePaths/0, where GetParam() = 1
27:
27:  1 FAILED TEST
27:   YOU HAVE 12 DISABLED TESTS
27:
1/2 Test #27: UNIT_Server_TEST .................***Failed    6.54 sec
~~~

After this patch the test is passing fine.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
