### PR TITLE
Fix display of Pose3d and Vector3d on macOS

### DIFF
--- a/src/gui/plugins/component_inspector/Pose3d.qml
+++ b/src/gui/plugins/component_inspector/Pose3d.qml
@@ -103,6 +103,7 @@ Rectangle {
         GzPose {
           id: gzPoseInstance
           Layout.fillWidth: true
+          Layout.preferredWidth: parent.width
 
           readOnly: {
             var isModel = entityType == "model"

--- a/src/gui/plugins/component_inspector/Vector3d.qml
+++ b/src/gui/plugins/component_inspector/Vector3d.qml
@@ -97,6 +97,7 @@ Rectangle {
         GzVector3 {
           id: gzVectorInstance
           Layout.fillWidth: true
+          Layout.preferredWidth: parent.width
           gzUnit: model && model.unit != undefined ? model.unit : 'm'
 
           xValue: model.data[0]


### PR DESCRIPTION
This PR fixes the display of Pose3d and Vector3d on macOS.

# 🦟 Bug fix

Fixes #1668

## Summary

The fix sets an additional layout attribute `Layout.preferredWidth: parent.width` to the GzPose and GzVector3 declarations in Pose3d.qml and Vector3d.qml of the component inspector. Without these the entries render empty on macOS / Metal.

Further details and tests are provided in https://github.com/gazebosim/gz-sim/issues/1668.

## Checklist
- [ x ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ x ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ x ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
