### PR TITLE
ign -> gz : Fix Python bindings

### DIFF
--- a/python/src/gz/sim/EntityComponentManager.cc
+++ b/python/src/gz/sim/EntityComponentManager.cc
@@ -24,7 +24,7 @@ namespace sim
 namespace python
 {
 /////////////////////////////////////////////////
-void defineGazeboEntityComponentManager(pybind11::object module)
+void defineSimEntityComponentManager(pybind11::object module)
 {
   pybind11::class_<gz::sim::EntityComponentManager>(
       module, "EntityComponentManager")

--- a/python/src/gz/sim/EntityComponentManager.hh
+++ b/python/src/gz/sim/EntityComponentManager.hh
@@ -32,7 +32,7 @@ namespace python
  * \param[in] module a pybind11 module to add the definition to
  */
 void
-defineGazeboEntityComponentManager(pybind11::object module);
+defineSimEntityComponentManager(pybind11::object module);
 }  // namespace python
 }  // namespace sim
 }  // namespace gz

--- a/python/src/gz/sim/EventManager.cc
+++ b/python/src/gz/sim/EventManager.cc
@@ -27,7 +27,7 @@ namespace sim
 namespace python
 {
 /////////////////////////////////////////////////
-void defineGazeboEventManager(pybind11::object module)
+void defineSimEventManager(pybind11::object module)
 {
   pybind11::class_<gz::sim::EventManager>(module, "EventManager")
   .def(pybind11::init<>());

--- a/python/src/gz/sim/EventManager.hh
+++ b/python/src/gz/sim/EventManager.hh
@@ -31,7 +31,7 @@ namespace python
  * \param[in] module a pybind11 module to add the definition to
  */
 void
-defineGazeboEventManager(pybind11::object module);
+defineSimEventManager(pybind11::object module);
 }  // namespace python
 }  // namespace sim
 }  // namespace gz

--- a/python/src/gz/sim/TestFixture.cc
+++ b/python/src/gz/sim/TestFixture.cc
@@ -30,7 +30,7 @@ namespace sim
 namespace python
 {
 void
-defineGazeboTestFixture(pybind11::object module)
+defineSimTestFixture(pybind11::object module)
 {
   pybind11::class_<TestFixture, std::shared_ptr<TestFixture>> testFixture(module, "TestFixture");
 

--- a/python/src/gz/sim/TestFixture.hh
+++ b/python/src/gz/sim/TestFixture.hh
@@ -30,7 +30,7 @@ namespace python
  * \param[in] module a pybind11 module to add the definition to
  */
 void
-defineGazeboTestFixture(pybind11::object module);
+defineSimTestFixture(pybind11::object module);
 }
 }
 }

--- a/python/src/gz/sim/UpdateInfo.cc
+++ b/python/src/gz/sim/UpdateInfo.cc
@@ -28,7 +28,7 @@ namespace sim
 {
 namespace python
 {
-void defineGazeboUpdateInfo(pybind11::object module)
+void defineSimUpdateInfo(pybind11::object module)
 {
   pybind11::class_<gz::sim::UpdateInfo>(module, "UpdateInfo")
   .def(pybind11::init<>())

--- a/python/src/gz/sim/UpdateInfo.hh
+++ b/python/src/gz/sim/UpdateInfo.hh
@@ -31,7 +31,7 @@ namespace python
  * \param[in] module a pybind11 module to add the definition to
  */
 void
-defineGazeboUpdateInfo(pybind11::object module);
+defineSimUpdateInfo(pybind11::object module);
 }  // namespace python
 }  // namespace sim
 }  // namespace gz

--- a/python/src/gz/sim/Util.cc
+++ b/python/src/gz/sim/Util.cc
@@ -29,7 +29,7 @@ namespace sim
 {
 namespace python
 {
-void defineGazeboUtil(pybind11::module &_module)
+void defineSimUtil(pybind11::module &_module)
 {
   _module.def("world_entity",
       pybind11::overload_cast<const EntityComponentManager &>(

--- a/python/src/gz/sim/Util.hh
+++ b/python/src/gz/sim/Util.hh
@@ -29,7 +29,7 @@ namespace python
 {
 /// Define a pybind11 wrapper for a gz::sim::Util
 /// \param[in] _module a pybind11 module to add the definition to
-void defineGazeboUtil(pybind11::module &_module);
+void defineSimUtil(pybind11::module &_module);
 }  // namespace python
 }  // namespace sim
 }  // namespace gz

--- a/python/src/gz/sim/World.cc
+++ b/python/src/gz/sim/World.cc
@@ -28,7 +28,7 @@ namespace sim
 {
 namespace python
 {
-void defineGazeboWorld(pybind11::object module)
+void defineSimWorld(pybind11::object module)
 {
   pybind11::class_<gz::sim::World>(module, "World")
   .def(pybind11::init<gz::sim::Entity>())

--- a/python/src/gz/sim/World.hh
+++ b/python/src/gz/sim/World.hh
@@ -32,7 +32,7 @@ namespace python
  * \param[in] module a pybind11 module to add the definition to
  */
 void
-defineGazeboWorld(pybind11::object module);
+defineSimWorld(pybind11::object module);
 }  // namespace python
 }  // namespace sim
 }  // namespace gz

--- a/python/src/gz/sim/_gz_sim_pybind11.cc
+++ b/python/src/gz/sim/_gz_sim_pybind11.cc
@@ -25,15 +25,28 @@
 #include "Util.hh"
 #include "World.hh"
 
-PYBIND11_MODULE(gazebo, m) {
-  m.doc() = "Gazebo Python Library.";
+PYBIND11_MODULE(sim, m) {
+  m.doc() = "Gazebo Sim Python Library.";
 
-  gz::sim::python::defineGazeboEntityComponentManager(m);
-  gz::sim::python::defineGazeboEventManager(m);
+  gz::sim::python::defineSimEntityComponentManager(m);
+  gz::sim::python::defineSimEventManager(m);
   gz::sim::python::defineSimServer(m);
   gz::sim::python::defineSimServerConfig(m);
-  gz::sim::python::defineGazeboTestFixture(m);
-  gz::sim::python::defineGazeboUpdateInfo(m);
-  gz::sim::python::defineGazeboWorld(m);
-  gz::sim::python::defineGazeboUtil(m);
+  gz::sim::python::defineSimTestFixture(m);
+  gz::sim::python::defineSimUpdateInfo(m);
+  gz::sim::python::defineSimWorld(m);
+  gz::sim::python::defineSimUtil(m);
+}
+
+PYBIND11_MODULE(gazebo, m) {  // TODO(CH3): Deprecated. Remove on tock.
+  m.doc() = "Gazebo Sim Python Library.";
+
+  gz::sim::python::defineSimEntityComponentManager(m);
+  gz::sim::python::defineSimEventManager(m);
+  gz::sim::python::defineSimServer(m);
+  gz::sim::python::defineSimServerConfig(m);
+  gz::sim::python::defineSimTestFixture(m);
+  gz::sim::python::defineSimUpdateInfo(m);
+  gz::sim::python::defineSimWorld(m);
+  gz::sim::python::defineSimUtil(m);
 }


### PR DESCRIPTION
Part of: https://github.com/gazebo-tooling/release-tools/issues/698

This should fix these failures:
```
    File "/github/workspace/python/test/testFixture_TEST.py", line 19, in <module>
      from gz.sim import TestFixture, World, world_entity
  ImportError: dynamic module does not define module export function (PyInit_sim)
```

But I'm explicitly using CI to test if my changes worked.. so.. Draft for now!

Signed-off-by: methylDragon <methylDragon@gmail.com>
