### PR TITLE
Fixes ign-gazebo3 homebrew build regression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ set(IGN_PHYSICS_VER ${ignition-physics2_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-sensors
-ign_find_package(ignition-sensors3 REQUIRED VERSION 3.3
+ign_find_package(ignition-sensors3 REQUIRED VERSION 3.4
   COMPONENTS
     rendering
     air_pressure


### PR DESCRIPTION
Signed-off-by: Crola1702 <cristobal.arroyo@ekumenlab.com>

:man_farmer: 

Fixes [this](https://build.osrfoundation.org/job/ignition_gazebo-ci-ign-gazebo3-homebrew-amd64/248/) build regression.
Investigation/Description: https://github.com/osrf/buildfarmer/issues/336#issuecomment-1222381942
