### PR TITLE
Fix loading worlds from CLI

### DIFF
--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -219,12 +219,29 @@ std::unique_ptr<ignition::gui::Application> createGui(
   {
     std::string configInUse = configFromCli ? _guiConfig : defaultConfig;
     startingWorld = launchQuickStart(_argc, _argv, defaultConfig, configInUse);
+  }
+  else if (hasSdfFile)
+  {
+    startingWorld = _sdfFile;
+  }
 
+  if (sigKilled)
+  {
+    igndbg << "Received kill signal. Not starting main window." << std::endl;
+    return nullptr;
+  }
+
+  // Publish starting world even if it's empty. The server is blocking waiting
+  // for it.
+  if (_waitGui)
+  {
     std::string topic{"/gazebo/starting_world"};
     auto startingWorldPub = node.Advertise<msgs::StringMsg>(topic);
     msgs::StringMsg msg;
     msg.set_data(startingWorld);
 
+    // Wait for the server to be listening, so we're sure it receives the message.
+    igndbg << "Waiting for subscribers to [" << topic << "]..." << std::endl;
     for (int sleep = 0; sleep < 100 && !startingWorldPub.HasConnections();
         ++sleep)
     {
@@ -236,16 +253,6 @@ std::unique_ptr<ignition::gui::Application> createGui(
               << "] and got none." << std::endl;
     }
     startingWorldPub.Publish(msg);
-  }
-  else if (hasSdfFile)
-  {
-    startingWorld = _sdfFile;
-  }
-
-  if (sigKilled)
-  {
-    igndbg << "Received kill signal. Not starting main window." << std::endl;
-    return nullptr;
   }
 
   // Launch main window

--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -240,7 +240,8 @@ std::unique_ptr<ignition::gui::Application> createGui(
     msgs::StringMsg msg;
     msg.set_data(startingWorld);
 
-    // Wait for the server to be listening, so we're sure it receives the message.
+    // Wait for the server to be listening, so we're sure it receives the
+    // message.
     igndbg << "Waiting for subscribers to [" << topic << "]..." << std::endl;
     for (int sleep = 0; sleep < 100 && !startingWorldPub.HasConnections();
         ++sleep)


### PR DESCRIPTION
# 🦟 Bug fix

* Follow up to https://github.com/gazebosim/gz-sim/pull/1536

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

I introduced a critical bug right at the end of #1536 when I added a test. I moved the logic to publish a starting world into the `if (!hasSdfFile && _waitGui && !isPlayback)`, which means that when the user tries to load any world, i.e. `ign gazebo shapes.sdf`, the server hangs forever waiting for a starting world from the GUI, and the GUI never sends it.

The solution is to always publish the starting world if `_waitGui`, even if `hasSdfFile`.

To test the fix, run:

* `ign gazebo shapes.sdf` - shouldn't hang
* `UNIT_Gui_TEST` - should pass even with this change

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
