### PR TITLE
Return absolute path when finding a resource

### DIFF
--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -863,6 +863,13 @@ msgs::Scene ignition::gazebo::convert(const sdf::Scene &_in)
     skyMsg->set_mean_cloud_size(_in.Sky()->CloudMeanSize());
     msgs::Set(skyMsg->mutable_cloud_ambient(),
         _in.Sky()->CloudAmbient());
+
+    if (!_in.Sky()->CubemapUri().empty())
+    {
+      auto header = skyMsg->mutable_header()->add_data();
+      header->set_key("cubemap_uri");
+      header->add_value(_in.Sky()->CubemapUri());
+    }
   }
 
   return out;
@@ -893,6 +900,16 @@ sdf::Scene ignition::gazebo::convert(const msgs::Scene &_in)
     sky.SetCloudHumidity(_in.sky().humidity());
     sky.SetCloudMeanSize(_in.sky().mean_cloud_size());
     sky.SetCloudAmbient(msgs::Convert(_in.sky().cloud_ambient()));
+
+    for (int i = 0; i < _in.sky().header().data_size(); ++i)
+    {
+      auto data = _in.sky().header().data(i);
+      if (data.key() == "cubemap_uri" && data.value_size() > 0)
+      {
+        sky.SetCubemapUri(data.value(0));
+      }
+    }
+
     out.SetSky(sky);
   }
   return out;

--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -710,6 +710,7 @@ TEST(Conversions, Scene)
   sky.SetCloudHumidity(0.11);
   sky.SetCloudMeanSize(0.88);
   sky.SetCloudAmbient(math::Color::Red);
+  sky.SetCubemapUri("test.dds");
   scene.SetSky(sky);
 
   auto sceneSkyMsg = convert<msgs::Scene>(scene);
@@ -723,6 +724,10 @@ TEST(Conversions, Scene)
   EXPECT_DOUBLE_EQ(0.88, sceneSkyMsg.sky().mean_cloud_size());
   EXPECT_EQ(math::Color::Red,
       msgs::Convert(sceneSkyMsg.sky().cloud_ambient()));
+  ASSERT_GT(sceneSkyMsg.sky().header().data_size(), 0);
+  auto header = sceneSkyMsg.sky().header().data(0);
+  EXPECT_EQ("cubemap_uri", header.key());
+  EXPECT_EQ("test.dds", header.value(0));
 
   auto newSceneSky = convert<sdf::Scene>(sceneSkyMsg);
   ASSERT_NE(nullptr, newSceneSky.Sky());
@@ -734,6 +739,7 @@ TEST(Conversions, Scene)
   EXPECT_DOUBLE_EQ(0.11, newSceneSky.Sky()->CloudHumidity());
   EXPECT_DOUBLE_EQ(0.88, newSceneSky.Sky()->CloudMeanSize());
   EXPECT_EQ(math::Color::Red, newSceneSky.Sky()->CloudAmbient());
+  EXPECT_EQ("test.dds", newSceneSky.Sky()->CubemapUri());
 }
 
 /////////////////////////////////////////////////

--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -490,9 +490,9 @@ bool ServerPrivate::ResourcePathsResolveService(
   std::string req = _req.data();
 
   // Handle the case where the request is already a valid path
-  if (common::exists(req))
+  if (common::exists(common::absPath(req)))
   {
-    _res.set_data(req);
+    _res.set_data(common::absPath(req));
     return true;
   }
 


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🦟 Bug fix

## Summary

The `/gazebo/resource_paths/resolve` service would return a relative path to the gazebo server process. This is a problem when the requester is not executed at the same path as the gazebo server.

This fixes the issue by returning an absolute path.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.