### PR TITLE
Fix minor bugs in RFComms plugin

### DIFF
--- a/src/systems/rf_comms/RFComms.cc
+++ b/src/systems/rf_comms/RFComms.cc
@@ -128,6 +128,9 @@ struct RadioState
 
   /// \brief Accumulation of bytes received in an epoch.
   uint64_t bytesReceivedThisEpoch = 0;
+
+  /// \brief Name of the model associated with the radio.
+  std::string name;
 };
 
 /// \brief Type for holding RF power as a Normally distributed random variable.
@@ -262,8 +265,8 @@ std::tuple<bool, double> RFComms::Implementation::AttemptSend(
   // Check current epoch bitrate vs capacity and fail to send accordingly
   if (bitsSent > this->radioConfig.capacity * this->epochDuration)
   {
-    ignwarn << "Bitrate limited: " << bitsSent << "bits sent (limit: "
-            << this->radioConfig.capacity * this->epochDuration << std::endl;
+    ignwarn << "Bitrate limited: [" << _txState.name << "] " << bitsSent << "bits sent (limit: "
+            << this->radioConfig.capacity * this->epochDuration << ")" << std::endl;
     return std::make_tuple(false, std::numeric_limits<double>::lowest());
   }
 
@@ -320,9 +323,9 @@ std::tuple<bool, double> RFComms::Implementation::AttemptSend(
   // Check current epoch bitrate vs capacity and fail to send accordingly.
   if (bitsReceived > this->radioConfig.capacity * this->epochDuration)
   {
-    // ignwarn << "Bitrate limited: " <<  bitsReceived
-    //         << "bits received (limit: "
-    //         << this->radioConfig.capacity * this->epochDuration << std::endl;
+    ignwarn << "Bitrate limited: [" << _rxState.name << "] " <<  bitsReceived
+            << "bits received (limit: "
+            << this->radioConfig.capacity * this->epochDuration << ")" << std::endl;
     return std::make_tuple(false, std::numeric_limits<double>::lowest());
   }
 
@@ -421,6 +424,7 @@ void RFComms::Step(
       this->dataPtr->radioStates[address].pose = kPose;
       this->dataPtr->radioStates[address].timeStamp =
         std::chrono::duration<double>(_info.simTime).count();
+      this->dataPtr->radioStates[address].name = content.modelName;
     }
   }
 

--- a/src/systems/rf_comms/RFComms.cc
+++ b/src/systems/rf_comms/RFComms.cc
@@ -306,7 +306,7 @@ std::tuple<bool, double> RFComms::Implementation::AttemptSend(
 
   // Maintain running window of bytes received over the last epoch, e.g., 1s.
   while (!_rxState.bytesReceived.empty() &&
-         _rxState.bytesReceived.front().first < now - this->epochDuration)
+         _rxState.bytesReceived.front().first <= now - this->epochDuration)
   {
     _rxState.bytesReceivedThisEpoch -= _rxState.bytesReceived.front().second;
     _rxState.bytesReceived.pop_front();

--- a/src/systems/rf_comms/RFComms.cc
+++ b/src/systems/rf_comms/RFComms.cc
@@ -446,11 +446,7 @@ void RFComms::Step(
           continue;
 
         auto [sendPacket, rssi] = this->dataPtr->AttemptSend(
-#if GOOGLE_PROTOBUF_VERSION < 3004001
-          itSrc->second, itDst->second, msg->ByteSize());
-#else
-          itSrc->second, itDst->second, msg->ByteSizeLong());
-#endif
+          itSrc->second, itDst->second, msg->data().size());
 
         if (sendPacket)
         {

--- a/src/systems/rf_comms/RFComms.cc
+++ b/src/systems/rf_comms/RFComms.cc
@@ -237,7 +237,7 @@ RFPower RFComms::Implementation::LogNormalReceivedPower(
   const double kPL = this->rangeConfig.l0 +
     10 * this->rangeConfig.fadingExponent * log10(kRange);
 
-  return {_txPower - kPL, this->rangeConfig.sigma};
+  return {_txPower - kPL, pow(this->rangeConfig.sigma, 2.)};
 }
 
 /////////////////////////////////////////////

--- a/src/systems/rf_comms/RFComms.cc
+++ b/src/systems/rf_comms/RFComms.cc
@@ -265,8 +265,10 @@ std::tuple<bool, double> RFComms::Implementation::AttemptSend(
   // Check current epoch bitrate vs capacity and fail to send accordingly
   if (bitsSent > this->radioConfig.capacity * this->epochDuration)
   {
-    ignwarn << "Bitrate limited: [" << _txState.name << "] " << bitsSent << "bits sent (limit: "
-            << this->radioConfig.capacity * this->epochDuration << ")" << std::endl;
+    ignwarn << "Bitrate limited: [" << _txState.name << "] " << bitsSent
+            << " bits sent (limit: "
+            << this->radioConfig.capacity * this->epochDuration << ")"
+            << std::endl;
     return std::make_tuple(false, std::numeric_limits<double>::lowest());
   }
 
@@ -324,8 +326,9 @@ std::tuple<bool, double> RFComms::Implementation::AttemptSend(
   if (bitsReceived > this->radioConfig.capacity * this->epochDuration)
   {
     ignwarn << "Bitrate limited: [" << _rxState.name << "] " <<  bitsReceived
-            << "bits received (limit: "
-            << this->radioConfig.capacity * this->epochDuration << ")" << std::endl;
+            << " bits received (limit: "
+            << this->radioConfig.capacity * this->epochDuration << ")"
+            << std::endl;
     return std::make_tuple(false, std::numeric_limits<double>::lowest());
   }
 

--- a/src/systems/rf_comms/RFComms.cc
+++ b/src/systems/rf_comms/RFComms.cc
@@ -248,7 +248,7 @@ std::tuple<bool, double> RFComms::Implementation::AttemptSend(
 
   // Maintain running window of bytes sent over the last epoch, e.g., 1s.
   while (!_txState.bytesSent.empty() &&
-         _txState.bytesSent.front().first < now - this->epochDuration)
+         _txState.bytesSent.front().first <= now - this->epochDuration)
   {
     _txState.bytesSentThisEpoch -= _txState.bytesSent.front().second;
     _txState.bytesSent.pop_front();


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #1738 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
Fixes 3 minor bugs in RFComms plugin:
1. Incorrect usage of standard deviation and variance in Gaussian noise generation
2. Incorrect calculation of sending and receiving bitrates
3. Incorrect calculation of the message size

More information and description of proposed solutions implemented in this PR for all three bugs can be found in #1738.

Additionally, there is a small change in the warning messages for bitrate limitation. Warning messages now specify which Radio/Model (robot in simulation) has broken the limit.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.