### PR TITLE
Adds a `TimeVaryingVolumetricGrid` component [WIP]

### DIFF
--- a/include/gz/sim/components/TimeVaryingVolumetricGrid.hh
+++ b/include/gz/sim/components/TimeVaryingVolumetricGrid.hh
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef GZ_SIM_COMPONENTS_TIME_VARYING_VOLUMETRIC_GRID_HH_
+#define GZ_SIM_COMPONENTS_TIME_VARYING_VOLUMETRIC_GRID_HH_
+
+#include <gz/math/TimeVaryingVolumetricGrid.hh>
+
+#include <gz/sim/components/Factory.hh>
+#include <gz/sim/components/Component.hh>
+#include <gz/sim/config.hh>
+
+namespace gz
+{
+namespace sim
+{
+// Inline bracket to help doxygen filtering.
+inline namespace GZ_SIM_VERSION_NAMESPACE {
+namespace components
+{
+  /// \brief A component used to spatio-temporally varying values. These values
+  /// can be loaded using a CSV file and then be used downstream by plugins.
+  using TimeVaryingVolumetricGrid = Component<
+    math::InMemoryTimeVaryingVolumetricGrid<double, double>,
+    class TimeVaryingVolumetricGridTag>;
+  GZ_SIM_REGISTER_COMPONENT(
+      "gz_sim_components.TimeVaryingVolumetricGrid", TimeVaryingVolumetricGrid);
+}
+}
+}
+}
+
+#endif


### PR DESCRIPTION

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

# 🎉 New feature

Closes #<NUMBER>

## Summary
This commit depends on: gazebosim/gz-math#456

This component adds a component for TimeVaryingVolumetric grids.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>->

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
