### PR TITLE
Remove fixed width from world control

### DIFF
--- a/src/gui/gui.config
+++ b/src/gui/gui.config
@@ -126,7 +126,6 @@
     <property type="bool" key="showTitleBar">false</property>
     <property type="bool" key="resizable">false</property>
     <property type="double" key="height">72</property>
-    <property type="double" key="width">121</property>
     <property type="double" key="z">1</property>
 
     <property type="string" key="state">floating</property>


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🦟 Bug fix

The world control widget used a fix width, set via the `gui.config` file. This prevents the world control widget from scaling based on the content of the widget.
## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
