### PR TITLE
Update URL in tutorial for `python_interfaces`

### DIFF
--- a/tutorials/python_interfaces.md
+++ b/tutorials/python_interfaces.md
@@ -43,7 +43,7 @@ server.run(True, 1000, False)
 # Run the example
 
 In the
-[examples/scripts/python_api](https://github.com/gazebosim/gz-sim/blob/ign-gazebo7/examples/scripts/python_api)
+[examples/scripts/python_api](https://github.com/gazebosim/gz-sim/tree/gz-sim7/examples/scripts/python_api)
 folder there is a Python script that shows how to make use of this API.
 
 If you compiled Gazebo from source you should modify your `PYTHONPATH`:


### PR DESCRIPTION
The current URL is invalid because there is no `ign-gazebo7` branch.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
