### PR TITLE
Fix two tests

### DIFF
--- a/test/integration/log_system.cc
+++ b/test/integration/log_system.cc
@@ -1523,7 +1523,7 @@ TEST_F(LogSystemTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(LogResources))
   // Recorded models should exist
   EXPECT_GT(entryCount(recordPath), 2);
   EXPECT_TRUE(common::exists(common::joinPaths(recordPath, homeFake,
-      ".ignition", "fuel", "fuel.ignitionrobotics.org", "openrobotics",
+      ".gz", "fuel", "fuel.ignitionrobotics.org", "openrobotics",
       "models", "x2 config 1")));
 
   // Remove artifacts. Recreate new directory
@@ -1558,7 +1558,7 @@ TEST_F(LogSystemTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(LogResources))
   EXPECT_GT(entryCount(recordPath), 1);
 #endif
   EXPECT_TRUE(common::exists(common::joinPaths(recordPath, homeFake,
-      ".ignition", "fuel", "fuel.ignitionrobotics.org", "openrobotics",
+      ".gz", "fuel", "fuel.ignitionrobotics.org", "openrobotics",
       "models", "x2 config 1")));
 
   // Revert environment variable after test is done

--- a/test/integration/save_world.cc
+++ b/test/integration/save_world.cc
@@ -903,7 +903,7 @@ TEST_F(SdfGeneratorFixture, ModelWithJoints)
   EXPECT_EQ(gz::math::Vector3d::UnitZ, axis->Xyz());
   EXPECT_EQ(gz::math::Vector3d::UnitY, axis2->Xyz());
 
-  EXPECT_EQ("__model__", axis->XyzExpressedIn());
+  EXPECT_EQ("", axis->XyzExpressedIn());
   EXPECT_TRUE(axis2->XyzExpressedIn().empty());
 
   EXPECT_DOUBLE_EQ(-0.5, axis->Lower());

--- a/test/worlds/joint_sensor.sdf
+++ b/test/worlds/joint_sensor.sdf
@@ -22,7 +22,6 @@
         <axis>
           <xyz>0 0 1</xyz>
           <initial_position>0.5</initial_position>
-          <use_parent_model_frame>true</use_parent_model_frame>
           <limit>
             <lower>-0.5</lower>
             <upper>0.5</upper>
@@ -39,7 +38,6 @@
         <axis2>
           <xyz>0 1 0</xyz>
           <initial_position>1.5</initial_position>
-          <use_parent_model_frame>false</use_parent_model_frame>
           <limit>
             <lower>-1</lower>
             <upper>1</upper>


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

This PR attempts to fix the `log_system` and `save_world` tests.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.