### PR TITLE
Use RTLD_NODELETE=true when loading libraries

### DIFF
--- a/src/SystemLoader.cc
+++ b/src/SystemLoader.cc
@@ -98,7 +98,7 @@ class gz::sim::SystemLoaderPrivate
       }
     }
 
-    auto pluginNames = this->loader.LoadLib(pathToLib);
+    auto pluginNames = this->loader.LoadLib(pathToLib, true);
     if (pluginNames.empty())
     {
       gzerr << "Failed to load system plugin [" << filename <<

--- a/src/gui/Gui_clean_exit_TEST.cc
+++ b/src/gui/Gui_clean_exit_TEST.cc
@@ -77,7 +77,7 @@ void startBoth(const std::string &_fileName)
 }
 
 /////////////////////////////////////////////////
-TEST_P(GazeboDeathTest, CleanExit)
+TEST_P(GazeboDeathTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(CleanExit))
 {
   std::string githubAction;
   // This test hangs when there is high CPU usage, so we skip it on Github

--- a/src/gui/Gui_clean_exit_TEST.cc
+++ b/src/gui/Gui_clean_exit_TEST.cc
@@ -77,9 +77,7 @@ void startBoth(const std::string &_fileName)
 }
 
 /////////////////////////////////////////////////
-/// TODO (azeey) Temporarliy disabled until
-/// https://github.com/gazebosim/gz-sim/issues/1443 is resolved
-TEST_P(GazeboDeathTest, DISABLED_CleanExit)
+TEST_P(GazeboDeathTest, CleanExit)
 {
   std::string githubAction;
   // This test hangs when there is high CPU usage, so we skip it on Github


### PR DESCRIPTION
Fixes (Potentially): https://github.com/gazebosim/gz-sim/issues/806

## Summary

Gazebo Garden [crashes](https://github.com/gazebosim/gz-sim/issues/1443) at exit because the destructor for an `EventT` object created by a gui plugin is accesses after the plugin is unloaded. For that particular crash, the plugin in question is in gz-gui, so I've submitted a fix there (https://github.com/gazebosim/gz-gui/pull/469). This PR is proactively using `RTLD_NODELETE` to prevent future bugs of this nature. 

I believe this might also fix #806 because if the shared libraries never get deleted, when a plugin goes through a load--unload--load cycle, the components (more specifically, the vtable of the components) it registers will be located in the same memory address. This was not the case before, which I think was the culprit for many of the flakiness in macOS.

More context:
* https://github.com/gazebosim/gz-common/pull/367

Requires:
*  https://github.com/gazebosim/gz-plugin/pull/102


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
