### PR TITLE
Acoustic comms example world

### DIFF
--- a/examples/standalone/acoustic_comms_demo/CMakeLists.txt
+++ b/examples/standalone/acoustic_comms_demo/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+
+project(gz-sim-acoustic-comms-demo)
+
+find_package(gz-transport12 QUIET REQUIRED OPTIONAL_COMPONENTS log)
+set(GZ_TRANSPORT_VER ${gz-transport12_VERSION_MAJOR})
+
+find_package(gz-sim8 REQUIRED)
+set(GZ_SIM_VER ${gz-sim8_VERSION_MAJOR})
+
+add_executable(acoustic_comms_demo acoustic_comms_demo.cc)
+target_link_libraries(acoustic_comms_demo
+  gz-transport${GZ_TRANSPORT_VER}::core
+  gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER})

--- a/examples/standalone/acoustic_comms_demo/README.md
+++ b/examples/standalone/acoustic_comms_demo/README.md
@@ -1,0 +1,31 @@
+# Multi-LRAUV Acoustic comms example
+
+This example shows the usage of the Acoustic comms plugin on
+multiple autonomous underwater vehicles (AUV) with buoyancy, lift drag, and
+hydrodynamics plugins. The multiple vehicles are differentiated by namespaces.
+
+It consists of 3 vehicles,
+Triton, Tethys, and Daphne floating side by side. Triton sends
+a move command using acoustic comms, to the other 2 vehicles,
+which start moving on receiving the command. The speed of sound
+is purposely slowed down here to show that the middle vehicle (Tethys)
+will receive the signal and start moving before Daphne.
+
+## Build Instructions
+
+From this directory, run the following to compile:
+
+    mkdir build
+    cd build
+    cmake ..
+    make
+
+## Execute Instructions
+
+From the `build` directory, run Gazebo Sim and the example controller:
+
+    gz sim -r ../../../worlds/acoustic_comms_demo.sdf
+    ./acoustic_comms_demo
+
+It can be seen visually that one of the vehicles (Triton) starts moving
+immediately, then afer a while Tethys will start moving, and then finally Daphne.

--- a/examples/standalone/acoustic_comms_demo/acoustic_comms_demo.cc
+++ b/examples/standalone/acoustic_comms_demo/acoustic_comms_demo.cc
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
+ * Check README for detailed instructions.
+ * Usage:
+ *   $ gz sim -r worlds/acoustic_comms_demo.sdf
+ *   $ acoustic_comms_demo
+ */
+
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gz/msgs.hh>
+#include <gz/transport.hh>
+
+using namespace gz;
+
+bool tethysMsgReceived = false;
+bool daphneMsgReceived = false;
+std::mutex mutex;
+
+void cbTethys(const msgs::Dataframe &_msg)
+{
+  std::lock_guard<std::mutex> lock(mutex);
+  msgs::StringMsg receivedMsg;
+  receivedMsg.ParseFromString(_msg.data());
+  if (receivedMsg.data() == "START")
+    std::cout  << "Hello 1 again" << std::endl;
+    tethysMsgReceived = true;
+}
+
+void cbDaphne(const msgs::Dataframe &_msg)
+{
+  std::lock_guard<std::mutex> lock(mutex);
+  msgs::StringMsg receivedMsg;
+  receivedMsg.ParseFromString(_msg.data());
+  if (receivedMsg.data() == "START")
+    std::cout << "Hello 2 again" << std::endl;
+    daphneMsgReceived = true;
+}
+
+int main(int argc, char** argv)
+{
+  std::vector<std::string> ns;
+  ns.push_back("triton");
+  ns.push_back("tethys");
+  ns.push_back("daphne");
+
+  transport::Node node;
+
+  std::vector<std::string> rudderTopics;
+  rudderTopics.resize(ns.size(), "");
+  std::vector<gz::transport::Node::Publisher> rudderPubs;
+  rudderPubs.resize(ns.size());
+
+  std::vector<std::string> propellerTopics;
+  propellerTopics.resize(ns.size(), "");
+  std::vector<gz::transport::Node::Publisher> propellerPubs;
+  propellerPubs.resize(ns.size());
+
+  // Set up topic names and publishers
+  for (int i = 0; i < ns.size(); i++)
+  {
+    propellerTopics[i] = gz::transport::TopicUtils::AsValidTopic(
+      "/model/" + ns[i] + "/joint/propeller_joint/cmd_pos");
+    propellerPubs[i] = node.Advertise<gz::msgs::Double>(
+      propellerTopics[i]);
+  }
+
+  std::vector<double> rudderCmds = {0.0, 0.0, 0.0};
+  std::vector<double> propellerCmds = {-20, 0, 0};
+
+  // Setup publishers and callbacks for comms topics.
+  auto senderAddressTriton = "1";
+
+  auto receiverAddressTethys = "2";
+  auto receiverAddressDaphne = "3";
+
+  node.Subscribe(std::string("/2/rx"), cbTethys);
+  node.Subscribe(std::string("/3/rx"), cbDaphne);
+
+  // Publisher to send the START msg.
+  auto pub = node.Advertise<gz::msgs::Dataframe>(
+      "/broker/msgs");
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  // Prepare and send the msgs from triton to tethys and daphne
+  msgs::Dataframe msgTethys;
+  msgs::Dataframe msgDaphne;
+
+  msgTethys.set_src_address(senderAddressTriton);
+  msgDaphne.set_src_address(senderAddressTriton);
+
+  msgTethys.set_dst_address(receiverAddressTethys);
+  msgDaphne.set_dst_address(receiverAddressDaphne);
+
+  msgTethys.set_data("START");
+  msgDaphne.set_data("START");
+
+  while (true)
+  {
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    std::lock_guard<std::mutex> lock(mutex);
+    std::cout << "--------------------------" << std::endl;
+
+    if (tethysMsgReceived)
+      propellerCmds[1] = -20.0;
+    else
+      pub.Publish(msgTethys);
+
+    if (daphneMsgReceived)
+      propellerCmds[2] = -20.0;
+    else
+      pub.Publish(msgDaphne);
+
+    for (int i = 0; i < ns.size(); i++)
+    {
+      msgs::Double propellerMsg;
+      propellerMsg.set_data(propellerCmds[i]);
+      propellerPubs[i].Publish(propellerMsg);
+
+      std::cout << "Commanding " << ns[i] << " rudder angle " << rudderCmds[i]
+        << " rad, thrust " << propellerCmds[i] << " Newtons" << std::endl;
+    }
+  }
+}

