### PR TITLE
Garden: ensure targets exist before referencing

### DIFF
--- a/src/gui/plugins/component_inspector_editor/CMakeLists.txt
+++ b/src/gui/plugins/component_inspector_editor/CMakeLists.txt
@@ -20,4 +20,6 @@ gz_add_gui_plugin(ComponentInspectorEditor
     Magnetometer.hh
     ModelEditor.hh
     Pose3d.hh
+  PRIVATE_LINK_LIBS
+    gz-common${GZ_COMMON_VER}::graphics
 )

--- a/src/systems/collada_world_exporter/CMakeLists.txt
+++ b/src/systems/collada_world_exporter/CMakeLists.txt
@@ -1,4 +1,6 @@
 gz_add_system(collada-world-exporter
   SOURCES
     ColladaWorldExporter.cc
+  PRIVATE_LINK_LIBS
+    gz-common${GZ_COMMON_VER}::graphics
 )

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -142,7 +142,7 @@ if (POLICY CMP0074)
 endif()
 gz_find_package(DART CONFIG)
 cmake_policy(POP)
-if (DART_FOUND)
+if (DART_FOUND AND TARGET INTEGRATION_physics_system)
   # Only adding include directories, no need to link against DART to check version
   target_include_directories(INTEGRATION_physics_system SYSTEM PRIVATE ${DART_INCLUDE_DIRS})
   target_compile_definitions(INTEGRATION_physics_system PRIVATE HAVE_DART)
@@ -152,25 +152,36 @@ if (DART_FOUND)
   )
 endif()
 
-target_link_libraries(INTEGRATION_tracked_vehicle_system
-  gz-physics${GZ_PHYSICS_VER}::core
-  gz-plugin${GZ_PLUGIN_VER}::loader
-)
+if (TARGET INTEGRATION_tracked_vehicle_system)
+  target_link_libraries(INTEGRATION_tracked_vehicle_system
+    gz-physics${GZ_PHYSICS_VER}::core
+    gz-plugin${GZ_PLUGIN_VER}::loader
+  )
+endif()
 
-target_link_libraries(INTEGRATION_model_photo_shoot_default_joints
-  gz-rendering${GZ_RENDERING_VER}::gz-rendering${GZ_RENDERING_VER}
-)
-target_link_libraries(INTEGRATION_model_photo_shoot_random_joints
-  gz-rendering${GZ_RENDERING_VER}::gz-rendering${GZ_RENDERING_VER}
-)
+if (TARGET INTEGRATION_model_photo_shoot_default_joints)
+  target_link_libraries(INTEGRATION_model_photo_shoot_default_joints
+    gz-rendering${GZ_RENDERING_VER}::gz-rendering${GZ_RENDERING_VER}
+  )
+endif()
 
-target_link_libraries(INTEGRATION_log_system
-  gz-transport${GZ_TRANSPORT_VER}::log
-)
+if (TARGET INTEGRATION_model_photo_shoot_random_joints)
+  target_link_libraries(INTEGRATION_model_photo_shoot_random_joints
+    gz-rendering${GZ_RENDERING_VER}::gz-rendering${GZ_RENDERING_VER}
+  )
+endif()
 
-target_link_libraries(INTEGRATION_collada_world_exporter
-  gz-common${GZ_COMMON_VER}::graphics
-)
+if (TARGET INTEGRATION_log_system)
+  target_link_libraries(INTEGRATION_log_system
+    gz-transport${GZ_TRANSPORT_VER}::log
+  )
+endif()
+
+if (TARGET INTEGRATION_collada_world_exporter)
+  target_link_libraries(INTEGRATION_collada_world_exporter
+    gz-common${GZ_COMMON_VER}::graphics
+  )
+endif()
 
 if(TARGET INTEGRATION_reset_sensors)
   target_link_libraries(INTEGRATION_reset_sensors
@@ -179,13 +190,15 @@ if(TARGET INTEGRATION_reset_sensors)
 endif()
 
 # The default timeout (240s) doesn't seem to be enough for this test.
-set_tests_properties(INTEGRATION_tracked_vehicle_system PROPERTIES TIMEOUT 300)
+if(TARGET INTEGRATION_tracked_vehicle_system )
+  set_tests_properties(INTEGRATION_tracked_vehicle_system PROPERTIES TIMEOUT 300)
+endif()
 
 if(TARGET INTEGRATION_examples_build)
   set_tests_properties(INTEGRATION_examples_build PROPERTIES TIMEOUT 320)
 endif()
 
-if(VALID_DISPLAY AND VALID_DRI_DISPLAY)
+if(VALID_DISPLAY AND VALID_DRI_DISPLAY AND TARGET INTEGRATION_sensors_system)
   target_link_libraries(INTEGRATION_sensors_system
     gz-rendering${GZ_RENDERING_VER}::gz-rendering${GZ_RENDERING_VER}
   )


### PR DESCRIPTION
# 🦟 Bug fix

Attempting to fix the windows build.

## Summary

The windows build on Garden has been broken for a while due to an inability to find the ign-common `av` component. This has been fixed by https://github.com/gazebosim/gz-cmake/pull/271, but there are still cmake issues with the windows build:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_gazebo-ci-win&build=207)](https://build.osrfoundation.org/view/ign-garden/job/ign_gazebo-ci-win/207/) https://build.osrfoundation.org/view/ign-garden/job/ign_gazebo-ci-win/207/

~~~
CMake Error at test/integration/CMakeLists.txt:167 (target_link_libraries):
  Cannot specify link libraries for target "INTEGRATION_log_system" which is
  not built by this project.
~~~

I've added `if (TARGET <TARGET_NAME>)` checks around each `target_*` call in `test/integration/CMakeLists.txt` that was missing it to see if that is enough to fix the windows build.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
