### PR TITLE
Restore CXX_STANDARD 17 and test gz-cmake PR

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,7 +142,7 @@ if (MSVC)
 endif()
 
 # Create the library target
-gz_create_core_library(SOURCES ${sources})
+gz_create_core_library(SOURCES ${sources} CXX_STANDARD 17)
 target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
   PUBLIC
   gz-math${GZ_MATH_VER}


### PR DESCRIPTION
# 🦟 Bug fix

Testing https://github.com/gazebosim/gz-cmake/pull/274.

## Summary

Restore `CXX_STANDARD` export in core library since it uses c++ features in API, and also test a gz-cmake PR using `ci_matching_branch/` with https://github.com/gazebo-tooling/gazebodistro/commit/2eb328d4057c1c8344d7ed13e833c7901fc61891 and https://github.com/osrf/homebrew-simulation/commit/b1acded8859997c960b540d648cde7a4878f2d71

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

