### PR TITLE
Fix compilation of scene broadcaster test

### DIFF
--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -320,7 +320,8 @@ TEST_P(SceneBroadcasterTest, DeletedTopic)
 
   // The id of the deleted entity should have been published
   // Note: Only model entities are currently supported for deletion
-  EXPECT_TRUE(std::find_if(delMsg.data().cbegin(), delMsg.data().cend(),
+  EXPECT_NE(delMsg.data().cend(),
+      std::find_if(delMsg.data().cbegin(), delMsg.data().cend(),
       [&cylinderModelId](const auto &_val)
       {
         return _val == cylinderModelId;


### PR DESCRIPTION
# 🦟 Bug fix

Fixes build on macOS with latest version of protobuf

## Summary

This test fails to compile with the latest version of protobuf, which is currently available on macOS. Both `ign-gazebo6` and `ign-gazebo3` fail in the same way.

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gazebo-ci-ign-gazebo3-homebrew-amd64&build=231)](https://build.osrfoundation.org/view/ign-citadel/job/ignition_gazebo-ci-ign-gazebo3-homebrew-amd64/231/) https://build.osrfoundation.org/view/ign-citadel/job/ignition_gazebo-ci-ign-gazebo3-homebrew-amd64/231/
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gazebo-ci-ign-gazebo6-homebrew-amd64&build=112)](https://build.osrfoundation.org/view/ign-fortress/job/ignition_gazebo-ci-ign-gazebo6-homebrew-amd64/112/) https://build.osrfoundation.org/view/ign-fortress/job/ignition_gazebo-ci-ign-gazebo6-homebrew-amd64/112/

A protobuf iterator no longer implicitly converts to `bool`, so compare to the end iterator instead.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
