### PR TITLE
[garden] cherry pick build fix

### DIFF
--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -327,7 +327,8 @@ TEST_P(SceneBroadcasterTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(DeletedTopic))
 
   // The id of the deleted entity should have been published
   // Note: Only model entities are currently supported for deletion
-  EXPECT_TRUE(std::find_if(delMsg.data().cbegin(), delMsg.data().cend(),
+  EXPECT_NE(delMsg.data().cend(),
+      std::find_if(delMsg.data().cbegin(), delMsg.data().cend(),
       [&cylinderModelId](const auto &_val)
       {
         return _val == cylinderModelId;


### PR DESCRIPTION
# 🦟 Bug fix

Cherry-pick #1599 forward to `ign-gazebo6`

## Summary

This fixes the build with new versions of protobuf in use on macOS. I tried merging it forward, but there were tons of conflicts, so I'm cherry-picking it to more quickly fix CI.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Rebase-and-merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
