### PR TITLE
Some minor changes to hydrodynamic flags test

### DIFF
--- a/test/worlds/hydrodynamics_flags.sdf
+++ b/test/worlds/hydrodynamics_flags.sdf
@@ -1,16 +1,7 @@
 <?xml version="1.0" ?>
 
-<!-- Run demo with ign-gazebo examples/standalone/multi_lrauv_race
-  (example is provided in ign-gazebo6+). -->
-
 <sdf version="1.6">
   <world name="multi_lrauv">
-    <scene>
-      <!-- For turquoise ambient to match particle effect -->
-      <ambient>0.0 1.0 1.0</ambient>
-      <background>0.0 0.7 0.8</background>
-    </scene>
-
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
       <real_time_factor>1.0</real_time_factor>
@@ -18,14 +9,6 @@
     <plugin
       filename="ignition-gazebo-physics-system"
       name="ignition::gazebo::systems::Physics">
-    </plugin>
-    <plugin
-      filename="ignition-gazebo-user-commands-system"
-      name="ignition::gazebo::systems::UserCommands">
-    </plugin>
-    <plugin
-      filename="ignition-gazebo-scene-broadcaster-system"
-      name="ignition::gazebo::systems::SceneBroadcaster">
     </plugin>
     <plugin
       filename="ignition-gazebo-contact-system"
@@ -54,7 +37,7 @@
 
     <include>
       <pose>0 0 1 0 0 1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
 
       <!-- Joint controllers -->
       <plugin
@@ -149,7 +132,7 @@
 
     <include>
       <pose>5 0 1 0 0 1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
       <name>triton</name>
 
       <!-- Joint controllers -->
@@ -335,18 +318,5 @@
         <disable_coriolis>true</disable_coriolis>
       </plugin>
     </include>
-
-    <!-- Swimming race lane signs -->
-    <include>
-      <pose>0 0 -1 0 0 3.1415926</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/mabelzhang/models/ABCSign_5m</uri>
-      <name>start_line</name>
-    </include>
-    <include>
-      <pose>0 -25 -1 0 0 3.1415926</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/mabelzhang/models/ABCSign_5m</uri>
-      <name>finish_line</name>
-    </include>
-
   </world>
 </sdf>


### PR DESCRIPTION
# 🦟 Bug fix

This commit changes the url to use the more recent url. It also removes the scene-broadcaster plugin as we don't need it in the test itself.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
