### PR TITLE
Clarify errors when plugins fail to load

### DIFF
--- a/src/SystemLoader.cc
+++ b/src/SystemLoader.cc
@@ -88,13 +88,14 @@ class gz::sim::SystemLoaderPrivate
           ss << "Failed to load system plugin: "
              << "(Reason: Could not find shared library)\n"
              << "- Requested plugin name: [" << _sdfPlugin.Name() << "]\n"
-             << "- Requested library name: [" << _sdfPlugin.Filename() << "\n"
+             << "- Requested library name: [" << _sdfPlugin.Filename() << "]\n"
              << "- Library search paths:\n";
-          for (const auto &path: systemPaths.FilePaths())
+
+          for (const auto &path : systemPaths.PluginPaths())
           {
             ss << "  - " << path << "\n";
           }
-          for (const auto &path: systemPathsDep.FilePaths())
+          for (const auto &path : systemPathsDep.PluginPaths())
           {
             ss << "  - (Deprecated) " << path << "\n";
           }
@@ -118,8 +119,8 @@ class gz::sim::SystemLoaderPrivate
       ss << "Failed to load system plugin: "
          << "(Reason: No plugins detected in library)\n"
          << "- Requested plugin name: [" << _sdfPlugin.Name() << "]\n"
-         << "- Requested library name: [" << _sdfPlugin.Filename() << "\n"
-         << "- Resolved library path: [" << pathToLib << "\n";
+         << "- Requested library name: [" << _sdfPlugin.Filename() << "]\n"
+         << "- Resolved library path: [" << pathToLib << "]\n";
       gzerr << ss.str();
       return false;
     }
@@ -131,8 +132,8 @@ class gz::sim::SystemLoaderPrivate
       ss << "Failed to load system plugin: "
          << "(Reason: No plugins detected in library)\n"
          << "- Requested plugin name: [" << _sdfPlugin.Name() << "]\n"
-         << "- Requested library name: [" << _sdfPlugin.Filename() << "\n"
-         << "- Resolved library path: [" << pathToLib << "\n";
+         << "- Requested library name: [" << _sdfPlugin.Filename() << "]\n"
+         << "- Resolved library path: [" << pathToLib << "]\n";
       gzerr << ss.str();
       return false;
     }
@@ -144,12 +145,21 @@ class gz::sim::SystemLoaderPrivate
       ss << "Failed to load system plugin: "
          << "(Reason: library does not contain requested plugin)\n"
          << "- Requested plugin name: [" << _sdfPlugin.Name() << "]\n"
-         << "- Requested library name: [" << _sdfPlugin.Filename() << "\n"
-         << "- Resolved library path: [" << pathToLib << "\n"
+         << "- Requested library name: [" << _sdfPlugin.Filename() << "]\n"
+         << "- Resolved library path: [" << pathToLib << "]\n"
          << "- Detected Plugins:\n";
-      for (const auto &pluginIt: pluginNames)
+      for (const auto &pluginIt : pluginNames)
       {
-        ss << "  - " << pluginIt << "\n";
+        ss << "  - " << pluginIt;
+        auto aliases = this->loader.AliasesOfPlugin(pluginIt);
+        if (!aliases.empty())
+        {
+          ss << "\n    aliases:\n";
+          for (const auto& alias : aliases)
+          {
+            ss << "      " << alias << "\n";
+          }
+        }
       }
       gzerr << ss.str();
       return false;
@@ -161,15 +171,24 @@ class gz::sim::SystemLoaderPrivate
       ss << "Failed to load system plugin: "
          << "(Reason: plugin does not implement System interface)\n"
          << "- Requested plugin name: [" << _sdfPlugin.Name() << "]\n"
-         << "- Requested library name: [" << _sdfPlugin.Filename() << "\n"
-         << "- Resolved library path: [" << pathToLib << "\n"
+         << "- Requested library name: [" << _sdfPlugin.Filename() << "]\n"
+         << "- Resolved library path: [" << pathToLib << "]\n"
          << "- Detected Plugins:\n";
-      for (const auto &pluginIt: pluginNames)
+      for (const auto &pluginIt : pluginNames)
       {
         ss << "  - " << pluginIt << "\n";
+        auto aliases = this->loader.AliasesOfPlugin(pluginIt);
+        if (!aliases.empty())
+        {
+          ss << "\n    aliases:\n";
+          for (const auto& alias : aliases)
+          {
+            ss << "      " << alias << "\n";
+          }
+        }
       }
       ss << "- Plugin Interfaces Implemented:\n";
