### PR TITLE
Fix thruster integration test

### DIFF
--- a/test/integration/thruster.cc
+++ b/test/integration/thruster.cc
@@ -245,7 +245,7 @@ void ThrusterTest::TestWorld(const std::string &_world,
     //    linear_velocity) / (angular_velocity * propeller_diameter))
     // omega = sqrt(thrust /
     //     (fluid_density * thrust_coefficient * propeller_diameter ^ 4))
-    if (_calculateCoefficient && gz::math::equal(angularVelocity, 0.0))
+    if (_calculateCoefficient && !gz::math::equal(angularVelocity, 0.0))
     {
       _thrustCoefficient = _alpha1 + _alpha2 * (((1 - _wakeFraction) *
           propellerLinVels[i].Length()) / (angularVelocity * _diameter));


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🦟 Bug fix

## Summary

PR #1754 applied the wrong logic [here](https://github.com/gazebosim/gz-sim/pull/1754/files#diff-e2f32b0dccaccdba6cba24acfc16cc2b3e52b1f989ceb4e99ffee0fccc67c687L247). This fixes the problem.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.