### PR TITLE
Populate Add System dialog's filename list

### DIFF
--- a/include/ignition/gazebo/SystemLoader.hh
+++ b/include/ignition/gazebo/SystemLoader.hh
@@ -17,6 +17,7 @@
 #ifndef IGNITION_GAZEBO_SYSTEMLOADER_HH_
 #define IGNITION_GAZEBO_SYSTEMLOADER_HH_
 
+#include <list>
 #include <memory>
 #include <optional>
 #include <string>

--- a/include/ignition/gazebo/SystemLoader.hh
+++ b/include/ignition/gazebo/SystemLoader.hh
@@ -62,7 +62,8 @@ namespace ignition
 
       /// \brief Load and instantiate system plugin from name/filename.
       /// \param[in] _filename Shared library filename to load plugin from.
-      /// \param[in] _name Class name to be instantiated.
+      /// \param[in] _name Class name to be instantiated. If empty, the first
+      /// the first plugin in the shared library will be loaded.
       /// \param[in] _sdf SDF Element describing plugin instance to be loaded.
       /// \returns Shared pointer to system instance or nullptr.
       /// \note This will be deprecated in Gazebo 7 (Garden), please the use

--- a/include/ignition/gazebo/SystemLoader.hh
+++ b/include/ignition/gazebo/SystemLoader.hh
@@ -85,6 +85,7 @@ namespace ignition
       /// \return Paths to search for plugins
       public: std::list<std::string> PluginPaths() const;
 
+      /// \brief Pointer to private data.
       private: std::unique_ptr<SystemLoaderPrivate> dataPtr;
     };
     }

--- a/include/ignition/gazebo/SystemLoader.hh
+++ b/include/ignition/gazebo/SystemLoader.hh
@@ -81,7 +81,10 @@ namespace ignition
       /// \returns A pretty string
       public: std::string PrettyStr() const;
 
-      /// \brief Pointer to private data.
+      /// \brief Get the plugin search paths used for loading system plugins
+      /// \return Paths to search for plugins
+      public: std::list<std::string> PluginPaths() const;
+
       private: std::unique_ptr<SystemLoaderPrivate> dataPtr;
     };
     }

--- a/include/ignition/gazebo/SystemLoader.hh
+++ b/include/ignition/gazebo/SystemLoader.hh
@@ -63,7 +63,7 @@ namespace ignition
       /// \brief Load and instantiate system plugin from name/filename.
       /// \param[in] _filename Shared library filename to load plugin from.
       /// \param[in] _name Class name to be instantiated. If empty, the first
-      /// the first plugin in the shared library will be loaded.
+      /// plugin in the shared library will be loaded.
       /// \param[in] _sdf SDF Element describing plugin instance to be loaded.
       /// \returns Shared pointer to system instance or nullptr.
       /// \note This will be deprecated in Gazebo 7 (Garden), please the use

--- a/src/SystemLoader.cc
+++ b/src/SystemLoader.cc
@@ -99,6 +99,7 @@ class ignition::gazebo::SystemLoaderPrivate
       return false;
     }
 
+    // use the first plugin name in the library if not specified
     std::string pluginToInstantiate = _sdfPlugin.Name().empty() ?
         pluginName : _sdfPlugin.Name();
 

--- a/src/SystemLoader.cc
+++ b/src/SystemLoader.cc
@@ -51,7 +51,8 @@ class ignition::gazebo::SystemLoaderPrivate
 
     std::string homePath;
     ignition::common::env(IGN_HOMEDIR, homePath);
-    systemPaths.AddPluginPaths(homePath + "/.ignition/gazebo/plugins");
+    systemPaths.AddPluginPaths(common::joinPaths(
+        homePath, ".ignition", "gazebo", "plugins"));
     systemPaths.AddPluginPaths(IGN_GAZEBO_PLUGIN_INSTALL_DIR);
 
     return systemPaths.PluginPaths();

