### PR TITLE
Acoustic comms : Propagation model

### DIFF
--- a/examples/worlds/acoustic_comms_propagation.sdf
+++ b/examples/worlds/acoustic_comms_propagation.sdf
@@ -32,7 +32,6 @@
       <propagation_model>
         <source_power>0.001</source_power>
         <noise_level>150</noise_level>
-        <directivity_index>4</directivity_index>
         <spectral_efficiency>7</spectral_efficiency>
       </propagation_model>
 

--- a/examples/worlds/acoustic_comms_propagation.sdf
+++ b/examples/worlds/acoustic_comms_propagation.sdf
@@ -33,6 +33,7 @@
         <source_power>0.001</source_power>
         <noise_level>150</noise_level>
         <spectral_efficiency>7</spectral_efficiency>
+        <seed>0</seed>
       </propagation_model>
 
     </plugin>

--- a/examples/worlds/acoustic_comms_propagation.sdf
+++ b/examples/worlds/acoustic_comms_propagation.sdf
@@ -1,0 +1,264 @@
+<?xml version="1.0" ?>
+<!--
+  Gazebo acoustic-comms plugin demo.
+-->
+<sdf version="1.6">
+  <world name="acoustic_comms">
+
+    <physics name="1ms" type="ignored">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin
+      filename="gz-sim-user-commands-system"
+      name="gz::sim::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+    <plugin
+      filename="gz-sim-acoustic-comms-system"
+      name="gz::sim::systems::AcousticComms">
+      <max_range>6</max_range>
+      <speed_of_sound>1400</speed_of_sound>
+
+      <!-- Values are exaggerated here to make the -->
+      <!-- packets drop. -->
+      <propagation_model>
+        <source_power>0.001</source_power>
+        <noise_level>150</noise_level>
+        <directivity_index>4</directivity_index>
+        <spectral_efficiency>7</spectral_efficiency>
+      </propagation_model>
+
+    </plugin>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>1 1 1 1</diffuse>
+      <specular>0.5 0.5 0.5 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="box1">
+      <pose>2 0 0.5 0 0 0</pose>
+      <link name="box_link">
+        <inertial>
+          <inertia>
+            <ixx>0.16666</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.16666</iyy>
+            <iyz>0</iyz>
+            <izz>0.16666</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+
+        <visual name="box_visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>1 0 0 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <plugin
+        filename="gz-sim-comms-endpoint-system"
+        name="gz::sim::systems::CommsEndpoint">
+        <address>addr1</address>
+        <topic>addr1/rx</topic>
+      </plugin>
+    </model>
+
+    <model name="box2">
+      <pose>-2 0 0.5 0 0 0</pose>
+      <link name="box_link">
+        <inertial>
+          <inertia>
+            <ixx>0.16666</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.16666</iyy>
+            <iyz>0</iyz>
+            <izz>0.16666</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+
+        <visual name="box_visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 0 1 1</ambient>
+            <diffuse>0 0 1 1</diffuse>
+            <specular>0 0 1 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <plugin
+        filename="gz-sim-comms-endpoint-system"
+        name="gz::sim::systems::CommsEndpoint">
+        <address>addr2</address>
+        <topic>addr2/rx</topic>
+        <broker>
+          <bind_service>/broker/bind</bind_service>
+          <unbind_service>/broker/unbind</unbind_service>
+        </broker>
+      </plugin>
+
+    </model>
+
+    <model name="box3">
+      <pose>5 0 0.5 0 0 0</pose>
+      <link name="box_link">
+        <inertial>
+          <inertia>
+            <ixx>0.16666</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.16666</iyy>
+            <iyz>0</iyz>
+            <izz>0.16666</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+
+        <visual name="box_visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>1 0 0 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <plugin
+        filename="gz-sim-comms-endpoint-system"
+        name="gz::sim::systems::CommsEndpoint">
+        <address>addr3</address>
+        <topic>addr3/rx</topic>
+      </plugin>
+    </model>
+
+    <model name="box4">
+      <pose>-5 0 0.5 0 0 0</pose>
+      <link name="box_link">
+        <inertial>
+          <inertia>
+            <ixx>0.16666</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.16666</iyy>
+            <iyz>0</iyz>
+            <izz>0.16666</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+
+        <visual name="box_visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>1 0 0 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <plugin
+        filename="gz-sim-comms-endpoint-system"
+        name="gz::sim::systems::CommsEndpoint">
+        <address>addr4</address>
+        <topic>addr4/rx</topic>
+      </plugin>
+    </model>
+
+  </world>
+</sdf>

