### PR TITLE
Restore GUI support for macOS

### DIFF
--- a/src/cmd/cmdsim.rb.in
+++ b/src/cmd/cmdsim.rb.in
@@ -546,12 +546,6 @@ See https://github.com/gazebosim/gz-sim/issues/168 for more info."
             options['wait_gui'], options['headless-rendering'], options['record-period'])
             # Otherwise run the gui
       else options['gui']
-        if plugin.end_with? ".dylib"
-          puts "`gz sim` currently only works with the -s argument on macOS.
-See https://github.com/gazebosim/gz-sim/issues/44 for more info."
-          exit(-1)
-        end
-
         if plugin.end_with? ".dll"
           puts "`gz sim` currently only works with the -s argument on Windows.
 See https://github.com/gazebosim/gz-sim/issues/168 for more info."


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #1812

## Summary

Restore the change to `src/cmd/cmdsim.rb.in` from #1225 that allows macOS to run the GUI.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers