### PR TITLE
Fix from source installation instructions on Ubuntu 22.04

### DIFF
--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -61,7 +61,7 @@ feature which hasn't been released yet.
 
 1. Install tools
   ```
-  sudo apt install -y build-essential cmake g++-8 git gnupg lsb-release wget
+  sudo apt install -y build-essential cmake git gnupg lsb-release wget
   ```
 
 2. Enable the Ignition software repositories:


### PR DESCRIPTION
# 🦟 Bug fix

Following the installation instruction on Ubuntu 22.04 while using apt for installing dependencies result in the following error:
~~~
traversaro@IITICUBLAP257:~$ sudo apt install -y build-essential cmake g++-8 git gnupg lsb-release wget
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package g++-8 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'g++-8' has no installation candidate
~~~

## Summary

As `g++` is already installed by `build-essential` and the specificity of `g++-8` on Ubuntu 18.04 is already covered by Step 5, probably to fix this problem we can just remove `g++-8` from the packages installed in Step 1. 


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