--- a/src/systems/acoustic_comms/AcousticComms.cc
+++ b/src/systems/acoustic_comms/AcousticComms.cc
@@ -83,6 +83,9 @@ class AcousticComms::Implementation
 
   /// \brief Flag to store if the propagation model should be used.
   public: bool usePropagationModel = false;
+
+  /// \brief Seed value for random sampling.
+  public: unsigned int seed = 0;
 };
 
 //////////////////////////////////////////////////
@@ -125,6 +128,7 @@ bool AcousticComms::Implementation::propagationModel(
     1.0 - std::exp(static_cast<double>(_numBytes) *
                    std::log(1 - ber));
 
+  gz::math::Rand::Seed(this->seed);
   double randDraw = gz::math::Rand::DblUniform();
   return randDraw > packetDropProb;
 }
@@ -165,6 +169,7 @@ void AcousticComms::Load(
     this->dataPtr->noiseLevel = propElement->Get<double>("noise_level");
     this->dataPtr->spectralEfficiency =
       propElement->Get<double>("spectral_efficiency");
+    this->dataPtr->seed = propElement->Get<int>("seed");
   }
 
   gzmsg << "AcousticComms configured with max range : " <<

--- a/src/systems/acoustic_comms/AcousticComms.cc
+++ b/src/systems/acoustic_comms/AcousticComms.cc
@@ -67,7 +67,7 @@ class AcousticComms::Implementation
 
   /// \brief Source power in Watts.
   /// \ref https://www.sciencedirect.com/topics/
-  /// computer-science/underwater-acoustic-signal 
+  /// computer-science/underwater-acoustic-signal
   public: double sourcePower = 2000;
 
   /// \brief Ratio of the noise intensity at the
@@ -76,14 +76,14 @@ class AcousticComms::Implementation
 
   /// \brief Ratio of the total noise power at the array to the
   /// noise received by the array along its main response axis.
-  /// \ref https://ieeexplore.ieee.org/document/5664178 
+  /// \ref https://ieeexplore.ieee.org/document/5664178
   public: double directivityIndex = 4;
 
   /// \brief Information rate that can be transmitted over a given
-  /// bandwidth in a specific communication system, in (bits/sec)/Hz. 
+  /// bandwidth in a specific communication system, in (bits/sec)/Hz.
   /// \ref: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5514747/
   public: double spectralEfficiency = 7.0;
-  
+
   /// \brief Flag to store if the propagation model should be used.
   public: bool usePropagationModel = false;
 };

