### PR TITLE
Convert ignitionrobotics to gazebosim in tests directory

### DIFF
--- a/test/integration/battery_plugin.cc
+++ b/test/integration/battery_plugin.cc
@@ -107,7 +107,7 @@ TEST_F(BatteryPluginTest, SingleBattery)
       // the LinearBatteryPlugin is not zero when created. If
       // components::BatterySoC is zero on start, then the Physics plugin
       // can disable a joint. This in turn can prevent the joint from
-      // rotating. See https://github.com/ignitionrobotics/ign-gazebo/issues/55
+      // rotating. See https://github.com/gazebosim/gz-gazebo/issues/55
       EXPECT_GT(batComp->Data(), 0);
     };
 

--- a/test/integration/battery_plugin.cc
+++ b/test/integration/battery_plugin.cc
@@ -107,7 +107,7 @@ TEST_F(BatteryPluginTest, SingleBattery)
       // the LinearBatteryPlugin is not zero when created. If
       // components::BatterySoC is zero on start, then the Physics plugin
       // can disable a joint. This in turn can prevent the joint from
-      // rotating. See https://github.com/gazebosim/gz-gazebo/issues/55
+      // rotating. See https://github.com/gazebosim/gz-sim/issues/55
       EXPECT_GT(batComp->Data(), 0);
     };
 

--- a/test/integration/examples_build.cc
+++ b/test/integration/examples_build.cc
@@ -27,7 +27,7 @@
 #include "../helpers/EnvTestFixture.hh"
 
 // File copied from
-// https://github.com/ignitionrobotics/ign-gui/raw/ign-gui3/test/integration/ExamplesBuild_TEST.cc
+// https://github.com/gazebosim/gz-gui/raw/ign-gui3/test/integration/ExamplesBuild_TEST.cc
 
 using namespace ignition;
 

--- a/test/integration/log_system.cc
+++ b/test/integration/log_system.cc
@@ -59,7 +59,7 @@ using namespace gazebo;
 static const std::string kBinPath(PROJECT_BINARY_PATH);
 
 // TODO(anyone) Support command line options for OSX, see
-// https://github.com/ignitionrobotics/ign-gazebo/issues/25
+// https://github.com/gazebosim/gz-gazebo/issues/25
 #ifndef __APPLE__
 static const std::string kSdfFileOpt =  // NOLINT(runtime/string)
 " ";
@@ -1276,7 +1276,7 @@ TEST_F(LogSystemTest, LogOverwrite)
   // ign gazebo. server_main.cc is deprecated and does not have overwrite
   // renaming implemented. So will always overwrite. Will not test (#) type of
   // renaming on OS X until ign gazebo is fixed:
-  // https://github.com/ignitionrobotics/ign-gazebo/issues/25
+  // https://github.com/gazebosim/gz-gazebo/issues/25
 
   // New log files were created
   EXPECT_TRUE(common::exists(this->logDir + "(1)"));
@@ -1739,7 +1739,7 @@ TEST_F(LogSystemTest, LogResources)
   // Recorded models should exist
   EXPECT_GT(entryCount(recordPath), 2);
   EXPECT_TRUE(common::exists(common::joinPaths(recordPath, homeFake,
-      ".ignition", "fuel", "fuel.ignitionrobotics.org", "openrobotics",
+      ".ignition", "fuel", "fuel.gazebosim.org", "openrobotics",
       "models", "x2 config 1")));
 
   // Remove artifacts. Recreate new directory
@@ -1774,7 +1774,7 @@ TEST_F(LogSystemTest, LogResources)
   EXPECT_GT(entryCount(recordPath), 1);
 #endif
   EXPECT_TRUE(common::exists(common::joinPaths(recordPath, homeFake,
-      ".ignition", "fuel", "fuel.ignitionrobotics.org", "openrobotics",
+      ".ignition", "fuel", "fuel.gazebosim.org", "openrobotics",
       "models", "x2 config 1")));
 
   // Revert environment variable after test is done

