### PR TITLE
Acoustic comms plugin

### DIFF
--- a/examples/worlds/acoustic_comms.sdf
+++ b/examples/worlds/acoustic_comms.sdf
@@ -24,6 +24,8 @@
     <plugin
       filename="gz-sim-acoustic-comms-system"
       name="gz::sim::systems::AcousticComms">
+      <max_range>6</max_range>
+      <speed_of_sound>1400</speed_of_sound>
     </plugin>
 
     <light type="directional" name="sun">
@@ -158,6 +160,94 @@
         </broker>
       </plugin>
 
+    </model>
+
+    <model name="box3">
+      <pose>5 0 0.5 0 0 0</pose>
+      <link name="box_link">
+        <inertial>
+          <inertia>
+            <ixx>0.16666</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.16666</iyy>
+            <iyz>0</iyz>
+            <izz>0.16666</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+
+        <visual name="box_visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>1 0 0 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <plugin
+        filename="gz-sim-comms-endpoint-system"
+        name="gz::sim::systems::CommsEndpoint">
+        <address>addr3</address>
+        <topic>addr3/rx</topic>
+      </plugin>
+    </model>
+
+    <model name="box4">
+      <pose>-5 0 0.5 0 0 0</pose>
+      <link name="box_link">
+        <inertial>
+          <inertia>
+            <ixx>0.16666</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.16666</iyy>
+            <iyz>0</iyz>
+            <izz>0.16666</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+
+        <visual name="box_visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>1 0 0 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <plugin
+        filename="gz-sim-comms-endpoint-system"
+        name="gz::sim::systems::CommsEndpoint">
+        <address>addr4</address>
+        <topic>addr4/rx</topic>
+      </plugin>
     </model>
 
   </world>

--- a/examples/worlds/acoustic_comms.sdf
+++ b/examples/worlds/acoustic_comms.sdf
@@ -1,0 +1,164 @@
+<?xml version="1.0" ?>
+<!--
+  Gazebo acoustic-comms plugin demo.
+-->
+<sdf version="1.6">
+  <world name="acoustic_comms">
+
+    <physics name="1ms" type="ignored">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin
+      filename="gz-sim-user-commands-system"
+      name="gz::sim::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+    <plugin
+      filename="gz-sim-acoustic-comms-system"
+      name="gz::sim::systems::AcousticComms">
+    </plugin>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>1 1 1 1</diffuse>
+      <specular>0.5 0.5 0.5 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="box1">
+      <pose>2 0 0.5 0 0 0</pose>
+      <link name="box_link">
+        <inertial>
+          <inertia>
+            <ixx>0.16666</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.16666</iyy>
+            <iyz>0</iyz>
+            <izz>0.16666</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+
+        <visual name="box_visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>1 0 0 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <plugin
+        filename="gz-sim-comms-endpoint-system"
+        name="gz::sim::systems::CommsEndpoint">
+        <address>addr1</address>
+        <topic>addr1/rx</topic>
+      </plugin>
+    </model>
+
+    <model name="box2">
+      <pose>-2 0 0.5 0 0 0</pose>
+      <link name="box_link">
+        <inertial>
+          <inertia>
+            <ixx>0.16666</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.16666</iyy>
+            <iyz>0</iyz>
+            <izz>0.16666</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+
+        <visual name="box_visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 0 1 1</ambient>
+            <diffuse>0 0 1 1</diffuse>
+            <specular>0 0 1 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <plugin
+        filename="gz-sim-comms-endpoint-system"
+        name="gz::sim::systems::CommsEndpoint">
+        <address>addr2</address>
+        <topic>addr2/rx</topic>
+        <broker>
+          <bind_service>/broker/bind</bind_service>
+          <unbind_service>/broker/unbind</unbind_service>
+        </broker>
+      </plugin>
+
+    </model>
+
+  </world>
+</sdf>

--- a/examples/worlds/acoustic_comms_moving_targets.sdf
+++ b/examples/worlds/acoustic_comms_moving_targets.sdf
@@ -1,0 +1,250 @@
+<?xml version="1.0" ?>
+<!--
+  Gazebo acoustic-comms plugin demo.
+-->
+<sdf version="1.6">
+  <world name="acoustic_comms">
+    <gravity>0 1 -10</gravity>
+
+    <physics name="1ms" type="ignored">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin
+      filename="gz-sim-user-commands-system"
+      name="gz::sim::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+    <plugin
+      filename="gz-sim-acoustic-comms-system"
+      name="gz::sim::systems::AcousticComms">
+      <speed_of_sound>1400</speed_of_sound>
+    </plugin>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>1 1 1 1</diffuse>
+      <specular>0.5 0.5 0.5 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="sphere1">
+      <pose>2 0 1 0 0 0</pose>
+      <link name="box_link">
+        <inertial>
+          <inertia>
+            <ixx>0.16666</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.16666</iyy>
+            <iyz>0</iyz>
+            <izz>0.16666</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="sphere_collision">
+          <geometry>
+            <sphere>
+            </sphere>
+          </geometry>
+        </collision>
+
+        <visual name="sphere_visual">
+          <geometry>
+            <sphere>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>1 0 0 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <plugin
+        filename="gz-sim-comms-endpoint-system"
+        name="gz::sim::systems::CommsEndpoint">
+        <address>addr1</address>
+        <topic>addr1/rx</topic>
+      </plugin>
+    </model>
+
+    <model name="box2">
+      <pose>-2 0 0.5 0 0 0</pose>
+      <link name="box_link">
+        <inertial>
+          <inertia>
+            <ixx>0.16666</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.16666</iyy>
+            <iyz>0</iyz>
+            <izz>0.16666</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+
+        <visual name="box_visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 0 1 1</ambient>
+            <diffuse>0 0 1 1</diffuse>
+            <specular>0 0 1 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <plugin
+        filename="gz-sim-comms-endpoint-system"
+        name="gz::sim::systems::CommsEndpoint">
+        <address>addr2</address>
+        <topic>addr2/rx</topic>
+        <broker>
+          <bind_service>/broker/bind</bind_service>
+          <unbind_service>/broker/unbind</unbind_service>
+        </broker>
+      </plugin>
+
+    </model>
+
+    <model name="box3">
+      <pose>5 0 0.5 0 0 0</pose>
+      <link name="box_link">
+        <inertial>
+          <inertia>
+            <ixx>0.16666</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.16666</iyy>
+            <iyz>0</iyz>
+            <izz>0.16666</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+
+        <visual name="box_visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>1 0 0 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <plugin
+        filename="gz-sim-comms-endpoint-system"
+        name="gz::sim::systems::CommsEndpoint">
+        <address>addr3</address>
+        <topic>addr3/rx</topic>
+      </plugin>
+    </model>
+
+    <model name="sphere4">
+      <pose>-5 0 1 0 0 0</pose>
+      <link name="sphere_link">
+        <inertial>
+          <inertia>
+            <ixx>0.16666</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.16666</iyy>
+            <iyz>0</iyz>
+            <izz>0.16666</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="sphere_collision">
+          <geometry>
+            <sphere>
+            </sphere>
+          </geometry>
+        </collision>
+
+        <visual name="sphere_visual">
+          <geometry>
+            <sphere>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>1 0 0 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <plugin
+        filename="gz-sim-comms-endpoint-system"
+        name="gz::sim::systems::CommsEndpoint">
+        <address>addr4</address>
+        <topic>addr4/rx</topic>
+      </plugin>
+    </model>
+
+  </world>
+</sdf>