--- a/src/systems/acoustic_comms/AcousticComms.cc
+++ b/src/systems/acoustic_comms/AcousticComms.cc
@@ -306,9 +306,11 @@ void AcousticComms::Step(
             // Packet has survived collisions, check if the propagation model
             // should be run on this packet.
             if (this->dataPtr->usePropagationModel)
-            receivedSuccessfully = receivedSuccessfully &&
+            {
+              receivedSuccessfully = receivedSuccessfully &&
                 this->dataPtr->propagationModel(distanceCoveredByMessage,
                                                 msg->data().length());
+            }
 
             // This message needs to be processed.
             // Push the msg to inbound of the destination if

--- a/src/systems/acoustic_comms/AcousticComms.cc
+++ b/src/systems/acoustic_comms/AcousticComms.cc
@@ -76,11 +76,6 @@ class AcousticComms::Implementation
   /// receiver to the same reference intensity used for source level.
   public: double noiseLevel = 1;
 
-  /// \brief Ratio of the total noise power at the array to the
-  /// noise received by the array along its main response axis.
-  /// \ref https://ieeexplore.ieee.org/document/5664178
-  public: double directivityIndex = 4;
-
   /// \brief Information rate that can be transmitted over a given
   /// bandwidth in a specific communication system, in (bits/sec)/Hz.
   /// \ref: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5514747/
@@ -104,7 +99,6 @@ bool AcousticComms::Implementation::propagationModel(
   //      converted to dB.
   // TL : Transmission loss (dB)
   // NL : Noise level.
-  // DI : Receiver directivity index.
 
   // The constant 170.8 comes from reference intensity measured
   // 1m from the source.
@@ -112,7 +106,7 @@ bool AcousticComms::Implementation::propagationModel(
   double tl = 20 * std::log10(_distToSource);
 
   // Calculate SNR.
-  auto snr = sl - tl - (this->noiseLevel - this->directivityIndex);
+  auto snr = sl - tl - this->noiseLevel;
 
   // References : https://www.montana.edu/aolson/ee447/EB%20and%20NO.pdf
   // https://en.wikipedia.org/wiki/Eb/N0
@@ -169,8 +163,6 @@ void AcousticComms::Load(
                                    GetElement("propagation_model");
     this->dataPtr->sourcePower = propElement->Get<double>("source_power");
     this->dataPtr->noiseLevel = propElement->Get<double>("noise_level");
-    this->dataPtr->directivityIndex =
-      propElement->Get<double>("directivity_index");
     this->dataPtr->spectralEfficiency =
       propElement->Get<double>("spectral_efficiency");
   }

--- a/src/systems/acoustic_comms/AcousticComms.cc
+++ b/src/systems/acoustic_comms/AcousticComms.cc
@@ -62,6 +62,8 @@ class AcousticComms::Implementation
             std::chrono::duration<double>>>
           lastMsgReceivedInfo;
 
+  /// \brief This method simulates the propagation model,
+  /// and returns false if the packet was dropped, otherwise true.
   public: bool propagationModel(double _distToSource,
                                 int _numBytes);
 
@@ -104,7 +106,9 @@ bool AcousticComms::Implementation::propagationModel(
   // NL : Noise level.
   // DI : Receiver directivity index.
 
-  double sl = 171.5 + 10 * std::log10(this->sourcePower);
+  // The constant 170.8 comes from reference intensity measured
+  // 1m from the source.
+  double sl = 170.8 + 10 * std::log10(this->sourcePower);
   double tl = 20 * std::log10(_distToSource);
 
   // Calculate SNR.

--- a/src/systems/acoustic_comms/AcousticComms.hh
+++ b/src/systems/acoustic_comms/AcousticComms.hh
@@ -69,9 +69,6 @@ namespace systems
   ///       * <noise_level> : Ratio of the noise intensity at the
   ///                         receiver to the same reference intensity used
   ///                         for source level. Defaults to 1.
-  ///       * <directivity_index> : Ratio of the total noise power at the
-  ///                               array to the noise received by the array
-  ///                               along its main response axis. Defaults to 4.
   ///       * <spectral_efficiency> : Information rate that can be transmitted
   ///                                 over a given bandwidth in a specific
   ///                                 communication system, in (bits/sec)/Hz.
@@ -91,7 +88,6 @@ namespace systems
   ///    <propagation_model>
   ///      <source_power>2000</source_power>
   ///      <noise_level>1</noise_level>
-  ///      <directivity_index>4</directivity_index>
   ///      <spectral_efficiency>7</spectral_efficiency>
   ///    </propagation_model>
   ///

--- a/src/systems/acoustic_comms/AcousticComms.hh
+++ b/src/systems/acoustic_comms/AcousticComms.hh
@@ -28,6 +28,7 @@
 #include <unordered_map>
 
 #include <sdf/sdf.hh>
+#include <gz/math/Rand.hh>
 #include "gz/sim/comms/ICommsModel.hh"
 #include <gz/sim/System.hh>
 #include <gz/sim/Entity.hh>
@@ -55,16 +56,18 @@ namespace systems
   ///    * <collision_time_per_byte> : If a subscriber receives a message
   ///                         'b' bytes long at time 't0', it won't receive
   ///                         and other message till time :
-  ///                         't0 + b * collision_time_per_byte'
+  ///                         't0 + b * collision_time_per_byte'.
+  ///                         Defaults to zero.
   ///    * <collision_time_packet_drop> : If a packet is dropped at time
   ///                         `t0`, the next packet won't be received until
-  ///                         time `t0 + collision_time_packet_drop`
+  ///                         time `t0 + collision_time_packet_drop`.
+  ///                         Defaults to zero.
   ///
   /// Here's an example:
   ///  <plugin
   ///    filename="gz-sim-acoustic-comms-system"
   ///    name="gz::sim::systems::AcousticComms">
-  ///    <max_range>6</max_range>
+  ///    <max_range>500</max_range>
   ///    <speed_of_sound>1400</speed_of_sound>
   ///    <collision_time_per_byte>0.001</collision_time_per_byte>
   ///    <collision_time_packet_drop>0.001</collision_time_packet_drop>

--- a/src/systems/acoustic_comms/AcousticComms.hh
+++ b/src/systems/acoustic_comms/AcousticComms.hh
@@ -62,15 +62,39 @@ namespace systems
   ///                         `t0`, the next packet won't be received until
   ///                         time `t0 + collision_time_packet_drop`.
   ///                         Defaults to zero.
+  ///    * <propagation_model> : Enables the use of propagation model.
+  ///                            Disabled by default.
+  ///       * <source_power> : Source power at the transmitter in Watts.
+  ///                          Defaults to 2 kW.
+  ///       * <noise_level> : Ratio of the noise intensity at the
+  ///                         receiver to the same reference intensity used
+  ///                         for source level. Defaults to 1.
+  ///       * <directivity_index> : Ratio of the total noise power at the
+  ///                               array to the noise received by the array
+  ///                               along its main response axis. Defaults to 4.
+  ///       * <spectral_efficiency> : Information rate that can be transmitted
+  ///                                 over a given bandwidth in a specific
+  ///                                 communication system, in (bits/sec)/Hz.
+  ///                                 Defaults to 7 bits/sec/Hz.
   ///
   /// Here's an example:
   ///  <plugin
   ///    filename="gz-sim-acoustic-comms-system"
   ///    name="gz::sim::systems::AcousticComms">
+  ///
   ///    <max_range>500</max_range>
   ///    <speed_of_sound>1400</speed_of_sound>
+  ///
   ///    <collision_time_per_byte>0.001</collision_time_per_byte>
   ///    <collision_time_packet_drop>0.001</collision_time_packet_drop>
+  ///
+  ///    <propagation_model>
+  ///      <source_power>2000</source_power>
+  ///      <noise_level>1</noise_level>
+  ///      <directivity_index>4</directivity_index>
+  ///      <spectral_efficiency>7</spectral_efficiency>
+  ///    </propagation_model>
+  ///
   ///  </plugin>
 
   class AcousticComms:

--- a/src/systems/acoustic_comms/AcousticComms.hh
+++ b/src/systems/acoustic_comms/AcousticComms.hh
@@ -73,6 +73,7 @@ namespace systems
   ///                                 over a given bandwidth in a specific
   ///                                 communication system, in (bits/sec)/Hz.
   ///                                 Defaults to 7 bits/sec/Hz.
+  ///       * <seed> : Seed value to be used for random sampling.
   ///
   /// Here's an example:
   ///  <plugin

--- a/test/integration/acoustic_comms.cc
+++ b/test/integration/acoustic_comms.cc
@@ -161,6 +161,10 @@ INSTANTIATE_TEST_SUITE_P(
     // Message packets will be dropped as they are sent too fast
     // compared to "collision_time_interval".
     AcousticCommsTestDefinition(
-      "acoustic_comms_packet_collision.sdf", "addr2", "addr1", 3, 1)
+      "acoustic_comms_packet_collision.sdf", "addr2", "addr1", 3, 1),
+    // Source power is decreased and noise bumped up to make the packets
+    // drop.
+    AcousticCommsTestDefinition(
+      "acoustic_comms_propagation.sdf", "addr2", "addr1", 3, 0)
     )
 );


### PR DESCRIPTION
# 🎉 New feature

## Summary
This PR adds a propagation model for acoustic comms, using RFComms implementation as a guide. The difference is in the way signal loss is calculated and modulation is implemented.

Here, we use the sonar equation to calculate signal to noise ratio (SNR). SNR is used to calculate ``Eb/N0``, which gives us the bit error rate using BPSK modulation. FInally we calculate the packet drop probability.

This feaure is turned off by default and oly works if the SDF tags are used when declaring the plugin.

A short comparison of propagation model approaches :
* Acoustic comms propagation model (This PR) : 
  ``SNR using sonar equation`` -> ``Eb/N0`` -> ``bit error rate (BPSK)`` -> ``packetDropProbability``
* RFComms propagation model (Taken as a reference) : 
  ``Log path loss equation`` -> ``bit error rate (QPSK)`` -> ``packetDropProbability``

## Test it
Added a test with a world file ``acoustic_comms_propagation.sdf``. It is impossible to get the packets to drop with the default values and the LRAUvs being that close to each other (< 5 m). Moving them apart would make the tests run a lot slower.

I've exaggerated the noise and source power to make the packets drop.

## Note
This is still an experimental feature, and I'm no expert in communications. If there is a better model for propagation, I'd be happy to improve this.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