--- a/test/integration/log_system.cc
+++ b/test/integration/log_system.cc
@@ -59,7 +59,7 @@ using namespace gazebo;
 static const std::string kBinPath(PROJECT_BINARY_PATH);
 
 // TODO(anyone) Support command line options for OSX, see
-// https://github.com/gazebosim/gz-gazebo/issues/25
+// https://github.com/gazebosim/gz-sim/issues/25
 #ifndef __APPLE__
 static const std::string kSdfFileOpt =  // NOLINT(runtime/string)
 " ";
@@ -1276,7 +1276,7 @@ TEST_F(LogSystemTest, LogOverwrite)
   // ign gazebo. server_main.cc is deprecated and does not have overwrite
   // renaming implemented. So will always overwrite. Will not test (#) type of
   // renaming on OS X until ign gazebo is fixed:
-  // https://github.com/gazebosim/gz-gazebo/issues/25
+  // https://github.com/gazebosim/gz-sim/issues/25
 
   // New log files were created
   EXPECT_TRUE(common::exists(this->logDir + "(1)"));

--- a/test/integration/network_handshake.cc
+++ b/test/integration/network_handshake.cc
@@ -145,7 +145,7 @@ TEST_F(NetworkHandshake, IGN_UTILS_TEST_DISABLED_ON_MAC(Updates))
   configPrimary.SetUseLevels(true);
   // Can only test one secondary running physics, because running 2 physics in
   // the same process causes a segfault, see
-  // https://github.com/gazebosim/gz-gazebo/issues/18
+  // https://github.com/gazebosim/gz-sim/issues/18
   configPrimary.SetNetworkSecondaries(1);
   configPrimary.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
       "/test/worlds/performers.sdf");

--- a/test/integration/network_handshake.cc
+++ b/test/integration/network_handshake.cc
@@ -145,7 +145,7 @@ TEST_F(NetworkHandshake, IGN_UTILS_TEST_DISABLED_ON_MAC(Updates))
   configPrimary.SetUseLevels(true);
   // Can only test one secondary running physics, because running 2 physics in
   // the same process causes a segfault, see
-  // https://github.com/ignitionrobotics/ign-gazebo/issues/18
+  // https://github.com/gazebosim/gz-gazebo/issues/18
   configPrimary.SetNetworkSecondaries(1);
   configPrimary.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
       "/test/worlds/performers.sdf");

--- a/test/integration/save_world.cc
+++ b/test/integration/save_world.cc
@@ -100,7 +100,7 @@ TEST_F(SdfGeneratorFixture, WorldWithModelsSpawnedAfterLoad)
   // This has to be different from the backpack in order to test SDFormat
   // generation for a Fuel URI that was not known when simulation started.
   const std::string groundPlaneUri =
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/ground plane";
+      "https://fuel.gazebosim.org/1.0/OpenRobotics/models/ground plane";
 
   transport::Node node;
   {

--- a/test/integration/sdf_include.cc
+++ b/test/integration/sdf_include.cc
@@ -44,6 +44,6 @@ TEST_F(SdfInclude, DownloadFromFuel)
   Server server(serverConfig);
 
   EXPECT_TRUE(common::exists(path +
-        "/fuel.ignitionrobotics.org/openrobotics/models/ground plane" +
+        "/fuel.gazebosim.org/openrobotics/models/ground plane" +
         "/1/model.sdf"));
 }

--- a/test/integration/touch_plugin.cc
+++ b/test/integration/touch_plugin.cc
@@ -99,7 +99,7 @@ TEST_F(TouchPluginTest, OneLink)
     std::this_thread::sleep_for(std::chrono::milliseconds(30));
   }
 // Known to fail on OSX, see
-// https://github.com/ignitionrobotics/ign-gazebo/issues/22
+// https://github.com/gazebosim/gz-gazebo/issues/22
 #if !defined (__APPLE__)
   EXPECT_TRUE(whiteTouched);
 #endif
@@ -179,7 +179,7 @@ TEST_F(TouchPluginTest, StartDisabled)
     std::this_thread::sleep_for(std::chrono::milliseconds(30));
   }
 // Known to fail on OSX, see
