### PR TITLE
Add CLI to switch to Vulkan & Metal backends

### DIFF
--- a/include/gz/sim/ServerConfig.hh
+++ b/include/gz/sim/ServerConfig.hh
@@ -409,9 +409,27 @@ namespace gz
       public: void SetRenderEngineServer(
                   const std::string &_renderEngineServer);
 
+      /// \brief Set the render engine server API backend.
+      /// \param[in] _apiBackend See --render-engine-server-api-backend for
+      /// possible options
+      public: void SetRenderEngineServerApiBackend(
+                  const std::string &_apiBackend);
+
+      /// \return Api backend for server. See SetRenderEngineServerApiBackend()
+      const std::string &RenderEngineServerApiBackend() const;
+
       /// \brief Set the render engine gui plugin library.
       /// \param[in] _renderEngineGui File containing render engine library.
       public: void SetRenderEngineGui(const std::string &_renderEngineGui);
+
+      /// \brief Set the render engine gui API backend.
+      /// \param[in] _apiBackend See --render-engine-gui-api-backend for
+      /// possible options
+      public: void SetRenderEngineGuiApiBackend(
+                  const std::string &_apiBackend);
+
+      /// \return Api backend for gui. See SetRenderEngineGuiApiBackend()
+      const std::string &RenderEngineGuiApiBackend() const;
 
       /// \brief Instruct simulation to attach a plugin to a specific
       /// entity when simulation starts.

--- a/include/gz/sim/components/RenderEngineServerApiBackend.hh
+++ b/include/gz/sim/components/RenderEngineServerApiBackend.hh
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef GZ_SIM_COMPONENTS_RENDERENGINESERVERAPIBACKEND_HH_
+#define GZ_SIM_COMPONENTS_RENDERENGINESERVERAPIBACKEND_HH_
+
+#include <string>
+#include <gz/sim/components/Factory.hh>
+#include <gz/sim/components/Component.hh>
+#include <gz/sim/components/Serialization.hh>
+#include <gz/sim/config.hh>
+
+namespace gz
+{
+namespace sim
+{
+// Inline bracket to help doxygen filtering.
+inline namespace GZ_SIM_VERSION_NAMESPACE {
+namespace components
+{
+  /// \brief Holds the render engine server API backend name.
+  using RenderEngineServerApiBackend = Component<std::string,
+      class RenderEngineServerApiBackendTag, serializers::StringSerializer>;
+  GZ_SIM_REGISTER_COMPONENT(
+      "gz_sim_components.RenderEngineServerApiBackend",
+      RenderEngineServerApiBackend)
+}
+}
+}
+}
+
+#endif

--- a/include/gz/sim/gui/Gui.hh
+++ b/include/gz/sim/gui/Gui.hh
@@ -61,10 +61,12 @@ namespace gui
   /// \param[in] _waitGui Flag indicating whether the server waits until
   /// it receives a world path from GUI.
   /// \param[in] _renderEngine --render-engine-gui option
+  /// \param[in] _renderEngineGuiApiBackend --render-engine-gui-api-backend
   /// \return -1 on failure, 0 on success
   GZ_SIM_GUI_VISIBLE int runGui(int &_argc, char **_argv,
         const char *_guiConfig, const char *_sdfFile, int _waitGui,
-        const char *_renderEngine = nullptr);
+        const char *_renderEngine = nullptr,
+        const char *_renderEngineApiBackend = nullptr);
 
   /// \brief Create a Gazebo GUI application
   /// \param[in] _argc Number of command line arguments (Used when running
@@ -110,12 +112,15 @@ namespace gui
   /// \param[in] _waitGui True if the server is waiting for the GUI to decide on
   /// a starting world.
   /// \param[in] _renderEngine --render-engine-gui option
+  /// \param[in] _renderEngineGuiApiBackend --render-engine-gui-api-backend
+  /// option
   /// \return Newly created application.
   GZ_SIM_GUI_VISIBLE
   std::unique_ptr<gz::gui::Application> createGui(
       int &_argc, char **_argv, const char *_guiConfig,
       const char *_defaultGuiConfig, bool _loadPluginsFromSdf,
-      const char *_sdfFile, int _waitGui, const char *_renderEngine = nullptr);
+      const char *_sdfFile, int _waitGui, const char *_renderEngine = nullptr,
+      const char *_renderEngineGuiApiBackend = nullptr );
 }  // namespace gui
 }  // namespace GZ_SIM_VERSION_NAMESPACE
 }  // namespace sim