--- a/examples/worlds/acoustic_comms_demo.sdf
+++ b/examples/worlds/acoustic_comms_demo.sdf
@@ -1,0 +1,379 @@
+<?xml version="1.0" ?>
+
+<!-- Run demo with gz-sim examples/standalone/multi_lrauv_race
+  (example is provided in gz-sim6+). -->
+
+<sdf version="1.6">
+  <world name="multi_lrauv">
+    <scene>
+      <!-- For turquoise ambient to match particle effect -->
+      <ambient>0.0 1.0 1.0</ambient>
+      <background>0.0 0.7 0.8</background>
+    </scene>
+
+    <physics name="1ms" type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin
+      filename="gz-sim-user-commands-system"
+      name="gz::sim::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+    <plugin
+      filename="gz-sim-contact-system"
+      name="gz::sim::systems::Contact">
+    </plugin>
+
+    <plugin
+      filename="gz-sim-buoyancy-system"
+      name="gz::sim::systems::Buoyancy">
+      <uniform_fluid_density>1000</uniform_fluid_density>
+    </plugin>
+
+    <plugin
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
+    </plugin>
+
+    <plugin
+      filename="gz-sim-acoustic-comms-system"
+      name="gz::sim::systems::AcousticComms">
+      <max_range>2500</max_range>
+      <speed_of_sound>3</speed_of_sound>
+    </plugin>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>1 1 1 1</diffuse>
+      <specular>0.5 0.5 0.5 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <include>
+      <pose>-5 0 0 0 0 0</pose>
+      <uri>https://fuel.ignitionrobotics.org/1.0/mabelzhang/models/Turquoise turbidity generator</uri>
+    </include>
+
+    <include>
+      <pose>0 0 1 0 0 1.57</pose>
+      <uri>https://fuel.ignitionrobotics.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+
+      <!-- Acoustic comms endpoint -->
+      <plugin
+        filename="gz-sim-comms-endpoint-system"
+        name="gz::sim::systems::CommsEndpoint">
+        <address>2</address>
+        <topic>2/rx</topic>
+      </plugin>
+
+      <!-- Joint controllers -->
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>horizontal_fins_joint</joint_name>
+        <p_gain>0.1</p_gain>
+      </plugin>
+
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>vertical_fins_joint</joint_name>
+        <p_gain>0.1</p_gain>
+      </plugin>
+
+      <plugin
+        filename="gz-sim-thruster-system"
+        name="gz::sim::systems::Thruster">
+        <namespace>tethys</namespace>
+        <joint_name>propeller_joint</joint_name>
+        <thrust_coefficient>0.004422</thrust_coefficient>
+        <fluid_density>1000</fluid_density>
+        <propeller_diameter>0.2</propeller_diameter>
+      </plugin>
+
+      <!-- Lift and drag -->
+
+      <!-- Vertical fin -->
+      <plugin
+        filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
+        <air_density>1000</air_density>
+        <cla>4.13</cla>
+        <cla_stall>-1.1</cla_stall>
+        <cda>0.2</cda>
+        <cda_stall>0.03</cda_stall>
+        <alpha_stall>0.17</alpha_stall>
+        <a0>0</a0>
+        <area>0.0244</area>
+        <upward>0 1 0</upward>
+        <forward>1 0 0</forward>
+        <link_name>vertical_fins</link_name>
+        <cp>0 0 0</cp>
+      </plugin>
+
+      <!-- Horizontal fin -->
+      <plugin
+        filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
+        <air_density>1000</air_density>
+        <cla>4.13</cla>
+        <cla_stall>-1.1</cla_stall>
+        <cda>0.2</cda>
+        <cda_stall>0.03</cda_stall>
+        <alpha_stall>0.17</alpha_stall>
+        <a0>0</a0>
+        <area>0.0244</area>
+        <upward>0 0 1</upward>
+        <forward>1 0 0</forward>
+        <link_name>horizontal_fins</link_name>
+        <cp>0 0 0</cp>
+      </plugin>
+
+      <plugin
+        filename="gz-sim-hydrodynamics-system"
+        name="gz::sim::systems::Hydrodynamics">
+        <link_name>base_link</link_name>
+        <xDotU>-4.876161</xDotU>
+        <yDotV>-126.324739</yDotV>
+        <zDotW>-126.324739</zDotW>
+        <kDotP>0</kDotP>
+        <mDotQ>-33.46</mDotQ>
+        <nDotR>-33.46</nDotR>
+        <xUU>-6.2282</xUU>
+        <xU>0</xU>
+        <yVV>-601.27</yVV>
+        <yV>0</yV>
+        <zWW>-601.27</zWW>
+        <zW>0</zW>
+        <kPP>-0.1916</kPP>
+        <kP>0</kP>
+        <mQQ>-632.698957</mQQ>
+        <mQ>0</mQ>
+        <nRR>-632.698957</nRR>
+        <nR>0</nR>
+      </plugin>
+
+    </include>
+
+    <include>
+      <pose>15 0 1 0 0 1.57</pose>
+      <uri>https://fuel.ignitionrobotics.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <name>triton</name>
+
+      <!-- Acoustic comms endpoint -->
+      <plugin
+        filename="gz-sim-comms-endpoint-system"
+        name="gz::sim::systems::CommsEndpoint">
+        <address>1</address>
+        <topic>1/rx</topic>
+      </plugin>
+
+      <!-- Joint controllers -->
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>horizontal_fins_joint</joint_name>
+        <p_gain>0.1</p_gain>
+      </plugin>
+
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>vertical_fins_joint</joint_name>
+        <p_gain>0.1</p_gain>
+      </plugin>
+
+      <plugin
+        filename="gz-sim-thruster-system"
+        name="gz::sim::systems::Thruster">
+        <namespace>triton</namespace>
+        <joint_name>propeller_joint</joint_name>
+        <thrust_coefficient>0.004422</thrust_coefficient>
+        <fluid_density>1000</fluid_density>
+        <propeller_diameter>0.2</propeller_diameter>
+      </plugin>
+
+      <!-- Lift and drag -->
+
+      <!-- Vertical fin -->
+      <plugin
+        filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
+        <air_density>1000</air_density>
+        <cla>4.13</cla>
+        <cla_stall>-1.1</cla_stall>
+        <cda>0.2</cda>
+        <cda_stall>0.03</cda_stall>
+        <alpha_stall>0.17</alpha_stall>
+        <a0>0</a0>
+        <area>0.0244</area>
+        <upward>0 1 0</upward>
+        <forward>1 0 0</forward>
+        <link_name>vertical_fins</link_name>
+        <cp>0 0 0</cp>
+      </plugin>
+
+      <!-- Horizontal fin -->
+      <plugin
+        filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
+        <air_density>1000</air_density>
+        <cla>4.13</cla>
+        <cla_stall>-1.1</cla_stall>
+        <cda>0.2</cda>
+        <cda_stall>0.03</cda_stall>
+        <alpha_stall>0.17</alpha_stall>
+        <a0>0</a0>
+        <area>0.0244</area>
+        <upward>0 0 1</upward>
+        <forward>1 0 0</forward>
+        <link_name>horizontal_fins</link_name>
+        <cp>0 0 0</cp>
+      </plugin>
+
+      <plugin
+        filename="gz-sim-hydrodynamics-system"
+        name="gz::sim::systems::Hydrodynamics">
+        <link_name>base_link</link_name>
+        <xDotU>-4.876161</xDotU>
+        <yDotV>-126.324739</yDotV>
+        <zDotW>-126.324739</zDotW>
+        <kDotP>0</kDotP>
+        <mDotQ>-33.46</mDotQ>
+        <nDotR>-33.46</nDotR>
+        <xUU>-6.2282</xUU>
+        <xU>0</xU>
+        <yVV>-601.27</yVV>
+        <yV>0</yV>
+        <zWW>-601.27</zWW>
+        <zW>0</zW>
+        <kPP>-0.1916</kPP>
+        <kP>0</kP>
+        <mQQ>-632.698957</mQQ>
+        <mQ>0</mQ>
+        <nRR>-632.698957</nRR>
+        <nR>0</nR>
+      </plugin>
+
+    </include>
+
+    <include>
+      <pose>-15 0 1 0 0 1.57</pose>
+      <uri>https://fuel.ignitionrobotics.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <name>daphne</name>
+
+      <!-- Acoustic comms endpoint -->
+      <plugin
+        filename="gz-sim-comms-endpoint-system"
+        name="gz::sim::systems::CommsEndpoint">
+        <address>3</address>
+        <topic>3/rx</topic>
+      </plugin>
+
+      <!-- Joint controllers -->
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>horizontal_fins_joint</joint_name>
+        <p_gain>0.1</p_gain>
+      </plugin>
+
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>vertical_fins_joint</joint_name>
+        <p_gain>0.1</p_gain>
+      </plugin>
+
+      <plugin
+        filename="gz-sim-thruster-system"
+        name="gz::sim::systems::Thruster">
+        <namespace>daphne</namespace>
+        <joint_name>propeller_joint</joint_name>
+        <thrust_coefficient>0.004422</thrust_coefficient>
+        <fluid_density>1000</fluid_density>
+        <propeller_diameter>0.2</propeller_diameter>
+      </plugin>
+
+      <!-- Lift and drag -->
+
+      <!-- Vertical fin -->
+      <plugin
+        filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
+        <air_density>1000</air_density>
+        <cla>4.13</cla>
+        <cla_stall>-1.1</cla_stall>
+        <cda>0.2</cda>
+        <cda_stall>0.03</cda_stall>
+        <alpha_stall>0.17</alpha_stall>
+        <a0>0</a0>
+        <area>0.0244</area>
+        <upward>0 1 0</upward>
+        <forward>1 0 0</forward>
+        <link_name>vertical_fins</link_name>
+        <cp>0 0 0</cp>
+      </plugin>
+
+      <!-- Horizontal fin -->
+      <plugin
+        filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
+        <air_density>1000</air_density>
+        <cla>4.13</cla>
+        <cla_stall>-1.1</cla_stall>
+        <cda>0.2</cda>
+        <cda_stall>0.03</cda_stall>
+        <alpha_stall>0.17</alpha_stall>
+        <a0>0</a0>
+        <area>0.0244</area>
+        <upward>0 0 1</upward>
+        <forward>1 0 0</forward>
+        <link_name>horizontal_fins</link_name>
+        <cp>0 0 0</cp>
+      </plugin>
+
+      <plugin
+        filename="gz-sim-hydrodynamics-system"
+        name="gz::sim::systems::Hydrodynamics">
+        <link_name>base_link</link_name>
+        <xDotU>-4.876161</xDotU>
+        <yDotV>-126.324739</yDotV>
+        <zDotW>-126.324739</zDotW>
+        <kDotP>0</kDotP>
+        <mDotQ>-33.46</mDotQ>
+        <nDotR>-33.46</nDotR>
+        <xUU>-6.2282</xUU>
+        <xU>0</xU>
+        <yVV>-601.27</yVV>
+        <yV>0</yV>
+        <zWW>-601.27</zWW>
+        <zW>0</zW>
+        <kPP>-0.1916</kPP>
+        <kP>0</kP>
+        <mQQ>-632.698957</mQQ>
+        <mQ>0</mQ>
+        <nRR>-632.698957</nRR>
+        <nR>0</nR>
+      </plugin>
+
+    </include>
+
+
+  </world>
+</sdf>


### PR DESCRIPTION
🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
# 🎉 New feature

## Summary
This PR adds an example world for acoustic comms using LR AUVs. 
It consists of 3 vehicles placed side by side each other, with one of them sending the signal to start moving. Since the speed of sound is slowed down, it is visible clearly when sound reaches the farther vehicle slightly later and they start moving accordingly. The lag is visible clearly in the motion of the vehicles.

![image](https://user-images.githubusercontent.com/18661155/186857321-c693c0f6-7b97-4bf5-b687-3a779de1add2.png)

## Test it
To run the example, open up a terminal and run the world :
```
gz sim -v 4 -r ~/garden_ws/src/gz-sim/examples/worlds/acostic_comms_demo.sdf
```
and in another terminal, run :
```
cd ~/garden_ws/src/gz-sim/examples/standalone/acoustic_comms_demo
mkdir build ; cd build
cmake .. ; make
./acoustic_comms_demo
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