### PR TITLE
Restore Add System GUI plugin

### DIFF
--- a/include/ignition/gazebo/SystemLoader.hh
+++ b/include/ignition/gazebo/SystemLoader.hh
@@ -17,6 +17,7 @@
 #ifndef IGNITION_GAZEBO_SYSTEMLOADER_HH_
 #define IGNITION_GAZEBO_SYSTEMLOADER_HH_
 
+#include <list>
 #include <memory>
 #include <optional>
 #include <string>
@@ -61,7 +62,8 @@ namespace ignition
 
       /// \brief Load and instantiate system plugin from name/filename.
       /// \param[in] _filename Shared library filename to load plugin from.
-      /// \param[in] _name Class name to be instantiated.
+      /// \param[in] _name Class name to be instantiated. If empty, the first
+      /// plugin in the shared library will be loaded.
       /// \param[in] _sdf SDF Element describing plugin instance to be loaded.
       /// \returns Shared pointer to system instance or nullptr.
       /// \note This will be deprecated in Gazebo 7 (Garden), please the use
@@ -80,6 +82,10 @@ namespace ignition
       /// \brief Makes a printable string with info about systems
       /// \returns A pretty string
       public: std::string PrettyStr() const;
+
+      /// \brief Get the plugin search paths used for loading system plugins
+      /// \return Paths to search for plugins
+      public: std::list<std::string> PluginPaths() const;
 
       /// \brief Pointer to private data.
       private: std::unique_ptr<SystemLoaderPrivate> dataPtr;

--- a/src/ServerConfig.cc
+++ b/src/ServerConfig.cc
@@ -91,6 +91,7 @@ class ignition::gazebo::ServerConfig::PluginInfoPrivate
 
   /// \brief XML elements associated with this plugin
   public: sdf::ElementPtr sdf = nullptr;
+
 };
 
 //////////////////////////////////////////////////

--- a/src/ServerConfig.cc
+++ b/src/ServerConfig.cc
@@ -91,7 +91,6 @@ class ignition::gazebo::ServerConfig::PluginInfoPrivate
 
   /// \brief XML elements associated with this plugin
   public: sdf::ElementPtr sdf = nullptr;
-
 };
 
 //////////////////////////////////////////////////

--- a/src/SystemLoader.cc
+++ b/src/SystemLoader.cc
@@ -41,8 +41,7 @@ class ignition::gazebo::SystemLoaderPrivate
   public: explicit SystemLoaderPrivate() = default;
 
   //////////////////////////////////////////////////
-  public: bool InstantiateSystemPlugin(const sdf::Plugin &_sdfPlugin,
-              ignition::plugin::PluginPtr &_gzPlugin)
+  public: std::list<std::string> PluginPaths() const
   {
     ignition::common::SystemPaths systemPaths;
     systemPaths.SetPluginPathEnv(pluginPathEnv);
@@ -52,8 +51,23 @@ class ignition::gazebo::SystemLoaderPrivate
 
     std::string homePath;
     ignition::common::env(IGN_HOMEDIR, homePath);
-    systemPaths.AddPluginPaths(homePath + "/.ignition/gazebo/plugins");
+    systemPaths.AddPluginPaths(common::joinPaths(
+        homePath, ".ignition", "gazebo", "plugins"));
     systemPaths.AddPluginPaths(IGN_GAZEBO_PLUGIN_INSTALL_DIR);
+
+    return systemPaths.PluginPaths();
+  }
+
+  //////////////////////////////////////////////////
+  public: bool InstantiateSystemPlugin(const sdf::Plugin &_sdfPlugin,
+              ignition::plugin::PluginPtr &_gzPlugin)
+  {
+    std::list<std::string> paths = this->PluginPaths();
+    common::SystemPaths systemPaths;
+    for (const auto &p : paths)
+    {
+      systemPaths.AddPluginPaths(p);
+    }
 
     auto pathToLib = systemPaths.FindSharedLibrary(_sdfPlugin.Filename());
     if (pathToLib.empty())
@@ -85,7 +99,11 @@ class ignition::gazebo::SystemLoaderPrivate
       return false;
     }
 
