### PR TITLE
Fix two tests on Windows

### DIFF
--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -1108,9 +1108,9 @@ TEST_P(ServerFixture, AddResourcePaths)
 /////////////////////////////////////////////////
 TEST_P(ServerFixture, ResolveResourcePaths)
 {
-  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH", "");
-  ignition::common::setenv("SDF_PATH", "");
-  ignition::common::setenv("IGN_FILE_PATH", "");
+  common::setenv("IGN_GAZEBO_RESOURCE_PATH", "");
+  common::setenv("SDF_PATH", "");
+  common::setenv("IGN_FILE_PATH", "");
 
   ServerConfig serverConfig;
   gazebo::Server server(serverConfig);
@@ -1143,10 +1143,10 @@ TEST_P(ServerFixture, ResolveResourcePaths)
         });
 
   // Make sure the resource path is clear
-  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH", "");
+  common::setenv("IGN_GAZEBO_RESOURCE_PATH", "");
 
-  // An absolute path should return the same absolute path
-  test(PROJECT_SOURCE_PATH, PROJECT_SOURCE_PATH, true);
+  // A valid path should be returned as an absolute path
+  test(PROJECT_SOURCE_PATH, common::absPath(PROJECT_SOURCE_PATH), true);
 
   // An absolute path, with the file:// prefix, should return the absolute path
   test(std::string("file://") +
@@ -1168,7 +1168,7 @@ TEST_P(ServerFixture, ResolveResourcePaths)
 
   // The model:// URI should not resolve
   test("model://include_nested/model.sdf", "", false);
-  ignition::common::setenv("IGN_GAZEBO_RESOURCE_PATH",
+  common::setenv("IGN_GAZEBO_RESOURCE_PATH",
       common::joinPaths(PROJECT_SOURCE_PATH, "test", "worlds", "models"));
   // The model:// URI should now resolve because the RESOURCE_PATH has been
   // updated.

--- a/src/SystemLoader_TEST.cc
+++ b/src/SystemLoader_TEST.cc
@@ -93,13 +93,13 @@ TEST(SystemLoader, PluginPaths)
   for (const auto &s : paths)
   {
     // the returned path string may not be exact match due to extra '/'
-    // appended at the end of the string. So use absPath to generate
-    // a path string that matches the format returned by joinPaths
-    if (common::absPath(s) == testBuildPath)
+    // appended at the end of the string. So use NormalizeDirectoryPath
+    if (common::NormalizeDirectoryPath(s) ==
+        common::NormalizeDirectoryPath(testBuildPath))
     {
       hasPath = true;
       break;
     }
   }
-  EXPECT_TRUE(hasPath);
+  EXPECT_TRUE(hasPath) << testBuildPath;
 }

--- a/src/SystemLoader_TEST.cc
+++ b/src/SystemLoader_TEST.cc
@@ -21,6 +21,7 @@
 #include <sdf/World.hh>
 
 #include <ignition/common/Filesystem.hh>
+#include <ignition/common/SystemPaths.hh>
 #include "ignition/gazebo/System.hh"
 #include "ignition/gazebo/SystemLoader.hh"
 
@@ -94,8 +95,8 @@ TEST(SystemLoader, PluginPaths)
   {
     // the returned path string may not be exact match due to extra '/'
     // appended at the end of the string. So use NormalizeDirectoryPath
-    if (common::NormalizeDirectoryPath(s) ==
-        common::NormalizeDirectoryPath(testBuildPath))
+    if (common::SystemPaths::NormalizeDirectoryPath(s) ==
+        common::SystemPaths::NormalizeDirectoryPath(testBuildPath))
     {
       hasPath = true;
       break;


### PR DESCRIPTION
# 🦟 Bug fix

Fixes failing test on windows.

## Summary

The [UNIT_SystemLoader_TEST](https://build.osrfoundation.org/view/ign-fortress/job/ign_gazebo-ign-6-win/146/testReport/junit/(root)/SystemLoader/PluginPaths/) has been failing on ign-gazebo6 since [build 138](https://build.osrfoundation.org/view/ign-fortress/job/ign_gazebo-ign-6-win/138/) when #1685 was merged.

From debugging, I noticed that the problem was a trailing `\` in one set of paths but not the other. I've used `NormalizeDirectoryPath` to fix the path comparisons.

Also fixes `UNIT_Server_TEST`

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
