### PR TITLE
Readd namespaces for Q_ARGS

### DIFF
--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -693,7 +693,7 @@ void ComponentInspector::Update(const UpdateInfo &,
       QMetaObject::invokeMethod(&this->dataPtr->componentsModel,
           "RemoveComponentType",
           Qt::QueuedConnection,
-          Q_ARG(ComponentTypeId, typeId));
+          Q_ARG(ignition::gazebo::ComponentTypeId, typeId));
     }
   }
 }

--- a/src/gui/plugins/joint_position_controller/JointPositionController.cc
+++ b/src/gui/plugins/joint_position_controller/JointPositionController.cc
@@ -292,7 +292,7 @@ void JointPositionController::Update(const UpdateInfo &,
       QMetaObject::invokeMethod(&this->dataPtr->jointsModel,
           "RemoveJoint",
           Qt::QueuedConnection,
-          Q_ARG(Entity, jointEntity));
+          Q_ARG(ignition::gazebo::Entity, jointEntity));
     }
   }
 }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
In https://github.com/gazebosim/gz-sim/pull/1635, redundant namespaces were removed but it appears they are required for `Q_ARGS` in `QMetaObject::invokeMethod` calls.

To test, run `ign gazebo -v 4 shapes.sdf` then click/select a random shape
- **Without PR**: the console is spammed with
```bash
[GUI] [Wrn] [Application.cc:791] [QT] QMetaObject::invokeMethod: No such method ignition::gazebo::ComponentsModel::RemoveComponentType(ComponentTypeId)
Candidates are:
    RemoveComponentType(ignition::gazebo::ComponentTypeId)
```
-  **With PR**: fixes these errors

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.