-    _gzPlugin = this->loader.Instantiate(_sdfPlugin.Name());
+    // use the first plugin name in the library if not specified
+    std::string pluginToInstantiate = _sdfPlugin.Name().empty() ?
+        pluginName : _sdfPlugin.Name();
+
+    _gzPlugin = this->loader.Instantiate(pluginToInstantiate);
     if (!_gzPlugin)
     {
       ignerr << "Failed to load system plugin [" << _sdfPlugin.Name() <<
@@ -130,6 +148,12 @@ SystemLoader::SystemLoader()
 SystemLoader::~SystemLoader() = default;
 
 //////////////////////////////////////////////////
+std::list<std::string> SystemLoader::PluginPaths() const
+{
+  return this->dataPtr->PluginPaths();
+}
+
+//////////////////////////////////////////////////
 void SystemLoader::AddSystemPluginPath(const std::string &_path)
 {
   this->dataPtr->systemPluginPaths.insert(_path);
@@ -141,11 +165,10 @@ std::optional<SystemPluginPtr> SystemLoader::LoadPlugin(
   const std::string &_name,
   const sdf::ElementPtr &_sdf)
 {
-  if (_filename == "" || _name == "")
+  if (_filename == "")
   {
     ignerr << "Failed to instantiate system plugin: empty argument "
-              "[(filename): " << _filename << "] " <<
-              "[(name): " << _name << "]." << std::endl;
+              "[(filename): " << _filename << "] " << std::endl;
     return {};
   }
 
@@ -175,18 +198,16 @@ std::optional<SystemPluginPtr> SystemLoader::LoadPlugin(
 {
   ignition::plugin::PluginPtr plugin;
 
-  if (_plugin.Filename() == "" || _plugin.Name() == "")
+  if (_plugin.Filename() == "")
   {
     ignerr << "Failed to instantiate system plugin: empty argument "
-              "[(filename): " << _plugin.Filename() << "] " <<
-              "[(name): " << _plugin.Name() << "]." << std::endl;
+              "[(filename): " << _plugin.Filename() << "] " << std::endl;
     return {};
   }
 
   auto ret = this->dataPtr->InstantiateSystemPlugin(_plugin, plugin);
   if (ret && plugin)
     return plugin;
-
   return {};
 }
 

--- a/src/SystemLoader_TEST.cc
+++ b/src/SystemLoader_TEST.cc
@@ -27,6 +27,7 @@
 #include "ignition/gazebo/test_config.hh"  // NOLINT(build/include)
 
 using namespace ignition;
+using namespace gazebo;
 
 /////////////////////////////////////////////////
 TEST(SystemLoader, Constructor)
@@ -66,4 +67,39 @@ TEST(SystemLoader, EmptyNames)
   sdf::Plugin plugin;
   auto system = sm.LoadPlugin(plugin);
   ASSERT_FALSE(system.has_value());
+}
+
+/////////////////////////////////////////////////
+TEST(SystemLoader, PluginPaths)
+{
+  SystemLoader sm;
+
+  // verify that there should exist some default paths
+  std::list<std::string> paths = sm.PluginPaths();
+  unsigned int pathCount = paths.size();
+  EXPECT_LT(0u, pathCount);
+
+  // Add test path and verify that the loader now contains this path
+  auto testBuildPath = common::joinPaths(
+      std::string(PROJECT_BINARY_PATH), "lib");
+  sm.AddSystemPluginPath(testBuildPath);
+  paths = sm.PluginPaths();
+
+  // Number of paths should increase by 1
+  EXPECT_EQ(pathCount + 1, paths.size());
+
+  // verify newly added paths exists
+  bool hasPath = false;
+  for (const auto &s : paths)
+  {
+    // the returned path string may not be exact match due to extra '/'
+    // appended at the end of the string. So use absPath to generate
+    // a path string that matches the format returned by joinPaths
+    if (common::absPath(s) == testBuildPath)
+    {
+      hasPath = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(hasPath);
 }

--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -15,6 +15,11 @@
  *
 */
 
+#include <list>
+#include <set>
+
+#include <ignition/common/StringUtils.hh>
+
 #include "ignition/gazebo/components/SystemPluginInfo.hh"
 #include "ignition/gazebo/Conversions.hh"
 #include "SystemManager.hh"
@@ -34,11 +39,15 @@ SystemManager::SystemManager(const SystemLoaderPtr &_systemLoader,
   transport::NodeOptions opts;
   opts.SetNameSpace(_namespace);
   this->node = std::make_unique<transport::Node>(opts);
-  std::string entitySystemService{"entity/system/add"};
-  this->node->Advertise(entitySystemService,
+  std::string entitySystemAddService{"entity/system/add"};
+  this->node->Advertise(entitySystemAddService,
       &SystemManager::EntitySystemAddService, this);
   ignmsg << "Serving entity system service on ["
-         << "/" << entitySystemService << "]" << std::endl;
+         << "/" << entitySystemAddService << "]" << std::endl;
+
+  std::string entitySystemInfoService{"system/info"};
+  this->node->Advertise(entitySystemInfoService,
+      &SystemManager::EntitySystemInfoService, this);
 }
 
 //////////////////////////////////////////////////
@@ -212,6 +221,51 @@ bool SystemManager::EntitySystemAddService(const msgs::EntityPlugin_V &_req,
   std::lock_guard<std::mutex> lock(this->systemsMsgMutex);
   this->systemsToAdd.push_back(_req);
   _res.set_data(true);
+  return true;
+}
+
+//////////////////////////////////////////////////
+bool SystemManager::EntitySystemInfoService(const msgs::Empty &,
+                                            msgs::EntityPlugin_V &_res)
+{
+  // loop through all files in paths and populate the list of
+  // plugin libraries.
+  std::list<std::string> paths = this->systemLoader->PluginPaths();
+  std::set<std::string> filenames;
+  for (const auto &p : paths)
+  {
+    if (common::exists(p))
+    {
+      for (common::DirIter file(p);
+          file != common::DirIter(); ++file)
+      {
+        std::string current(*file);
+        std::string filename = common::basename(current);
+        if (common::isFile(current) &&
+            (common::EndsWith(filename, ".so") ||
+             common::EndsWith(filename, ".dll") ||
+             common::EndsWith(filename, ".dylib")))
+        {
+          // remove extension and lib prefix
+          size_t extensionIndex = filename.rfind(".");
+          std::string nameWithoutExtension =
+              filename.substr(0, extensionIndex);
+          if (common::StartsWith(nameWithoutExtension, "lib"))
+          {
+            nameWithoutExtension = nameWithoutExtension.substr(3);
+          }
+          filenames.insert(nameWithoutExtension);
+        }
+      }
+    }
+  }
+
+  for (const auto &fn : filenames)
+  {
+    auto plugin = _res.add_plugins();
+    plugin->set_filename(fn);
+  }
+
   return true;
 }
 

--- a/src/SystemManager.hh
+++ b/src/SystemManager.hh
@@ -142,6 +142,14 @@ namespace ignition
       private: bool EntitySystemAddService(const msgs::EntityPlugin_V &_req,
                                            msgs::Boolean &_res);
 
+      /// \brief Callback for entity info system service.
+      /// \param[in] _req Empty request message
+      /// \param[out] _res Response containing a list of plugin names
+      /// and filenames
+      /// \return True if request received.
+      private: bool EntitySystemInfoService(const msgs::Empty &_req,
+                                            msgs::EntityPlugin_V &_res);
+
       /// \brief All the systems.
       private: std::vector<SystemInternal> systems;
 

--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -18,6 +18,8 @@
 #include <iostream>
 #include <list>
 #include <regex>
+#include <unordered_map>
+#include <QColorDialog>
 #include <ignition/common/Console.hh>
 #include <ignition/common/Profiler.hh>
 #include <ignition/gui/Application.hh>
@@ -68,6 +70,7 @@
 #include "ignition/gazebo/components/Volume.hh"
 #include "ignition/gazebo/components/WindMode.hh"
 #include "ignition/gazebo/components/World.hh"
+#include "ignition/gazebo/config.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/gui/GuiEvents.hh"
 
@@ -118,7 +121,33 @@ namespace ignition::gazebo
 
     /// \brief Handles all system info components.
     public: std::unique_ptr<inspector::SystemPluginInfo> systemInfo;
+
+    /// \brief A list of system plugin human readable names.
+    public: QStringList systemNameList;
+
+    /// \brief Maps plugin display names to their filenames.
+    public: std::unordered_map<std::string, std::string> systemMap;
   };
+}
+
+// Helper to remove a prefix from a string if present
+void removePrefix(const std::string &_prefix, std::string &_s)
+{
+  auto id = _s.find(_prefix);
+  if (id != std::string::npos)
+  {
+    _s = _s.substr(_prefix.length());
+  }
+}
+
+// Helper to remove a suffix from a string if present
+void removeSuffix(const std::string &_suffix, std::string &_s)
+{
+  auto id = _s.find(_suffix);
+  if (id != std::string::npos && id + _suffix.length() == _s.length())
+  {
+    _s.erase(id, _suffix.length());
+  }
 }
 
 using namespace ignition;
@@ -317,22 +346,22 @@ void ignition::gazebo::setData(QStandardItem *_item,
   _item->setData(QString("Material"),
       ComponentsModel::RoleNames().key("dataType"));
   _item->setData(QList({
-    QVariant(_data.Ambient().R()),
-    QVariant(_data.Ambient().G()),
-    QVariant(_data.Ambient().B()),
-    QVariant(_data.Ambient().A()),
-    QVariant(_data.Diffuse().R()),
-    QVariant(_data.Diffuse().G()),
-    QVariant(_data.Diffuse().B()),
-    QVariant(_data.Diffuse().A()),
-    QVariant(_data.Specular().R()),
-    QVariant(_data.Specular().G()),
-    QVariant(_data.Specular().B()),
-    QVariant(_data.Specular().A()),
-    QVariant(_data.Emissive().R()),
-    QVariant(_data.Emissive().G()),
-    QVariant(_data.Emissive().B()),
-    QVariant(_data.Emissive().A())
+    QVariant(_data.Ambient().R() * 255),
+    QVariant(_data.Ambient().G() * 255),
+    QVariant(_data.Ambient().B() * 255),
+    QVariant(_data.Ambient().A() * 255),
+    QVariant(_data.Diffuse().R() * 255),
+    QVariant(_data.Diffuse().G() * 255),
+    QVariant(_data.Diffuse().B() * 255),
+    QVariant(_data.Diffuse().A() * 255),
+    QVariant(_data.Specular().R() * 255),
+    QVariant(_data.Specular().G() * 255),
+    QVariant(_data.Specular().B() * 255),
+    QVariant(_data.Specular().A() * 255),
+    QVariant(_data.Emissive().R() * 255),
+    QVariant(_data.Emissive().G() * 255),
+    QVariant(_data.Emissive().B() * 255),
+    QVariant(_data.Emissive().A() * 255)
   }), ComponentsModel::RoleNames().key("data"));
 
   // TODO(anyone) Only shows colors of material,
@@ -895,7 +924,6 @@ void ComponentInspector::Update(const UpdateInfo &,
       auto comp = _ecm.Component<components::Material>(this->dataPtr->entity);
       if (comp)
       {
-        this->SetType("material");
         setData(item, comp->Data());
       }
     }
@@ -1127,8 +1155,55 @@ void ComponentInspector::OnMaterialColor(
   double _rDiffuse, double _gDiffuse, double _bDiffuse, double _aDiffuse,
   double _rSpecular, double _gSpecular, double _bSpecular, double _aSpecular,
   double _rEmissive, double _gEmissive, double _bEmissive, double _aEmissive,
-  QString /*_type*/, QColor /*_currColor*/)
+  QString _type, QColor _currColor)
 {
+  // when type is not empty, open qt color dialog
+  std::string type = _type.toStdString();
+  if (!type.empty())
+  {
+    QColor newColor = QColorDialog::getColor(
+        _currColor, nullptr, "Pick a color",
+        {QColorDialog::DontUseNativeDialog, QColorDialog::ShowAlphaChannel});
+
+    // returns if the user hits cancel
+    if (!newColor.isValid())
+      return;
+
+    if (type == "ambient")
+    {
+      _rAmbient = newColor.red();
+      _gAmbient = newColor.green();
+      _bAmbient = newColor.blue();
+      _aAmbient = newColor.alpha();
+    }
+    else if (type == "diffuse")
+    {
+      _rDiffuse = newColor.red();
+      _gDiffuse = newColor.green();
+      _bDiffuse = newColor.blue();
+      _aDiffuse = newColor.alpha();
+    }
+    else if (type == "specular")
+    {
+      _rSpecular = newColor.red();
+      _gSpecular = newColor.green();
+      _bSpecular = newColor.blue();
+      _aSpecular = newColor.alpha();
+    }
+    else if (type == "emissive")
+    {
+      _rEmissive = newColor.red();
+      _gEmissive = newColor.green();
+      _bEmissive = newColor.blue();
+      _aEmissive = newColor.alpha();
+    }
+    else
+    {
+      ignerr << "Invalid material type: " << type << std::endl;
+      return;
+    }
+  }
+
   std::function<void(const ignition::msgs::Boolean &, const bool)> cb =
       [](const ignition::msgs::Boolean &/*_rep*/, const bool _result)
   {
@@ -1141,13 +1216,17 @@ void ComponentInspector::OnMaterialColor(
   req.set_id(this->dataPtr->entity);
 
   msgs::Set(req.mutable_material()->mutable_ambient(),
-    math::Color(_rAmbient, _gAmbient, _bAmbient, _aAmbient));
+    math::Color(_rAmbient / 255.0, _gAmbient / 255.0,
+      _bAmbient / 255.0, _aAmbient / 255.0));
   msgs::Set(req.mutable_material()->mutable_diffuse(),
-    math::Color(_rDiffuse, _gDiffuse, _bDiffuse, _aDiffuse));
+    math::Color(_rDiffuse / 255.0, _gDiffuse / 255.0,
+      _bDiffuse / 255.0, _aDiffuse / 255.0));
   msgs::Set(req.mutable_material()->mutable_specular(),
-    math::Color(_rSpecular, _gSpecular, _bSpecular, _aSpecular));
+    math::Color(_rSpecular / 255.0, _gSpecular / 255.0,
+      _bSpecular / 255.0, _aSpecular / 255.0));
   msgs::Set(req.mutable_material()->mutable_emissive(),
-    math::Color(_rEmissive, _gEmissive, _bEmissive, _aEmissive));
+    math::Color(_rEmissive / 255.0, _gEmissive / 255.0,
+      _bEmissive / 255.0, _aEmissive / 255.0));
 
   auto materialCmdService = "/world/" + this->dataPtr->worldName
       + "/visual_config";
@@ -1214,6 +1293,106 @@ const std::string &ComponentInspector::WorldName() const
 transport::Node &ComponentInspector::TransportNode()
 {
   return this->dataPtr->node;
+}
+
+/////////////////////////////////////////////////
+void ComponentInspector::QuerySystems()
+{
+  msgs::Empty req;
+  msgs::EntityPlugin_V res;
+  bool result;
+  unsigned int timeout = 5000;
+  std::string service{"/world/" + this->dataPtr->worldName +
+      "/system/info"};
+  if (!this->dataPtr->node.Request(service, req, timeout, res, result))
+  {
+    ignerr << "Unable to query available systems." << std::endl;
+    return;
+  }
+
+  this->dataPtr->systemNameList.clear();
+  this->dataPtr->systemMap.clear();
+  for (const auto &plugin : res.plugins())
+  {
+    if (plugin.filename().empty())
+    {
+      ignerr << "Received empty plugin name. This shouldn't happen."
+             << std::endl;
+      continue;
+    }
+
+    // Remove common prefixes and suffixes
+    auto humanReadable = plugin.filename();
+    removePrefix("ignition-gazebo-", humanReadable);
+    removePrefix("ignition-gazebo" +
+        std::string(IGNITION_GAZEBO_MAJOR_VERSION_STR) + "-", humanReadable);
+    removeSuffix("-system", humanReadable);
+    removeSuffix("system", humanReadable);
+    removeSuffix("-plugin", humanReadable);
+    removeSuffix("plugin", humanReadable);
+
+    // Replace - with space, capitalize
+    std::replace(humanReadable.begin(), humanReadable.end(), '-', ' ');
+    humanReadable[0] = std::toupper(humanReadable[0]);
+
+    this->dataPtr->systemMap[humanReadable] = plugin.filename();
+    this->dataPtr->systemNameList.push_back(
+        QString::fromStdString(humanReadable));
+  }
+  this->dataPtr->systemNameList.sort();
+  this->dataPtr->systemNameList.removeDuplicates();
+  this->SystemNameListChanged();
+}
+
+/////////////////////////////////////////////////
+QStringList ComponentInspector::SystemNameList() const
+{
+  return this->dataPtr->systemNameList;
+}
+
+/////////////////////////////////////////////////
+void ComponentInspector::SetSystemNameList(const QStringList &_list)
+{
+  this->dataPtr->systemNameList = _list;
+}
+
+/////////////////////////////////////////////////
+void ComponentInspector::OnAddSystem(const QString &_name,
+    const QString &_filename, const QString &_innerxml)
+{
+  auto filenameStr = _filename.toStdString();
+  auto it = this->dataPtr->systemMap.find(filenameStr);
+  if (it == this->dataPtr->systemMap.end())
+  {
+    ignerr << "Internal error: failed to find [" << filenameStr
+           << "] in system map." << std::endl;
+    return;
+  }
+
+  msgs::EntityPlugin_V req;
+  auto ent = req.mutable_entity();
+  ent->set_id(this->dataPtr->entity);
+  auto plugin = req.add_plugins();
+  std::string name = _name.toStdString();
+  std::string filename = this->dataPtr->systemMap[filenameStr];
+  std::string innerxml = _innerxml.toStdString();
+  plugin->set_name(name);
+  plugin->set_filename(filename);
+  plugin->set_innerxml(innerxml);
+
+  msgs::Boolean res;
+  bool result;
+  unsigned int timeout = 5000;
+  std::string service{"/world/" + this->dataPtr->worldName +
+      "/entity/system/add"};
+  if (!this->dataPtr->node.Request(service, req, timeout, res, result))
+  {
+    ignerr << "Error adding new system to entity: "
+           << this->dataPtr->entity << "\n"
+           << "Name: " << name << "\n"
+           << "Filename: " << filename << "\n"
+           << "Inner XML: " << innerxml << std::endl;
+  }
 }
 
 // Register this plugin

--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -19,7 +19,6 @@
 #include <list>
 #include <regex>
 #include <unordered_map>
-#include <QColorDialog>
 #include <ignition/common/Console.hh>
 #include <ignition/common/Profiler.hh>
 #include <ignition/gui/Application.hh>
@@ -346,22 +345,22 @@ void ignition::gazebo::setData(QStandardItem *_item,
   _item->setData(QString("Material"),
       ComponentsModel::RoleNames().key("dataType"));
   _item->setData(QList({
-    QVariant(_data.Ambient().R() * 255),
-    QVariant(_data.Ambient().G() * 255),
-    QVariant(_data.Ambient().B() * 255),
-    QVariant(_data.Ambient().A() * 255),
-    QVariant(_data.Diffuse().R() * 255),
-    QVariant(_data.Diffuse().G() * 255),
-    QVariant(_data.Diffuse().B() * 255),
-    QVariant(_data.Diffuse().A() * 255),
-    QVariant(_data.Specular().R() * 255),
-    QVariant(_data.Specular().G() * 255),
-    QVariant(_data.Specular().B() * 255),
-    QVariant(_data.Specular().A() * 255),
-    QVariant(_data.Emissive().R() * 255),
-    QVariant(_data.Emissive().G() * 255),
-    QVariant(_data.Emissive().B() * 255),
-    QVariant(_data.Emissive().A() * 255)
+    QVariant(_data.Ambient().R()),
+    QVariant(_data.Ambient().G()),
+    QVariant(_data.Ambient().B()),
+    QVariant(_data.Ambient().A()),
+    QVariant(_data.Diffuse().R()),
+    QVariant(_data.Diffuse().G()),
+    QVariant(_data.Diffuse().B()),
+    QVariant(_data.Diffuse().A()),
+    QVariant(_data.Specular().R()),
+    QVariant(_data.Specular().G()),
+    QVariant(_data.Specular().B()),
+    QVariant(_data.Specular().A()),
+    QVariant(_data.Emissive().R()),
+    QVariant(_data.Emissive().G()),
+    QVariant(_data.Emissive().B()),
+    QVariant(_data.Emissive().A())
   }), ComponentsModel::RoleNames().key("data"));
 
   // TODO(anyone) Only shows colors of material,
@@ -1155,55 +1154,8 @@ void ComponentInspector::OnMaterialColor(
   double _rDiffuse, double _gDiffuse, double _bDiffuse, double _aDiffuse,
   double _rSpecular, double _gSpecular, double _bSpecular, double _aSpecular,
   double _rEmissive, double _gEmissive, double _bEmissive, double _aEmissive,
-  QString _type, QColor _currColor)
+  QString /*_type*/, QColor /*_currColor*/)
 {
-  // when type is not empty, open qt color dialog
-  std::string type = _type.toStdString();
-  if (!type.empty())
-  {
-    QColor newColor = QColorDialog::getColor(
-        _currColor, nullptr, "Pick a color",
-        {QColorDialog::DontUseNativeDialog, QColorDialog::ShowAlphaChannel});
-
-    // returns if the user hits cancel
-    if (!newColor.isValid())
-      return;
-
-    if (type == "ambient")
-    {
-      _rAmbient = newColor.red();
-      _gAmbient = newColor.green();
-      _bAmbient = newColor.blue();
-      _aAmbient = newColor.alpha();
-    }
-    else if (type == "diffuse")
-    {
-      _rDiffuse = newColor.red();
-      _gDiffuse = newColor.green();
-      _bDiffuse = newColor.blue();
-      _aDiffuse = newColor.alpha();
-    }
-    else if (type == "specular")
-    {
-      _rSpecular = newColor.red();
-      _gSpecular = newColor.green();
-      _bSpecular = newColor.blue();
-      _aSpecular = newColor.alpha();
-    }
-    else if (type == "emissive")
-    {
-      _rEmissive = newColor.red();
-      _gEmissive = newColor.green();
-      _bEmissive = newColor.blue();
-      _aEmissive = newColor.alpha();
-    }
-    else
-    {
-      ignerr << "Invalid material type: " << type << std::endl;
-      return;
-    }
-  }
-
   std::function<void(const ignition::msgs::Boolean &, const bool)> cb =
       [](const ignition::msgs::Boolean &/*_rep*/, const bool _result)
   {
@@ -1216,17 +1168,13 @@ void ComponentInspector::OnMaterialColor(
   req.set_id(this->dataPtr->entity);
 
   msgs::Set(req.mutable_material()->mutable_ambient(),
-    math::Color(_rAmbient / 255.0, _gAmbient / 255.0,
-      _bAmbient / 255.0, _aAmbient / 255.0));
+    math::Color(_rAmbient, _gAmbient, _bAmbient, _aAmbient));
   msgs::Set(req.mutable_material()->mutable_diffuse(),
-    math::Color(_rDiffuse / 255.0, _gDiffuse / 255.0,
-      _bDiffuse / 255.0, _aDiffuse / 255.0));
+    math::Color(_rDiffuse, _gDiffuse, _bDiffuse, _aDiffuse));
   msgs::Set(req.mutable_material()->mutable_specular(),
-    math::Color(_rSpecular / 255.0, _gSpecular / 255.0,
-      _bSpecular / 255.0, _aSpecular / 255.0));
+    math::Color(_rSpecular, _gSpecular, _bSpecular, _aSpecular));
   msgs::Set(req.mutable_material()->mutable_emissive(),
-    math::Color(_rEmissive / 255.0, _gEmissive / 255.0,
-      _bEmissive / 255.0, _aEmissive / 255.0));
+    math::Color(_rEmissive, _gEmissive, _bEmissive, _aEmissive));
 
   auto materialCmdService = "/world/" + this->dataPtr->worldName
       + "/visual_config";

--- a/src/gui/plugins/component_inspector/ComponentInspector.hh
+++ b/src/gui/plugins/component_inspector/ComponentInspector.hh
@@ -212,6 +212,14 @@ namespace gazebo
       NOTIFY NestedModelChanged
     )
 
+    /// \brief System display name list
+    Q_PROPERTY(
+      QStringList systemNameList
+      READ SystemNameList
+      WRITE SetSystemNameList
+      NOTIFY SystemNameListChanged
+    )
+
     /// \brief Constructor
     public: ComponentInspector();
 
@@ -371,6 +379,28 @@ namespace gazebo
     /// \brief Node for communication
     /// \return Transport node
     public: transport::Node &TransportNode();
+
+    /// \brief Query system plugin info.
+    public: Q_INVOKABLE void QuerySystems();
+
+    /// \brief Get the system plugin display name list
+    /// \return A list of names that are potentially system plugins
+    public: Q_INVOKABLE QStringList SystemNameList() const;
+
+    /// \brief Set the system plugin display name list
+    /// \param[in] _systempFilenameList A list of system plugin display names
+    public: Q_INVOKABLE void SetSystemNameList(
+        const QStringList &_systemNameList);
+
+    /// \brief Notify that system plugin display name list has changed
+    signals: void SystemNameListChanged();
+
+    /// \brief Callback when a new system is to be added to an entity
+    /// \param[in] _name Name of system
+    /// \param[in] _filename Filename of system
+    /// \param[in] _innerxml Inner XML content of the system
+    public: Q_INVOKABLE void OnAddSystem(const QString &_name,
+        const QString &_filename, const QString &_innerxml);
 
     /// \internal
     /// \brief Pointer to private data.

--- a/src/gui/plugins/component_inspector/ComponentInspector.qml
+++ b/src/gui/plugins/component_inspector/ComponentInspector.qml
@@ -15,9 +15,9 @@
  *
 */
 import QtQuick 2.9
-import QtQuick.Controls 1.4
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.1
+import QtQuick.Dialogs 1.1
 import QtQuick.Layouts 1.3
 import QtQuick.Controls.Styles 1.4
 import IgnGazebo 1.0 as IgnGazebo
@@ -216,6 +216,27 @@ Rectangle {
         }
       }
 
