### PR TITLE
Fallback to zero wind outside declared regions

### DIFF
--- a/src/systems/wind_effects/WindEffects.cc
+++ b/src/systems/wind_effects/WindEffects.cc
@@ -598,11 +598,16 @@ void WindEffectsPrivate::ApplyWindForce(const UpdateInfo &,
 
         link.ResetEntity(_entity);
 
+        double forceScalingFactor =
+            this->forceApproximationScalingFactor(_linkPose->Data().Pos());
+        if (std::isnan(forceScalingFactor))
+        {
+          forceScalingFactor = 0.;
+        }
+
         const math::Vector3d windForce =
             _inertial->Data().MassMatrix().Mass() *
-            this->forceApproximationScalingFactor(
-                _linkPose->Data().Pos()) *
-            (windVel->Data() - _linkVel->Data());
+            forceScalingFactor * (windVel->Data() - _linkVel->Data());
 
         // Apply force at center of mass
         link.AddWorldForce(_ecm, windForce);

--- a/test/worlds/sea_storm_effects.sdf
+++ b/test/worlds/sea_storm_effects.sdf
@@ -20,7 +20,7 @@
       filename="gz-sim-wind-effects-system"
       name="gz::sim::systems::WindEffects">
       <force_approximation_scaling_factor>
-        <when zle="0">0</when>  <!-- No wind below sea level -->
+        <!-- No wind below sea level -->
         <when zgt="0" zlt="5">0.2</when>  <!-- Transition layer -->
         <when zge="5">  <!-- Vortex-like winds that worsen with height -->
           <k>0.5</k>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/1730.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
Use zero in lieu of NaN factors.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.