-      for (const auto &interfaceIt: this->loader.InterfacesImplemented())
+      for (const auto &interfaceIt : this->loader.InterfacesImplemented())
       {
         ss << "  - " << interfaceIt << "\n";
       }

--- a/src/SystemLoader.cc
+++ b/src/SystemLoader.cc
@@ -150,7 +150,7 @@ class gz::sim::SystemLoaderPrivate
          << "- Detected Plugins:\n";
       for (const auto &pluginIt : pluginNames)
       {
-        ss << "  - " << pluginIt;
+        ss << "  - " << pluginIt << "\n";
         auto aliases = this->loader.AliasesOfPlugin(pluginIt);
         if (!aliases.empty())
         {

--- a/src/SystemLoader.cc
+++ b/src/SystemLoader.cc
@@ -16,6 +16,7 @@
 */
 
 #include <optional>
+#include <sstream>
 #include <string>
 #include <unordered_set>
 

--- a/src/SystemLoader.cc
+++ b/src/SystemLoader.cc
@@ -84,8 +84,21 @@ class gz::sim::SystemLoaderPrivate
         // We assume gz::sim corresponds to the levels feature
         if (_sdfPlugin.Name() != "gz::sim")
         {
-          gzerr << "Failed to load system plugin [" << filename <<
-                    "] : couldn't find shared library." << std::endl;
+          std::stringstream ss;
+          ss << "Failed to load system plugin: "
+             << "(Reason: Could not find shared library)\n"
+             << "- Requested plugin name: [" << _sdfPlugin.Name() << "]\n"
+             << "- Requested library name: [" << _sdfPlugin.Filename() << "\n"
+             << "- Library search paths:\n";
+          for (const auto &path: systemPaths.FilePaths())
+          {
+            ss << "  - " << path << "\n";
+          }
+          for (const auto &path: systemPathsDep.FilePaths())
+          {
+            ss << "  - (Deprecated) " << path << "\n";
+          }
+          gzerr << ss.str();
         }
         return false;
       }
@@ -101,36 +114,65 @@ class gz::sim::SystemLoaderPrivate
     auto pluginNames = this->loader.LoadLib(pathToLib, true);
     if (pluginNames.empty())
     {
-      gzerr << "Failed to load system plugin [" << filename <<
-                "] : couldn't load library on path [" << pathToLib <<
-                "]." << std::endl;
+      std::stringstream ss;
+      ss << "Failed to load system plugin: "
+         << "(Reason: No plugins detected in library)\n"
+         << "- Requested plugin name: [" << _sdfPlugin.Name() << "]\n"
+         << "- Requested library name: [" << _sdfPlugin.Filename() << "\n"
+         << "- Resolved library path: [" << pathToLib << "\n";
+      gzerr << ss.str();
       return false;
     }
 
     auto pluginName = *pluginNames.begin();
     if (pluginName.empty())
     {
-      gzerr << "Failed to load system plugin [" << filename <<
-                "] : couldn't load library on path [" << pathToLib <<
-                "]." << std::endl;
+      std::stringstream ss;
+      ss << "Failed to load system plugin: "
+         << "(Reason: No plugins detected in library)\n"
+         << "- Requested plugin name: [" << _sdfPlugin.Name() << "]\n"
+         << "- Requested library name: [" << _sdfPlugin.Filename() << "\n"
+         << "- Resolved library path: [" << pathToLib << "\n";
+      gzerr << ss.str();
       return false;
     }
 
     _gzPlugin = this->loader.Instantiate(_sdfPlugin.Name());
     if (!_gzPlugin)
     {
-      gzerr << "Failed to load system plugin [" << _sdfPlugin.Name() <<
-        "] : could not instantiate from library [" << _sdfPlugin.Filename() <<
-        "] from path [" << pathToLib << "]." << std::endl;
+      std::stringstream ss;
+      ss << "Failed to load system plugin: "
+         << "(Reason: library does not contain requested plugin)\n"
+         << "- Requested plugin name: [" << _sdfPlugin.Name() << "]\n"
+         << "- Requested library name: [" << _sdfPlugin.Filename() << "\n"
+         << "- Resolved library path: [" << pathToLib << "\n"
+         << "- Detected Plugins:\n";
+      for (const auto &pluginIt: pluginNames)
+      {
+        ss << "  - " << pluginIt << "\n";
+      }
+      gzerr << ss.str();
       return false;
     }
 
     if (!_gzPlugin->HasInterface<System>())
     {
-      gzerr << "Failed to load system plugin [" << _sdfPlugin.Name() <<
-        "] : system not found in library  [" << _sdfPlugin.Filename() <<
-        "] from path [" << pathToLib << "]." << std::endl;
-
+      std::stringstream ss;
+      ss << "Failed to load system plugin: "
+         << "(Reason: plugin does not implement System interface)\n"
+         << "- Requested plugin name: [" << _sdfPlugin.Name() << "]\n"
+         << "- Requested library name: [" << _sdfPlugin.Filename() << "\n"
+         << "- Resolved library path: [" << pathToLib << "\n"
+         << "- Detected Plugins:\n";
+      for (const auto &pluginIt: pluginNames)
+      {
+        ss << "  - " << pluginIt << "\n";
+      }
+      ss << "- Plugin Interfaces Implemented:\n";
+      for (const auto &interfaceIt: this->loader.InterfacesImplemented())
+      {
+        ss << "  - " << interfaceIt << "\n";
+      }
       return false;
     }
 

--- a/src/SystemLoader_TEST.cc
+++ b/src/SystemLoader_TEST.cc
@@ -15,7 +15,6 @@
  *
 */
 
-#include "gtest/gtest.h"
 #include <gtest/gtest.h>
 
 #include <sdf/Root.hh>
@@ -143,4 +142,3 @@ TEST(SystemLoader, BadPluginName)
     }
   }
 }