+      ToolButton {
+        id: addSystemButton
+        checkable: false
+        text: "\u002B"
+        contentItem: Text {
+          text: addSystemButton.text
+          color: "#b5b5b5"
+          horizontalAlignment: Text.AlignHCenter
+          verticalAlignment: Text.AlignVCenter
+        }
+        visible: (entityType == "model" || entityType == "visual" ||
+                  entityType == "sensor" || entityType == "world")
+        ToolTip.text: "Add a system to this entity"
+        ToolTip.visible: hovered
+        ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+        onClicked: {
+          addSystemDialog.open()
+        }
+      }
+
+
       Label {
         id: entityLabel
         text: 'Entity ' + ComponentInspector.entity
@@ -226,6 +247,111 @@ Rectangle {
       }
     }
   }
+
+  Dialog {
+    id: addSystemDialog
+    modal: false
+    focus: true
+    title: "Add System"
+    closePolicy: Popup.CloseOnEscape
+    width: parent.width
+
+    ColumnLayout {
+      width: parent.width
+      GridLayout {
+        columns: 2
+        columnSpacing: 30
+        Text {
+          text: "Name"
+          Layout.row: 0
+          Layout.column: 0
+        }
+
+        TextField {
+          id: nameField
+          selectByMouse: true
+          Layout.row: 0
+          Layout.column: 1
+          Layout.fillWidth: true
+          Layout.minimumWidth: 250
+          onTextEdited: {
+            addSystemDialog.updateButtonState();
+          }
+          placeholderText: "Leave empty to load first plugin"
+        }
+
+        Text {
+          text: "Filename"
+          Layout.row: 1
+          Layout.column: 0
+        }
+
+        ComboBox {
+          id: filenameCB
+          Layout.row: 1
+          Layout.column: 1
+          Layout.fillWidth: true
+          Layout.minimumWidth: 250
+          model: ComponentInspector.systemNameList
+          currentIndex: 0
+          onCurrentIndexChanged: {
+            if (currentIndex < 0)
+              return;
+            addSystemDialog.updateButtonState();
+          }
+          ToolTip.visible: hovered
+          ToolTip.delay: tooltipDelay
+          ToolTip.text: currentText
+        }
+      }
+
+      Text {
+        id: innerxmlLabel
+        text: "Inner XML"
+      }
+
+      Flickable {
+        id: innerxmlFlickable
+        Layout.minimumHeight: 300
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+
+        flickableDirection: Flickable.VerticalFlick
+        TextArea.flickable: TextArea {
+          id: innerxmlField
+          wrapMode: Text.WordWrap
+          selectByMouse: true
+          textFormat: TextEdit.PlainText
+          font.pointSize: 10
+        }
+        ScrollBar.vertical: ScrollBar {
+          policy: ScrollBar.AlwaysOn
+        }
+      }
+    }
+
+    footer: DialogButtonBox {
+      id: buttons
+      standardButtons: Dialog.Ok | Dialog.Cancel
+    }
+
+    onOpened: {
+      ComponentInspector.QuerySystems();
+      addSystemDialog.updateButtonState();
+    }
+
+    onAccepted: {
+      ComponentInspector.OnAddSystem(nameField.text.trim(),
+          filenameCB.currentText.trim(), innerxmlField.text.trim())
+    }
+
+    function updateButtonState() {
+      buttons.standardButton(Dialog.Ok).enabled =
+          (filenameCB.currentText.trim() != '')
+    }
+  }
+
+
 
   ListView {
     anchors.top: header.bottom

--- a/test/integration/entity_system.cc
+++ b/test/integration/entity_system.cc
@@ -158,6 +158,54 @@ TEST_P(EntitySystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(PublishCmd))
       "/model/vehicle/cmd_vel");
 }
 