--- a/src/systems/CMakeLists.txt
+++ b/src/systems/CMakeLists.txt
@@ -96,6 +96,7 @@ function(gz_add_system system_name)
 endfunction()
 
 add_subdirectory(ackermann_steering)
+add_subdirectory(acoustic_comms)
 add_subdirectory(air_pressure)
 add_subdirectory(altimeter)
 add_subdirectory(apply_joint_force)

--- a/src/systems/acoustic_comms/AcousticComms.cc
+++ b/src/systems/acoustic_comms/AcousticComms.cc
@@ -37,7 +37,7 @@ class AcousticComms::Implementation
   // Default max range for acoustic comms in metres.
   public: double maxRange = 1000.0;
 
-  // Default speed of sound in air (m/s).
+  // Default speed of sound in air in metres/sec.
   public: double speedOfSound = 343.0;
 };
 

--- a/src/systems/acoustic_comms/AcousticComms.cc
+++ b/src/systems/acoustic_comms/AcousticComms.cc
@@ -33,26 +33,29 @@ using namespace gz;
 using namespace sim;
 using namespace systems;
 
+/// \brief Private Acoustic comms data class.
 class AcousticComms::Implementation
 {
-  // Default max range for acoustic comms in metres.
+  /// \brief Default max range for acoustic comms in metres.
   public: double maxRange = 1000.0;
 
-  // Default speed of sound in air in metres/sec.
+  /// \brief Default speed of sound in air in metres/sec.
   public: double speedOfSound = 343.0;
 
-  // Position of the transmitter at the time the message was
-  // sent, or first processed.
+  /// \brief Position of the transmitter at the time the message was
+  /// sent, or first processed.
   public: std::unordered_map
           <std::shared_ptr<msgs::Dataframe>, math::Vector3d>
           poseSrcAtMsgTimestamp;
 };
 
+//////////////////////////////////////////////////
 AcousticComms::AcousticComms()
   : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
 }
 
+//////////////////////////////////////////////////
 void AcousticComms::Load(
     const Entity &_entity,
     std::shared_ptr<const sdf::Element> _sdf,
@@ -69,6 +72,7 @@ void AcousticComms::Load(
   }
 }
 
