### PR TITLE
Add support for specifying log record period

### DIFF
--- a/include/ignition/gazebo/EntityComponentManager.hh
+++ b/include/ignition/gazebo/EntityComponentManager.hh
@@ -590,6 +590,11 @@ namespace ignition
       /// \return True if there are any components with one-time changes.
       public: bool HasOneTimeComponentChanges() const;
 
+      /// \brief Get whether there are periodic component changes. These changes
+      /// may happen frequently and are processed periodically.
+      /// \return True if there are any components with periodic changes.
+      public: bool HasPeriodicComponentChanges() const;
+
       /// \brief Get the components types that are marked as periodic changes.
       /// \return All the components that at least one entity marked as
       /// periodic changes.

--- a/include/ignition/gazebo/ServerConfig.hh
+++ b/include/ignition/gazebo/ServerConfig.hh
@@ -313,6 +313,15 @@ namespace ignition
       /// \param[in] _recordPath Path to place recorded states
       public: void SetLogRecordPath(const std::string &_recordPath);
 
+      /// \brief Get time period to record states
+      /// \return Time period to record states
+      public: std::chrono::steady_clock::duration LogRecordPeriod() const;
+
+      /// \brief Set time period to record states
+      /// \param[in] _period Time period to record states
+      public: void SetLogRecordPeriod(
+          const std::chrono::steady_clock::duration &_period);
+
       /// \brief Add a topic to record.
       /// \param[in] _topic Topic name, which can include wildcards.
       public: void AddLogRecordTopic(const std::string &_topic);

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -946,6 +946,12 @@ bool EntityComponentManager::HasOneTimeComponentChanges() const
 }
 
 /////////////////////////////////////////////////
