### PR TITLE
Fix macOS test segfaults

### DIFF
--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -22,6 +22,16 @@
 #include "gz/sim/Events.hh"
 #include "gz/sim/SdfEntityCreator.hh"
 
+#if __APPLE__
+// This is here to avoid segfaults on macOS tests. The segfaults
+// happen when components are registered by plugins and component creation is
+// attempted after the plugin that registered the component has been unloaded.
+// Including this header insures that all components are registered by the core
+// library ahead of any plugin.
+// TODO (azeey) Find a better solution for keeping track of component
+// registrations.
+#include "gz/sim/components/components.hh"
+#else
 #include "gz/sim/components/Actor.hh"
 #include "gz/sim/components/AirPressureSensor.hh"
 #include "gz/sim/components/Altimeter.hh"
@@ -81,6 +91,7 @@
 #include "gz/sim/components/WideAngleCamera.hh"
 #include "gz/sim/components/WindMode.hh"
 #include "gz/sim/components/World.hh"
+#endif
 
 class gz::sim::SdfEntityCreatorPrivate
 {

--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -28,7 +28,7 @@
 // attempted after the plugin that registered the component has been unloaded.
 // Including this header insures that all components are registered by the core
 // library ahead of any plugin.
-// TODO (azeey) Find a better solution for keeping track of component
+// TODO(azeey) Find a better solution for keeping track of component
 // registrations.
 #include "gz/sim/components/components.hh"
 #else

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -656,6 +656,7 @@ TEST_P(SceneBroadcasterTest,
       // remove a component from an entity
       if (_info.iterations == 2)
       {
+        std::vector<sim::Entity> entitiesToRemoveFrom;
         _ecm.Each<gz::sim::components::Model,
                   gz::sim::components::Name,
                   gz::sim::components::Pose>(
@@ -666,10 +667,14 @@ TEST_P(SceneBroadcasterTest,
           {
             if (_name->Data() == "box")
             {
-              _ecm.RemoveComponent<gz::sim::components::Pose>(_entity);
+              entitiesToRemoveFrom.push_back(_entity);
             }
             return true;
           });
+        for (const auto& entity: entitiesToRemoveFrom)
+        {
+          _ecm.RemoveComponent<gz::sim::components::Pose>(entity);
+        }
       }
       // add a component to an entity
       else if (_info.iterations == 3)

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -671,7 +671,7 @@ TEST_P(SceneBroadcasterTest,
             }
             return true;
           });
-        for (const auto& entity: entitiesToRemoveFrom)
+        for (const auto &entity : entitiesToRemoveFrom)
         {
           _ecm.RemoveComponent<gz::sim::components::Pose>(entity);
         }


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
The segfaults happen when components are registered by plugins and component creation is attempted after the plugin that registered the component has been unloaded and it's component storage object has become invalid. Including this header insures that all components are registered by the core library ahead of any plugin. 

This is a temporary solution. A better solution would be to keep track of all the plugins that have registered a component. When a plugin gets unloaded, we would unregister that component in the destructor (right before the plugin is unloaded), and check our list if there are other plugins that have registered the component. If so, we would register the component again, this time using the component storage object from a currently loaded plugin.

This is similar to https://github.com/gazebosim/gz-sim/pull/807 but has code to try to mitigate other issues. This PR targets `gz-sim7` because the segfaults appear to be not flaky anymore in this branch.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
