### PR TITLE
Remove actors from screen when they are supposed to

### DIFF
--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -1109,9 +1109,7 @@ void RenderUtilPrivate::RemoveRenderingEntities(
       {
         this->removeEntities[_entity] = _info.iterations;
         this->entityPoses.erase(_entity);
-        this->actorAnimationData.erase(_entity);
         this->actorTransforms.erase(_entity);
-        this->trajectoryPoses.erase(_entity);
         return true;
       });
   _ecm.EachRemoved<components::Model>(

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -1104,6 +1104,16 @@ void RenderUtilPrivate::RemoveRenderingEntities(
     const EntityComponentManager &_ecm, const UpdateInfo &_info)
 {
   IGN_PROFILE("RenderUtilPrivate::RemoveRenderingEntities");
+  _ecm.EachRemoved<components::Actor>(
+      [&](const Entity &_entity, const components::Actor *)->bool
+      {
+        this->removeEntities[_entity] = _info.iterations;
+        this->entityPoses.erase(_entity);
+        this->actorAnimationData.erase(_entity);
+        this->actorTransforms.erase(_entity);
+        this->trajectoryPoses.erase(_entity);
+        return true;
+      });
   _ecm.EachRemoved<components::Model>(
       [&](const Entity &_entity, const components::Model *)->bool
       {

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -1127,6 +1127,28 @@ void SceneManager::RemoveEntity(Entity _id)
     return;
 
   {
+    auto it = this->dataPtr->actors.find(_id);
+    if (it != this->dataPtr->actors.end())
+    {
+      this->dataPtr->actors.erase(it);
+    }
+  }
+  {
+    auto it = this->dataPtr->actorTrajectories.find(_id);
+    if (it != this->dataPtr->actorTrajectories.end())
+    {
+      this->dataPtr->actorTrajectories.erase(it);
+    }
+  }
+  {
+    auto it = this->dataPtr->actorSkeletons.find(_id);
+    if (it != this->dataPtr->actorSkeletons.end())
+    {
+      this->dataPtr->actorSkeletons.erase(it);
+    }
+  }
+
+  {
     auto it = this->dataPtr->visuals.find(_id);
     if (it != this->dataPtr->visuals.end())
     {


### PR DESCRIPTION
# 🦟 Bug fix

Supercedes #1697.  Note: When forward porting we will have to update the hashmaps to erase the new hashmaps created.

Fixes #<NUMBER>

## Summary
Found that when actors are De-spawned the actor visuals are not destroyed. This commit addresses this bug by adding the missing remove logic in RenderUtils.

## Before
![bug](https://user-images.githubusercontent.com/542272/189558600-196d98c5-1dcf-4d6c-93d6-7493df38c0e4.gif)

## After
![no_bug](https://user-images.githubusercontent.com/542272/189558924-3f2e3c5d-68f3-4d80-aee4-3dc3ce6742a1.gif)

## Notes:
Theres a lot of hashmaps being populated in RenderUtils whenever a new actor is spawned. I hope I've caught them all. 
Also while I need these working in garden (as all the projects Im working on use garden), should I backport these changes?

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