+bool EntityComponentManager::HasPeriodicComponentChanges() const
+{
+  return !this->dataPtr->periodicChangedComponents.empty();
+}
+
+/////////////////////////////////////////////////
 std::unordered_set<ComponentTypeId>
     EntityComponentManager::ComponentTypesWithPeriodicChanges() const
 {

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -2220,6 +2220,7 @@ TEST_P(EntityComponentManagerFixture,
   ASSERT_NE(nullptr, c2);
 
   EXPECT_TRUE(manager.HasOneTimeComponentChanges());
+  EXPECT_FALSE(manager.HasPeriodicComponentChanges());
   EXPECT_EQ(0u, manager.ComponentTypesWithPeriodicChanges().size());
   EXPECT_EQ(ComponentState::OneTimeChange,
       manager.ComponentState(e1, c1->TypeId()));
@@ -2232,6 +2233,7 @@ TEST_P(EntityComponentManagerFixture,
   // updated
   manager.RunSetAllComponentsUnchanged();
   EXPECT_FALSE(manager.HasOneTimeComponentChanges());
+  EXPECT_FALSE(manager.HasPeriodicComponentChanges());
   EXPECT_EQ(0u, manager.ComponentTypesWithPeriodicChanges().size());
   EXPECT_EQ(ComponentState::NoChange,
       manager.ComponentState(e1, c1->TypeId()));
@@ -2246,6 +2248,7 @@ TEST_P(EntityComponentManagerFixture,
   EXPECT_EQ(ComponentState::NoChange,
       manager.ComponentState(e1, c1->TypeId()));
   EXPECT_FALSE(manager.HasOneTimeComponentChanges());
+  EXPECT_FALSE(manager.HasPeriodicComponentChanges());
   EXPECT_EQ(0u, manager.ComponentTypesWithPeriodicChanges().size());
   EXPECT_EQ(0, manager.ChangedState().entities_size());
 
@@ -2273,6 +2276,7 @@ TEST_P(EntityComponentManagerFixture,
 
   EXPECT_TRUE(manager.HasOneTimeComponentChanges());
   // Expect a single component type to be marked as PeriodicChange
+  EXPECT_TRUE(manager.HasPeriodicComponentChanges());
   ASSERT_EQ(1u, manager.ComponentTypesWithPeriodicChanges().size());
   EXPECT_EQ(IntComponent().TypeId(),
       *manager.ComponentTypesWithPeriodicChanges().begin());
@@ -2285,6 +2289,7 @@ TEST_P(EntityComponentManagerFixture,
   EXPECT_TRUE(manager.RemoveComponent(e1, c1->TypeId()));
 
   EXPECT_TRUE(manager.HasOneTimeComponentChanges());
+  EXPECT_FALSE(manager.HasPeriodicComponentChanges());
   EXPECT_EQ(0u, manager.ComponentTypesWithPeriodicChanges().size());
   EXPECT_EQ(ComponentState::NoChange,
       manager.ComponentState(e1, c1->TypeId()));

--- a/src/ServerConfig.cc
+++ b/src/ServerConfig.cc
@@ -269,6 +269,7 @@ class ignition::gazebo::ServerConfigPrivate
             useLevels(_cfg->useLevels),
             useLogRecord(_cfg->useLogRecord),
             logRecordPath(_cfg->logRecordPath),
+            logRecordPeriod(_cfg->logRecordPeriod),
             logPlaybackPath(_cfg->logPlaybackPath),
             logRecordResources(_cfg->logRecordResources),
             logRecordCompressPath(_cfg->logRecordCompressPath),
@@ -300,6 +301,9 @@ class ignition::gazebo::ServerConfigPrivate
 
   /// \brief Path to place recorded states
   public: std::string logRecordPath = "";
+
+  /// \brief Time period to record states
+  public: std::chrono::steady_clock::duration logRecordPeriod{0};
 
   /// \brief Path to recorded states to play back using logging system
   public: std::string logPlaybackPath = "";
@@ -499,6 +503,19 @@ void ServerConfig::SetLogRecordPath(const std::string &_recordPath)
 }
 
 /////////////////////////////////////////////////
+std::chrono::steady_clock::duration ServerConfig::LogRecordPeriod() const
+{
+  return this->dataPtr->logRecordPeriod;
+}
+
+/////////////////////////////////////////////////
+void ServerConfig::SetLogRecordPeriod(
+  const std::chrono::steady_clock::duration &_period)
+{
+  this->dataPtr->logRecordPeriod = _period;
+}
+
+/////////////////////////////////////////////////
 const std::string ServerConfig::LogPlaybackPath() const
 {
   return this->dataPtr->logPlaybackPath;
@@ -688,6 +705,17 @@ ServerConfig::LogRecordPlugin() const
     topicElem->AddValue("string", "false", false, "");
     topicElem->Set<std::string>(topic);
     plugin.InsertContent(topicElem);
+  }
+
+  if (this->LogRecordPeriod() > std::chrono::steady_clock::duration::zero())
+  {
+    sdf::ElementPtr periodElem = std::make_shared<sdf::Element>();
+    periodElem->SetName("record_period");
+    periodElem->AddValue("double", "0", false, "");
+    double t = std::chrono::duration_cast<std::chrono::milliseconds>(
+        this->LogRecordPeriod()).count() * 1e-3;
+    periodElem->Set<double>(t);
+    plugin.InsertContent(periodElem);
   }
 
   igndbg << plugin.ToElement()->ToString("") << std::endl;

--- a/src/ServerConfig_TEST.cc
+++ b/src/ServerConfig_TEST.cc
@@ -236,6 +236,11 @@ TEST(ServerConfig, GenerateRecordPlugin)
   config.SetUseLogRecord(true);
   config.SetLogRecordPath("foo/bar");
   config.SetLogRecordResources(true);
+  auto period =
+    std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+    std::chrono::duration<double>(0.04));
+  config.SetLogRecordPeriod(period);
+  EXPECT_EQ(period, config.LogRecordPeriod());
 
   auto plugin = config.LogRecordPlugin();
   EXPECT_EQ(plugin.EntityName(), "*");

--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -252,6 +252,11 @@ void ServerPrivate::AddRecordPlugin(const ServerConfig &_config)
     this->config.SetLogRecordPath(_config.LogRecordPath());
   }
 
+  if (_config.LogRecordPeriod() > std::chrono::steady_clock::duration::zero())
+  {
+    this->config.SetLogRecordPeriod(_config.LogRecordPeriod());
+  }
+
   if (_config.LogRecordResources())
     this->config.SetLogRecordResources(true);
 

--- a/src/cmd/cmdgazebo.rb.in
+++ b/src/cmd/cmdgazebo.rb.in
@@ -98,6 +98,9 @@ COMMANDS = { 'gazebo' =>
   "                                     --record-topic /stats \                    \n"\
   "                                     --record-topic /clock                      \n"\
   "\n"\
+  "  --record-period [arg]        Specify the time period (seconds) between        \n"\
+  "                               state recording.                                 \n"\
+  "\n"\
   "  --log-overwrite              When recording, overwrite existing files.        \n"\
   "                               Only valid if recording is enabled.              \n"\
   "\n"\
@@ -213,6 +216,7 @@ class Cmd
       'record-path' => '',
       'record-resources' => 0,
       'record-topics' => [],
+      'record-period' => -1,
       'log-overwrite' => 0,
       'log-compress' => 0,
       'playback' => '',
@@ -276,6 +280,9 @@ class Cmd
       end
       opts.on('--record-topic [arg]', String) do |t|
         options['record-topics'].append(t)
+      end
+      opts.on('--record-period [arg]', Float) do |d|
+        options['record-period'] = d
       end
       opts.on('--log-overwrite') do
         options['log-overwrite'] = 1
@@ -438,7 +445,7 @@ has properly set the DYLD_LIBRARY_PATH environment variables."
                                const char *, int, int, const char *,
                                int, int, int, const char *, const char *,
                                const char *, const char *, const char *,
-                               const char *, int, int)'
+                               const char *, int, int, float)'
 
       # Import the runGui function
       Importer.extern 'int runGui(const char *, const char *, int, const char *)'
@@ -473,7 +480,7 @@ See https://github.com/ignitionrobotics/ign-gazebo/issues/44 for more info."
             options['render_engine_server'], options['render_engine_gui'],
             options['file'], options['record-topics'].join(':'),
             options['wait_gui'],
-            options['headless-rendering'])
+            options['headless-rendering'], options['record-period'])
         end
 
         guiPid = Process.fork do