--- a/include/gz/sim/rendering/RenderUtil.hh
+++ b/include/gz/sim/rendering/RenderUtil.hh
@@ -93,6 +93,15 @@ inline namespace GZ_SIM_VERSION_NAMESPACE {
     /// \return Name of the rendering engine
     public: std::string EngineName() const;
 
+    /// \brief Set the API backend the rendering engine will use
+    /// \param[in] _apiBackend Name of the api backend.
+    /// See --render-engine-server-api-backend for possible options
+    public: void SetApiBackend(const std::string &_apiBackend);
+
+    /// \brief Get the API backend the rendering engine used
+    /// \return Name of the API backend. May be empty.
+    public: std::string ApiBackend() const;
+
     /// \brief Set the headless mode
     /// \param[in] _headless Set to true to enable headless mode.
     public: void SetHeadlessRendering(const bool &_headless);

--- a/src/LevelManager.cc
+++ b/src/LevelManager.cc
@@ -51,6 +51,7 @@
 #include "gz/sim/components/PhysicsEnginePlugin.hh"
 #include "gz/sim/components/Pose.hh"
 #include "gz/sim/components/RenderEngineGuiPlugin.hh"
+#include "gz/sim/components/RenderEngineServerApiBackend.hh"
 #include "gz/sim/components/RenderEngineServerHeadless.hh"
 #include "gz/sim/components/RenderEngineServerPlugin.hh"
 #include "gz/sim/components/Scene.hh"
@@ -149,6 +150,10 @@ void LevelManager::ReadLevelPerformerInfo()
   this->runner->entityCompMgr.CreateComponent(this->worldEntity,
       components::RenderEngineServerPlugin(
       this->runner->serverConfig.RenderEngineServer()));
+
+  this->runner->entityCompMgr.CreateComponent(this->worldEntity,
+      components::RenderEngineServerApiBackend(
+      this->runner->serverConfig.RenderEngineServerApiBackend()));
 
   this->runner->entityCompMgr.CreateComponent(this->worldEntity,
       components::RenderEngineServerHeadless(

--- a/src/ServerConfig.cc
+++ b/src/ServerConfig.cc
@@ -258,7 +258,9 @@ class gz::sim::ServerConfigPrivate
             resourceCache(_cfg->resourceCache),
             physicsEngine(_cfg->physicsEngine),
             renderEngineServer(_cfg->renderEngineServer),
+            renderEngineServerApiBackend(_cfg->renderEngineServerApiBackend),
             renderEngineGui(_cfg->renderEngineGui),
+            renderEngineGuiApiBackend(_cfg->renderEngineGuiApiBackend),
             plugins(_cfg->plugins),
             networkRole(_cfg->networkRole),
             networkSecondaries(_cfg->networkSecondaries),
@@ -307,9 +309,17 @@ class gz::sim::ServerConfigPrivate
   /// will be used.
   public: std::string renderEngineServer = "";
 
+  /// \brief String on which API to select.
+  /// See --render-engine-server-api-backend for possible options
+  public: std::string renderEngineServerApiBackend = "";
+
   /// \brief File containing render engine gui plugin. If empty, OGRE2
   /// will be used.
   public: std::string renderEngineGui = "";
+
+  /// \brief String on which API to select.
+  /// See --render-engine-gui-api-backend for possible options
+  public: std::string renderEngineGuiApiBackend = "";
 
   /// \brief List of plugins to load.
   public: std::list<ServerConfig::PluginInfo> plugins;
@@ -593,6 +603,19 @@ void ServerConfig::SetRenderEngineServer(const std::string &_engine)
 }
 
 /////////////////////////////////////////////////
+void ServerConfig::SetRenderEngineServerApiBackend(
+  const std::string &_apiBackend)
+{
+  this->dataPtr->renderEngineServerApiBackend = _apiBackend;
+}
+
+/////////////////////////////////////////////////
+const std::string &ServerConfig::RenderEngineServerApiBackend() const
+{
+  return this->dataPtr->renderEngineServerApiBackend;
+}
+
+/////////////////////////////////////////////////
 void ServerConfig::SetHeadlessRendering(const bool _headless)
 {
   this->dataPtr->isHeadlessRendering = _headless;
@@ -624,6 +647,18 @@ void ServerConfig::SetRenderEngineGui(const std::string &_engine)
            << "] for the GUI. Use [" << engine << "] instead." << std::endl;
   }
   this->dataPtr->renderEngineGui = engine;
+}
+
+/////////////////////////////////////////////////
+void ServerConfig::SetRenderEngineGuiApiBackend(const std::string &_apiBackend)
+{
+  this->dataPtr->renderEngineGuiApiBackend = _apiBackend;
+}
+
+/////////////////////////////////////////////////
+const std::string &ServerConfig::RenderEngineGuiApiBackend() const
+{
+  return this->dataPtr->renderEngineGuiApiBackend;
 }
 
 /////////////////////////////////////////////////

--- a/src/cmd/cmdsim.rb.in
+++ b/src/cmd/cmdsim.rb.in
@@ -143,17 +143,35 @@ COMMANDS = { 'sim' =>
   "                               Make sure custom plugins are in                  \n"\
   "                               GZ_SIM_RENDER_ENGINE_PATH.                       \n"\
   "\n"\
+  "  --render-engine-api-backend [arg]                                             \n"\
+  "                               API to use for both the Server & GUI.            \n"\
+  "                               Possible values for ogre2:                       \n"\
+  "                                 - opengl (default)                             \n"\
+  "                                 - vulkan (beta)                                \n"\
+  "                                 - metal (Apple only, default for Apple)        \n"\
+  "                               Note: If using Vulkan in the GUI and gz-gui      \n"\
+  "                               was built against Qt < 5.15.2, it may be very    \n"\
+  "                               slow.                                            \n"\
+  "\n"\
   "  --render-engine-gui [arg]    Gazebo Rendering engine plugin to load for       \n"\
   "                               the GUI. Gazebo will use OGRE2 by default.       \n"\
   "                               (ogre2)                                          \n"\
   "                               Make sure custom plugins are in                  \n"\
   "                               GZ_SIM_RENDER_ENGINE_PATH.                       \n"\
   "\n"\
+  "  --render-engine-gui-api-backend [arg]                                         \n"\
+  "                               Same as --render-engine-api-backend but only     \n"\
+  "                               for the GUI.                                     \n"\
+  "\n"\
   "  --render-engine-server [arg] Gazebo Rendering engine plugin to load for       \n"\
   "                               the server. Gazebo will use OGRE2 by default.    \n"\
   "                               (ogre2)                                          \n"\
   "                               Make sure custom plugins are in                  \n"\
   "                               GZ_SIM_RENDER_ENGINE_PATH.                       \n"\
+  "\n"\
+  "  --render-engine-server-api-backend [arg]                                      \n"\
+  "                               Same as --render-engine-api-backend but only     \n"\
+  "                               for the server.                                  \n"\
   "\n"\
   "  --version                    Print Gazebo version information.                \n"\
   "\n"\
@@ -230,9 +248,11 @@ class Cmd
       'gui_config' => '',
       'physics_engine' => '',
       'render_engine_gui' => '',
+      'render_engine_gui_api_backend' => '',
       'render_engine_server' => '',
-      'wait_gui' => 1,
+      'render_engine_server_api_backend' => '',
       'headless-rendering' => 0,
+      'wait_gui' => 1,
       'seed' => 0
     }
 
@@ -313,12 +333,22 @@ class Cmd
       opts.on('--render-engine-gui [arg]', String) do |g|
         options['render_engine_gui'] = g
       end
+      opts.on('--render-engine-gui-api-backend [arg]', String) do |a|
+        options['render_engine_gui_api_backend'] = a
+      end
       opts.on('--render-engine-server [arg]', String) do |k|
         options['render_engine_server'] = k
+      end
+      opts.on('--render-engine-server-api-backend [arg]', String) do |a|
+        options['render_engine_server_api_backend'] = a
       end
       opts.on('--render-engine [arg]', String) do |f|
         options['render_engine_gui'] = f
         options['render_engine_server'] = f
+      end
+      opts.on('--render-engine-api-backend [arg]', String) do |a|
+        options['render_engine_gui_api_backend'] = a
+        options['render_engine_server_api_backend'] = a
       end
       opts.on('--version') do
         options['version'] = '1'
@@ -465,10 +495,12 @@ Please use [GZ_SIM_RESOURCE_PATH] instead."
                                const char *, int, int, const char *,
                                int, int, int, const char *, const char *,
                                const char *, const char *, const char *,
+                               const char *, const char *,
                                const char *, int, int, float, int)'
 
       # Import the runGui function
