### PR TITLE
Update examples to used gazebosim

### DIFF
--- a/examples/plugin/command_actor/command_actor.sdf
+++ b/examples/plugin/command_actor/command_actor.sdf
@@ -52,7 +52,7 @@
 
     <include>
       <pose>1 1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
       <plugin filename="CommandActor"
               name="command_actor::CommandActor">
 

--- a/examples/plugin/reset_plugin/joint_position_randomizer.sdf
+++ b/examples/plugin/reset_plugin/joint_position_randomizer.sdf
@@ -37,7 +37,7 @@
       </link>
     </model>
     <include>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Simple Arm</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Simple Arm</uri>
       <plugin filename="build/libJointPositionRandomizer.so" name="reset_plugin::JointPositionRandomizer"/>
     </include>
   </world>

--- a/examples/scripts/log_video_recorder/README.md
+++ b/examples/scripts/log_video_recorder/README.md
@@ -40,7 +40,7 @@ timestamped directory where the `record_one_run.bash` is in.
 ## Troubleshooting
 
 1. The world / models are not being loaded on log playback?
-    A: Make sure you have all the fuel models downloaded in ~/.ignition/fuel cache
+    A: Make sure you have all the fuel models downloaded in ~/.gz/fuel cache
 directory
 
 1. I see `tmp_record` dir, `tmp_recording.mp4` and other left over mp4 files

--- a/examples/standalone/joy_to_twist/README.md
+++ b/examples/standalone/joy_to_twist/README.md
@@ -1,9 +1,9 @@
 # Joy to Twist
 
 Standalone program that subscribes to
