### PR TITLE
Fix macOS test segfaults (#1728)

### DIFF
--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -22,6 +22,16 @@
 #include "ignition/gazebo/Events.hh"
 #include "ignition/gazebo/SdfEntityCreator.hh"
 
+#if __APPLE__
+// This is here to avoid segfaults on macOS tests. The segfaults
+// happen when components are registered by plugins and component creation is
+// attempted after the plugin that registered the component has been unloaded.
+// Including this header insures that all components are registered by the core
+// library ahead of any plugin.
+// TODO(azeey) Find a better solution for keeping track of component
+// registrations.
+#include "ignition/gazebo/components/components.hh"
+#else
 #include "ignition/gazebo/components/Actor.hh"
 #include "ignition/gazebo/components/AirPressureSensor.hh"
 #include "ignition/gazebo/components/Altimeter.hh"
@@ -80,6 +90,7 @@
 #include "ignition/gazebo/components/Visual.hh"
 #include "ignition/gazebo/components/WindMode.hh"
 #include "ignition/gazebo/components/World.hh"
+#endif
 
 class ignition::gazebo::SdfEntityCreatorPrivate
 {

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -656,6 +656,7 @@ TEST_P(SceneBroadcasterTest,
       // remove a component from an entity
       if (_info.iterations == 2)
       {
+        std::vector<gazebo::Entity> entitiesToRemoveFrom;
         _ecm.Each<ignition::gazebo::components::Model,
                   ignition::gazebo::components::Name,
                   ignition::gazebo::components::Pose>(
@@ -666,10 +667,14 @@ TEST_P(SceneBroadcasterTest,
           {
             if (_name->Data() == "box")
             {
-              _ecm.RemoveComponent<ignition::gazebo::components::Pose>(_entity);
+              entitiesToRemoveFrom.push_back(_entity);
             }
             return true;
           });
+        for (const auto &entity : entitiesToRemoveFrom)
+        {
+          _ecm.RemoveComponent<ignition::gazebo::components::Pose>(entity);
+        }
       }
       // add a component to an entity
       else if (_info.iterations == 3)


### PR DESCRIPTION
# 🦟 Bug fix

Backport #1728 to fix #1780 on `ign-gazebo6`

## Summary

Temporary fix for macOS test failure reported in #1780.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Rebase-and-merge**.