-// https://github.com/ignitionrobotics/ign-gazebo/issues/22
+// https://github.com/gazebosm/gz-gazebo/issues/22
 #if !defined (__APPLE__)
   EXPECT_TRUE(blueTouched);
 #endif

--- a/test/integration/touch_plugin.cc
+++ b/test/integration/touch_plugin.cc
@@ -99,7 +99,7 @@ TEST_F(TouchPluginTest, OneLink)
     std::this_thread::sleep_for(std::chrono::milliseconds(30));
   }
 // Known to fail on OSX, see
-// https://github.com/gazebosim/gz-gazebo/issues/22
+// https://github.com/gazebosim/gz-sim/issues/22
 #if !defined (__APPLE__)
   EXPECT_TRUE(whiteTouched);
 #endif
@@ -179,7 +179,7 @@ TEST_F(TouchPluginTest, StartDisabled)
     std::this_thread::sleep_for(std::chrono::milliseconds(30));
   }
 // Known to fail on OSX, see
-// https://github.com/gazebosm/gz-gazebo/issues/22
+// https://github.com/gazebosm/gz-sim/issues/22
 #if !defined (__APPLE__)
   EXPECT_TRUE(blueTouched);
 #endif

--- a/test/integration/tracked_vehicle_system.cc
+++ b/test/integration/tracked_vehicle_system.cc
@@ -69,7 +69,7 @@ class TrackedVehicleTest : public InternalFixture<::testing::Test>
                                       bool &_shouldSkip)
   {
 #if __APPLE__
-    // until https://github.com/gazebosim/gz-gazebo/issues/806 is fixed
+    // until https://github.com/gazebosim/gz-sim/issues/806 is fixed
     _shouldSkip = true;
 #else
     _shouldSkip = false;

--- a/test/integration/tracked_vehicle_system.cc
+++ b/test/integration/tracked_vehicle_system.cc
@@ -69,7 +69,7 @@ class TrackedVehicleTest : public InternalFixture<::testing::Test>
                                       bool &_shouldSkip)
   {
 #if __APPLE__
-    // until https://github.com/ignitionrobotics/ign-gazebo/issues/806 is fixed
+    // until https://github.com/gazebosim/gz-gazebo/issues/806 is fixed
     _shouldSkip = true;
 #else
     _shouldSkip = false;

--- a/test/worlds/breadcrumbs.sdf
+++ b/test/worlds/breadcrumbs.sdf
@@ -481,7 +481,7 @@
               <pose>-2.2 0 5 0 0 0</pose>
               <include>
                 <uri>
-                    https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Cardboard box
+                    https://fuel.gazebosim.org/1.0/OpenRobotics/models/Cardboard box
                 </uri>
               </include>
             </model>

--- a/test/worlds/include.sdf
+++ b/test/worlds/include.sdf
@@ -6,7 +6,7 @@
     </physics>
 
     <include>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/ground plane/1</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/ground plane/1</uri>
     </include>
   </world>
 </sdf>

--- a/test/worlds/log_record_resources.sdf
+++ b/test/worlds/log_record_resources.sdf
@@ -56,7 +56,7 @@
       <static>false</static>
       <name>staging_area</name>
       <pose>0 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/X2 Config 1</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/X2 Config 1</uri>
     </include>
 
     <model name="ground_plane">

--- a/test/worlds/save_world.sdf
+++ b/test/worlds/save_world.sdf
@@ -24,17 +24,17 @@
     </model>
 
     <include>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack</uri>
       <name>backpack1</name>
       <pose>1 0 0 0 0 0</pose>
     </include>
     <include>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack</uri>
       <name>backpack2</name>
       <pose>1 2 3 0.1 0.2 0.3</pose>
     </include>
     <include>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Backpack/2</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack/2</uri>
       <name>backpack3</name>
       <pose>2 0 0 0.1 0.2 0.3</pose>
     </include>


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

Converts use of `ignitionrobotics` to `gazebosim` in the `tests` directory.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.