### PR TITLE
Add checkbox in view angle plugin for toggling view control reference visual

### DIFF
--- a/src/gui/plugins/view_angle/ViewAngle.cc
+++ b/src/gui/plugins/view_angle/ViewAngle.cc
@@ -60,6 +60,9 @@ namespace ignition::gazebo
     /// \brief View Control service name
     public: std::string viewControlService;
 
+    /// \brief View Control service name
+    public: std::string viewControlRefVisualService;
+
     /// \brief Move gui camera to pose service name
     public: std::string moveToPoseService;
 
@@ -139,6 +142,9 @@ void ViewAngle::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
 
   // view control requests
   this->dataPtr->viewControlService = "/gui/camera/view_control";
+
+  // view control reference visual requests
+  this->dataPtr->viewControlRefVisualService = "/gui/camera/reference_visual";
 
   // Subscribe to camera pose
   std::string topic = "/gui/camera/pose";
@@ -245,6 +251,23 @@ void ViewAngle::OnViewControl(const QString &_controller)
   }
 
   this->dataPtr->node.Request(this->dataPtr->viewControlService, req, cb);
+}
+
+/////////////////////////////////////////////////
+void ViewAngle::OnViewControlReferenceVisual(bool _enable)
+{
+  std::function<void(const msgs::Boolean &, const bool)> cb =
+      [](const msgs::Boolean &/*_rep*/, const bool _result)
+  {
+    if (!_result)
+      ignerr << "Error setting view controller reference visual" << std::endl;
+  };
+
+  msgs::Boolean req;
+  req.set_data(_enable);
+
+  this->dataPtr->node.Request(
+      this->dataPtr->viewControlRefVisualService, req, cb);
 }
 
 /////////////////////////////////////////////////

--- a/src/gui/plugins/view_angle/ViewAngle.cc
+++ b/src/gui/plugins/view_angle/ViewAngle.cc
@@ -60,7 +60,7 @@ namespace ignition::gazebo
     /// \brief View Control service name
     public: std::string viewControlService;
 
-    /// \brief View Control service name
+    /// \brief View Control reference visual service name
     public: std::string viewControlRefVisualService;
 
     /// \brief Move gui camera to pose service name

--- a/src/gui/plugins/view_angle/ViewAngle.hh
+++ b/src/gui/plugins/view_angle/ViewAngle.hh
@@ -79,6 +79,12 @@ namespace gazebo
     /// \param[in] _mode New camera view controller
     public slots: void OnViewControl(const QString &_controller);
 
+    /// \brief Callback in Qt thread when camera view reference visual state
+    /// changes.
+    /// \param[in] _enable True to enable camera view control reference visual,
+    /// false to hide it
+    public slots: void OnViewControlReferenceVisual(bool _enable);
+
     /// \brief Get the current gui camera pose.
     public: Q_INVOKABLE QList<double> CamPose() const;
 

--- a/src/gui/plugins/view_angle/ViewAngle.qml
+++ b/src/gui/plugins/view_angle/ViewAngle.qml
@@ -207,6 +207,19 @@ ColumnLayout {
     }
   }
 
+  // toggle view control reference visual
+  CheckBox {
+    Layout.alignment: Qt.AlignHCenter
+    id: displayVisual
+    Layout.columnSpan: 6
+    Layout.fillWidth: true
+    text: qsTr("Display View Control Reference Visual")
+    checked: true
+    onClicked: {
+      ViewAngle.OnViewControlReferenceVisual(checked)
+    }
+  }
+
   // Set camera pose
   Text {
     text: "Camera Pose"


### PR DESCRIPTION
# 🎉 New feature

Depends on https://github.com/gazebosim/gz-gui/pull/500

## Summary

Adds check box for toggling the view control reference visual added in https://github.com/gazebosim/gz-gui/pull/500.

## Test it

Enable the `View Angle` plugin by going to the top right 3 dots menu and select `View Angle`

Click on the `Display View Control Reference Visual` check box to enable / disable view control anchor visualization. Use mouse to move camera and see the effect. When disabled, the yellow ellipsoid should not be drawn in the 3d render window.

![ref_visual_toggle](https://user-images.githubusercontent.com/4000684/200974937-9057403e-7c3e-4147-93c4-319857130868.png)



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

