### PR TITLE
Fix scene_broadcaster_system test

### DIFF
--- a/test/worlds/shapes_scene_broadcaster_only.sdf
+++ b/test/worlds/shapes_scene_broadcaster_only.sdf
@@ -3,7 +3,7 @@
   <world name="default">
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>0</real_time_factor>
+      <real_time_factor>1</real_time_factor>
     </physics>
 
     <plugin


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>


# 🦟 Bug fix

## Summary
I found that slowing the test down resolve the flakiness locally.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.