### PR TITLE
Fix loading render engine plugins in GUI

### DIFF
--- a/include/ignition/gazebo/rendering/RenderUtil.hh
+++ b/include/ignition/gazebo/rendering/RenderUtil.hh
@@ -201,6 +201,10 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     /// \brief Clears the set of selected entities and lowlights all of them.
     public: void DeselectAllEntities();
 
+    /// \brief Init render engine plugins paths. This lets gz-rendering know
+    /// paths to find render engine plugins
+    public: void InitRenderEnginePluginPaths();
+
     /// \brief Helper function to get all child links of a model entity.
     /// \param[in] _entity Entity to find child links
     /// \return Vector of child links found for the parent entity

--- a/src/gui/plugins/scene_manager/GzSceneManager.cc
+++ b/src/gui/plugins/scene_manager/GzSceneManager.cc
@@ -59,6 +59,9 @@ inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
     /// \brief Rendering utility
     public: RenderUtil renderUtil;
 
+    /// \brief True if render engine plugins paths are initialized
+    public: bool renderEnginePluginPathsInit{false};
+
     /// \brief List of new entities from a gui event
     public: std::set<Entity> newEntities;
 
@@ -122,6 +125,12 @@ void GzSceneManager::Update(const UpdateInfo &_info,
     return;
 
   IGN_PROFILE("GzSceneManager::Update");
+
+  if (!this->dataPtr->renderEnginePluginPathsInit)
+  {
+    this->dataPtr->renderUtil.InitRenderEnginePluginPaths();
+    this->dataPtr->renderEnginePluginPathsInit = true;
+  }
 
   this->dataPtr->renderUtil.UpdateECM(_info, _ecm);
 

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -2497,15 +2497,21 @@ bool RenderUtil::HeadlessRendering() const
 }
 
 /////////////////////////////////////////////////
+void RenderUtil::InitRenderEnginePluginPaths()
+{
+  ignition::common::SystemPaths pluginPath;
+  pluginPath.SetPluginPathEnv(kRenderPluginPathEnv);
+  rendering::setPluginPaths(pluginPath.PluginPaths());
+}
+
+/////////////////////////////////////////////////
 void RenderUtil::Init()
 {
   // Already initialized
   if (nullptr != this->dataPtr->scene)
     return;
 
-  ignition::common::SystemPaths pluginPath;
-  pluginPath.SetPluginPathEnv(kRenderPluginPathEnv);
-  rendering::setPluginPaths(pluginPath.PluginPaths());
+  this->InitRenderEnginePluginPaths();
 
   std::map<std::string, std::string> params;
   if (this->dataPtr->useCurrentGLContext)


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

When going over [the rendering plugin tutorial](https://gazebosim.org/api/rendering/6/renderingplugin.html), I noticed that gazebo does not load external render engine plugins any more when the GUI is launched. This fixes the issue.

More info:

Gazebo GUI no longer calls `RenderUtil::Init` which is responsible for setting the render engine plugin paths in gz-rendering. This may have been the caused by the separation of the `Scene3D` plugin into `MinimalScene` and  `GzSceneManager` done some time ago. This PR adds a separate function call for setting up the render plugin paths.

To test, go through the [tutorial](https://gazebosim.org/api/rendering/6/renderingplugin.html). Without the changes in this PR, gazebo will output a msg about not being able to find the `HelloWorldPlugin`. 

## Summary

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

