### PR TITLE
Enable inherited model topic name.

### DIFF
--- a/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
+++ b/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
@@ -253,7 +253,7 @@ void MulticopterMotorModel::Configure(const Entity &_entity,
   else
   {
     ignwarn << "No robotNamespace set using entity name.\n";
-    this->dataPtr->robotNamespace = scopedName(_entity, _ecm);
+    this->dataPtr->robotNamespace = this->dataPtr->model.Name(_ecm);
   }
 
   // Get params from SDF

--- a/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
+++ b/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
@@ -6,6 +6,7 @@
  * Copyright 2015 Markus Achtelik, ASL, ETH Zurich, Switzerland
  * Copyright 2016 Geoffrey Hunter <gbmhunter@gmail.com>
  * Copyright (C) 2019 Open Source Robotics Foundation
+ * Copyright (C) 2022 Benjamin Perseghetti, Rudis Laboratories
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +50,7 @@
 #include "ignition/gazebo/components/Wind.hh"
 #include "ignition/gazebo/Link.hh"
 #include "ignition/gazebo/Model.hh"
+#include "ignition/gazebo/Util.hh"
 
 // from rotors_gazebo_plugins/include/rotors_gazebo_plugins/common.h
 /// \brief    This class can be used to apply a first order filter on a signal.
@@ -250,7 +252,8 @@ void MulticopterMotorModel::Configure(const Entity &_entity,
   }
   else
   {
-    ignerr << "Please specify a robotNamespace.\n";
+    ignwarn << "No robotNamespace set using entity name.\n";
+    this->dataPtr->robotNamespace = scopedName(_entity, _ecm);
   }
 
   // Get params from SDF
@@ -364,6 +367,10 @@ void MulticopterMotorModel::Configure(const Entity &_entity,
     ignerr << "Failed to create topic for [" << this->dataPtr->robotNamespace
            << "]" << std::endl;
     return;
+  }
+  else
+  {
+    igndbg << "Listening to topic: " << topic << std::endl;
   }
   this->dataPtr->node.Subscribe(topic,
       &MulticopterMotorModelPrivate::OnActuatorMsg, this->dataPtr.get());


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #1688

## Summary
Allows for inheriting model name for robotNamespace when SDF element is not set and provides a debug message showing the topics it subscribes to.

![image](https://user-images.githubusercontent.com/10233412/188332692-97fa5b59-b61b-4ad4-991d-6e669b4dadd9.png)


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