--- a/src/SystemLoader.cc
+++ b/src/SystemLoader.cc
@@ -63,7 +63,7 @@ class ignition::gazebo::SystemLoaderPrivate
               ignition::plugin::PluginPtr &_gzPlugin)
   {
     std::list<std::string> paths = this->PluginPaths();
-    ignition::common::SystemPaths systemPaths;
+    common::SystemPaths systemPaths;
     for (const auto &p : paths)
     {
       systemPaths.AddPluginPaths(p);
@@ -168,8 +168,7 @@ std::optional<SystemPluginPtr> SystemLoader::LoadPlugin(
   if (_filename == "")
   {
     ignerr << "Failed to instantiate system plugin: empty argument "
-              "[(filename): " << _filename << "] " <<
-              "[(name): " << _name << "]." << std::endl;
+              "[(filename): " << _filename << "] " << std::endl;
     return {};
   }
 
@@ -202,8 +201,7 @@ std::optional<SystemPluginPtr> SystemLoader::LoadPlugin(
   if (_plugin.Filename() == "")
   {
     ignerr << "Failed to instantiate system plugin: empty argument "
-              "[(filename): " << _plugin.Filename() << "] " <<
-              "[(name): " << _plugin.Name() << "]." << std::endl;
+              "[(filename): " << _plugin.Filename() << "] " << std::endl;
     return {};
   }
 

--- a/src/SystemLoader_TEST.cc
+++ b/src/SystemLoader_TEST.cc
@@ -27,6 +27,7 @@
 #include "ignition/gazebo/test_config.hh"  // NOLINT(build/include)
 
 using namespace ignition;
+using namespace gazebo;
 
 /////////////////////////////////////////////////
 TEST(SystemLoader, Constructor)
@@ -71,7 +72,7 @@ TEST(SystemLoader, EmptyNames)
 /////////////////////////////////////////////////
 TEST(SystemLoader, PluginPaths)
 {
-  gazebo::SystemLoader sm;
+  SystemLoader sm;
 
   // verify that there should exist some default paths
   std::list<std::string> paths = sm.PluginPaths();
@@ -79,7 +80,7 @@ TEST(SystemLoader, PluginPaths)
   EXPECT_LT(0u, pathCount);
 
   // Add test path and verify that the loader now contains this path
-  auto testBuildPath = ignition::common::joinPaths(
+  auto testBuildPath = common::joinPaths(
       std::string(PROJECT_BINARY_PATH), "lib");
   sm.AddSystemPluginPath(testBuildPath);
   paths = sm.PluginPaths();

--- a/src/SystemLoader_TEST.cc
+++ b/src/SystemLoader_TEST.cc
@@ -67,3 +67,38 @@ TEST(SystemLoader, EmptyNames)
   auto system = sm.LoadPlugin(plugin);
   ASSERT_FALSE(system.has_value());
 }
+
+/////////////////////////////////////////////////
+TEST(SystemLoader, PluginPaths)
+{
+  gazebo::SystemLoader sm;
+
+  // verify that there should exist some default paths
+  std::list<std::string> paths = sm.PluginPaths();
+  unsigned int pathCount = paths.size();
+  EXPECT_LT(0u, pathCount);
+
+  // Add test path and verify that the loader now contains this path
+  auto testBuildPath = ignition::common::joinPaths(
+      std::string(PROJECT_BINARY_PATH), "lib");
+  sm.AddSystemPluginPath(testBuildPath);
+  paths = sm.PluginPaths();
+
+  // Number of paths should increase by 1
+  EXPECT_EQ(pathCount + 1, paths.size());
+
+  // verify newly added paths exists
+  bool hasPath = false;
+  for (const auto &s : paths)
+  {
+    // the returned path string may not be exact match due to extra '/'
+    // appended at the end of the string. So use absPath to generate
+    // a path string that matches the format returned by joinPaths
+    if (common::absPath(s) == testBuildPath)
+    {
+      hasPath = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(hasPath);
+}

--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -15,6 +15,9 @@
  *
 */
 
+#include <list>
+#include <set>
+
 #include <ignition/common/StringUtils.hh>
 
 #include "ignition/gazebo/components/SystemPluginInfo.hh"

--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -45,7 +45,7 @@ SystemManager::SystemManager(const SystemLoaderPtr &_systemLoader,
   ignmsg << "Serving entity system service on ["
          << "/" << entitySystemAddService << "]" << std::endl;
 
-  std::string entitySystemInfoService{"entity/system/info"};
+  std::string entitySystemInfoService{"system/info"};
   this->node->Advertise(entitySystemInfoService,
       &SystemManager::EntitySystemInfoService, this);
 }
@@ -260,7 +260,7 @@ bool SystemManager::EntitySystemInfoService(const msgs::Empty &,
     }
   }
 
-  for (auto fn : filenames)
+  for (const auto &fn : filenames)
   {
     auto plugin = _res.add_plugins();
     plugin->set_filename(fn);

--- a/src/SystemManager.hh
+++ b/src/SystemManager.hh
@@ -142,6 +142,14 @@ namespace ignition
       private: bool EntitySystemAddService(const msgs::EntityPlugin_V &_req,
                                            msgs::Boolean &_res);
 
+      /// \brief Callback for entity info system service.
+      /// \param[in] _req Empty request message
+      /// \param[out] _res Response containing a list of plugin names
+      /// and filenames
+      /// \return True if request received.
+      private: bool EntitySystemInfoService(const msgs::Empty &_req,
+                                            msgs::EntityPlugin_V &_res);
+
       /// \brief All the systems.
       private: std::vector<SystemInternal> systems;
 

--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -1281,7 +1281,8 @@ void ComponentInspector::QuerySystems()
       "/entity/system/info"};
   if (!this->dataPtr->node.Request(service, req, timeout, res, result))
   {
-    ignerr << "querying systems " << std::endl;
+    ignerr << "Unable to query available systems." << std::endl;
+    return;
   }
 
   this->dataPtr->systemFilenameList.clear();

--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -1326,7 +1326,9 @@ void ComponentInspector::QuerySystems()
     removePrefix("ignition-gazebo" + std::string(IGNITION_GAZEBO_MAJOR_VERSION_STR)
         + "-", humanReadable);
     removeSuffix("-system", humanReadable);
+    removeSuffix("system", humanReadable);
     removeSuffix("-plugin", humanReadable);
+    removeSuffix("plugin", humanReadable);
 
     // Replace - with space, capitalize
     std::replace(humanReadable.begin(), humanReadable.end(), '-', ' ');

--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -119,6 +119,9 @@ namespace ignition::gazebo
 
     /// \brief Handles all system info components.
     public: std::unique_ptr<inspector::SystemPluginInfo> systemInfo;
+
+    /// \brief A list of system plugin filenames
+    public: QStringList systemFilenameList;
   };
 }
 
@@ -1265,6 +1268,41 @@ const std::string &ComponentInspector::WorldName() const
 transport::Node &ComponentInspector::TransportNode()
 {
   return this->dataPtr->node;
+}
+
+/////////////////////////////////////////////////
+void ComponentInspector::QuerySystems()
+{
+  msgs::Empty req;
+  msgs::EntityPlugin_V res;
+  bool result;
+  unsigned int timeout = 5000;
+  std::string service{"/world/" + this->dataPtr->worldName +
+      "/entity/system/info"};
+  if (!this->dataPtr->node.Request(service, req, timeout, res, result))
+  {
+    ignerr << "querying systems " << std::endl;
+  }
+
+  this->dataPtr->systemFilenameList.clear();
+  for (auto &plugin : res.plugins())
+  {
+    this->dataPtr->systemFilenameList.push_back(
+        QString(plugin.filename().c_str()));
+  }
+  this->SystemFilenameListChanged();
+}
+
+/////////////////////////////////////////////////
+QStringList ComponentInspector::SystemFilenameList() const
+{
+  return this->dataPtr->systemFilenameList;
+}
+
+/////////////////////////////////////////////////
+void ComponentInspector::SetSystemFilenameList(const QStringList &_list)
+{
+  this->dataPtr->systemFilenameList = _list;
 }
 
 /////////////////////////////////////////////////

--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -69,6 +69,7 @@
 #include "ignition/gazebo/components/Volume.hh"
 #include "ignition/gazebo/components/WindMode.hh"
 #include "ignition/gazebo/components/World.hh"
+#include "ignition/gazebo/config.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/gui/GuiEvents.hh"
 
@@ -120,9 +121,32 @@ namespace ignition::gazebo
     /// \brief Handles all system info components.
     public: std::unique_ptr<inspector::SystemPluginInfo> systemInfo;
 
-    /// \brief A list of system plugin filenames
-    public: QStringList systemFilenameList;
+    /// \brief A list of system plugin human readable names.
+    public: QStringList systemNameList;
+
+    /// \brief Maps plugin display names to their filenames.
+    public: std::unordered_map<std::string, std::string> systemMap;
   };
+}
+
+// Helper to remove a prefix from a string if present
+void removePrefix(const std::string &_prefix, std::string &_s)
+{
+  auto id = _s.find(_prefix);
+  if (id != std::string::npos)
+  {
+    _s = _s.substr(_prefix.length());
+  }
+}
+
+// Helper to remove a suffix from a string if present
+void removeSuffix(const std::string &_suffix, std::string &_s)
+{
+  auto id = _s.find(_suffix);
+  if (id != std::string::npos && id + _suffix.length() == _s.length())
+  {
+    _s.erase(id, _suffix.length());
+  }
 }
 
 using namespace ignition;
@@ -1285,37 +1309,69 @@ void ComponentInspector::QuerySystems()
     return;
   }
 
-  this->dataPtr->systemFilenameList.clear();
-  for (auto &plugin : res.plugins())
+  this->dataPtr->systemNameList.clear();
+  this->dataPtr->systemMap.clear();
+  for (const auto &plugin : res.plugins())
   {
-    this->dataPtr->systemFilenameList.push_back(
-        QString(plugin.filename().c_str()));
+    if (plugin.filename().empty())
+    {
+      ignerr << "Received empty plugin name. This shouldn't happen."
+             << std::endl;
+      continue;
+    }
+
+    // Remove common prefixes and suffixes
+    auto humanReadable = plugin.filename();
+    removePrefix("ignition-gazebo-", humanReadable);
+    removePrefix("ignition-gazebo" + std::string(IGNITION_GAZEBO_MAJOR_VERSION_STR)
+        + "-", humanReadable);
+    removeSuffix("-system", humanReadable);
+    removeSuffix("-plugin", humanReadable);
+
+    // Replace - with space, capitalize
+    std::replace(humanReadable.begin(), humanReadable.end(), '-', ' ');
+    humanReadable[0] = std::toupper(humanReadable[0]);
+
+    this->dataPtr->systemMap[humanReadable] = plugin.filename();
+    this->dataPtr->systemNameList.push_back(
+        QString::fromStdString(humanReadable));
   }
-  this->SystemFilenameListChanged();
+  this->dataPtr->systemNameList.sort();
+  this->dataPtr->systemNameList.removeDuplicates();
+  this->SystemNameListChanged();
 }
 
 /////////////////////////////////////////////////