-      Importer.extern 'int runGui(const char *, const char *, int, const char *)'
+      Importer.extern 'int runGui(const char *, const char *, int,
+                                  const char *, const char *)'
 
       # If playback is specified, and the user has not specified a
       # custom gui config, set the gui config to load the playback
@@ -504,7 +536,10 @@ See https://github.com/gazebosim/gz-sim/issues/168 for more info."
             options['record-path'], options['record-resources'],
             options['log-overwrite'], options['log-compress'],
             options['playback'], options['physics_engine'],
-            options['render_engine_server'], options['render_engine_gui'],
+            options['render_engine_server'],
+            options['render_engine_server_api_backend'],
+            options['render_engine_gui'],
+            options['render_engine_gui_api_backend'],
             options['file'], options['record-topics'].join(':'),
             options['wait_gui'],
             options['headless-rendering'], options['record-period'],
@@ -516,7 +551,8 @@ See https://github.com/gazebosim/gz-sim/issues/168 for more info."
           Process.setpgid(0, 0)
           Process.setproctitle('gz sim gui')
           Importer.runGui(options['gui_config'], options['file'],
-              options['wait_gui'], options['render_engine_gui'])
+                          options['wait_gui'], options['render_engine_gui'],
+                          options['render_engine_gui_api_backend'])
         end
 
         Signal.trap("INT") {
@@ -543,7 +579,10 @@ See https://github.com/gazebosim/gz-sim/issues/168 for more info."
             options['record-path'], options['record-resources'],
             options['log-overwrite'], options['log-compress'],
             options['playback'], options['physics_engine'],
-            options['render_engine_server'], options['render_engine_gui'],
+            options['render_engine_server'],
+            options['render_engine_server_api_backend'],
+            options['render_engine_gui'],
+            options['render_engine_gui_api_backend'],
             options['file'], options['record-topics'].join(':'),
             options['wait_gui'], options['headless-rendering'],
             options['record-period'], options['seed'])