-

--- a/src/SystemLoader_TEST.cc
+++ b/src/SystemLoader_TEST.cc
@@ -60,6 +60,7 @@ TEST(SystemLoader, Constructor)
   }
 }
 
+/////////////////////////////////////////////////
 TEST(SystemLoader, EmptyNames)
 {
   sim::SystemLoader sm;
@@ -67,3 +68,67 @@ TEST(SystemLoader, EmptyNames)
   auto system = sm.LoadPlugin(plugin);
   ASSERT_FALSE(system.has_value());
 }
+
+/////////////////////////////////////////////////
+TEST(SystemLoader, BadLibraryPath)
+{
+  sim::SystemLoader sm;
+
+  // Add test plugin to path (referenced in config)
+  auto testBuildPath = gz::common::joinPaths(
+      std::string(PROJECT_BINARY_PATH), "lib");
+  sm.AddSystemPluginPath(testBuildPath);
+
+  sdf::Root root;
+  root.LoadSdfString(std::string("<?xml version='1.0'?><sdf version='1.6'>"
+      "<world name='default'>"
+      "<plugin filename='foo.so'"
+      "name='gz::sim::systems::Physics'></plugin>"
+      "</world></sdf>"));
+
+  auto worldElem = root.WorldByIndex(0)->Element();
+  if (worldElem->HasElement("plugin")) {
+    sdf::ElementPtr pluginElem = worldElem->GetElement("plugin");
+    while (pluginElem)
+    {
+      sdf::Plugin plugin;
+      plugin.Load(pluginElem);
+      auto system = sm.LoadPlugin(plugin);
+      ASSERT_FALSE(system.has_value());
+      pluginElem = pluginElem->GetNextElement("plugin");
+    }
+  }
+}
+
+/////////////////////////////////////////////////
+TEST(SystemLoader, BadPluginName)
+{
+  sim::SystemLoader sm;
+
+  // Add test plugin to path (referenced in config)
+  auto testBuildPath = gz::common::joinPaths(
+      std::string(PROJECT_BINARY_PATH), "lib");
+  sm.AddSystemPluginPath(testBuildPath);
+
+  sdf::Root root;
+  root.LoadSdfString(std::string("<?xml version='1.0'?><sdf version='1.6'>"
+      "<world name='default'>"
+      "<plugin filename='libgz-sim") +
+      GZ_SIM_MAJOR_VERSION_STR + "-physics-system.so' "
+      "name='gz::sim::systems::Foo'></plugin>"
+      "</world></sdf>");
+
+  auto worldElem = root.WorldByIndex(0)->Element();
+  if (worldElem->HasElement("plugin")) {
+    sdf::ElementPtr pluginElem = worldElem->GetElement("plugin");
+    while (pluginElem)
+    {
+      sdf::Plugin plugin;
+      plugin.Load(pluginElem);
+      auto system = sm.LoadPlugin(plugin);
+      ASSERT_FALSE(system.has_value());
+      pluginElem = pluginElem->GetNextElement("plugin");
+    }
+  }
+}
+

