### PR TITLE
Quiet libSDFormat console on --verbose 0

### DIFF
--- a/src/ign.cc
+++ b/src/ign.cc
@@ -52,7 +52,7 @@ extern "C" IGNITION_GAZEBO_VISIBLE void cmdVerbosity(
     const char *_verbosity)
 {
   int verbosity = std::atoi(_verbosity);
-  gz::common::Console::SetVerbosity(verbosity);
+  ignition::common::Console::SetVerbosity(verbosity);
 
   // SDFormat only has 2 levels: quiet / loud. Let sim users suppress all SDF
   // console output with zero verbosity.

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -27,6 +27,7 @@
 #include <ignition/fuel_tools/ClientConfig.hh>
 #include <ignition/fuel_tools/Result.hh>
 #include <ignition/fuel_tools/WorldIdentifier.hh>
+#include <sdf/Console.hh>
 
 #include "ignition/gazebo/config.hh"
 #include "ignition/gazebo/Server.hh"
@@ -50,7 +51,15 @@ extern "C" IGNITION_GAZEBO_VISIBLE char *gazeboVersionHeader()
 extern "C" IGNITION_GAZEBO_VISIBLE void cmdVerbosity(
     const char *_verbosity)
 {
-  ignition::common::Console::SetVerbosity(std::atoi(_verbosity));
+  int verbosity = std::atoi(_verbosity);
+  gz::common::Console::SetVerbosity(verbosity);
+
+  // SDFormat only has 2 levels: quiet / loud. Let sim users suppress all SDF
+  // console output with zero verbosity.
+  if (verbosity == 0)
+  {
+    sdf::Console::SetQuiet(true);
+  }
 }
 
 //////////////////////////////////////////////////

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -58,7 +58,7 @@ extern "C" IGNITION_GAZEBO_VISIBLE void cmdVerbosity(
   // console output with zero verbosity.
   if (verbosity == 0)
   {
-    sdf::Console::SetQuiet(true);
+    sdf::Console::Instance()->SetQuiet(true);
   }
 }
 


### PR DESCRIPTION
* Related to https://github.com/gazebosim/sdformat/pull/1096

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

SDFormat only has 2 levels: quiet / loud. Let sim users at least suppress all SDF console output with zero verbosity.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