-QStringList ComponentInspector::SystemFilenameList() const
+QStringList ComponentInspector::SystemNameList() const
 {
-  return this->dataPtr->systemFilenameList;
+  return this->dataPtr->systemNameList;
 }
 
 /////////////////////////////////////////////////
-void ComponentInspector::SetSystemFilenameList(const QStringList &_list)
+void ComponentInspector::SetSystemNameList(const QStringList &_list)
 {
-  this->dataPtr->systemFilenameList = _list;
+  this->dataPtr->systemNameList = _list;
 }
 
 /////////////////////////////////////////////////
 void ComponentInspector::OnAddSystem(const QString &_name,
     const QString &_filename, const QString &_innerxml)
 {
+  auto filenameStr = _filename.toStdString();
+  auto it = this->dataPtr->systemMap.find(filenameStr);
+  if (it == this->dataPtr->systemMap.end())
+  {
+    ignerr << "Internal error: failed to find [" << filenameStr
+           << "] in system map." << std::endl;
+    return;
+  }
+
   msgs::EntityPlugin_V req;
   auto ent = req.mutable_entity();
   ent->set_id(this->dataPtr->entity);
   auto plugin = req.add_plugins();
   std::string name = _name.toStdString();
-  std::string filename = _filename.toStdString();
+  std::string filename = this->dataPtr->systemMap[filenameStr];
   std::string innerxml = _innerxml.toStdString();
   plugin->set_name(name);
   plugin->set_filename(filename);

--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -1278,7 +1278,7 @@ void ComponentInspector::QuerySystems()
   bool result;
   unsigned int timeout = 5000;
   std::string service{"/world/" + this->dataPtr->worldName +
-      "/entity/system/info"};
+      "/system/info"};
   if (!this->dataPtr->node.Request(service, req, timeout, res, result))
   {
     ignerr << "Unable to query available systems." << std::endl;

--- a/src/gui/plugins/component_inspector/ComponentInspector.hh
+++ b/src/gui/plugins/component_inspector/ComponentInspector.hh
@@ -212,6 +212,14 @@ namespace gazebo
       NOTIFY NestedModelChanged
     )
 