+//////////////////////////////////////////////////
 void AcousticComms::Step(
     const UpdateInfo &_info,
     const comms::Registry &_currentRegistry,

--- a/src/systems/acoustic_comms/AcousticComms.cc
+++ b/src/systems/acoustic_comms/AcousticComms.cc
@@ -70,6 +70,10 @@ void AcousticComms::Load(
   {
     this->dataPtr->speedOfSound = _sdf->Get<double>("speed_of_sound");
   }
+
+  gzmsg << "AcousticComms configured with max range : " <<
+    this->dataPtr->maxRange << " m and speed of sound : " <<
+    this->dataPtr->speedOfSound << " m/s." << std::endl;
 }
 
 //////////////////////////////////////////////////
@@ -144,27 +148,26 @@ void AcousticComms::Step(
             worldPose(itSrc->second.entity, _ecm).Pos();
         }
 
-        math::Vector3d poseSrc =
+        const auto& poseSrc =
           this->dataPtr->poseSrcAtMsgTimestamp[msg];
 
         // Calculate distance between the bodies.
-        auto poseDst = worldPose(itDst->second.entity, _ecm).Pos();
-        auto distanceToTransmitter =
-          (poseSrc - poseDst).Length();
+        const auto poseDst = worldPose(itDst->second.entity, _ecm).Pos();
+        const auto distanceToTransmitter = (poseSrc - poseDst).Length();
 
         // Calculate distance covered by the message.
-        std::chrono::steady_clock::time_point currTime(_info.simTime);
-        auto timeOfTransmission = msg->mutable_header()->stamp();
+        const std::chrono::steady_clock::time_point currTime(_info.simTime);
+        const auto timeOfTransmission = msg->mutable_header()->stamp();
 
-        auto currTimestamp =
-          std::chrono::nanoseconds(currTime.time_since_epoch().count());
-        auto packetTimestamp =
+        const auto currTimestamp =
+          std::chrono::nanoseconds(currTime.time_since_epoch());
+        const auto packetTimestamp =
           std::chrono::seconds(timeOfTransmission.sec()) +
           std::chrono::nanoseconds(timeOfTransmission.nsec());
 
-        std::chrono::duration<double> deltaT =
+        const std::chrono::duration<double> deltaT =
           currTimestamp - packetTimestamp;
-        double distanceCoveredByMessage = deltaT.count() *
+        const double distanceCoveredByMessage = deltaT.count() *
           this->dataPtr->speedOfSound;
 
         // Check the msgs that haven't exceeded the maxRange.

--- a/src/systems/acoustic_comms/AcousticComms.cc
+++ b/src/systems/acoustic_comms/AcousticComms.cc
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
+ * Development of this module has been funded by the Monterey Bay Aquarium
+ * Research Institute (MBARI) and the David and Lucile Packard Foundation
+ */
+
+#include <gz/common/Profiler.hh>
+#include <gz/plugin/Register.hh>
+#include <gz/sim/Entity.hh>
+#include "gz/sim/comms/Broker.hh"
+#include "gz/sim/comms/MsgManager.hh"
+#include "gz/sim/Util.hh"
+#include "AcousticComms.hh"
+
+using namespace gz;
+using namespace sim;
+using namespace systems;
+
+class AcousticComms::Implementation
+{
+  public: double maxRange;
+  public: double speedOfSound;
+  public: double DistanceBetweenBodies(Entity _src, Entity _dst);
+};
+
+AcousticComms::AcousticComms()
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
+{
+}
+
+void AcousticComms::Load(
+    const Entity &_entity,
+    std::shared_ptr<const sdf::Element> _sdf,
+    EntityComponentManager &_ecm,
+    EventManager &_eventMgr)
+{
+  if (_sdf->HasElement("max_range"))
+  {
+    this->dataPtr->maxRange = _sdf->Get<double>("max_range");
+  }
+  if (_sdf->HasElement("speed_of_sound"))
+  {
+    this->dataPtr->maxRange = _sdf->Get<double>("speed_of_sound");
+  }
+}
+
+void AcousticComms::Step(
+    const UpdateInfo &_info,
+    const comms::Registry &_currentRegistry,
+    comms::Registry &_newRegistry,
+    EntityComponentManager &_ecm)
+{
+  // Initialize entity if needed.
+  for (auto & [address, content] : _currentRegistry)
+  {
+    if (content.entity == kNullEntity)
+    {
+      auto entities = entitiesFromScopedName(content.modelName, _ecm);
+      if (entities.empty())
+        continue;
+
+      auto entityId = *(entities.begin());
+      if (entityId == kNullEntity)
+        continue;
+
+      _newRegistry[address].entity = entityId;
+    }
+  }
+
+  for (auto & [address, content] : _currentRegistry)
+  {
+    // Reference to the outbound queue for this address.
+    auto &outbound = content.outboundMsgs;
+
+    // Is the source address bound?
+    auto itSrc = _currentRegistry.find(address);
+    bool srcAddressBound = itSrc != _currentRegistry.end();
+
+    // Is the source address attached to a model?
+    bool srcAddressAttachedToModel =
+      srcAddressBound && itSrc->second.entity != kNullEntity;
+
+    if (srcAddressAttachedToModel)
+    {
+      // All these messages need to be processed.
+      for (auto &msg : outbound)
+      {
+        // Is the destination address bound?
+        auto itDst = _currentRegistry.find(msg->dst_address());
+        bool dstAddressBound = itDst != _currentRegistry.end();
+
+        // Is the destination address attached to a model?
+        bool dstAddressAttachedToModel =
+          dstAddressBound && itDst->second.entity != kNullEntity;
+
+        if (dstAddressAttachedToModel)
+          _newRegistry[msg->dst_address()].inboundMsgs.push_back(msg);
+      }
+    }
+
+    // Clear the outbound queue.
+    _newRegistry[address].outboundMsgs.clear();
+  }
+}
+
+GZ_ADD_PLUGIN(AcousticComms,
+              System,
+              comms::ICommsModel::ISystemConfigure,
+              comms::ICommsModel::ISystemPreUpdate)
+
+GZ_ADD_PLUGIN_ALIAS(AcousticComms,
+                          "gz::sim::systems::AcousticComms")

--- a/src/systems/acoustic_comms/AcousticComms.cc
+++ b/src/systems/acoustic_comms/AcousticComms.cc
@@ -116,6 +116,14 @@ void AcousticComms::Step(
         if (!dstAddressAttachedToModel)
           continue;
 
+        // The plugin checks the distance travelled by the signal
+        // so far. If it is more than the maxRange, it is dropped
+        // and would never reach the destination.
+        // If it has already reached the destination but not as far
+        // as maxRange, it is processed.
+        // If it has reached neither the destination nor the maxRange,
+        // it is considered in transit.
+
         // Check if the message header contains the position of sender
         // at the time the message was sent. If yes, use that as poseSrc,
         // else use current position of the sender.

--- a/src/systems/acoustic_comms/AcousticComms.cc
+++ b/src/systems/acoustic_comms/AcousticComms.cc
@@ -157,7 +157,8 @@ void AcousticComms::Step(
       }
     }
 
-    // Clear the outbound queue, leaving the message in transit.
+    // Clear the outbound queue, except for messages that were
+    // in transit.
     _newRegistry[address].outboundMsgs = newOutbound;
   }
 }

