### PR TITLE
Lock step video recording is broken, disabling

### DIFF
--- a/examples/worlds/minimal_scene.sdf
+++ b/examples/worlds/minimal_scene.sdf
@@ -245,7 +245,7 @@ Features:
 
         <record_video>
           <use_sim_time>true</use_sim_time>
-          <lockstep>true</lockstep>
+          <lockstep>false</lockstep>
           <bitrate>4000000</bitrate>
         </record_video>
       </plugin>

--- a/examples/worlds/video_record_dbl_pendulum.sdf
+++ b/examples/worlds/video_record_dbl_pendulum.sdf
@@ -219,7 +219,7 @@
 
         <record_video>
           <use_sim_time>true</use_sim_time>
-          <lockstep>true</lockstep>
+          <lockstep>false</lockstep>
           <bitrate>4000000</bitrate>
         </record_video>
       </plugin>


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🦟 Bug fix

Lock step video recording is broken. Attempting to record a video with lock step enabled causes the GUI to deadlock.
Here is the issue: https://github.com/gazebosim/gz-sim/issues/1706

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.