### PR TITLE
Use stepping field in message

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -37,6 +37,10 @@ release will remove the deprecated code.
 * The shared libraries have `gz` where there used to be `ignition`.
   * Using the un-migrated version is still possible due to tick-tocks, but will be removed in future versions.
 
+* The WorldStatistics message published on the 'stats' topic now has
+a `stepping` field that should be used in place the 'step' field in the
+message's header.
+
 * **Breaking Changes**
   * The project name has been changed to use the `gz-` prefix, you **must** use the `gz` prefix!
     * This also means that any generated code that use the project name (e.g. CMake variables, in-source macros) would have to be migrated.

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -428,8 +428,11 @@ void SimulationRunner::PublishStats()
 
   if (this->Stepping())
   {
+    // Remove this header in Gazebo H
     auto headerData = msg.mutable_header()->add_data();
     headerData->set_key("step");
+
+    msg.set_stepping(true);
   }
 
   // Publish the stats message. The stats message is throttled.

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -428,7 +428,7 @@ void SimulationRunner::PublishStats()
 
   if (this->Stepping())
   {
-    // Remove this header in Gazebo H
+    // (deprecated) Remove this header in Gazebo H
     auto headerData = msg.mutable_header()->add_data();
     headerData->set_key("step");
 


### PR DESCRIPTION
# 🎉 New feature

Uses the `stepping` field in the world statistics message that became available in: https://github.com/gazebosim/gz-msgs/pull/199

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.