### PR TITLE
Fix shader params system on macOS

### DIFF
--- a/src/systems/shader_param/ShaderParam.cc
+++ b/src/systems/shader_param/ShaderParam.cc
@@ -306,8 +306,6 @@ void ShaderParamPrivate::OnUpdate()
   {
     auto mat = scene->CreateMaterial();
 
-    bool shadersSet = false;
-
     if (scene->Engine() && scene->Engine()->GraphicsAPI() ==
         rendering::GraphicsAPI::METAL)
     {

--- a/src/systems/shader_param/ShaderParam.cc
+++ b/src/systems/shader_param/ShaderParam.cc
@@ -27,6 +27,7 @@
 #include <gz/common/Profiler.hh>
 #include <gz/plugin/Register.hh>
 #include <gz/rendering/Material.hh>
+#include <gz/rendering/RenderEngine.hh>
 #include <gz/rendering/RenderingIface.hh>
 #include <gz/rendering/Scene.hh>
 #include <gz/rendering/ShaderParams.hh>
@@ -305,29 +306,32 @@ void ShaderParamPrivate::OnUpdate()
   {
     auto mat = scene->CreateMaterial();
 
-    // default to glsl
-    auto it = this->shaders.find("glsl");
-    if (it != this->shaders.end())
+    bool shadersSet = false;
+
+    if (scene->Engine() && scene->Engine()->GraphicsAPI() ==
+        rendering::GraphicsAPI::METAL)
     {
-      mat->SetVertexShader(it->second.vertexShaderUri);
-      mat->SetFragmentShader(it->second.fragmentShaderUri);
-    }
-    // prefer metal over glsl on macOS
-    // \todo(anyone) instead of using ifdef to check for macOS,
-    // expose add an accessor function to get the GraphicsApi
-    // from rendering::RenderEngine
-#ifdef __APPLE__
-    auto metalIt = this->shaders.find("metal");
-    if (metalIt != this->shaders.end())
-    {
-      mat->SetVertexShader(metalIt->second.vertexShaderUri);
-      mat->SetFragmentShader(metalIt->second.fragmentShaderUri);
-      // if both glsl and metal are specified, print a msg to inform that
-      // metal is used instead of glsl
-      if (it != this->shaders.end())
+      // metal
+      auto metalIt = this->shaders.find("metal");
+      if (metalIt != this->shaders.end())
+      {
+        mat->SetVertexShader(metalIt->second.vertexShaderUri);
+        mat->SetFragmentShader(metalIt->second.fragmentShaderUri);
         gzmsg << "Using metal shaders. " << std::endl;
+      }
     }
-#endif
+    else
+    {
+      //  try glsl for all others
+      auto it = this->shaders.find("glsl");
+      if (it != this->shaders.end())
+      {
+        mat->SetVertexShader(it->second.vertexShaderUri);
+        mat->SetFragmentShader(it->second.fragmentShaderUri);
+        gzmsg << "Using glsll shaders. " << std::endl;
+      }
+    }
+
     this->visual->SetMaterial(mat);
     scene->DestroyMaterial(mat);
     this->material = this->visual->Material();

--- a/src/systems/shader_param/ShaderParam.cc
+++ b/src/systems/shader_param/ShaderParam.cc
@@ -326,7 +326,7 @@ void ShaderParamPrivate::OnUpdate()
       {
         mat->SetVertexShader(it->second.vertexShaderUri);
         mat->SetFragmentShader(it->second.fragmentShaderUri);
-        gzmsg << "Using glsll shaders. " << std::endl;
+        gzmsg << "Using glsl shaders. " << std::endl;
       }
     }
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Loading the `shader_param.sdf` example world file currently crashes on macOS as it tries to compile glsl shaders before the metal shaders. This PR checks the current rendering API and only try to load the correct shader type.

to test, launch `shader_param.sdf` world on macOS and it should no longer crash

```
# in one terminal
gz sim -s -v 4 shader_param.sdf

# in another terminal
gz sim -v 4  -g
```
<img width="1312" alt="shader_param_macos sdf" src="https://user-images.githubusercontent.com/4000684/190481828-8fbeb9fe-9851-4665-9ce5-50b584ef3c2b.png">




## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