@@ -557,7 +596,8 @@ See https://github.com/gazebosim/gz-sim/issues/168 for more info."
 
         ENV['RMT_PORT'] = '1501'
         Importer.runGui(options['gui_config'], options['file'],
-            options['wait_gui'], options['render_engine_gui'])
+                        options['wait_gui'], options['render_engine_gui'],
+                        options['render_engine_gui_api_backend'])
       end
     rescue
       puts "Library error: Problem running [#{options['command']}]() "\

--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -194,14 +194,15 @@ std::unique_ptr<gz::gui::Application> createGui(
     const char *_renderEngine)
 {
   return createGui(_argc, _argv, _guiConfig, _defaultGuiConfig,
-    _loadPluginsFromSdf, nullptr, 0, _renderEngine);
+    _loadPluginsFromSdf, nullptr, 0, _renderEngine, nullptr);
 }
 
 //////////////////////////////////////////////////
 std::unique_ptr<gz::gui::Application> createGui(
-    int &_argc, char **_argv, const char *_guiConfig,
-    const char *_defaultGuiConfig, bool _loadPluginsFromSdf,
-    const char *_sdfFile, int _waitGui, const char *_renderEngine)
+  int &_argc, char **_argv, const char *_guiConfig,
+  const char *_defaultGuiConfig, bool _loadPluginsFromSdf, const char *_sdfFile,
+  int _waitGui, const char *_renderEngine,
+  const char *_renderEngineGuiApiBackend)
 {
   gz::common::SignalHandler sigHandler;
   bool sigKilled = false;
@@ -274,7 +275,7 @@ std::unique_ptr<gz::gui::Application> createGui(
 
   // Launch main window
   auto app = std::make_unique<gz::gui::Application>(
-    _argc, _argv, gz::gui::WindowType::kMainWindow);
+    _argc, _argv, gz::gui::WindowType::kMainWindow, _renderEngineGuiApiBackend);
 
   app->AddPluginPath(GZ_SIM_GUI_PLUGIN_INSTALL_DIR);
 
@@ -507,10 +508,10 @@ int runGui(int &_argc, char **_argv, const char *_guiConfig,
 //////////////////////////////////////////////////
 int runGui(int &_argc, char **_argv,
   const char *_guiConfig, const char *_sdfFile, int _waitGui,
-  const char *_renderEngine)
+  const char *_renderEngine, const char *_renderEngineGuiApiBackend)
 {
   auto app = sim::gui::createGui(_argc, _argv, _guiConfig, nullptr, true,
-      _sdfFile, _waitGui, _renderEngine);
+      _sdfFile, _waitGui, _renderEngine, _renderEngineGuiApiBackend);
   if (nullptr != app)
   {
     // Run main window.

--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -60,6 +60,7 @@
 #include "gz/sim/components/Physics.hh"
 #include "gz/sim/components/PhysicsEnginePlugin.hh"
 #include "gz/sim/components/RenderEngineGuiPlugin.hh"
+#include "gz/sim/components/RenderEngineServerApiBackend.hh"
 #include "gz/sim/components/RenderEngineServerPlugin.hh"
 #include "gz/sim/components/SelfCollide.hh"
 #include "gz/sim/components/Sensor.hh"
@@ -776,6 +777,13 @@ void ComponentInspector::Update(const UpdateInfo &,
     else if (typeId == components::RenderEngineServerPlugin::typeId)
     {
       auto comp = _ecm.Component<components::RenderEngineServerPlugin>(
+          this->dataPtr->entity);
+      if (comp)
+        setData(item, comp->Data());
+    }
+    else if (typeId == components::RenderEngineServerApiBackend::typeId)
+    {
+      auto comp = _ecm.Component<components::RenderEngineServerApiBackend>(
           this->dataPtr->entity);
       if (comp)
         setData(item, comp->Data());

--- a/src/gui/plugins/component_inspector_editor/ComponentInspectorEditor.cc
+++ b/src/gui/plugins/component_inspector_editor/ComponentInspectorEditor.cc
@@ -66,6 +66,7 @@
 #include "gz/sim/components/Pose.hh"
 #include "gz/sim/components/Recreate.hh"
 #include "gz/sim/components/RenderEngineGuiPlugin.hh"
+#include "gz/sim/components/RenderEngineServerApiBackend.hh"
 #include "gz/sim/components/RenderEngineServerPlugin.hh"
 #include "gz/sim/components/SelfCollide.hh"
 #include "gz/sim/components/Sensor.hh"
@@ -821,6 +822,13 @@ void ComponentInspectorEditor::Update(const UpdateInfo &_info,
     else if (typeId == components::RenderEngineServerPlugin::typeId)
     {
       auto comp = _ecm.Component<components::RenderEngineServerPlugin>(
+          this->dataPtr->entity);
+      if (comp)
+        setData(item, comp->Data());
+    }
+    else if (typeId == components::RenderEngineServerApiBackend::typeId)
+    {
+      auto comp = _ecm.Component<components::RenderEngineServerApiBackend>(
           this->dataPtr->entity);
       if (comp)
         setData(item, comp->Data());

--- a/src/gz.cc
+++ b/src/gz.cc
@@ -403,6 +403,11 @@ extern "C" int runServer(const char *_sdfString,
     serverConfig.SetRenderEngineServerApiBackend(_renderEngineServerApiBackend);
   }
 
+  if (_renderEngineGuiApiBackend != nullptr)
+  {
+    serverConfig.SetRenderEngineGuiApiBackend(_renderEngineGuiApiBackend);
+  }
+
   if (_renderEngineGui != nullptr && std::strlen(_renderEngineGui) > 0)
   {
     serverConfig.SetRenderEngineGui(_renderEngineGui);

--- a/src/gz.cc
+++ b/src/gz.cc
@@ -134,7 +134,8 @@ extern "C" int runServer(const char *_sdfString,
     int _networkSecondaries, int _record, const char *_recordPath,
     int _recordResources, int _logOverwrite, int _logCompress,
     const char *_playback, const char *_physicsEngine,
-    const char *_renderEngineServer, const char *_renderEngineGui,
+    const char *_renderEngineServer, const char *_renderEngineServerApiBackend,
+    const char *_renderEngineGui, const char *_renderEngineGuiApiBackend,
     const char *_file, const char *_recordTopics, int _waitGui,
     int _headless, float _recordPeriod, int _seed)
 {
@@ -397,6 +398,11 @@ extern "C" int runServer(const char *_sdfString,
     serverConfig.SetRenderEngineServer(_renderEngineServer);
   }
 
+  if (_renderEngineServerApiBackend != nullptr)
+  {
+    serverConfig.SetRenderEngineServerApiBackend(_renderEngineServerApiBackend);
+  }
+
   if (_renderEngineGui != nullptr && std::strlen(_renderEngineGui) > 0)
   {
     serverConfig.SetRenderEngineGui(_renderEngineGui);
@@ -420,7 +426,8 @@ extern "C" int runServer(const char *_sdfString,
 
 //////////////////////////////////////////////////
 extern "C" int runGui(const char *_guiConfig, const char *_file, int _waitGui,
-  const char *_renderEngine)
+                      const char *_renderEngine,
+                      const char *_renderEngineGuiApiBackend)
 {
   // argc and argv are going to be passed to a QApplication. The Qt
   // documentation has a warning about these:
@@ -449,6 +456,6 @@ extern "C" int runGui(const char *_guiConfig, const char *_file, int _waitGui,
   };
   int argc = sizeof(argv) / sizeof(argv[0]);
 
-  return gz::sim::gui::runGui(
-    argc, argv, _guiConfig, _file, _waitGui, _renderEngine);
+  return gz::sim::gui::runGui(argc, argv, _guiConfig, _file, _waitGui,
+                              _renderEngine, _renderEngineGuiApiBackend);
 }

--- a/src/gz.hh
+++ b/src/gz.hh
@@ -82,7 +82,8 @@ extern "C" GZ_SIM_VISIBLE int runServer(const char *_sdfString,
 /// \param[in] _renderEngine --render-engine-gui option
 /// \param[in] _renderEngineGuiApiBackend --render-engine-gui-api-backend option
 /// \return 0 if successful, 1 if not.
-extern "C" int GZ_SIM_VISIBLE runGui(const char *_guiConfig, const char *_file, int _waitGui,
+extern "C" int GZ_SIM_VISIBLE runGui(const char *_guiConfig, const char *_file,
+                                     int _waitGui,
                                      const char *_renderEngine,
                                      const char *_renderEngineGuiApiBackend);
 

--- a/src/gz.hh
+++ b/src/gz.hh
@@ -50,7 +50,9 @@ extern "C" GZ_SIM_VISIBLE const char *worldInstallDir();
 /// \param[in] _playback --playback option
 /// \param[in] _physicsEngine --physics-engine option
 /// \param[in] _renderEngineServer --render-engine-server option
+/// \param[in] _renderEngineServerApiBackend --render-engine-server-api-backend
 /// \param[in] _renderEngineGui --render-engine-gui option
+/// \param[in] _renderEngineGuiApiBackend --render-engine-gui-api-backend
 /// \param[in] _file Path to file being loaded
 /// \param[in] _recordTopics Colon separated list of topics to record. Leave
 /// \param[in] _waitGui Flag indicating whether the server waits until
@@ -65,9 +67,10 @@ extern "C" GZ_SIM_VISIBLE int runServer(const char *_sdfString,
     const char *_networkRole, int _networkSecondaries, int _record,
     const char *_recordPath, int _recordResources, int _logOverwrite,
     int _logCompress, const char *_playback,
-    const char *_physicsEngine, const char *_renderEngineServer,
-    const char *_renderEngineGui, const char *_file,
-    const char *_recordTopics, int _waitGui, int _headless,
+    const char *_physicsEngine,
+    const char *_renderEngineServer, const char *_renderEngineServerApiBackend,
+    const char *_renderEngineGui, const char *_renderEngineGuiApiBackend,
+    const char *_file, const char *_recordTopics, int _waitGui, int _headless,
     float _recordPeriod, int _seed);
 
 /// \brief External hook to run simulation GUI.
@@ -77,9 +80,11 @@ extern "C" GZ_SIM_VISIBLE int runServer(const char *_sdfString,
 /// \param[in] _waitGui Flag indicating whether the server waits until
 /// it receives a world path from GUI.
 /// \param[in] _renderEngine --render-engine-gui option
+/// \param[in] _renderEngineGuiApiBackend --render-engine-gui-api-backend option
 /// \return 0 if successful, 1 if not.
-extern "C" GZ_SIM_VISIBLE int runGui(const char *_guiConfig,
-    const char *_file, int _waitGui, const char *_renderEngine);
+extern "C" int GZ_SIM_VISIBLE runGui(const char *_guiConfig, const char *_file, int _waitGui,
+                                     const char *_renderEngine,
+                                     const char *_renderEngineGuiApiBackend);
 
 /// \brief External hook to find or download a fuel world provided a URL.
 /// \param[in] _pathToResource Path to the fuel world resource, ie,

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -209,6 +209,9 @@ class gz::sim::RenderUtilPrivate
   /// \brief Name of rendering engine
   public: std::string engineName = "ogre2";
 
+  /// \brief Name of API backend
+  public: std::string apiBackend = "";
+
   /// \brief Name of scene
   public: std::string sceneName = "scene";
 
@@ -2581,16 +2584,20 @@ void RenderUtil::Init()
   this->InitRenderEnginePluginPaths();
 
   std::map<std::string, std::string> params;
-#ifdef __APPLE__
-  // TODO(srmainwaring): implement facility for overriding the default
-  //    graphics API in macOS, in which case there are restrictions on
-  //    the version of OpenGL used.
-  params["metal"] = "1";
-#else
-  if (this->dataPtr->useCurrentGLContext)
+  if (this->dataPtr->useCurrentGLContext &&
+      this->dataPtr->apiBackend != "vulkan" &&
+      this->dataPtr->apiBackend != "metal")
+  {
     params["useCurrentGLContext"] = "1";
-#endif
-
+  }
+  if (this->dataPtr->apiBackend == "vulkan")
+  {
+    params["vulkan"] = "1";
+  }
+  else if (this->dataPtr->apiBackend == "metal")
+  {
+    params["metal"] = "1";
+  }
   if (this->dataPtr->isHeadlessRendering)
     params["headless"] = "1";
   params["winID"] = this->dataPtr->winID;
@@ -2700,6 +2707,18 @@ void RenderUtil::SetEngineName(const std::string &_name)
 std::string RenderUtil::EngineName() const
 {
   return this->dataPtr->engineName;
+}
+
+/////////////////////////////////////////////////
+void RenderUtil::SetApiBackend(const std::string &_apiBackend)
+{
+  this->dataPtr->apiBackend = _apiBackend;
+}
+
+/////////////////////////////////////////////////
+std::string RenderUtil::ApiBackend() const
+{
+  return this->dataPtr->apiBackend;
 }
 
 /////////////////////////////////////////////////

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -2598,6 +2598,7 @@ void RenderUtil::Init()
   {
     params["metal"] = "1";
   }
+
   if (this->dataPtr->isHeadlessRendering)
     params["headless"] = "1";
   params["winID"] = this->dataPtr->winID;

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -50,6 +50,7 @@
 #include "gz/sim/components/DepthCamera.hh"
 #include "gz/sim/components/GpuLidar.hh"
 #include "gz/sim/components/ParentEntity.hh"
+#include "gz/sim/components/RenderEngineServerApiBackend.hh"
 #include "gz/sim/components/RenderEngineServerHeadless.hh"
 #include "gz/sim/components/RenderEngineServerPlugin.hh"
 #include "gz/sim/components/RgbdCamera.hh"
@@ -504,6 +505,9 @@ void Sensors::Configure(const Entity &/*_id*/,
   std::string engineName =
       _sdf->Get<std::string>("render_engine", "ogre2").first;
 
+  const std::string apiBackend =
+    _sdf->Get<std::string>("render_engine_api_backend", "").first;
+
   // get whether or not to disable sensor when model battery is drained
   this->dataPtr->disableOnDrainedBattery =
       _sdf->Get<bool>("disable_on_drained_battery",
@@ -518,6 +522,7 @@ void Sensors::Configure(const Entity &/*_id*/,
     this->dataPtr->ambientLight = _sdf->Get<math::Color>("ambient_light");
 
   this->dataPtr->renderUtil.SetEngineName(engineName);
+  this->dataPtr->renderUtil.SetApiBackend(apiBackend);
   this->dataPtr->renderUtil.SetEnableSensors(true,
       std::bind(&Sensors::CreateSensor, this,
       std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
@@ -545,6 +550,16 @@ void Sensors::Configure(const Entity &/*_id*/,
     if (renderEngineServerComp && !renderEngineServerComp->Data().empty())
     {
       this->dataPtr->renderUtil.SetEngineName(renderEngineServerComp->Data());
+    }
+
+    // Set API backend if specified from command line
+    auto renderEngineServerApiBackendComp =
+      _ecm.Component<components::RenderEngineServerApiBackend>(worldEntity);
+    if (renderEngineServerApiBackendComp &&
+        !renderEngineServerApiBackendComp->Data().empty())
+    {
+      this->dataPtr->renderUtil.SetApiBackend(
+        renderEngineServerApiBackendComp->Data());
     }
 
     // Set headless mode if specified from command line

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -505,7 +505,7 @@ void Sensors::Configure(const Entity &/*_id*/,
   std::string engineName =
       _sdf->Get<std::string>("render_engine", "ogre2").first;
 
-  const std::string apiBackend =
+  std::string apiBackend =
     _sdf->Get<std::string>("render_engine_api_backend", "").first;
 
   // get whether or not to disable sensor when model battery is drained
@@ -522,6 +522,10 @@ void Sensors::Configure(const Entity &/*_id*/,
     this->dataPtr->ambientLight = _sdf->Get<math::Color>("ambient_light");
 
   this->dataPtr->renderUtil.SetEngineName(engineName);
+#ifdef __APPLE__
+  if (apiBackend.empty())
+    apiBackend = "metal";
+#endif
   this->dataPtr->renderUtil.SetApiBackend(apiBackend);
   this->dataPtr->renderUtil.SetEnableSensors(true,
       std::bind(&Sensors::CreateSensor, this,


### PR DESCRIPTION
# 🎉 New feature

## Order in which PRs must be merged

1. gazebosim/gz-rendering#706
2. gazebosim/gz-gui#357
    - or optionally, merge this one as part of the next one aka PR 467, which includes it
3. gazebosim/gz-gui#467
4. This PR.

## Summary

This PR adds the following CLI options:

 - `--render-engine-gui-api-backend [arg]`
 - `--render-engine-server-api-backend [arg]`
 - `--render-engine-api-backend [arg]`

The default is `metal` in Apple systems, and `opengl` in the rest; and the other option being `vulkan`.

This setting gets forwarded to the other components so it actually gets applied.

## Test it

After merging all dependent PRs, run:

`gz help sim`

For help with the new CLI options

*To test everything:*

`gz sim segmentation_camera.sdf -v4 --render-engine-api-backend vulkan`

*Server only:*

`gz sim segmentation_camera.sdf -v4 -s -r --render-engine-server-api-backend vulkan`

*GUI only:*

`gz sim -v4 -g --render-engine-gui-api-backend vulkan`

And see the Ogre.log to check Vulkan is being used.

I use segmentation_camera.sdf because it forces the server to render.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