+    /// \brief System filename list
+    Q_PROPERTY(
+      QStringList systemFilenameList
+      READ SystemFilenameList
+      WRITE SetSystemFilenameList
+      NOTIFY SystemFilenameListChanged
+    )
+
     /// \brief Constructor
     public: ComponentInspector();
 
@@ -371,6 +379,21 @@ namespace gazebo
     /// \brief Node for communication
     /// \return Transport node
     public: transport::Node &TransportNode();
+
+    /// \brief Query system plugin info.
+    public: Q_INVOKABLE void QuerySystems();
+
+    /// \brief Get the system plugin filename list
+    /// \return A list of filenames that are potentially system plugins
+    public: Q_INVOKABLE QStringList SystemFilenameList() const;
+
+    /// \brief Set the system plugin filename list
+    /// \param[in] _systempFilenameList A list of system plugin filenames
+    public: Q_INVOKABLE void SetSystemFilenameList(
+        const QStringList &_systemFilenameList);
+
+    /// \brief Notify that system plugin filename list has changed
+    signals: void SystemFilenameListChanged();
 
     /// \brief Callback when a new system is to be added to an entity
     /// \param[in] _name Name of system

--- a/src/gui/plugins/component_inspector/ComponentInspector.hh
+++ b/src/gui/plugins/component_inspector/ComponentInspector.hh
@@ -212,12 +212,12 @@ namespace gazebo
       NOTIFY NestedModelChanged
     )
 