+/////////////////////////////////////////////////
+TEST_P(EntitySystemTest, SystemInfo)
+{
+  // Start server
+  ServerConfig serverConfig;
+  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
+    "/test/worlds/empty.sdf";
+  serverConfig.SetSdfFile(sdfFile);
+
+  Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  // get info on systems available
+  msgs::Empty req;
+  msgs::EntityPlugin_V res;
+  bool result;
+  unsigned int timeout = 5000;
+  std::string service{"/world/empty/system/info"};
+  transport::Node node;
+  EXPECT_TRUE(node.Request(service, req, timeout, res, result));
+  EXPECT_TRUE(result);
+
+  // verify plugins are not empty
+  EXPECT_FALSE(res.plugins().empty());
+
+  // check for a few known plugins that we know should exist in gazebo
+  std::set<std::string> knownPlugins;
+  knownPlugins.insert("user-commands-system");
+  knownPlugins.insert("physics-system");
+  knownPlugins.insert("scene-broadcaster-system");
+  knownPlugins.insert("sensors-system");
+
+  for (const auto &plugin : res.plugins())
+  {
+    for (const auto &kp : knownPlugins)
+    {
+      if (plugin.filename().find(kp) != std::string::npos)
+      {
+        knownPlugins.erase(kp);
+        break;
+      }
+    }
+  }
+  // verify all known plugins are found and removed from the set
+  EXPECT_TRUE(knownPlugins.empty());
+}
+
 // Run multiple times
 INSTANTIATE_TEST_SUITE_P(ServerRepeat, EntitySystemTest,
     ::testing::Range(1, 2));

--- a/test/worlds/diff_drive_no_plugin.sdf
+++ b/test/worlds/diff_drive_no_plugin.sdf
@@ -10,6 +10,10 @@
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">
     </plugin>
+    <plugin
+      filename="ignition-gazebo-scene-broadcaster-system"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
 
     <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

The Add System GUI plugin was added in https://github.com/gazebosim/gz-sim/pull/1549 but removed during forward port https://github.com/gazebosim/gz-sim/pull/1626. This PR restores the feature.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
