### PR TITLE
Remove unused function

### DIFF
--- a/src/gui/GuiRunner.cc
+++ b/src/gui/GuiRunner.cc
@@ -267,13 +267,6 @@ void GuiRunner::RequestState()
 }
 
 /////////////////////////////////////////////////
-void GuiRunner::OnPluginAdded(const QString &)
-{
-  // This function used to call Update on the plugin, but that's no longer
-  // necessary. The function is left here for ABI compatibility.
-}
-
-/////////////////////////////////////////////////
 void GuiRunner::OnStateAsyncService(const msgs::SerializedStepMap &_res)
 {
   // Since this function may be called from a transport thread, we push the

--- a/src/gui/GuiRunner.hh
+++ b/src/gui/GuiRunner.hh
@@ -70,7 +70,6 @@ class GZ_SIM_GUI_VISIBLE GuiRunner : public QObject
   private: Q_INVOKABLE void OnStateQt(const msgs::SerializedStepMap &_msg);
 
   /// \brief Update the plugins.
-  /// \todo(anyone) Move to GuiRunner::Implementation when porting to v5
   private: Q_INVOKABLE void UpdatePlugins();
 
   /// \brief Load systems

--- a/src/gui/GuiRunner.hh
+++ b/src/gui/GuiRunner.hh
@@ -53,11 +53,6 @@ class GZ_SIM_GUI_VISIBLE GuiRunner : public QObject
   // Documentation inherited
   protected: bool eventFilter(QObject *_obj, QEvent *_event) override;
 
-  /// \brief Callback when a plugin has been added.
-  /// This function has no effect and is left here for ABI compatibility.
-  /// \param[in] _objectName Plugin's object name.
-  public slots: void OnPluginAdded(const QString &_objectName);
-
   /// \brief Make a new state request to the server.
   public slots: void RequestState();
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
c73c72000ff1ee00f21c23aa60e3fe600643fad3 Removed `GuiRunner::OnPluginAdded` function that was left for abi compatibility in previous releases
68447cb8b51cfe4287459969f54251c8a861330c Removed invalid `TODO` which was written before `GuiRunner::UpdatePlugins` was a `Q_INVOKABLE` function ( [connect](https://github.com/gazebosim/gz-sim/blob/f8733fa6d3a88281579e70aef0186c9d97ef9f06/src/gui/GuiRunner.cc#L152) requires the receiver to be a `QObject`)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.