-    /// \brief System filename list
+    /// \brief System display name list
     Q_PROPERTY(
-      QStringList systemFilenameList
-      READ SystemFilenameList
-      WRITE SetSystemFilenameList
-      NOTIFY SystemFilenameListChanged
+      QStringList systemNameList
+      READ SystemNameList
+      WRITE SetSystemNameList
+      NOTIFY SystemNameListChanged
     )
 
     /// \brief Constructor
@@ -383,17 +383,17 @@ namespace gazebo
     /// \brief Query system plugin info.
     public: Q_INVOKABLE void QuerySystems();
 
-    /// \brief Get the system plugin filename list
-    /// \return A list of filenames that are potentially system plugins
-    public: Q_INVOKABLE QStringList SystemFilenameList() const;
+    /// \brief Get the system plugin display name list
+    /// \return A list of names that are potentially system plugins
+    public: Q_INVOKABLE QStringList SystemNameList() const;
 
-    /// \brief Set the system plugin filename list
-    /// \param[in] _systempFilenameList A list of system plugin filenames
-    public: Q_INVOKABLE void SetSystemFilenameList(
-        const QStringList &_systemFilenameList);
+    /// \brief Set the system plugin display name list
+    /// \param[in] _systempFilenameList A list of system plugin display names
+    public: Q_INVOKABLE void SetSystemNameList(
+        const QStringList &_systemNameList);
 