@@ -510,7 +517,7 @@ See https://github.com/ignitionrobotics/ign-gazebo/issues/44 for more info."
             options['playback'], options['physics_engine'],
             options['render_engine_server'], options['render_engine_gui'],
             options['file'], options['record-topics'].join(':'),
-            options['wait_gui'], options['headless-rendering'])
+            options['wait_gui'], options['headless-rendering'], options['record-period'])
             # Otherwise run the gui
       else options['gui']
         if plugin.end_with? ".dylib"

--- a/src/cmd/gazebo.bash_completion.sh
+++ b/src/cmd/gazebo.bash_completion.sh
@@ -30,6 +30,7 @@ GZ_SIM_COMPLETION_LIST="
   --record-path
   --record-resources
   --record-topic
+  --record-period
   --log-overwrite
   --log-compress
   --playback

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -135,7 +135,7 @@ extern "C" int runServer(const char *_sdfString,
     const char *_playback, const char *_physicsEngine,
     const char *_renderEngineServer, const char *_renderEngineGui,
     const char *_file, const char *_recordTopics, int _waitGui,
-    int _headless)
+    int _headless, float _recordPeriod)
 {
   std::string startingWorldPath{""};
   ignition::gazebo::ServerConfig serverConfig;
@@ -182,7 +182,7 @@ extern "C" int runServer(const char *_sdfString,
 
   // Initialize console log
   if ((_recordPath != nullptr && std::strlen(_recordPath) > 0) ||
-    _record > 0 || _recordResources > 0 ||
+    _record > 0 || _recordResources > 0 || _recordPeriod >= 0 ||
     (_recordTopics != nullptr && std::strlen(_recordTopics) > 0))
   {
     if (_playback != nullptr && std::strlen(_playback) > 0)
@@ -193,6 +193,12 @@ extern "C" int runServer(const char *_sdfString,
 
     serverConfig.SetUseLogRecord(true);
     serverConfig.SetLogRecordResources(_recordResources);
+    if (_recordPeriod >= 0)
+    {
+      serverConfig.SetLogRecordPeriod(
+           std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+           std::chrono::duration<double>(_recordPeriod)));
+    }
 
     // If a record path is specified
     if (_recordPath != nullptr && std::strlen(_recordPath) > 0)

--- a/src/ign.hh
+++ b/src/ign.hh
@@ -57,6 +57,7 @@ extern "C" const char *worldInstallDir();
 /// it receives a world path from GUI.
 /// null to record the default topics.
 /// \param[in] _headless True if server rendering should run headless
+/// \param[in] _recordPeriod --record-period option
 /// \return 0 if successful, 1 if not.
 extern "C" int runServer(const char *_sdfString,
     int _iterations, int _run, float _hz, int _levels,
@@ -65,7 +66,7 @@ extern "C" int runServer(const char *_sdfString,
     int _logCompress, const char *_playback,
     const char *_physicsEngine, const char *_renderEngineServer,
     const char *_renderEngineGui, const char *_file,
-    const char *_recordTopics, int _waitGui, int _headless);
+    const char *_recordTopics, int _waitGui, int _headless, float _recordPeriod);
 
 /// \brief External hook to run simulation GUI.
 /// \param[in] _guiConfig Path to Ignition GUI configuration file.

--- a/src/ign.hh
+++ b/src/ign.hh
@@ -66,7 +66,8 @@ extern "C" int runServer(const char *_sdfString,
     int _logCompress, const char *_playback,
     const char *_physicsEngine, const char *_renderEngineServer,
     const char *_renderEngineGui, const char *_file,
-    const char *_recordTopics, int _waitGui, int _headless, float _recordPeriod);
+    const char *_recordTopics, int _waitGui, int _headless,
+    float _recordPeriod);
 
 /// \brief External hook to run simulation GUI.
 /// \param[in] _guiConfig Path to Ignition GUI configuration file.

--- a/src/systems/log/LogRecord.cc
+++ b/src/systems/log/LogRecord.cc
@@ -218,7 +218,8 @@ void LogRecord::Configure(const Entity &_entity,
 
   this->dataPtr->recordPeriod =
     std::chrono::duration_cast<std::chrono::steady_clock::duration>(
-    std::chrono::duration<double>(_sdf->Get<double>("record_period", 0.0).first));
+    std::chrono::duration<double>(
+    _sdf->Get<double>("record_period", 0.0).first));
 
   this->dataPtr->compress = _sdf->Get<bool>("compress", false).first;
   this->dataPtr->cmpPath = _sdf->Get<std::string>("compress_path", "").first;

--- a/src/systems/log/LogRecord.cc
+++ b/src/systems/log/LogRecord.cc
@@ -709,7 +709,7 @@ void LogRecord::PostUpdate(const UpdateInfo &_info,
         (_info.simTime - this->dataPtr->lastRecordSimTime) >=
         this->dataPtr->recordPeriod)
     {
-       this->dataPtr->lastRecordSimTime = _info.simTime;
+      this->dataPtr->lastRecordSimTime = _info.simTime;
     }
     else
     {

--- a/src/systems/scene_broadcaster/SceneBroadcaster.cc
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.cc
@@ -45,6 +45,7 @@
 #include "ignition/gazebo/components/Light.hh"
 #include "ignition/gazebo/components/Link.hh"
 #include "ignition/gazebo/components/LogicalCamera.hh"
+#include "ignition/gazebo/components/LogPlaybackStatistics.hh"
 #include "ignition/gazebo/components/Material.hh"
 #include "ignition/gazebo/components/Model.hh"
 #include "ignition/gazebo/components/Name.hh"
@@ -252,6 +253,10 @@ class ignition::gazebo::systems::SceneBroadcasterPrivate
   /// \brief Store SDF scene information so that it can be inserted into
   /// scene message.
   public: sdf::Scene sdfScene;
+
+  /// \brief Flag used to indicate if periodic changes need to be published
+  /// This is currently only used in playback mode.
+  public: bool pubPeriodicChanges{false};
 };
 
 //////////////////////////////////////////////////
@@ -351,8 +356,11 @@ void SceneBroadcaster::PostUpdate(const UpdateInfo &_info,
   auto now = std::chrono::system_clock::now();
   bool itsPubTime = (now - this->dataPtr->lastStatePubTime >
        this->dataPtr->statePublishPeriod[_info.paused]);
+  // check if we need to publish periodic changes in playback mode.
+  bool pubChanges = this->dataPtr->pubPeriodicChanges &&
+      _manager.HasPeriodicComponentChanges();
   auto shouldPublish = this->dataPtr->statePub.HasConnections() &&
-       (changeEvent || itsPubTime);
+       (changeEvent || itsPubTime || pubChanges);
 
   if (this->dataPtr->stateServiceRequest || shouldPublish)
   {
@@ -375,9 +383,39 @@ void SceneBroadcaster::PostUpdate(const UpdateInfo &_info,
     else if (!_info.paused)
     {
       IGN_PROFILE("SceneBroadcast::PostUpdate UpdateState");
-      auto periodicComponents = _manager.ComponentTypesWithPeriodicChanges();
-      _manager.State(*this->dataPtr->stepMsg.mutable_state(),
-          {}, periodicComponents);
+
+      if (_manager.HasPeriodicComponentChanges())
+      {
+        auto periodicComponents = _manager.ComponentTypesWithPeriodicChanges();
+        _manager.State(*this->dataPtr->stepMsg.mutable_state(),
+             {}, periodicComponents);
+        this->dataPtr->pubPeriodicChanges = false;
+      }
+      else
+      {
+        // log files may be recorded at lower rate than sim time step. So in
+        // playback mode, the scene broadcaster may not see any periodic
+        // changed states here since it no longer happens every iteration.
+        // As the result, no state changes are published to be GUI, causing
+        // visuals in the GUI scene to miss updates. The visuals are only
+        // updated if by some timing coincidence that log playback updates
+        // the ECM at the same iteration as when the scene broadcaster is going
+        // to publish perioidc changes here.
+        // To work around the issue, we force the scene broadcaster
+        // to publish states at an offcycle iteration the next time it sees
+        // periodic changes.
+        auto playbackComp =
+            _manager.Component<components::LogPlaybackStatistics>(
+            this->dataPtr->worldEntity);
+        if (playbackComp)
+        {
+          this->dataPtr->pubPeriodicChanges = true;
+        }
+        // this creates an empty state in the msg even there are no periodic
+        // changed components - done to preseve existing behavior.
+        // we may be able to remove this in the future and update tests
+        this->dataPtr->stepMsg.mutable_state();
+      }
     }
 
     // Full state on demand

--- a/test/integration/log_system.cc
+++ b/test/integration/log_system.cc
@@ -1681,7 +1681,7 @@ TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(RecordPeriod))
     std::cout << output << std::endl;
   }
 
-  std::string consolePath = common::joinPaths(this->logDir, "server_console.log");
+  std::string consolePath = common::joinPaths(recordPath, "server_console.log");
   EXPECT_TRUE(common::exists(consolePath)) << consolePath;
   EXPECT_TRUE(common::exists(statePath)) << statePath;
 

--- a/test/integration/log_system.cc
+++ b/test/integration/log_system.cc
@@ -1643,3 +1643,84 @@ TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LogTopics))
   this->CreateLogsDir();
 #endif
 }
