### PR TITLE
Example of using the static plugin in gz-sim

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -187,6 +187,25 @@ gz_build_tests(TYPE UNIT
     gz-sim${PROJECT_VERSION_MAJOR}
 )
 
+if (TARGET UNIT_SystemLoader_TEST)
+  target_link_libraries(UNIT_SystemLoader_TEST TestPlugins)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    # MSVC link flag doesn't work with generator expressions
+    # TODO(mjcarroll) When CMake 3.24 is genrally available, use
+    # linking generator expressions as described here:
+    # https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#genex:LINK_LIBRARY
+    target_link_libraries(UNIT_SystemLoader_TEST -WHOLEARCHIVE:$<TARGET_FILE:TestPlugins>)
+  else()
+    target_link_libraries(UNIT_SystemLoader_TEST
+        $<$<CXX_COMPILER_ID:GNU>:-Wl,--whole-archive>
+        $<$<CXX_COMPILER_ID:Clang>:-Wl,--whole-archive>
+        $<$<CXX_COMPILER_ID:AppleClang>:-force_load> TestPlugins 
+        $<$<CXX_COMPILER_ID:GNU>:-Wl,--no-whole-archive>
+        $<$<CXX_COMPILER_ID:Clang>:-Wl,--no-whole-archive>)
+  endif()
+
+endif()
+
 # Command line tests need extra settings
 foreach(CMD_TEST
   UNIT_gz_TEST

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -188,6 +188,13 @@ if(TARGET INTEGRATION_reset_sensors)
   target_link_libraries(INTEGRATION_reset_sensors
     gz-common${GZ_COMMON_VER}::graphics
   )
+
+  target_link_libraries(INTEGRATION_reset_sensors
+      $<$<CXX_COMPILER_ID:GNU>:-Wl,--whole-archive>
+      $<$<CXX_COMPILER_ID:Clang>:-Wl,--whole-archive>
+      $<$<CXX_COMPILER_ID:AppleClang>:-force_load> TestPlugins 
+      $<$<CXX_COMPILER_ID:GNU>:-Wl,--no-whole-archive>
+      $<$<CXX_COMPILER_ID:Clang>:-Wl,--no-whole-archive>)
 endif()
 
 # The default timeout (240s) doesn't seem to be enough for this test.

--- a/test/integration/reset_sensors.cc
+++ b/test/integration/reset_sensors.cc
@@ -54,7 +54,7 @@ class ResetFixture: public InternalFixture<InternalFixture<::testing::Test>>
   {
     InternalFixture::SetUp();
 
-    auto plugin = sm.LoadPlugin("libMockSystem.so",
+    auto plugin = sm.LoadPlugin("static",
                                 "gz::sim::MockSystem",
                                 nullptr);
     EXPECT_TRUE(plugin.has_value());

--- a/test/plugins/CMakeLists.txt
+++ b/test/plugins/CMakeLists.txt
@@ -6,9 +6,6 @@ include_directories(
   ${PROJECT_SOURCE_DIR}
 )
 
-link_directories(
-)
-
 set (test_plugins
   EventTriggerSystem
   TestModelSystem
@@ -19,7 +16,21 @@ set (test_plugins
   Null
 )
 
-# TODO: someone with knowledge of gz-plugin please resolve:
+add_library(TestPlugins STATIC
+  MockSystem.cc
+)  
+target_link_libraries(TestPlugins
+  PRIVATE
+    gz-plugin${GZ_PLUGIN_VER}::register
+    gz-transport${GZ_TRANSPORT_VER}::gz-transport${GZ_TRANSPORT_VER}
+    gz-sim${PROJECT_VERSION_MAJOR}
+)
+target_compile_options(TestPlugins
+  PUBLIC
+  "-DBUILD_STATIC_PLUGINS=1"
+)
+
+# TODO: someone with knowledge of ign-plugin please resolve:
 # TestSystem.obj : error LNK2001: unresolved external symbol GzPluginHook
 if(NOT WIN32)
   set (test_plugins

--- a/test/plugins/MockSystem.cc
+++ b/test/plugins/MockSystem.cc
@@ -1,11 +1,19 @@
 #include "MockSystem.hh"
 
+#if BUILD_STATIC_PLUGINS
+#include <gz/plugin/RegisterStatic.hh>
+GZ_ADD_STATIC_PLUGIN(gz::sim::MockSystem, gz::sim::System,
+    gz::sim::MockSystem::ISystemConfigure,
+    gz::sim::MockSystem::ISystemReset,
+    gz::sim::MockSystem::ISystemPreUpdate,
+    gz::sim::MockSystem::ISystemUpdate,
+    gz::sim::MockSystem::ISystemPostUpdate)
+#else
 #include <gz/plugin/Register.hh>
-
 GZ_ADD_PLUGIN(gz::sim::MockSystem, gz::sim::System,
     gz::sim::MockSystem::ISystemConfigure,
     gz::sim::MockSystem::ISystemReset,
     gz::sim::MockSystem::ISystemPreUpdate,
     gz::sim::MockSystem::ISystemUpdate,
     gz::sim::MockSystem::ISystemPostUpdate)
-
+#endif


### PR DESCRIPTION
# 🎉 New feature

Related to: https://github.com/gazebosim/gz-plugin/pull/97

## Summary

A quick demo of how to use statically linked plugins inside of gz-sim.

## Test it

* The INTEGRATION_reset_sensors test should still work without using the shared library.
* The UNIT_system_loader should show additional statically linked plugins

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