-    /// \brief Notify that system plugin filename list has changed
-    signals: void SystemFilenameListChanged();
+    /// \brief Notify that system plugin display name list has changed
+    signals: void SystemNameListChanged();
 
     /// \brief Callback when a new system is to be added to an entity
     /// \param[in] _name Name of system

--- a/src/gui/plugins/component_inspector/ComponentInspector.qml
+++ b/src/gui/plugins/component_inspector/ComponentInspector.qml
@@ -274,6 +274,7 @@ Rectangle {
           onTextEdited: {
             addSystemDialog.updateButtonState();
           }
+          placeholderText: "Leave empty to load first plugin"
         }
 
         Text {
@@ -282,15 +283,23 @@ Rectangle {
           Layout.column: 0
         }
 
-        TextField {
-          id: filenameField
-          selectByMouse: true
+        ComboBox {
+          id: filenameCB
           Layout.row: 1
           Layout.column: 1
+          Layout.fillWidth: true
           Layout.minimumWidth: 250
-          onTextEdited: {
+          model: ComponentInspector.systemFilenameList
+          currentIndex: 0
+          onCurrentIndexChanged: {
+            if (currentIndex < 0)
+              return;
             addSystemDialog.updateButtonState();
           }
+          ToolTip.visible: hovered
+          ToolTip.delay: tooltipDelay
+          ToolTip.timeout: tooltipTimeout
+          ToolTip.text: currentText
         }
       }
 
@@ -325,18 +334,18 @@ Rectangle {
     }
 
     onOpened: {
+      ComponentInspector.QuerySystems();
       addSystemDialog.updateButtonState();
     }
 
     onAccepted: {
       ComponentInspector.OnAddSystem(nameField.text.trim(),
-          filenameField.text.trim(), innerxmlField.text.trim())
+          filenameCB.currentText.trim(), innerxmlField.text.trim())
     }
 
     function updateButtonState() {
       buttons.standardButton(Dialog.Ok).enabled =
-          (nameField.text.trim() != '' &&
-          filenameField.text.trim() != '')
+          (filenameCB.currentText.trim() != '')
     }
   }
 