--- a/src/SystemLoader_TEST.cc
+++ b/src/SystemLoader_TEST.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include "gtest/gtest.h"
 #include <gtest/gtest.h>
 
 #include <sdf/Root.hh>
@@ -65,8 +66,11 @@ TEST(SystemLoader, EmptyNames)
 {
   sim::SystemLoader sm;
   sdf::Plugin plugin;
+  ::testing::internal::CaptureStderr();
   auto system = sm.LoadPlugin(plugin);
   ASSERT_FALSE(system.has_value());
+  auto output = ::testing::internal::GetCapturedStderr();
+  EXPECT_NE(std::string::npos, output.find("empty argument"));
 }
 
 /////////////////////////////////////////////////
@@ -91,10 +95,14 @@ TEST(SystemLoader, BadLibraryPath)
     sdf::ElementPtr pluginElem = worldElem->GetElement("plugin");
     while (pluginElem)
     {
+      ::testing::internal::CaptureStderr();
       sdf::Plugin plugin;
       plugin.Load(pluginElem);
       auto system = sm.LoadPlugin(plugin);
       ASSERT_FALSE(system.has_value());
+      auto output = ::testing::internal::GetCapturedStderr();
+      EXPECT_NE(std::string::npos,
+          output.find("Could not find shared library")) << output.c_str();
       pluginElem = pluginElem->GetNextElement("plugin");
     }
   }
@@ -123,10 +131,14 @@ TEST(SystemLoader, BadPluginName)
     sdf::ElementPtr pluginElem = worldElem->GetElement("plugin");
     while (pluginElem)
     {
+      ::testing::internal::CaptureStderr();
       sdf::Plugin plugin;
       plugin.Load(pluginElem);
       auto system = sm.LoadPlugin(plugin);
       ASSERT_FALSE(system.has_value());
+      auto output = ::testing::internal::GetCapturedStderr();
+      EXPECT_NE(std::string::npos,
+          output.find("library does not contain")) << output.c_str();
       pluginElem = pluginElem->GetNextElement("plugin");
     }
   }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

I find that it's hard to tell one plugin failure mode from another with the current error messages.  This expands the messages and also includes relevant information for helping to diagnose system plugin issues.

Now in the case that it fails to find a library, gz-sim will output the list of paths that were searched for the library.

When a bad (or misspelled!) plugin name is provided, it will output a list of the known plugins and aliases in that shared library.

Example Improved output:
```
[ RUN      ] SystemLoader.BadLibraryPath
[Err] [SystemLoader.cc:102] Failed to load system plugin: (Reason: Could not find shared library)
- Requested plugin name: [gz::sim::systems::Physics]
- Requested library name: [foo.so]
- Library search paths:
  - /home/mjcarroll/workspaces/gz_garden/build/gz-sim7/lib/
  - /home/mjcarroll/.gz/sim/plugins/
  - /home/mjcarroll/.ignition/gazebo/plugins/
  - /home/mjcarroll/workspaces/gz_garden/install/lib/gz-sim-7/plugins/
[       OK ] SystemLoader.BadLibraryPath (79 ms)
[ RUN      ] SystemLoader.BadPluginName
[Err] [SystemLoader.cc:164] Failed to load system plugin: (Reason: library does not contain requested plugin)
- Requested plugin name: [gz::sim::systems::Foo]
- Requested library name: [libgz-sim7-physics-system.so]
- Resolved library path: [/home/mjcarroll/workspaces/gz_garden/build/gz-sim7/lib/libgz-sim7-physics-system.so]
- Detected Plugins:
  - gz::sim::v7::systems::Physics
    aliases:
      gz::sim::systems::Physics
      ignition::gazebo::systems::Physics
[       OK ] SystemLoader.BadPluginName (43 ms)

```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

