### PR TITLE
Update playback_gui.config

### DIFF
--- a/src/gui/playback_gui.config
+++ b/src/gui/playback_gui.config
@@ -26,7 +26,7 @@
 <!-- GUI plugins -->
 
 <!-- 3D scene -->
-<plugin filename="GzScene3D" name="3D View">
+<plugin filename="MinimalScene" name="3D View">
   <ignition-gui>
     <title>3D View</title>
     <property type="bool" key="showTitleBar">false</property>
@@ -37,7 +37,71 @@
   <scene>scene</scene>
   <ambient_light>0.4 0.4 0.4</ambient_light>
   <background_color>0.8 0.8 0.8</background_color>
-  <camera_pose>6 0 6 0 0.5 3.14</camera_pose>
+  <camera_pose>-6 0 6 0 0.5 0</camera_pose>
+</plugin>
+
+<!-- Plugins that add functionality to the scene -->
+<plugin filename="EntityContextMenuPlugin" name="Entity context menu">
+  <ignition-gui>
+    <property key="state" type="string">floating</property>
+    <property key="width" type="double">5</property>
+    <property key="height" type="double">5</property>
+    <property key="showTitleBar" type="bool">false</property>
+  </ignition-gui>
+</plugin>
+<plugin filename="GzSceneManager" name="Scene Manager">
+  <ignition-gui>
+    <property key="resizable" type="bool">false</property>
+    <property key="width" type="double">5</property>
+    <property key="height" type="double">5</property>
+    <property key="state" type="string">floating</property>
+    <property key="showTitleBar" type="bool">false</property>
+  </ignition-gui>
+</plugin>
+<plugin filename="InteractiveViewControl" name="Interactive view control">
+  <ignition-gui>
+    <property key="resizable" type="bool">false</property>
+    <property key="width" type="double">5</property>
+    <property key="height" type="double">5</property>
+    <property key="state" type="string">floating</property>
+    <property key="showTitleBar" type="bool">false</property>
+  </ignition-gui>
+</plugin>
+<plugin filename="CameraTracking" name="Camera Tracking">
+  <ignition-gui>
+    <property key="resizable" type="bool">false</property>
+    <property key="width" type="double">5</property>
+    <property key="height" type="double">5</property>
+    <property key="state" type="string">floating</property>
+    <property key="showTitleBar" type="bool">false</property>
+  </ignition-gui>
+</plugin>
+<plugin filename="MarkerManager" name="Marker manager">
+  <ignition-gui>
+    <property key="resizable" type="bool">false</property>
+    <property key="width" type="double">5</property>
+    <property key="height" type="double">5</property>
+    <property key="state" type="string">floating</property>
+    <property key="showTitleBar" type="bool">false</property>
+  </ignition-gui>
+</plugin>
+<plugin filename="SelectEntities" name="Select Entities">
+  <ignition-gui>
+    <property key="resizable" type="bool">false</property>
+    <property key="width" type="double">5</property>
+    <property key="height" type="double">5</property>
+    <property key="state" type="string">floating</property>
+    <property key="showTitleBar" type="bool">false</property>
+  </ignition-gui>
+</plugin>
+<plugin filename="VisualizationCapabilities" name="Visualization Capabilities">
+  <ignition-gui>
+    <property key="resizable" type="bool">false</property>
+    <property key="width" type="double">5</property>
+    <property key="height" type="double">5</property>
+    <property key="state" type="string">floating</property>
+    <property key="showTitleBar" type="bool">false</property>
+  </ignition-gui>
 </plugin>
 
 <!-- Play / pause / step -->


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

Updated `playaback_gui.config` to use the individual GUI plugins instead of `GzScene3D`.

I left out the `Shapes`, `Lights`, `Spawn`, `TransformControl`, `Screenshot`, `CopyPaste`   GUI plugins.

One advantage of switching to use the individual plugins (specifically `MinimalScene` and `GzSceneManager`)  is that this allows visual plugins to load during playback.

To test:

1. Remove existing `playback_gui.confg` file in `~/.ignition/gazebo/6/`

1. Launch `shader_param.sdf` world
    ```
    ign gazebo --record --record-path playback_test -v 4  ./src/ign-gazebo/examples/worlds/shader_param.sdf
    ```

1. Use the `Entity Tree` plugin to select the deformable shape and use the `Component Inspector` to set its pose and move it around (This forces logging entity states)

1. Close Gazebo and verify that a directory with state log exists in your current directory, i.e. `playback_test/state.tlog`

1. Playback the log file:

    ```
    ign gazebo -v 4 --playback playback_test
    ```

Before this change, the waves would be white and the deformable sphere would be black in playback. After this change, the visual plugins should be loaded on the GUI side and these visuals should be properly colored and animated.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