+
+/////////////////////////////////////////////////
+TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(RecordPeriod))
+{
+  // Create temp directory to store log
+  this->CreateLogsDir();
+
+  // World with moving entities
+  const auto recordSdfPath = common::joinPaths(
+    std::string(PROJECT_SOURCE_PATH), "test", "worlds",
+    "log_record_resources.sdf");
+
+  // Change environment variable so that downloaded fuel files aren't written
+  // to $HOME
+  std::string homeOrig;
+  common::env(IGN_HOMEDIR, homeOrig);
+  std::string homeFake = common::joinPaths(this->logsDir, "default");
+  EXPECT_TRUE(ignition::common::setenv(IGN_HOMEDIR, homeFake.c_str()));
+
+  const std::string recordPath = this->logDir;
+  std::string statePath = common::joinPaths(recordPath, "state.tlog");
+
+  int numIterations = 100;
+#ifndef __APPLE__
+  // Log from command line
+  {
+    // Command line triggers ign.cc, which handles initializing ignLogDirectory
+    std::string cmd = kIgnCommand + " -r -v 4 --iterations "
+      + std::to_string(numIterations) + " "
+      + "--record-period 0.002 "
+      + "--record-path " + recordPath + " " + recordSdfPath;
+    std::cout << "Running command [" << cmd << "]" << std::endl;
+
+    // Run
+    std::string output = customExecStr(cmd);
+    std::cout << output << std::endl;
+  }
+
+  std::string consolePath = common::joinPaths(this->logDir, "server_console.log");
+  EXPECT_TRUE(common::exists(consolePath)) << consolePath;
+  EXPECT_TRUE(common::exists(statePath)) << statePath;
+
+  // Recorded models should exist
+  EXPECT_GT(entryCount(recordPath), 1);
+
+  // Verify file is created
+  auto logFile = common::joinPaths(recordPath, "state.tlog");
+  EXPECT_TRUE(common::exists(logFile));
+
+  // Load the state log file into a player.
+  transport::log::Playback player(statePath);
+  const int64_t addTopicResult = player.AddTopic(std::regex(".*"));
+
+  // There should be 2 topics (sdf, & state)
+  EXPECT_EQ(2, addTopicResult);
+
+  int msgCount = 0;
+  std::function<void(const msgs::SerializedStateMap &)> stateCb =
+      [&](const msgs::SerializedStateMap &) -> void
+  {
+    msgCount++;
+  };
+
+  // Subscribe to the state topic
+  transport::Node node;
+  node.Subscribe("/world/default/changed_state", stateCb);
+
+  // Begin playback
+  transport::log::PlaybackHandlePtr handle =
+    player.Start(std::chrono::seconds(5), false);
+  handle->WaitUntilFinished();
+
+  // There were 100 iterations of simulation, and we are recording at 2ms
+  // so there should be 50 clock messages.
+  EXPECT_EQ(50, msgCount);
+
+  // Remove artifacts. Recreate new directory
+  this->RemoveLogsDir();
+  this->CreateLogsDir();
+#endif
+}