--- a/src/gui/plugins/component_inspector/ComponentInspector.qml
+++ b/src/gui/plugins/component_inspector/ComponentInspector.qml
@@ -254,8 +254,10 @@ Rectangle {
     focus: true
     title: "Add System"
     closePolicy: Popup.CloseOnEscape
+    width: parent.width
 
     ColumnLayout {
+      width: parent.width
       GridLayout {
         columns: 2
         columnSpacing: 30
@@ -270,6 +272,7 @@ Rectangle {
           selectByMouse: true
           Layout.row: 0
           Layout.column: 1
+          Layout.fillWidth: true
           Layout.minimumWidth: 250
           onTextEdited: {
             addSystemDialog.updateButtonState();
@@ -289,7 +292,7 @@ Rectangle {
           Layout.column: 1
           Layout.fillWidth: true
           Layout.minimumWidth: 250
-          model: ComponentInspector.systemFilenameList
+          model: ComponentInspector.systemNameList
           currentIndex: 0
           onCurrentIndexChanged: {
             if (currentIndex < 0)

--- a/src/gui/plugins/component_inspector/ComponentInspector.qml
+++ b/src/gui/plugins/component_inspector/ComponentInspector.qml
@@ -298,7 +298,6 @@ Rectangle {
           }
           ToolTip.visible: hovered
           ToolTip.delay: tooltipDelay
-          ToolTip.timeout: tooltipTimeout
           ToolTip.text: currentText
         }
       }

--- a/test/integration/entity_system.cc
+++ b/test/integration/entity_system.cc
@@ -158,6 +158,54 @@ TEST_P(EntitySystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(PublishCmd))
       "/model/vehicle/cmd_vel");
 }
 
+/////////////////////////////////////////////////
+TEST_P(EntitySystemTest, SystemInfo)
+{
+  // Start server
+  ServerConfig serverConfig;
+  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
+    "/test/worlds/empty.sdf";
+  serverConfig.SetSdfFile(sdfFile);
+
+  Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  // get info on systems available
+  msgs::Empty req;
+  msgs::EntityPlugin_V res;
+  bool result;
+  unsigned int timeout = 5000;
+  std::string service{"/world/empty/system/info"};
+  transport::Node node;
+  EXPECT_TRUE(node.Request(service, req, timeout, res, result));
+  EXPECT_TRUE(result);
+
+  // verify plugins are not empty
+  EXPECT_FALSE(res.plugins().empty());
+
+  // check for a few known plugins that we know should exist in gazebo
+  std::set<std::string> knownPlugins;
+  knownPlugins.insert("user-commands-system");
+  knownPlugins.insert("physics-system");
+  knownPlugins.insert("scene-broadcaster-system");
+  knownPlugins.insert("sensors-system");
+
+  for (const auto &plugin : res.plugins())
+  {
+    for (const auto &kp: knownPlugins)
+    {
+      if (plugin.filename().find(kp) != std::string::npos)
+      {
+        knownPlugins.erase(kp);
+        break;
+      }
+    }
+  }
+  // verify all known plugins are found and removed from the set
+  EXPECT_TRUE(knownPlugins.empty());
+}
+
 // Run multiple times
 INSTANTIATE_TEST_SUITE_P(ServerRepeat, EntitySystemTest,
     ::testing::Range(1, 2));

--- a/test/integration/entity_system.cc
+++ b/test/integration/entity_system.cc
@@ -193,7 +193,7 @@ TEST_P(EntitySystemTest, SystemInfo)
 
   for (const auto &plugin : res.plugins())
   {
-    for (const auto &kp: knownPlugins)
+    for (const auto &kp : knownPlugins)
     {
       if (plugin.filename().find(kp) != std::string::npos)
       {


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🎉 New feature

## Summary

Continuation of https://github.com/gazebosim/gz-sim/pull/1549 in response to https://github.com/gazebosim/gz-sim/pull/1549/files#r905599324

This PR changes the Add System GUI dialog's Filename field to a drop down list containing a list of plugins that the user can add to an entity.  In addition, if the `Name` field is empty, it'll load the first plugin from the shared library.

Some notes:
* we do not attempt to load every library and verify that they are valid plugins - it simply displays a list of shared libraries in the gz plugin path that can potentially be loaded as a system plugin.
* If `Name` is empty, the plugin will load fine but the console will display an error msg `Error [Param.cc:1035] Empty string used when setting a required parameter. Key[name]`. I think this is because SDF considers the name field a required param.

## Test it

Steps for testing are similar to those listed in https://github.com/gazebosim/gz-sim/pull/1549. Instead of entering the `Filename` manually, select `ignition-gazebo-diff-drive-system` from the drop down list. You can also leave the `Name` field empty.

![entity_system_add_gui_filenames](https://user-images.githubusercontent.com/4000684/177885996-0465ab55-30f9-4bd9-a8c5-8d16c55fb31c.png)



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
