### PR TITLE
Change nameFilter of saveDialog from "World files" to "SDF files"

### DIFF
--- a/src/gui/resources/GazeboDrawer.qml
+++ b/src/gui/resources/GazeboDrawer.qml
@@ -133,7 +133,7 @@ Rectangle {
     id: saveWorldDialog
     title: "Save world"
     folder: shortcuts.home
-    nameFilters: [ "World files (*.sdf)" ]
+    nameFilters: [ "SDF files (*.sdf)" ]
     selectMultiple: false
     selectExisting: false
     onAccepted: {


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

In the world save dialog, the file extension does not show up. By having "World files", many people may misinterpret this to be a .world file (like I did).

![image](https://user-images.githubusercontent.com/18237662/199150601-8e61dec7-006a-43eb-a906-89db62861044.png)

By having SDF files, this would at least suggest usage of .sdf file. Without the correct extension, the OK button stays greyed out:

![image](https://user-images.githubusercontent.com/18237662/199151002-3f4fa916-2e02-406b-8cd6-5e3f8fee4452.png)

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