-[gz::msgs::Joy](https://gazebosim.org/api/msgs/5.6/classignition_1_1msgs_1_1Joy.html)
+[gz::msgs::Joy](https://gazebosim.org/api/msgs/9/classgz_1_1msgs_1_1Joy.html)
 messages and converts publishes
-[gz::msgs::Twist](https://gazebosim.org/api/msgs/5.6/classignition_1_1msgs_1_1Twist.html)
+[gz::msgs::Twist](https://gazebosim.org/api/msgs/9/classgz_1_1msgs_1_1Twist.html)
 messages according to user-defined configuration.
 
 ## Build

--- a/examples/standalone/joystick/README.md
+++ b/examples/standalone/joystick/README.md
@@ -1,7 +1,7 @@
 # Joystick
 
 Standalone program that publishes
-[gz::msgs::Joy](https://gazebosim.org/api/msgs/5.6/classignition_1_1msgs_1_1Joy.html)
+[gz::msgs::Joy](https://gazebosim.org/api/msgs/9/classgz_1_1msgs_1_1Joy.html)
 messages from a joystick device using Gazebo Transport.
 
 The mapping of joystick buttons to fields in the message is the same as [this](http://wiki.ros.org/joy).

--- a/examples/worlds/actor.sdf
+++ b/examples/worlds/actor.sdf
@@ -67,16 +67,16 @@
       <name>demo_actor</name>
       <!-- override actor's pose, which has 1m in Z -->
       <pose>0 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <actor name="actor_talking">
       <skin>
-        <filename>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor/tip/files/meshes/talk_b.dae</filename>
+        <filename>https://fuel.gazebosim.org/1.0/Mingfei/models/actor/tip/files/meshes/talk_b.dae</filename>
         <scale>1.0</scale>
       </skin>
       <animation name="talk_b">
-        <filename>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor/tip/files/meshes/talk_b.dae</filename>
+        <filename>https://fuel.gazebosim.org/1.0/Mingfei/models/actor/tip/files/meshes/talk_b.dae</filename>
         <scale>0.055</scale>
         <interpolate_x>true</interpolate_x>
       </animation>
@@ -167,11 +167,11 @@
 
     <actor name="actor_walking">
       <skin>
-        <filename>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor/tip/files/meshes/walk.dae</filename>
+        <filename>https://fuel.gazebosim.org/1.0/Mingfei/models/actor/tip/files/meshes/walk.dae</filename>
         <scale>1.0</scale>
       </skin>
       <animation name="walk">
-        <filename>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor/tip/files/meshes/walk.dae</filename>
+        <filename>https://fuel.gazebosim.org/1.0/Mingfei/models/actor/tip/files/meshes/walk.dae</filename>
         <interpolate_x>true</interpolate_x>
       </animation>
       <script>

--- a/examples/worlds/actor_crowd.sdf
+++ b/examples/worlds/actor_crowd.sdf
@@ -61,727 +61,727 @@
     <include>
       <name>demo_actor_0_0</name>
       <pose>-5 -5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_0_1</name>
       <pose>-5 -4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_0_2</name>
       <pose>-5 -3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_0_3</name>
       <pose>-5 -2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_0_4</name>
       <pose>-5 -1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_0_5</name>
       <pose>-5 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_0_6</name>
       <pose>-5 1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_0_7</name>
       <pose>-5 2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_0_8</name>
       <pose>-5 3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_0_9</name>
       <pose>-5 4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_0_10</name>
       <pose>-5 5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_1_0</name>
       <pose>-4 -5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_1_1</name>
       <pose>-4 -4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_1_2</name>
       <pose>-4 -3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_1_3</name>
       <pose>-4 -2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_1_4</name>
       <pose>-4 -1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_1_5</name>
       <pose>-4 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_1_6</name>
       <pose>-4 1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_1_7</name>
       <pose>-4 2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_1_8</name>
       <pose>-4 3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_1_9</name>
       <pose>-4 4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_1_10</name>
       <pose>-4 5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_2_0</name>
       <pose>-3 -5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_2_1</name>
       <pose>-3 -4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_2_2</name>
       <pose>-3 -3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_2_3</name>
       <pose>-3 -2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_2_4</name>
       <pose>-3 -1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_2_5</name>
       <pose>-3 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_2_6</name>
       <pose>-3 1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_2_7</name>
       <pose>-3 2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_2_8</name>
       <pose>-3 3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_2_9</name>
       <pose>-3 4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_2_10</name>
       <pose>-3 5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_3_0</name>
       <pose>-2 -5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_3_1</name>
       <pose>-2 -4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_3_2</name>
       <pose>-2 -3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_3_3</name>
       <pose>-2 -2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_3_4</name>
       <pose>-2 -1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_3_5</name>
       <pose>-2 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_3_6</name>
       <pose>-2 1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_3_7</name>
       <pose>-2 2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_3_8</name>
       <pose>-2 3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_3_9</name>
       <pose>-2 4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_3_10</name>
       <pose>-2 5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_4_0</name>
       <pose>-1 -5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_4_1</name>
       <pose>-1 -4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_4_2</name>
       <pose>-1 -3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_4_3</name>
       <pose>-1 -2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_4_4</name>
       <pose>-1 -1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_4_5</name>
       <pose>-1 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_4_6</name>
       <pose>-1 1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_4_7</name>
       <pose>-1 2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_4_8</name>
       <pose>-1 3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_4_9</name>
       <pose>-1 4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_4_10</name>
       <pose>-1 5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_5_0</name>
       <pose>0 -5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_5_1</name>
       <pose>0 -4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_5_2</name>
       <pose>0 -3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_5_3</name>
       <pose>0 -2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_5_4</name>
       <pose>0 -1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_5_5</name>
       <pose>0 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_5_6</name>
       <pose>0 1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_5_7</name>
       <pose>0 2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_5_8</name>
       <pose>0 3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_5_9</name>
       <pose>0 4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_5_10</name>
       <pose>0 5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_6_0</name>
       <pose>1 -5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_6_1</name>
       <pose>1 -4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_6_2</name>
       <pose>1 -3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_6_3</name>
       <pose>1 -2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_6_4</name>
       <pose>1 -1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_6_5</name>
       <pose>1 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_6_6</name>
       <pose>1 1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_6_7</name>
       <pose>1 2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_6_8</name>
       <pose>1 3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_6_9</name>
       <pose>1 4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_6_10</name>
       <pose>1 5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_7_0</name>
       <pose>2 -5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_7_1</name>
       <pose>2 -4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_7_2</name>
       <pose>2 -3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_7_3</name>
       <pose>2 -2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_7_4</name>
       <pose>2 -1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_7_5</name>
       <pose>2 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_7_6</name>
       <pose>2 1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_7_7</name>
       <pose>2 2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_7_8</name>
       <pose>2 3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_7_9</name>
       <pose>2 4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_7_10</name>
       <pose>2 5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_8_0</name>
       <pose>3 -5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_8_1</name>
       <pose>3 -4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_8_2</name>
       <pose>3 -3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_8_3</name>
       <pose>3 -2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_8_4</name>
       <pose>3 -1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_8_5</name>
       <pose>3 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_8_6</name>
       <pose>3 1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_8_7</name>
       <pose>3 2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_8_8</name>
       <pose>3 3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_8_9</name>
       <pose>3 4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_8_10</name>
       <pose>3 5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_9_0</name>
       <pose>4 -5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_9_1</name>
       <pose>4 -4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_9_2</name>
       <pose>4 -3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_9_3</name>
       <pose>4 -2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_9_4</name>
       <pose>4 -1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_9_5</name>
       <pose>4 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_9_6</name>
       <pose>4 1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_9_7</name>
       <pose>4 2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_9_8</name>
       <pose>4 3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_9_9</name>
       <pose>4 4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_9_10</name>
       <pose>4 5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_10_0</name>
       <pose>5 -5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_10_1</name>
       <pose>5 -4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_10_2</name>
       <pose>5 -3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_10_3</name>
       <pose>5 -2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_10_4</name>
       <pose>5 -1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_10_5</name>
       <pose>5 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_10_6</name>
       <pose>5 1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_10_7</name>
       <pose>5 2 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_10_8</name>
       <pose>5 3 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_10_9</name>
       <pose>5 4 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
     <include>
       <name>demo_actor_10_10</name>
       <pose>5 5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
     </include>
 
 

--- a/examples/worlds/actors_population.sdf.erb
+++ b/examples/worlds/actors_population.sdf.erb
@@ -84,11 +84,11 @@
 
     <actor name="actor_<%= j*column + i %>">
       <skin>
-        <filename>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor/tip/files/meshes/talk_b.dae</filename>
+        <filename>https://fuel.gazebosim.org/1.0/Mingfei/models/actor/tip/files/meshes/talk_b.dae</filename>
         <scale>1.0</scale>
       </skin>
       <animation name="talk_b">
-        <filename>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor/tip/files/meshes/talk_b.dae</filename>
+        <filename>https://fuel.gazebosim.org/1.0/Mingfei/models/actor/tip/files/meshes/talk_b.dae</filename>
         <scale>0.055</scale>
         <interpolate_x>true</interpolate_x>
       </animation>

--- a/examples/worlds/auv_controls.sdf
+++ b/examples/worlds/auv_controls.sdf
@@ -71,7 +71,7 @@
 
     <include>
       <pose>0 0 1 0 0 1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/accurrent/models/MBARI%20Tethys%20LRAUV</uri>
+      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI%20Tethys%20LRAUV</uri>
 
       <!-- Joint controllers -->
       <plugin

--- a/examples/worlds/boundingbox_camera.sdf
+++ b/examples/worlds/boundingbox_camera.sdf
@@ -403,7 +403,7 @@
     <include>
       <pose>-1 0 3 0.0 0.0 1.57</pose>
       <uri>
-      https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Construction Cone
+      https://fuel.gazebosim.org/1.0/OpenRobotics/models/Construction Cone
       </uri>
       <plugin filename="gz-sim-label-system" name="gz::sim::systems::Label">
         <label>30</label>

--- a/examples/worlds/breadcrumbs.sdf
+++ b/examples/worlds/breadcrumbs.sdf
@@ -404,7 +404,7 @@
               <pose>-2 0 0 0 0 0</pose>
               <include>
                 <uri>
-                  https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/X2 Config 1
+                  https://fuel.gazebosim.org/1.0/OpenRobotics/models/X2 Config 1
                 </uri>
               </include>
             </model>

--- a/examples/worlds/camera_sensor.sdf
+++ b/examples/worlds/camera_sensor.sdf
@@ -307,7 +307,7 @@
     <include>
       <pose>0 1 3 0.0 0.0 1.57</pose>
       <uri>
-      https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Construction Cone
+      https://fuel.gazebosim.org/1.0/OpenRobotics/models/Construction Cone
       </uri>
     </include>
 

--- a/examples/worlds/dem_monterey_bay.sdf
+++ b/examples/worlds/dem_monterey_bay.sdf
@@ -138,7 +138,7 @@
 
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/jennuine/models/Monterey Bay
+        https://fuel.gazebosim.org/1.0/jennuine/models/Monterey Bay
       </uri>
     </include>
   </world>

--- a/examples/worlds/dem_moon.sdf
+++ b/examples/worlds/dem_moon.sdf
@@ -23,11 +23,11 @@
 
     <gui fullscreen="0">
       <plugin filename="MinimalScene" name="3D View">
-        <ignition-gui>
+        <gz-gui>
           <title>3D View</title>
           <property type="bool" key="showTitleBar">false</property>
           <property type="string" key="state">docked</property>
-        </ignition-gui>
+        </gz-gui>
 
         <engine>ogre</engine>
         <scene>scene</scene>
@@ -38,42 +38,42 @@
 
       <!-- Plugins that add functionality to the scene -->
       <plugin filename="EntityContextMenuPlugin" name="Entity context menu">
-        <ignition-gui>
+        <gz-gui>
           <property key="state" type="string">floating</property>
           <property key="width" type="double">5</property>
           <property key="height" type="double">5</property>
           <property key="showTitleBar" type="bool">false</property>
-        </ignition-gui>
+        </gz-gui>
       </plugin>
       <plugin filename="GzSceneManager" name="Scene Manager">
-        <ignition-gui>
+        <gz-gui>
           <property key="resizable" type="bool">false</property>
           <property key="width" type="double">5</property>
           <property key="height" type="double">5</property>
           <property key="state" type="string">floating</property>
           <property key="showTitleBar" type="bool">false</property>
-        </ignition-gui>
+        </gz-gui>
       </plugin>
       <plugin filename="InteractiveViewControl" name="Interactive view control">
-        <ignition-gui>
+        <gz-gui>
           <property key="resizable" type="bool">false</property>
           <property key="width" type="double">5</property>
           <property key="height" type="double">5</property>
           <property key="state" type="string">floating</property>
           <property key="showTitleBar" type="bool">false</property>
-        </ignition-gui>
+        </gz-gui>
       </plugin>
       <plugin filename="CameraTracking" name="Camera Tracking">
-        <ignition-gui>
+        <gz-gui>
           <property key="resizable" type="bool">false</property>
           <property key="width" type="double">5</property>
           <property key="height" type="double">5</property>
           <property key="state" type="string">floating</property>
           <property key="showTitleBar" type="bool">false</property>
-        </ignition-gui>
+        </gz-gui>
       </plugin>
       <plugin filename="WorldControl" name="World control">
-        <ignition-gui>
+        <gz-gui>
           <title>World control</title>
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
@@ -86,7 +86,7 @@
             <line own="left" target="left"/>
             <line own="bottom" target="bottom"/>
           </anchors>
-        </ignition-gui>
+        </gz-gui>
 
         <play_pause>true</play_pause>
         <step>true</step>
@@ -96,7 +96,7 @@
       </plugin>
 
       <plugin filename="WorldStats" name="World stats">
-        <ignition-gui>
+        <gz-gui>
           <title>World stats</title>
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
@@ -109,7 +109,7 @@
             <line own="right" target="right"/>
             <line own="bottom" target="bottom"/>
           </anchors>
-        </ignition-gui>
+        </gz-gui>
 
         <sim_time>true</sim_time>
         <real_time>true</real_time>
@@ -118,15 +118,15 @@
       </plugin>
 
       <plugin filename="ComponentInspector" name="Component inspector">
-        <ignition-gui>
+        <gz-gui>
           <property type="string" key="state">docked</property>
-        </ignition-gui>
+        </gz-gui>
       </plugin>
 
       <plugin filename="EntityTree" name="Entity tree">
-        <ignition-gui>
+        <gz-gui>
           <property type="string" key="state">docked</property>
-        </ignition-gui>
+        </gz-gui>
       </plugin>
     </gui>
 
@@ -183,7 +183,7 @@
 
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Moon DEM
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Moon DEM
       </uri>
     </include>
 

--- a/examples/worlds/dem_volcano.sdf
+++ b/examples/worlds/dem_volcano.sdf
@@ -175,7 +175,7 @@
 
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/jennuine/models/Volcano
+        https://fuel.gazebosim.org/1.0/jennuine/models/Volcano
       </uri>
     </include>
   </world>

--- a/examples/worlds/depth_camera_sensor.sdf
+++ b/examples/worlds/depth_camera_sensor.sdf
@@ -216,7 +216,7 @@
     <include>
       <pose>0 1 3 0.0 0.0 1.57</pose>
       <uri>
-      https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Construction Barrel
+      https://fuel.gazebosim.org/1.0/OpenRobotics/models/Construction Barrel
       </uri>
     </include>
 

--- a/examples/worlds/elevator.sdf
+++ b/examples/worlds/elevator.sdf
@@ -73,7 +73,7 @@
     </model>
 
     <include>
-      <uri>https://fuel.ignitionrobotics.org/1.0/nlamprian/models/Elevator</uri>
+      <uri>https://fuel.gazebosim.org/1.0/nlamprian/models/Elevator</uri>
     </include>
 
   </world>

--- a/examples/worlds/follow_actor.sdf
+++ b/examples/worlds/follow_actor.sdf
@@ -215,7 +215,7 @@
       <name>walker_slow_red</name>
       <!-- Root node pose (torso) -->
       <pose>0 -2 1.0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/chapulina/models/Walking actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/chapulina/models/Walking actor</uri>
       <plugin filename="gz-sim-follow-actor-system"
               name="gz::sim::systems::FollowActor">
         <target>red_box</target>
@@ -229,7 +229,7 @@
     <include>
       <name>walker_fast_green</name>
       <pose>0 0 1.0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/chapulina/models/Walking actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/chapulina/models/Walking actor</uri>
       <plugin filename="gz-sim-follow-actor-system"
               name="gz::sim::systems::FollowActor">
         <target>green_box</target>
@@ -243,7 +243,7 @@
     <include>
       <name>runner_slow_blue</name>
       <pose>0 2 1.0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
       <plugin filename="gz-sim-follow-actor-system"
               name="gz::sim::systems::FollowActor">
         <target>blue_box</target>
@@ -258,7 +258,7 @@
     <include>
       <name>runner_fast_yellow</name>
       <pose>0 4 1.0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/Mingfei/models/actor</uri>
+      <uri>https://fuel.gazebosim.org/1.0/Mingfei/models/actor</uri>
       <plugin filename="gz-sim-follow-actor-system"
               name="gz::sim::systems::FollowActor">
         <target>yellow_box</target>

--- a/examples/worlds/fuel.sdf
+++ b/examples/worlds/fuel.sdf
@@ -62,27 +62,27 @@
     <include>
       <name>Double pendulum</name>
       <pose>-3 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Double pendulum with base</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Double pendulum with base</uri>
     </include>
 
     <!-- Included model with meshes -->
     <include>
       <pose>3 -1 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack</uri>
     </include>
 
     <!-- Included model with meshes using relative paths -->
     <include>
       <name>Gazebo (relative paths)</name>
       <pose>2 5 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Gazebo - relative paths</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Gazebo - relative paths</uri>
     </include>
 
     <!-- Included actor with meshes using relative paths -->
     <include>
       <name>Actor Test</name>
       <pose>0 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/actor - relative paths</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/actor - relative paths</uri>
     </include>
 
     <!-- Model with meshes -->
@@ -93,14 +93,14 @@
         <collision name="collision">
           <geometry>
             <mesh>
-              <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Radio/4/files/meshes/Radio.dae</uri>
+              <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Radio/4/files/meshes/Radio.dae</uri>
             </mesh>
           </geometry>
         </collision>
         <visual name="visual">
           <geometry>
             <mesh>
-              <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Radio/4/files/meshes/Radio.dae</uri>
+              <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Radio/4/files/meshes/Radio.dae</uri>
             </mesh>
           </geometry>
         </visual>
@@ -116,18 +116,18 @@
             <heightmap>
               <use_terrain_paging>false</use_terrain_paging>
               <texture>
-                <diffuse>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/dirt_diffusespecular.png</diffuse>
-                <normal>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/flat_normal.png</normal>
+                <diffuse>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/dirt_diffusespecular.png</diffuse>
+                <normal>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/flat_normal.png</normal>
                 <size>10</size>
               </texture>
               <texture>
-                <diffuse>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/grass_diffusespecular.png</diffuse>
-                <normal>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/flat_normal.png</normal>
+                <diffuse>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/grass_diffusespecular.png</diffuse>
+                <normal>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/flat_normal.png</normal>
                 <size>10</size>
               </texture>
               <texture>
-                <diffuse>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/fungus_diffusespecular.png</diffuse>
-                <normal>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/flat_normal.png</normal>
+                <diffuse>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/fungus_diffusespecular.png</diffuse>
+                <normal>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/flat_normal.png</normal>
                 <size>10</size>
               </texture>
               <blend>
@@ -138,7 +138,7 @@
                 <min_height>35</min_height>
                 <fade_dist>18</fade_dist>
               </blend>
-              <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/fortress_heightmap.png</uri>
+              <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/fortress_heightmap.png</uri>
               <size>257 257 50</size>
               <pos>0 0 -28</pos>
             </heightmap>
@@ -147,7 +147,7 @@
         <collision name="collision">
           <geometry>
             <heightmap>
-              <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/fortress_heightmap.png</uri>
+              <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Fortress heightmap/tip/files/materials/textures/fortress_heightmap.png</uri>
               <size>257 257 50</size>
               <pos>0 0 -28</pos>
             </heightmap>

--- a/examples/worlds/fuel_textured_mesh.sdf
+++ b/examples/worlds/fuel_textured_mesh.sdf
@@ -202,7 +202,7 @@
       <static>true</static>
       <name>Rescue Randy</name>
       <pose>0 0 0 0 0 1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Rescue Randy</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Rescue Randy</uri>
     </include>
 
     <!-- Tube Light -->
@@ -210,7 +210,7 @@
       <static>true</static>
       <name>Tube Light</name>
       <pose>1.5 0 3 0 0.78 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Tube Light</uri>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/Tube Light</uri>
     </include>
 
     <light type="spot" name="tube_light">

--- a/examples/worlds/gpu_lidar_sensor.sdf
+++ b/examples/worlds/gpu_lidar_sensor.sdf
@@ -169,7 +169,7 @@
     <include>
       <pose>0 0 0 0 0 1.57</pose>
       <uri>
-      https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Playground
+      https://fuel.gazebosim.org/1.0/OpenRobotics/models/Playground
       </uri>
     </include>
 

--- a/examples/worlds/heightmap.sdf
+++ b/examples/worlds/heightmap.sdf
@@ -173,7 +173,7 @@
 
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/chapulina/models/Heightmap Bowl
+        https://fuel.gazebosim.org/1.0/chapulina/models/Heightmap Bowl
       </uri>
     </include>
   </world>

--- a/examples/worlds/import_mesh.sdf
+++ b/examples/worlds/import_mesh.sdf
@@ -75,7 +75,7 @@
       <static>true</static>
       <name>Electrical Box</name>
       <pose>0 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Electrical Box</uri>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/Electrical Box</uri>
     </include>
 
   </world>

--- a/examples/worlds/lightmap.sdf
+++ b/examples/worlds/lightmap.sdf
@@ -22,7 +22,7 @@ There are no dynamic lights or shadows in the scene.
       <static>true</static>
       <name>Indoor Lightmap</name>
       <pose>0 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Indoor Lightmap</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Indoor Lightmap</uri>
     </include>
 
   </world>

--- a/examples/worlds/log_record_resources.sdf
+++ b/examples/worlds/log_record_resources.sdf
@@ -55,7 +55,7 @@
       <static>false</static>
       <name>staging_area</name>
       <pose>0 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/X2 Config 1</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/X2 Config 1</uri>
     </include>
 
     <model name="ground_plane">

--- a/examples/worlds/mecanum_drive.sdf
+++ b/examples/worlds/mecanum_drive.sdf
@@ -77,7 +77,7 @@
       </link>
     </model>
 
-    <model name='vehicle_blue' xmlns:ignition="http://gazebosim.org/schema">
+    <model name='vehicle_blue' xmlns:gz="http://gazebosim.org/schema">
       <pose>0 2 0.325 0 -0 0</pose>
 
       <link name='chassis'>

--- a/examples/worlds/model_photo_shoot.sdf
+++ b/examples/worlds/model_photo_shoot.sdf
@@ -20,7 +20,7 @@
       <background_color>1, 1, 1</background_color>
     </plugin>
     <include>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Robonaut</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Robonaut</uri>
       <plugin
         filename="gz-sim-model-photo-shoot-system"
         name="gz::sim::systems::ModelPhotoShoot">

--- a/examples/worlds/multi_lrauv_race.sdf
+++ b/examples/worlds/multi_lrauv_race.sdf
@@ -59,12 +59,12 @@
 
     <include>
       <pose>-5 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/mabelzhang/models/Turquoise turbidity generator</uri>
+      <uri>https://fuel.gazebosim.org/1.0/mabelzhang/models/Turquoise turbidity generator</uri>
     </include>
 
     <include>
       <pose>0 0 1 0 0 1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
 
       <!-- Joint controllers -->
       <plugin
@@ -157,7 +157,7 @@
 
     <include>
       <pose>5 0 1 0 0 1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
       <name>triton</name>
 
       <!-- Joint controllers -->
@@ -251,7 +251,7 @@
 
     <include>
       <pose>-5 0 1 0 0 1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
       <name>daphne</name>
 
       <!-- Joint controllers -->
@@ -346,12 +346,12 @@
     <!-- Swimming race lane signs -->
     <include>
       <pose>0 0 -1 0 0 3.1415926</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/mabelzhang/models/ABCSign_5m</uri>
+      <uri>https://fuel.gazebosim.org/1.0/mabelzhang/models/ABCSign_5m</uri>
       <name>start_line</name>
     </include>
     <include>
       <pose>0 -25 -1 0 0 3.1415926</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/mabelzhang/models/ABCSign_5m</uri>
+      <uri>https://fuel.gazebosim.org/1.0/mabelzhang/models/ABCSign_5m</uri>
       <name>finish_line</name>
     </include>
 

--- a/examples/worlds/multicopter_velocity_control.sdf
+++ b/examples/worlds/multicopter_velocity_control.sdf
@@ -102,7 +102,7 @@ You can use the velocity controller and command linear velocity and yaw angular 
 
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/X3 UAV/4
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/X3 UAV/4
       </uri>
       <plugin
         filename="gz-sim-multicopter-motor-model-system"
@@ -232,7 +232,7 @@ You can use the velocity controller and command linear velocity and yaw angular 
     <include>
       <pose>0 3 1 0 0 0</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/X4 UAV Config 1
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/X4 UAV Config 1
       </uri>
 
       <plugin filename="gz-sim-multicopter-motor-model-system"

--- a/examples/worlds/optical_tactile_sensor_plugin.sdf
+++ b/examples/worlds/optical_tactile_sensor_plugin.sdf
@@ -257,22 +257,22 @@
 
     <include>
       <pose>0 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/SurgicalTrolleyMed</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/SurgicalTrolleyMed</uri>
     </include>
 
     <include>
       <pose>0 0 0.7 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Coke</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Coke</uri>
     </include>
 
     <include>
     <pose>0 -0.7 0 0 0 3.14</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/OfficeChairBlue</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/OfficeChairBlue</uri>
     </include>
 
     <include>
     <pose>-1.5 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/VendingMachine</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/VendingMachine</uri>
     </include>
 
   </world>

--- a/examples/worlds/particle_emitter.sdf
+++ b/examples/worlds/particle_emitter.sdf
@@ -87,7 +87,7 @@
     </model>
 
     <include>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/fog generator</uri>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/fog generator</uri>
     </include>
 
     <!-- Nested model example, where the particles are bright red

--- a/examples/worlds/plot_3d.sdf
+++ b/examples/worlds/plot_3d.sdf
@@ -193,7 +193,7 @@
 
     <include>
       <name>Double_pendulum</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Double pendulum with base</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Double pendulum with base</uri>
     </include>
 
   </world>

--- a/examples/worlds/quadcopter.sdf
+++ b/examples/worlds/quadcopter.sdf
@@ -78,7 +78,7 @@
 
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/X3 UAV/4
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/X3 UAV/4
       </uri>
       <plugin
         filename="gz-sim-multicopter-motor-model-system"

--- a/examples/worlds/segmentation_camera.sdf
+++ b/examples/worlds/segmentation_camera.sdf
@@ -203,7 +203,7 @@
       <name>Car1</name>
       <pose>-2 -2 0 0 0 0</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Hatchback blue
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Hatchback blue
       </uri>
       <plugin filename="gz-sim-label-system" name="gz::sim::systems::Label">
         <label>40</label>
@@ -214,7 +214,7 @@
       <name>Car2</name>
       <pose>-3 -5 0 0 0 0</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Pickup
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Pickup
       </uri>
       <plugin filename="gz-sim-label-system" name="gz::sim::systems::Label">
         <label>40</label>
@@ -225,7 +225,7 @@
       <name>Car3</name>
       <pose>-4 3 0 0 0 -1.57</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/SUV
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/SUV
       </uri>
       <plugin filename="gz-sim-label-system" name="gz::sim::systems::Label">
         <label>40</label>
@@ -237,7 +237,7 @@
       <name>tree1</name>
       <pose>-2 5 0 0 0 0</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Pine Tree
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Pine Tree
       </uri>
       <plugin filename="gz-sim-label-system" name="gz::sim::systems::Label">
         <label>30</label>
@@ -248,7 +248,7 @@
       <name>tree2</name>
       <pose>-7 2 0 0 0 0</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Pine Tree
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Pine Tree
       </uri>
       <plugin filename="gz-sim-label-system" name="gz::sim::systems::Label">
         <label>30</label>
@@ -259,7 +259,7 @@
       <name>tree3</name>
       <pose>-7 -4 0 0 0 0</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Pine Tree
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Pine Tree
       </uri>
       <plugin filename="gz-sim-label-system" name="gz::sim::systems::Label">
         <label>30</label>
@@ -271,7 +271,7 @@
       <name>home</name>
       <pose>-15 0 0 0 0 1.57</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Collapsed House
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Collapsed House
       </uri>
     </include>
 
@@ -280,7 +280,7 @@
       <name>cone1</name>
       <pose>0 1 0 0 0 1.570796</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Construction Cone
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Construction Cone
       </uri>
       <plugin filename="gz-sim-label-system" name="gz::sim::systems::Label">
         <label>20</label>
@@ -291,7 +291,7 @@
       <name>cone2</name>
       <pose>0 4 0 0 0 1.570796</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Construction Cone
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Construction Cone
       </uri>
       <plugin filename="gz-sim-label-system" name="gz::sim::systems::Label">
         <label>20</label>
@@ -302,7 +302,7 @@
       <name>cone3</name>
       <pose>2 -2 0 0 0.0 1.57</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Construction Cone
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Construction Cone
       </uri>
       <plugin filename="gz-sim-label-system" name="gz::sim::systems::Label">
         <label>20</label>

--- a/examples/worlds/sensors_demo.sdf
+++ b/examples/worlds/sensors_demo.sdf
@@ -521,7 +521,7 @@
     <include>
       <pose>0 1 3 0.0 0.0 1.57</pose>
       <uri>
-      https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Construction Cone
+      https://fuel.gazebosim.org/1.0/OpenRobotics/models/Construction Cone
       </uri>
     </include>
 

--- a/examples/worlds/shader_param.sdf
+++ b/examples/worlds/shader_param.sdf
@@ -182,12 +182,12 @@ ShaderParam visual plugin over time.
     <include>
       <name>deformable_sphere</name>
       <pose>0 0 1.5 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/deformable_sphere</uri>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/deformable_sphere</uri>
     </include>
     <include>
       <name>waves</name>
       <pose>0 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/waves</uri>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/waves</uri>
     </include>
 
     <model name="camera">

--- a/examples/worlds/thermal_camera.sdf
+++ b/examples/worlds/thermal_camera.sdf
@@ -358,19 +358,19 @@
     <include>
       <pose>1 0 0 0 0 1.570796</pose>
       <name>rescue_randy</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Rescue Randy</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Rescue Randy</uri>
     </include>
 
     <include>
       <pose>2.25 .5 .1 0 0 1.570796</pose>
       <name>phone</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Samsung J8 Black</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Samsung J8 Black</uri>
     </include>
 
     <include>
       <pose>2.25 -.5 .1 0 0 1.570796</pose>
       <name>backpack</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack</uri>
     </include>
 
   </world>

--- a/examples/worlds/tracked_vehicle_simple.sdf
+++ b/examples/worlds/tracked_vehicle_simple.sdf
@@ -1719,7 +1719,7 @@
         <include>
             <name>pallet</name>
             <pose>2 -2 0.1 0 0 0</pose>
-            <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Euro pallet</uri>
+            <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/Euro pallet</uri>
         </include>
 
         <gui fullscreen='0'>

--- a/examples/worlds/triggered_camera_sensor.sdf
+++ b/examples/worlds/triggered_camera_sensor.sdf
@@ -315,7 +315,7 @@
     <include>
       <pose>0 1 3 0.0 0.0 1.57</pose>
       <uri>
-      https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Construction Cone
+      https://fuel.gazebosim.org/1.0/OpenRobotics/models/Construction Cone
       </uri>
     </include>
 

--- a/examples/worlds/tunnel.sdf
+++ b/examples/worlds/tunnel.sdf
@@ -213,13 +213,13 @@
       <static>true</static>
       <name>staging_area</name>
       <pose>0 0 -0.005 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/subt_tunnel_staging_area</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/subt_tunnel_staging_area</uri>
     </include>
 
     <include>
       <pose>9.23 2.18 0 0 0 -1.226</pose>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/chapulina/models/Extinguisher PBR
+        https://fuel.gazebosim.org/1.0/chapulina/models/Extinguisher PBR
       </uri>
     </include>
 
@@ -245,168 +245,168 @@
     <!-- Tunnel tiles and artifacts -->
     <include>
       <name>tile_0</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>240.000000 240.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_1</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>260.000000 240.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_2</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Constrained Tunnel Tile Tall</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Constrained Tunnel Tile Tall</uri>
       <pose>280.000000 240.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_3</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>300.000000 240.000000 -15.000000 0 0 4.712389</pose>
     </include>
 
     <include>
       <name>tile_4</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>160.000000 211.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_5</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>240.000000 220.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>radio_1</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Radio
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Radio
       </uri>
       <pose>241.500000 220.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_6</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>300.000000 220.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_7</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>69.000000 200.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_8</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>80.000000 200.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_9</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>100.000000 200.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_10</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>120.000000 200.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_11</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>140.000000 200.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_12</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
       <pose>160.000000 200.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_13</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>180.000000 200.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_14</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>200.000000 200.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_15</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>220.000000 200.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_16</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>240.000000 200.000000 -15.000000 0 0 3.141593</pose>
     </include>
 
     <include>
       <name>tile_17</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>300.000000 200.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_18</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>160.000000 180.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>backpack_1</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack
       </uri>
       <pose>219.000000 202.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_19</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>260.000000 180.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_20</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>280.000000 180.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_21</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
       <pose>300.000000 180.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_22</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>320.000000 180.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_23</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>340.000000 180.000000 -15.000000 0 0 4.712389</pose>
     </include>
 
     <include>
       <name>tile_24</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Constrained Tunnel Tile Tall
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Constrained Tunnel Tile Tall
       </uri>
       <pose>160.000000 160.000000 -15.000000 0 0 0.000000</pose>
     </include>
@@ -414,509 +414,509 @@
     <include>
       <name>phone_1</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Phone
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Phone
       </uri>
       <pose>260.000000 160.000000 -14.996000 -1.570796 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_25</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>260.000000 160.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_26</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>300.000000 169.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_27</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>340.000000 160.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>toolbox_1</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Toolbox
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Toolbox
       </uri>
       <pose>342.000000 160.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_28</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>60.000000 131.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_29</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>80.000000 131.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_30</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>160.000000 140.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>extinguisher_1</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Extinguisher
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Extinguisher
       </uri>
       <pose>158.000000 140.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_31</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>260.000000 149.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_32</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>340.000000 149.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_33</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>60.000000 120.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_34</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
       <pose>80.000000 120.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_35</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>100.000000 120.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_36</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>120.000000 120.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_37</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>140.000000 120.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_38</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>160.000000 120.000000 -15.000000 0 0 3.141593</pose>
     </include>
 
     <include>
       <name>tile_39</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>80.000000 100.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_40</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>200.000000 100.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_41</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>220.000000 100.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_42</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>240.000000 100.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_43</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>260.000000 100.000000 -15.000000 0 0 4.712389</pose>
     </include>
 
     <include>
       <name>radio_2</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Radio
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Radio
       </uri>
       <pose>260.000000 82.300000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_44</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>80.000000 80.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_45</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>200.000000 80.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_46</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>260.000000 80.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_47</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>280.000000 80.000000 -15.000000 0 0 4.712389</pose>
     </include>
 
     <include>
       <name>tile_48</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 6</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 6</uri>
       <pose>80.000000 60.000000 -15.000000 0 0 3.141593</pose>
     </include>
 
     <include>
       <name>tile_49</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>200.000000 60.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_50</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>280.000000 60.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>toolbox_2</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Toolbox
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Toolbox
       </uri>
       <pose>278.000000 60.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_51</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>80.000000 40.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_52</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>200.000000 40.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_53</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>280.000000 40.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_54</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>80.000000 20.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_55</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>200.000000 20.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>phone_2</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Phone
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Phone
       </uri>
       <pose>201.800000 20.000000 -14.996000 -1.570796 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_56</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>280.000000 20.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_57</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>320.000000 20.000000 -20.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_58</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>340.000000 20.000000 -20.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_59</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>360.000000 20.000000 -20.000000 0 0 4.712389</pose>
     </include>
 
     <include>
       <name>electrical_box_1</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Electrical Box
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Electrical Box
       </uri>
       <pose>400.000000 -1.000000 -20.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_60</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>20.000000 0.000000 0.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_61</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 6</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 6</uri>
       <pose>40.000000 0.000000 -5.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_62</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 6</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 6</uri>
       <pose>60.000000 0.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_63</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
       <pose>80.000000 0.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_64</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>100.000000 0.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_65</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>120.000000 0.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_66</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>140.000000 0.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_67</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 6</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 6</uri>
       <pose>160.000000 0.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_68</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>180.000000 0.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_69</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
       <pose>200.000000 0.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_70</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>211.000000 0.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_71</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>269.000000 0.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_72</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
       <pose>280.000000 0.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_73</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 6</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 6</uri>
       <pose>300.000000 0.000000 -20.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_74</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
       <pose>320.000000 0.000000 -20.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_75</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>340.000000 0.000000 -20.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_76</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 1</uri>
       <pose>360.000000 0.000000 -20.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_77</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>380.000000 0.000000 -20.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_78</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>400.000000 0.000000 -20.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_79</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>411.000000 0.000000 -20.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_80</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 7</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 7</uri>
       <pose>80.000000 -20.000000 -10.000000 0 0 3.141593</pose>
     </include>
 
     <include>
       <name>tile_81</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>200.000000 -20.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_82</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>280.000000 -20.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_83</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>320.000000 -20.000000 -20.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_84</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>340.000000 -20.000000 -20.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_85</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>360.000000 -20.000000 -20.000000 0 0 3.141593</pose>
     </include>
 
     <include>
       <name>tile_86</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>80.000000 -40.000000 -5.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_87</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>200.000000 -40.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_88</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>280.000000 -40.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>backpack_2</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack
       </uri>
       <pose>340.000000 -22.000000 -20.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_89</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>80.000000 -60.000000 -5.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_90</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>200.000000 -60.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_91</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>220.000000 -60.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_92</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>240.000000 -60.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_93</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>260.000000 -60.000000 -15.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_94</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>280.000000 -60.000000 -15.000000 0 0 3.141593</pose>
     </include>
 
     <include>
       <name>tile_95</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>80.000000 -80.000000 -5.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_96</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 7</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 7</uri>
       <pose>100.000000 -80.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_97</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>120.000000 -80.000000 -10.000000 0 0 4.712389</pose>
     </include>
 
     <include>
       <name>phone_3</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Phone
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Phone
       </uri>
       <pose>120.800000 -98.400000 -9.996000 1.570796 0 0.000000</pose>
     </include>
@@ -924,174 +924,174 @@
     <include>
       <name>valve_1</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Valve
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Valve
       </uri>
       <pose>240.000000 -58.000000 -15.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_98</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>120.000000 -100.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_99</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>140.000000 -100.000000 -10.000000 0 0 4.712389</pose>
     </include>
 
     <include>
       <name>tile_100</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>140.000000 -120.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>valve_2</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Valve
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Valve
       </uri>
       <pose>141.750000 -119.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_101</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>140.000000 -140.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_102</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Constrained Tunnel Tile Short
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Constrained Tunnel Tile Short
       </uri>
       <pose>140.000000 -160.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_103</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile Blocker</uri>
       <pose>280.000000 -169.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>electrical_box_2</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Electrical Box
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Electrical Box
       </uri>
       <pose>138.000000 -180.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_104</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>140.000000 -180.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>backpack_3</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack
       </uri>
       <pose>180.000000 -198.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_105</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>280.000000 -180.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_106</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>140.000000 -200.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_107</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>160.000000 -200.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_108</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>180.000000 -200.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_109</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>200.000000 -200.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_110</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>220.000000 -200.000000 -10.000000 0 0 4.712389</pose>
     </include>
 
     <include>
       <name>tile_111</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>280.000000 -200.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_112</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>140.000000 -220.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_113</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>160.000000 -220.000000 -10.000000 0 0 3.141593</pose>
     </include>
 
     <include>
       <name>tile_114</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>220.000000 -220.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_115</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>280.000000 -220.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>extinguisher_2</name>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Extinguisher
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Extinguisher
       </uri>
       <pose>278.000000 -220.000000 -10.000000 0 0 0.000000</pose>
     </include>
 
     <include>
       <name>tile_116</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>220.000000 -240.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_117</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>240.000000 -240.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_118</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 5</uri>
       <pose>260.000000 -240.000000 -10.000000 0 0 1.570796</pose>
     </include>
 
     <include>
       <name>tile_119</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Tunnel Tile 2</uri>
       <pose>280.000000 -240.000000 -10.000000 0 0 3.141593</pose>
     </include>
     <model name="vehicle">
@@ -1137,7 +1137,7 @@
                 <pose>0.180 0 .24 0 0 -1.5707963267948966</pose>
                 <geometry>
                     <mesh>
-                        <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/meshes/r2.dae</uri>
+                        <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/meshes/r2.dae</uri>
                         <submesh>
                             <name>BodyFront</name>
                             <center>true</center>
@@ -1149,9 +1149,9 @@
                     <specular>1.0 1.0 1.0</specular>
                     <pbr>
                         <metal>
-                            <albedo_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Albedo.png</albedo_map>
-                            <metalness_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Metalness.png</metalness_map>
-                            <roughness_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Roughness.png</roughness_map>
+                            <albedo_map>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Albedo.png</albedo_map>
+                            <metalness_map>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Metalness.png</metalness_map>
+                            <roughness_map>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Roughness.png</roughness_map>
                         </metal>
                     </pbr>
                 </material>
@@ -1235,7 +1235,7 @@
                 <pose>-0.428 0.068 0 -1.5707963267948966 -1.5707963267948966 0</pose>
                 <geometry>
                     <mesh>
-                        <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/meshes/r2.dae</uri>
+                        <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/meshes/r2.dae</uri>
                         <submesh>
                             <name>BodyRear</name>
                             <center>true</center>
@@ -1247,9 +1247,9 @@
                     <specular>1.0 1.0 1.0</specular>
                     <pbr>
                         <metal>
-                            <albedo_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Albedo.png</albedo_map>
-                            <metalness_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Metalness.png</metalness_map>
-                            <roughness_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Roughness.png</roughness_map>
+                            <albedo_map>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Albedo.png</albedo_map>
+                            <metalness_map>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Metalness.png</metalness_map>
+                            <roughness_map>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Roughness.png</roughness_map>
                         </metal>
                     </pbr>
                 </material>
@@ -1318,7 +1318,7 @@
             <visual name="left_front_wheel_link_visual">
                 <geometry>
                     <mesh>
-                        <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/meshes/r2.dae</uri>
+                        <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/meshes/r2.dae</uri>
                         <submesh>
                             <name>WheelFL</name>
                             <center>true</center>
@@ -1330,9 +1330,9 @@
                     <specular>1.0 1.0 1.0</specular>
                     <pbr>
                         <metal>
-                            <albedo_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Albedo.png</albedo_map>
-                            <metalness_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Metalness.png</metalness_map>
-                            <roughness_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Roughness.png</roughness_map>
+                            <albedo_map>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Albedo.png</albedo_map>
+                            <metalness_map>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Metalness.png</metalness_map>
+                            <roughness_map>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Roughness.png</roughness_map>
                         </metal>
                     </pbr>
                 </material>
@@ -1401,7 +1401,7 @@
             <visual name="left_rear_wheel_link_visual">
                 <geometry>
                     <mesh>
-                        <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/meshes/r2.dae</uri>
+                        <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/meshes/r2.dae</uri>
                         <submesh>
                             <name>WheelBL</name>
                             <center>true</center>
@@ -1413,9 +1413,9 @@
                     <specular>1.0 1.0 1.0</specular>
                     <pbr>
                         <metal>
-                            <albedo_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Albedo.png</albedo_map>
-                            <metalness_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Metalness.png</metalness_map>
-                            <roughness_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Roughness.png</roughness_map>
+                            <albedo_map>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Albedo.png</albedo_map>
+                            <metalness_map>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Metalness.png</metalness_map>
+                            <roughness_map>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Roughness.png</roughness_map>
                         </metal>
                     </pbr>
                 </material>
@@ -1484,7 +1484,7 @@
             <visual name="right_front_wheel_link_visual">
                 <geometry>
                     <mesh>
-                        <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/meshes/r2.dae</uri>
+                        <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/meshes/r2.dae</uri>
                         <submesh>
                             <name>WheelFR</name>
                             <center>true</center>
@@ -1496,9 +1496,9 @@
                     <specular>1.0 1.0 1.0</specular>
                     <pbr>
                         <metal>
-                            <albedo_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Albedo.png</albedo_map>
-                            <metalness_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Metalness.png</metalness_map>
-                            <roughness_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Roughness.png</roughness_map>
+                            <albedo_map>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Albedo.png</albedo_map>
+                            <metalness_map>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Metalness.png</metalness_map>
+                            <roughness_map>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Roughness.png</roughness_map>
                         </metal>
                     </pbr>
                 </material>
@@ -1567,7 +1567,7 @@
             <visual name="right_rear_wheel_link_visual">
                 <geometry>
                     <mesh>
-                        <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/meshes/r2.dae</uri>
+                        <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/meshes/r2.dae</uri>
                         <submesh>
                             <name>WheelBR</name>
                             <center>true</center>
@@ -1579,9 +1579,9 @@
                     <specular>1.0 1.0 1.0</specular>
                     <pbr>
                         <metal>
-                            <albedo_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Albedo.png</albedo_map>
-                            <metalness_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Metalness.png</metalness_map>
-                            <roughness_map>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Roughness.png</roughness_map>
+                            <albedo_map>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Albedo.png</albedo_map>
+                            <metalness_map>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Metalness.png</metalness_map>
+                            <roughness_map>https://fuel.gazebosim.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/materials/textures/R2_Roughness.png</roughness_map>
                         </metal>
                     </pbr>
                 </material>

--- a/examples/worlds/visualize_lidar.sdf
+++ b/examples/worlds/visualize_lidar.sdf
@@ -514,7 +514,7 @@
 
     <include>
       <pose>0 0 0 0 0 1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Playground</uri>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/Playground</uri>
     </include>
 
   </world>

--- a/examples/worlds/wide_angle_camera.sdf
+++ b/examples/worlds/wide_angle_camera.sdf
@@ -347,7 +347,7 @@
     <include>
       <pose>0 1 3 0.0 0.0 1.57</pose>
       <uri>
-      https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Construction Cone
+      https://fuel.gazebosim.org/1.0/OpenRobotics/models/Construction Cone
       </uri>
     </include>
 

--- a/include/gz/sim/EntityComponentManager.hh
+++ b/include/gz/sim/EntityComponentManager.hh
@@ -556,6 +556,11 @@ namespace gz
       /// \return True if there are any components with one-time changes.
       public: bool HasOneTimeComponentChanges() const;
 
+      /// \brief Get whether there are periodic component changes. These changes
+      /// may happen frequently and are processed periodically.
+      /// \return True if there are any components with periodic changes.
+      public: bool HasPeriodicComponentChanges() const;
+
       /// \brief Get the components types that are marked as periodic changes.
       /// \return All the components that at least one entity marked as
       /// periodic changes.


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🦟 Bug fix

## Summary
Use gazebosim.org in the example worlds. This also updates a few deprecated uses of `ignition-gui` and API documentation links.

Merge after the garden release.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.