### PR TITLE
Silly typo mistake for triggered_publisher example

### DIFF
--- a/examples/worlds/triggered_publisher.sdf
+++ b/examples/worlds/triggered_publisher.sdf
@@ -472,7 +472,7 @@ start falling.
         reqType="ignition.msgs.Pose"
         repType="ignition.msgs.Boolean"
         timeout="3000"
-        reqMsg="name: 'blue_vehicle', position: {x: -3, z: 0.325}">
+        reqMsg="name: 'vehicle_blue', position: {x: -3, z: 0.325}">
       </service>
     </plugin>
     <plugin


### PR DESCRIPTION
found a silly typo that was pushed back in PR (https://github.com/gazebosim/gz-sim/pull/1611)