### PR TITLE
Update documentation on `UpdateInfo::realTime`

### DIFF
--- a/include/ignition/gazebo/Types.hh
+++ b/include/ignition/gazebo/Types.hh
@@ -40,8 +40,8 @@ namespace ignition
       /// paused.
       std::chrono::steady_clock::duration simTime{0};
 
-      /// \brief Total wall clock time elapsed. This increases even if
-      /// simulation is paused.
+      /// \brief Total wall clock time elapsed while simulation is running. This
+      /// will not increase while paused.
       std::chrono::steady_clock::duration realTime{0};
 
       /// \brief Simulation time handled during a single update.


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #1777

## Summary
The documentation for `UpdateInfo::realTime` says the value would increase even if simulation is paused. This is definitely not the case as can be seen from the code
https://github.com/gazebosim/gz-sim/blob/5ad7694505150730b9a7c4f7c23b673358f2626e/src/SimulationRunner.cc#L636-L639


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