--- a/src/systems/acoustic_comms/AcousticComms.cc
+++ b/src/systems/acoustic_comms/AcousticComms.cc
@@ -38,7 +38,7 @@ class AcousticComms::Implementation
 {
   // Default max range for acoustic comms in metres.
   public: double maxRange = 1000.0;
-  
+
   // Default speed of sound in air (m/s).
   public: double speedOfSound = 343.0;
 

--- a/src/systems/acoustic_comms/AcousticComms.cc
+++ b/src/systems/acoustic_comms/AcousticComms.cc
@@ -37,10 +37,10 @@ using namespace systems;
 class AcousticComms::Implementation
 {
   // Default max range for acoustic comms in metres.
-  public: double maxRange = 500;
+  public: double maxRange = 1000.0;
   
   // Default speed of sound in air (m/s).
-  public: double speedOfSound = 343;
+  public: double speedOfSound = 343.0;
 
   public: double DistanceBetweenBodies(
               math::Vector3<double> _src,
@@ -73,7 +73,7 @@ void AcousticComms::Load(
   }
   if (_sdf->HasElement("speed_of_sound"))
   {
-    this->dataPtr->maxRange = _sdf->Get<double>("speed_of_sound");
+    this->dataPtr->speedOfSound = _sdf->Get<double>("speed_of_sound");
   }
 }
 
@@ -150,7 +150,8 @@ void AcousticComms::Step(
           static_cast<double>(timeOfTransmission.nsec()) / 1000000000.0;
 
         double deltaT = currTimestamp - packetTimestamp;
-        double distanceCoveredByMessage = deltaT * this->dataPtr->speedOfSound;
+        double distanceCoveredByMessage = deltaT *
+          this->dataPtr->speedOfSound;
 
         // Only check msgs that haven't exceeded the maxRange.
         if (distanceCoveredByMessage <= this->dataPtr->maxRange)

--- a/src/systems/acoustic_comms/AcousticComms.cc
+++ b/src/systems/acoustic_comms/AcousticComms.cc
@@ -116,10 +116,27 @@ void AcousticComms::Step(
         if (!dstAddressAttachedToModel)
           continue;
 
-        // Calculate distance between the bodies.
-        auto poseSrc = worldPose(itSrc->second.entity, _ecm).Pos();
-        auto poseDst = worldPose(itDst->second.entity, _ecm).Pos();
+        // Check if the message header contains the position of sender
+        // at the time the message was sent. If yes, use that as poseSrc,
+        // else use current position of the sender.
+        math::Vector3d poseSrc =
+          worldPose(itSrc->second.entity, _ecm).Pos();
 
+        for (int i = 0; i < msg->header().data_size(); i++)
+        {
+          if (msg->header().data(i).key() == "transmitter_position"
+              && msg->header().data(i).value_size() == 3)
+          {
+            auto poseSrcX = std::stod(msg->header().data(i).value().Get(0));
+            auto poseSrcY = std::stod(msg->header().data(i).value().Get(1));
+            auto poseSrcZ = std::stod(msg->header().data(i).value().Get(2));
+            poseSrc = math::Vector3d(poseSrcX, poseSrcY, poseSrcZ);
+            break;
+          }
+        }
+
+        // Calculate distance between the bodies.
+        auto poseDst = worldPose(itDst->second.entity, _ecm).Pos();
         auto distanceToTransmitter =
           (poseSrc - poseDst).Length();
 

--- a/src/systems/acoustic_comms/AcousticComms.hh
+++ b/src/systems/acoustic_comms/AcousticComms.hh
@@ -53,14 +53,6 @@ namespace systems
   ///    * <speed_of_sound>: Speed of sound in the medium (meters/sec).
   ///                         Default is 343.0
   ///
-  /// This plugin expects the message publishers to include the position
-  /// of the transmitter as a part of the header data map. It must be
-  /// in the form of a key value pair, with the key being
-  /// "transmitter_position" and the value being 3 strings, one for X,Y,Z
-  /// position of the sender. Defaults to current position of the sender
-  /// if not provided. This can cause issues if the sender is moving fast
-  /// compared to "<speed_of_sound>".
-  ///
   /// Here's an example:
   ///  <plugin
   ///    filename="gz-sim-acoustic-comms-system"

--- a/src/systems/acoustic_comms/AcousticComms.hh
+++ b/src/systems/acoustic_comms/AcousticComms.hh
@@ -53,6 +53,14 @@ namespace systems
   ///    * <speed_of_sound>: Speed of sound in the medium (meters/sec).
   ///                         Default is 343.0
   ///
+  /// This plugin expects the message publishers to include the position
+  /// of the transmitter as a part of the header data map. It must be
+  /// in the form of a key value pair, with the key being
+  /// "transmitter_position" and the value being 3 strings, one for X,Y,Z
+  /// position of the sender. Defaults to current position of the sender
+  /// if not provided. This can cause issues if the sender is moving fast
+  /// compared to "<speed_of_sound>".
+  ///
   /// Here's an example:
   ///  <plugin
   ///    filename="gz-sim-acoustic-comms-system"

--- a/src/systems/acoustic_comms/AcousticComms.hh
+++ b/src/systems/acoustic_comms/AcousticComms.hh
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
+ * Development of this module has been funded by the Monterey Bay Aquarium
+ * Research Institute (MBARI) and the David and Lucile Packard Foundation
+ */
+#ifndef GZ_SIM_SYSTEMS_ACOUSTICCOMMS_HH_
+#define GZ_SIM_SYSTEMS_ACOUSTICCOMMS_HH_
+
+#include <memory>
+
+#include <sdf/sdf.hh>
+#include "gz/sim/comms/ICommsModel.hh"
+#include <gz/sim/System.hh>
+#include <gz/sim/Entity.hh>
+#include <gz/sim/EntityComponentManager.hh>
+#include <gz/sim/EventManager.hh>
+
+namespace gz
+{
+namespace sim
+{
+// Inline bracket to help doxygen filtering.
+inline namespace GZ_SIM_VERSION_NAMESPACE {
+namespace systems
+{
+
+  class AcousticComms:
+    public gz::sim::comms::ICommsModel
+  {
+    public: explicit AcousticComms();
+  
+    // Documentation inherited.
+    public: void Load(const gz::sim::Entity &_entity,
+                        std::shared_ptr<const sdf::Element> _sdf,
+                        gz::sim::EntityComponentManager &_ecm,
+                        gz::sim::EventManager &_eventMgr) override;
+  
+    // Documentation inherited.
+    public: void Step(const gz::sim::UpdateInfo &_info,
+                        const gz::sim::comms::Registry &_currentRegistry,
+                        gz::sim::comms::Registry &_newRegistry,
+                        gz::sim::EntityComponentManager &_ecm) override;
+  
+    // Impl pointer
+    GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
+  };
+}
+}
+}
+}
+
+#endif

--- a/src/systems/acoustic_comms/AcousticComms.hh
+++ b/src/systems/acoustic_comms/AcousticComms.hh
@@ -44,19 +44,19 @@ namespace systems
     public gz::sim::comms::ICommsModel
   {
     public: explicit AcousticComms();
-  
+
     // Documentation inherited.
     public: void Load(const gz::sim::Entity &_entity,
                         std::shared_ptr<const sdf::Element> _sdf,
                         gz::sim::EntityComponentManager &_ecm,
                         gz::sim::EventManager &_eventMgr) override;
-  
+
     // Documentation inherited.
     public: void Step(const gz::sim::UpdateInfo &_info,
                         const gz::sim::comms::Registry &_currentRegistry,
                         gz::sim::comms::Registry &_newRegistry,
                         gz::sim::EntityComponentManager &_ecm) override;
-  
+
     // Impl pointer
     GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };

--- a/src/systems/acoustic_comms/AcousticComms.hh
+++ b/src/systems/acoustic_comms/AcousticComms.hh
@@ -39,6 +39,27 @@ namespace sim
 inline namespace GZ_SIM_VERSION_NAMESPACE {
 namespace systems
 {
+  /// \brief A comms model that simulates communication using acoustic
+  /// devices. The model uses simple distance based acoustics model.
+  ///
+  /// This communication model has been ported from:
+  /// https://github.com/osrf/subt .
+  ///
+  /// This system can be configured with the following SDF parameters:
+  ///
+  /// * Optional parameters:
+  ///    * <max_range>: Hard limit on range (meters). No communication will
+  ///                   happen beyond this range. Default is 1000.
+  ///    * <speed_of_sound>: Speed of sound in the medium (meters/sec).
+  ///                         Default is 343.0
+  ///
+  /// Here's an example:
+  ///  <plugin
+  ///    filename="gz-sim-acoustic-comms-system"
+  ///    name="gz::sim::systems::AcousticComms">
+  ///    <max_range>6</max_range>
+  ///    <speed_of_sound>1400</speed_of_sound>
+  ///  </plugin>
 
   class AcousticComms:
     public gz::sim::comms::ICommsModel

--- a/src/systems/acoustic_comms/AcousticComms.hh
+++ b/src/systems/acoustic_comms/AcousticComms.hh
@@ -42,9 +42,6 @@ namespace systems
   /// \brief A comms model that simulates communication using acoustic
   /// devices. The model uses simple distance based acoustics model.
   ///
-  /// This communication model has been ported from:
-  /// https://github.com/osrf/subt .
-  ///
   /// This system can be configured with the following SDF parameters:
   ///
   /// * Optional parameters:

--- a/src/systems/acoustic_comms/CMakeLists.txt
+++ b/src/systems/acoustic_comms/CMakeLists.txt
@@ -1,0 +1,6 @@
+gz_add_system(acoustic-comms
+  SOURCES
+  AcousticComms.cc
+  PUBLIC_LINK_LIBS
+    gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
+)

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TEST_TYPE "INTEGRATION")
 
 set(tests
   ackermann_steering_system.cc
+  acoustic_comms.cc
   air_pressure_system.cc
   altimeter_system.cc
   apply_joint_force_system.cc

--- a/test/integration/acoustic_comms.cc
+++ b/test/integration/acoustic_comms.cc
@@ -108,8 +108,10 @@ TEST_F(AcousticCommsTest,
   bool done = false;
   while (!done && sleep++ < 3)
   {
-    std::lock_guard<std::mutex> lock(mutex);
-    done = msgCounter == pubCount;
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      done = msgCounter == pubCount;
+    }
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
   EXPECT_EQ(pubCount, msgCounter);
@@ -178,12 +180,7 @@ TEST_F(AcousticCommsTest,
   }
 
   // Verify subscriber received no msgs.
-  int sleep = 0;
-  while (sleep++ < 3)
-  {
-    std::lock_guard<std::mutex> lock(mutex);
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
   EXPECT_EQ(0, msgCounter);
 }
 
@@ -259,8 +256,10 @@ TEST_F(AcousticCommsTest,
   bool done = false;
   while (!done && sleep++ < 3)
   {
-    std::lock_guard<std::mutex> lock(mutex);
-    done = msgCounter == pubCount;
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      done = msgCounter == pubCount;
+    }
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
   EXPECT_EQ(pubCount, msgCounter);
@@ -338,8 +337,10 @@ TEST_F(AcousticCommsTest,
   bool done = false;
   while (!done && sleep++ < 3)
   {
-    std::lock_guard<std::mutex> lock(mutex);
-    done = msgCounter == pubCount;
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      done = msgCounter == pubCount;
+    }
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
   EXPECT_EQ(pubCount, msgCounter);

--- a/test/integration/acoustic_comms.cc
+++ b/test/integration/acoustic_comms.cc
@@ -37,7 +37,8 @@ class AcousticCommsTest : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(AcousticCommsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(AcousticComms))
+TEST_F(AcousticCommsTest,
+    GZ_UTILS_TEST_DISABLED_ON_WIN32(AcousticCommsInRange))
 {
   // Start server
   ServerConfig serverConfig;
@@ -112,4 +113,76 @@ TEST_F(AcousticCommsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(AcousticComms))
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
   EXPECT_EQ(pubCount, msgCounter);
+}
+
+/////////////////////////////////////////////////
+TEST_F(AcousticCommsTest,
+    GZ_UTILS_TEST_DISABLED_ON_WIN32(AcousticCommsOutOfRange))
+{
+  // Start server
+  ServerConfig serverConfig;
+  const auto sdfFile =
+    gz::common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+      "examples", "worlds", "acoustic_comms.sdf");
+  serverConfig.SetSdfFile(sdfFile);
+
+  Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  // Run server
+  size_t iters = 1000;
+  server.Run(true, iters, false);
+
+  unsigned int msgCounter = 0u;
+  std::mutex mutex;
+  auto cb = [&](const msgs::Dataframe &_msg) -> void
+  {
+    // Verify msg content
+    std::lock_guard<std::mutex> lock(mutex);
+    msgCounter++;
+  };
+
+  // Create subscriber.
+  gz::transport::Node node;
+  std::string addr  = "addr3";
+  std::string subscriptionTopic = "addr3/rx";
+
+  // Subscribe to a topic by registering a callback.
+  auto cbFunc = std::function<void(const msgs::Dataframe &)>(cb);
+  EXPECT_TRUE(node.Subscribe(subscriptionTopic, cbFunc))
+      << "Error subscribing to topic [" << subscriptionTopic << "]";
+
+  // Create publisher.
+  std::string publicationTopic = "/broker/msgs";
+  auto pub = node.Advertise<gz::msgs::Dataframe>(publicationTopic);
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Prepare the message.
+  gz::msgs::Dataframe msg;
+  msg.set_src_address("addr4");
+  msg.set_dst_address(addr);
+
+  // Publish 10 messages.
+  gz::msgs::StringMsg payload;
+  unsigned int pubCount = 10u;
+  for (unsigned int i = 0u; i < pubCount; ++i)
+  {
+    // Prepare the payload.
+    payload.set_data("hello world " + std::to_string(i));
+    std::string serializedData;
+    EXPECT_TRUE(payload.SerializeToString(&serializedData))
+        << payload.DebugString();
+    msg.set_data(serializedData);
+    EXPECT_TRUE(pub.Publish(msg));
+    server.Run(true, 100, false);
+  }
+
+  // Verify subscriber received no msgs.
+  int sleep = 0;
+  while (sleep++ < 5)
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  EXPECT_EQ(0, msgCounter);
 }

--- a/test/integration/acoustic_comms.cc
+++ b/test/integration/acoustic_comms.cc
@@ -88,6 +88,13 @@ TEST_F(AcousticCommsTest,
   msg.set_src_address("addr2");
   msg.set_dst_address(addr);
 
+  // Set the pose of sender in header.
+  gz::msgs::Header::Map *frame = msg.mutable_header()->add_data();
+  frame->set_key("transmitter_position");
+  frame->add_value("-2");
+  frame->add_value("0");
+  frame->add_value("0.5");
+
   // Publish 10 messages.
   gz::msgs::StringMsg payload;
   unsigned int pubCount = 3u;

--- a/test/integration/acoustic_comms.cc
+++ b/test/integration/acoustic_comms.cc
@@ -149,7 +149,7 @@ TEST_F(AcousticCommsTest,
 TEST_F(AcousticCommsTest,
     GZ_UTILS_TEST_DISABLED_ON_WIN32(AcousticCommsOutOfRange))
 {
-  // Source and destination are outise the maximum allowed range
+  // Source and destination are outside the maximum allowed range
   // and hence should not receive any msgs.
   this->CommsTestFixture("acoustic_comms.sdf", "addr4", "addr3", 0);
 }

--- a/test/integration/acoustic_comms.cc
+++ b/test/integration/acoustic_comms.cc
@@ -95,7 +95,7 @@ TEST_F(AcousticCommsTest,
   frame->add_value("0");
   frame->add_value("0.5");
 
-  // Publish 10 messages.
+  // Publish some messages.
   gz::msgs::StringMsg payload;
   unsigned int pubCount = 3u;
   for (unsigned int i = 0u; i < pubCount; ++i)
@@ -169,7 +169,7 @@ TEST_F(AcousticCommsTest,
   msg.set_src_address("addr4");
   msg.set_dst_address(addr);
 
-  // Publish 10 messages.
+  // Publish some messages.
   gz::msgs::StringMsg payload;
   unsigned int pubCount = 3u;
   for (unsigned int i = 0u; i < pubCount; ++i)
@@ -246,7 +246,7 @@ TEST_F(AcousticCommsTest,
   msg.set_src_address("addr2");
   msg.set_dst_address(addr);
 
-  // Publish 10 messages.
+  // Publish some messages.
   gz::msgs::StringMsg payload;
   unsigned int pubCount = 3u;
   for (unsigned int i = 0u; i < pubCount; ++i)
@@ -325,7 +325,7 @@ TEST_F(AcousticCommsTest,
   msg.set_src_address("addr4");
   msg.set_dst_address(addr);
 
-  // Publish 10 messages.
+  // Publish some messages.
   gz::msgs::StringMsg payload;
   unsigned int pubCount = 3u;
   for (unsigned int i = 0u; i < pubCount; ++i)

--- a/test/integration/acoustic_comms.cc
+++ b/test/integration/acoustic_comms.cc
@@ -88,13 +88,6 @@ TEST_F(AcousticCommsTest,
   msg.set_src_address("addr2");
   msg.set_dst_address(addr);
 
-  // Set the pose of sender in header.
-  gz::msgs::Header::Map *frame = msg.mutable_header()->add_data();
-  frame->set_key("transmitter_position");
-  frame->add_value("-2");
-  frame->add_value("0");
-  frame->add_value("0.5");
-
   // Publish some messages.
   gz::msgs::StringMsg payload;
   unsigned int pubCount = 3u;

--- a/test/integration/acoustic_comms.cc
+++ b/test/integration/acoustic_comms.cc
@@ -104,15 +104,18 @@ class AcousticCommsTest : public InternalFixture<::testing::Test>
       }
 
       // Verify subscriber received all msgs.
-      int sleep = 0;
       bool done = false;
-      while (!done && sleep++ < 3)
+      for (int sleep = 0; !done && sleep < 3; ++sleep)
       {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
         {
           std::lock_guard<std::mutex> lock(mutex);
           done = (msgCounter == pubCount) && (pubCount != 0);
         }
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      }
+      if (numMsgs != 0) 
+      {
+        EXPECT_TRUE(done);
       }
       EXPECT_EQ(pubCount, msgCounter);
     }

--- a/test/integration/acoustic_comms.cc
+++ b/test/integration/acoustic_comms.cc
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <functional>
+#include <mutex>
+
+#include <gz/msgs.hh>
+#include <gz/transport/Node.hh>
+#include <gz/utils/ExtraTestMacros.hh>
+#include "gz/sim/Server.hh"
+#include "test_config.hh"  // NOLINT(build/include)
+#include "../helpers/EnvTestFixture.hh"
+
+using namespace gz;
+using namespace sim;
+
+/////////////////////////////////////////////////
+class AcousticCommsTest : public InternalFixture<::testing::Test>
+{
+};
+
+/////////////////////////////////////////////////
+TEST_F(AcousticCommsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(AcousticComms))
+{
+  // Start server
+  ServerConfig serverConfig;
+  const auto sdfFile =
+    gz::common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+      "examples", "worlds", "acoustic_comms.sdf");
+  serverConfig.SetSdfFile(sdfFile);
+
+  Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  // Run server
+  size_t iters = 1000;
+  server.Run(true, iters, false);
+
+  unsigned int msgCounter = 0u;
+  std::mutex mutex;
+  auto cb = [&](const msgs::Dataframe &_msg) -> void
+  {
+    // Verify msg content
+    std::lock_guard<std::mutex> lock(mutex);
+    std::string expected = "hello world " + std::to_string(msgCounter);
+
+    gz::msgs::StringMsg receivedMsg;
+    receivedMsg.ParseFromString(_msg.data());
+    EXPECT_EQ(expected, receivedMsg.data());
+    msgCounter++;
+  };
+
+  // Create subscriber.
+  gz::transport::Node node;
+  std::string addr  = "addr1";
+  std::string subscriptionTopic = "addr1/rx";
+
+  // Subscribe to a topic by registering a callback.
+  auto cbFunc = std::function<void(const msgs::Dataframe &)>(cb);
+  EXPECT_TRUE(node.Subscribe(subscriptionTopic, cbFunc))
+      << "Error subscribing to topic [" << subscriptionTopic << "]";
+
+  // Create publisher.
+  std::string publicationTopic = "/broker/msgs";
+  auto pub = node.Advertise<gz::msgs::Dataframe>(publicationTopic);
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Prepare the message.
+  gz::msgs::Dataframe msg;
+  msg.set_src_address("addr2");
+  msg.set_dst_address(addr);
+
+  // Publish 10 messages.
+  gz::msgs::StringMsg payload;
+  unsigned int pubCount = 10u;
+  for (unsigned int i = 0u; i < pubCount; ++i)
+  {
+    // Prepare the payload.
+    payload.set_data("hello world " + std::to_string(i));
+    std::string serializedData;
+    EXPECT_TRUE(payload.SerializeToString(&serializedData))
+        << payload.DebugString();
+    msg.set_data(serializedData);
+    EXPECT_TRUE(pub.Publish(msg));
+    server.Run(true, 100, false);
+  }
+
+  // Verify subscriber received all msgs.
+  int sleep = 0;
+  bool done = false;
+  while (!done && sleep++ < 10)
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    done = msgCounter == pubCount;
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  EXPECT_EQ(pubCount, msgCounter);
+}

--- a/test/integration/acoustic_comms.cc
+++ b/test/integration/acoustic_comms.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>
 
 #include <chrono>
@@ -32,127 +33,125 @@ using namespace gz;
 using namespace sim;
 
 /////////////////////////////////////////////////
-class AcousticCommsTest : public InternalFixture<::testing::Test>
+class AcousticCommsTestDefinition
 {
-  public:
-    void CommsTestFixture(
-        std::string worldFile,
-        std::string srcAddr, std::string dstAddr,
-        int numMsgs = 3)
-    {
-      // Start server
-      ServerConfig serverConfig;
-      const auto sdfFile =
-        gz::common::joinPaths(std::string(PROJECT_SOURCE_PATH),
-          "examples", "worlds", worldFile);
-      serverConfig.SetSdfFile(sdfFile);
+public:
+  std::string worldFile;
+  std::string srcAddr;
+  std::string dstAddr;
+  int numMsgs;
 
-      Server server(serverConfig);
-      EXPECT_FALSE(server.Running());
-      EXPECT_FALSE(*server.Running(0));
-
-      // Run server
-      size_t iters = 1000;
-      server.Run(true, iters, false);
-
-      int msgCounter = 0;
-      std::mutex mutex;
-      auto cb = [&](const msgs::Dataframe &_msg) -> void
-      {
-        // Verify msg content
-        std::lock_guard<std::mutex> lock(mutex);
-        std::string expected = "hello world " + std::to_string(msgCounter);
-
-        gz::msgs::StringMsg receivedMsg;
-        receivedMsg.ParseFromString(_msg.data());
-        EXPECT_EQ(expected, receivedMsg.data());
-        msgCounter++;
-      };
-
-      // Create subscriber.
-      gz::transport::Node node;
-      std::string addr  = dstAddr;
-      std::string subscriptionTopic = dstAddr + "/rx";
-
-      // Subscribe to a topic by registering a callback.
-      auto cbFunc = std::function<void(const msgs::Dataframe &)>(cb);
-      EXPECT_TRUE(node.Subscribe(subscriptionTopic, cbFunc))
-          << "Error subscribing to topic [" << subscriptionTopic << "]";
-
-      // Create publisher.
-      std::string publicationTopic = "/broker/msgs";
-      auto pub = node.Advertise<gz::msgs::Dataframe>(publicationTopic);
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
-      // Prepare the message.
-      gz::msgs::Dataframe msg;
-      msg.set_src_address(srcAddr);
-      msg.set_dst_address(addr);
-
-      // Publish some messages.
-      gz::msgs::StringMsg payload;
-      int pubCount = numMsgs;
-      for (int i = 0; i < pubCount; ++i)
-      {
-        // Prepare the payload.
-        payload.set_data("hello world " + std::to_string(i));
-        std::string serializedData;
-        EXPECT_TRUE(payload.SerializeToString(&serializedData))
-            << payload.DebugString();
-        msg.set_data(serializedData);
-        EXPECT_TRUE(pub.Publish(msg));
-        server.Run(true, 100, false);
-      }
-
-      // Verify subscriber received all msgs.
-      bool done = false;
-      for (int sleep = 0; !done && sleep < 3; ++sleep)
-      {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        {
-          std::lock_guard<std::mutex> lock(mutex);
-          done = (msgCounter == pubCount) && (pubCount != 0);
-        }
-      }
-      if (numMsgs != 0) 
-      {
-        EXPECT_TRUE(done);
-      }
-      EXPECT_EQ(pubCount, msgCounter);
-    }
+  AcousticCommsTestDefinition(
+    std::string worldFile_, std::string srcAddr_,
+    std::string dstAddr_, int numMsgs_) :
+    worldFile(worldFile_), srcAddr(srcAddr_),
+    dstAddr(dstAddr_), numMsgs(numMsgs_) {}
 };
 
 /////////////////////////////////////////////////
-TEST_F(AcousticCommsTest,
-    GZ_UTILS_TEST_DISABLED_ON_WIN32(AcousticCommsInRange))
+class AcousticCommsTestFixture :
+  public ::testing::TestWithParam<AcousticCommsTestDefinition>
 {
-  this->CommsTestFixture("acoustic_comms.sdf", "addr2", "addr1");
+};
+
+TEST_P(AcousticCommsTestFixture,
+    GZ_UTILS_TEST_DISABLED_ON_WIN32(AcousticCommsTestTemplate))
+{
+  auto param = GetParam();
+
+  // Start server
+  ServerConfig serverConfig;
+  const auto sdfFile =
+    gz::common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+      "examples", "worlds", param.worldFile);
+  serverConfig.SetSdfFile(sdfFile);
+
+  Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  // Run server
+  size_t iters = 1000;
+  server.Run(true, iters, false);
+
+  int msgCounter = 0;
+  std::mutex mutex;
+  auto cb = [&](const msgs::Dataframe &_msg) -> void
+  {
+    // Verify msg content
+    std::lock_guard<std::mutex> lock(mutex);
+    std::string expected = "hello world " + std::to_string(msgCounter);
+
+    gz::msgs::StringMsg receivedMsg;
+    receivedMsg.ParseFromString(_msg.data());
+    EXPECT_EQ(expected, receivedMsg.data());
+    msgCounter++;
+  };
+
+  // Create subscriber.
+  gz::transport::Node node;
+  std::string addr  = param.dstAddr;
+  std::string subscriptionTopic = param.dstAddr + "/rx";
+
+  // Subscribe to a topic by registering a callback.
+  auto cbFunc = std::function<void(const msgs::Dataframe &)>(cb);
+  EXPECT_TRUE(node.Subscribe(subscriptionTopic, cbFunc))
+      << "Error subscribing to topic [" << subscriptionTopic << "]";
+
+  // Create publisher.
+  std::string publicationTopic = "/broker/msgs";
+  auto pub = node.Advertise<gz::msgs::Dataframe>(publicationTopic);
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Prepare the message.
+  gz::msgs::Dataframe msg;
+  msg.set_src_address(param.srcAddr);
+  msg.set_dst_address(addr);
+
+  // Publish some messages.
+  gz::msgs::StringMsg payload;
+  int pubCount = param.numMsgs;
+  for (int i = 0; i < pubCount; ++i)
+  {
+    // Prepare the payload.
+    payload.set_data("hello world " + std::to_string(i));
+    std::string serializedData;
+    EXPECT_TRUE(payload.SerializeToString(&serializedData))
+        << payload.DebugString();
+    msg.set_data(serializedData);
+    EXPECT_TRUE(pub.Publish(msg));
+    server.Run(true, 100, false);
+  }
+
+  // Verify subscriber received all msgs.
+  bool done = false;
+  for (int sleep = 0; !done && sleep < 3; ++sleep)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      done = (msgCounter == pubCount) && (pubCount != 0);
+    }
+  }
+  if (param.numMsgs != 0)
+  {
+    EXPECT_TRUE(done);
+  }
+  EXPECT_EQ(pubCount, msgCounter);
 }
 
-/////////////////////////////////////////////////
-TEST_F(AcousticCommsTest,
-    GZ_UTILS_TEST_DISABLED_ON_WIN32(AcousticCommsMovingSource))
-{
-  // The source is moving and the destination is stationary.
-  this->CommsTestFixture(
-      "acoustic_comms_moving_targets.sdf",
-      "addr2", "addr1");
-}
-
-/////////////////////////////////////////////////
-TEST_F(AcousticCommsTest,
-    GZ_UTILS_TEST_DISABLED_ON_WIN32(AcousticCommsMovingDst))
-{
-  // The source is stationary and the destnation is moving.
-  this->CommsTestFixture(
-      "acoustic_comms_moving_targets.sdf",
-      "addr4", "addr3");
-}
-
-/////////////////////////////////////////////////
-TEST_F(AcousticCommsTest,
-    GZ_UTILS_TEST_DISABLED_ON_WIN32(AcousticCommsOutOfRange))
-{
-  // Source and destination are outside the maximum allowed range
-  // and hence should not receive any msgs.
-  this->CommsTestFixture("acoustic_comms.sdf", "addr4", "addr3", 0);
-}
+INSTANTIATE_TEST_SUITE_P(
+  AcousticCommsTests,
+  AcousticCommsTestFixture,
+  ::testing::Values(
+    AcousticCommsTestDefinition(
+      "acoustic_comms.sdf", "addr2", "addr1", 3),
+    AcousticCommsTestDefinition(
+      "acoustic_comms.sdf", "addr4", "addr3", 0),
+    // The source is moving and the destination is stationary.
+    AcousticCommsTestDefinition(
+      "acoustic_comms_moving_targets.sdf", "addr2", "addr1", 3),
+    // The source is stationary and the destnation is moving.
+    AcousticCommsTestDefinition(
+      "acoustic_comms_moving_targets.sdf", "addr4", "addr3", 3)
+  )
+);


### PR DESCRIPTION
🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

# 🎉 New feature

## Summary
This plugin adds a simple acoustic comms plugin to gz-sim.

## Test it
Added a small test case which contains 2 pairs of boxes which communicate with each other. One set in inside the max range of comms, and the other is outside it. The one outside the range should not receive any messages.

## TODO
* The current calculation for ``distanceToTransmitter`` considers the current distance between the 2 bodies, when actually it should be the distance between current receiver position and position of the sender at the time at which the packet was sent, as the sender might be moving. This is not a big problem if the 2 bodies are at rest or moving slowly compared to speed of sound.

Since the packet does not contain a field related to position of sender at the time the packet was sent, I;m not sure how to implement this. 

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