### PR TITLE
Fix abi-checker: patch typo in Export.hh

### DIFF
--- a/include/ignition/gazebo/thermal-sensor-system-system/Export.hh
+++ b/include/ignition/gazebo/thermal-sensor-system-system/Export.hh
@@ -15,5 +15,5 @@
  *
  */
 
-#include <gz/sim/thermal-sensor-system-system/Export.hh>
+#include <gz/sim/thermal-sensor-system/Export.hh>
 #include <ignition/gazebo/config.hh>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes problem with abi checking in gz-sim7 branch. Note that there are probably more problems in abichecking preventing it to work, but solve fixed in release-tools.

## Summary

Small duplicate word in an include is making the abichecker to fail since the file does not exist.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.