### PR TITLE
Update examples for `camera_sensor` and `depth_camera_sensor`

### DIFF
--- a/examples/worlds/camera_sensor.sdf
+++ b/examples/worlds/camera_sensor.sdf
@@ -136,6 +136,7 @@
         <gz-gui>
           <property key="state" type="string">docked</property>
         </gz-gui>
+        <topic>camera</topic>
       </plugin>
 
       <!-- Inspector -->

--- a/examples/worlds/depth_camera_sensor.sdf
+++ b/examples/worlds/depth_camera_sensor.sdf
@@ -75,6 +75,28 @@
           <property key="showTitleBar" type="bool">false</property>
         </gz-gui>
       </plugin>
+      <!-- World control -->
+      <plugin filename="WorldControl" name="World control">
+        <gz-gui>
+          <title>World control</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="bool" key="resizable">false</property>
+          <property type="double" key="height">72</property>
+          <property type="double" key="width">121</property>
+          <property type="double" key="z">1</property>
+
+          <property type="string" key="state">floating</property>
+          <anchors target="3D View">
+            <line own="left" target="left"/>
+            <line own="bottom" target="bottom"/>
+          </anchors>
+        </gz-gui>
+
+        <play_pause>true</play_pause>
+        <step>true</step>
+        <start_paused>true</start_paused>
+        <use_event>true</use_event>
+      </plugin>
 
       <plugin filename="ImageDisplay" name="Image Display">
         <gz-gui>

--- a/examples/worlds/depth_camera_sensor.sdf
+++ b/examples/worlds/depth_camera_sensor.sdf
@@ -102,6 +102,7 @@
         <gz-gui>
           <property key="state" type="string">docked</property>
         </gz-gui>
+        <topic>depth_camera</topic>
       </plugin>
     </gui>
 


### PR DESCRIPTION
Tiny edits of example SDF files.
- Add default topics for the image viewers, such that the output is immediately visible when running these examples.
- Add WorldControl for `depth_camera_sensor` in order to enable starting the simulation even without running the example with `-r` flag.


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
