### PR TITLE
Add Model::CanonicalLink getter

### DIFF
--- a/include/ignition/gazebo/Model.hh
+++ b/include/ignition/gazebo/Model.hh
@@ -169,6 +169,12 @@ namespace ignition
       public: void SetWorldPoseCmd(EntityComponentManager &_ecm,
           const math::Pose3d &_pose);
 
+      /// \brief Get the model's canonical link entity.
+      /// \param[in] _ecm Entity-component manager.
+      /// \return Link entity.
+      public: gazebo::Entity CanonicalLink(
+          const EntityComponentManager &_ecm) const;
+
       /// \brief Pointer to private data.
       private: std::unique_ptr<ModelPrivate> dataPtr;
     };

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include "ignition/gazebo/components/CanonicalLink.hh"
 #include "ignition/gazebo/components/Joint.hh"
 #include "ignition/gazebo/components/Link.hh"
 #include "ignition/gazebo/components/Model.hh"
@@ -193,3 +194,10 @@ void Model::SetWorldPoseCmd(EntityComponentManager &_ecm,
   }
 }
 
+//////////////////////////////////////////////////
+Entity Model::CanonicalLink(const EntityComponentManager &_ecm) const
+{
+  return _ecm.EntityByComponents(
+      components::ParentEntity(this->dataPtr->id),
+      components::CanonicalLink());
+}

--- a/test/integration/model.cc
+++ b/test/integration/model.cc
@@ -23,6 +23,7 @@
 
 #include <ignition/gazebo/EntityComponentManager.hh>
 #include <ignition/gazebo/Model.hh>
+#include <ignition/gazebo/components/CanonicalLink.hh>
 #include <ignition/gazebo/components/Joint.hh>
 #include <ignition/gazebo/components/Link.hh>
 #include <ignition/gazebo/components/Model.hh>
@@ -230,5 +231,34 @@ TEST_F(ModelIntegrationTest, SetWorldPoseCmd)
   ASSERT_NE(nullptr, worldPoseCmdComp);
   EXPECT_EQ(math::Pose3d(1, 2, 3, 0, 0, 0), worldPoseCmdComp->Data());
   EXPECT_TRUE(ecm.HasOneTimeComponentChanges());
+}
+
+//////////////////////////////////////////////////
+TEST_F(ModelIntegrationTest, CanonicalLink)
+{
+  EntityComponentManager ecm;
+
+  // Model
+  auto eModel = ecm.CreateEntity();
+  Model model(eModel);
+  EXPECT_EQ(eModel, model.Entity());
+  EXPECT_EQ(0u, model.LinkCount(ecm));
+
+  // Links
+  auto canonicalLink = ecm.CreateEntity();
+  ecm.CreateComponent(canonicalLink, components::Link());
+  ecm.CreateComponent(canonicalLink, components::CanonicalLink());
+  ecm.CreateComponent(canonicalLink,
+      components::ParentEntity(eModel));
+  ecm.CreateComponent(canonicalLink, components::Name("canonical"));
+
+  auto anotherLink = ecm.CreateEntity();
+  ecm.CreateComponent(anotherLink, components::Link());
+  ecm.CreateComponent(anotherLink, components::ParentEntity(eModel));
+  ecm.CreateComponent(anotherLink, components::Name("another"));
+
+  // Check model
+  EXPECT_EQ(canonicalLink, model.CanonicalLink(ecm));
+  EXPECT_EQ(2u, model.LinkCount(ecm));
 }
 


### PR DESCRIPTION
# 🎉 New feature

* Broken off https://github.com/gazebosim/gz-sim/pull/1593

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Add a convenient function to get a model's canonical link.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

See the added tests.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