--- a/test/integration/log_system.cc
+++ b/test/integration/log_system.cc
@@ -1650,7 +1650,7 @@ TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(RecordPeriod))
   // Create temp directory to store log
   this->CreateLogsDir();
 
-  // World with moving entities
+  // test world
   const auto recordSdfPath = common::joinPaths(
     std::string(PROJECT_SOURCE_PATH), "test", "worlds",
     "log_record_resources.sdf");
@@ -1715,8 +1715,8 @@ TEST_F(LogSystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(RecordPeriod))
     player.Start(std::chrono::seconds(5), false);
   handle->WaitUntilFinished();
 
-  // There were 100 iterations of simulation, and we are recording at 2ms
-  // so there should be 50 clock messages.
+  // There were 100 iterations of simulation, and we were recording at 2ms
+  // so there should be 50 state messages.
   EXPECT_EQ(50, msgCount);
 
   // Remove artifacts. Recreate new directory


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🎉 New feature

## Summary

Current log recorder records states on every update. By specifying the log record period, the user is able to control how often the simulator records states.  A new command line arg `--record-period` is added (gazebo-classic also has the same arg name)

## Test it
Run the `INTEGRATION_log_system` test.

You can also try enabling log recording through the command line, e.g.

```sh
# record at 10ms instead of the default 1ms and save the log file in a `log_test` dir
ign gazebo -v 4 -r --record --record-path ./log_test --record-period 0.01  pendulum_links.sdf
```

then playback the log file:

```sh
ign gazebo -v 4 --playback  ./log_test
```

You should see that the playback is now choppy due to reduced recording rate.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
