### PR TITLE
Fixed light entity number

### DIFF
--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -544,7 +544,12 @@ Entity SdfEntityCreator::CreateEntities(const sdf::Light *_light)
   this->dataPtr->ecm->CreateComponent(lightVisualEntity,
       components::Pose());
   this->dataPtr->ecm->CreateComponent(lightVisualEntity,
-      components::Name(_light->Name() + "_visual"));
+      components::Name(_light->Name() + "Visual"));
+  this->dataPtr->ecm->CreateComponent(lightVisualEntity,
+      components::CastShadows(false));
+  this->dataPtr->ecm->CreateComponent(lightVisualEntity,
+      components::Transparency(false));
+  this->SetParent(lightVisualEntity, lightEntity);
 
   return lightEntity;
 }

--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -538,6 +538,14 @@ Entity SdfEntityCreator::CreateEntities(const sdf::Light *_light)
   this->dataPtr->ecm->CreateComponent(lightEntity,
     components::LightType(convert(_light->Type())));
 
+  // Light Visual
+  Entity lightVisualEntity = this->dataPtr->ecm->CreateEntity();
+  this->dataPtr->ecm->CreateComponent(lightVisualEntity, components::Visual());
+  this->dataPtr->ecm->CreateComponent(lightVisualEntity,
+      components::Pose());
+  this->dataPtr->ecm->CreateComponent(lightVisualEntity,
+      components::Name(_light->Name() + "_visual"));
+
   return lightEntity;
 }
 

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -1195,17 +1195,14 @@ void RenderUtil::Update()
 
       if (newLightRendering)
       {
-        // TODO(anyone) This needs to be updated for when sensors and GUI use
-        // the same scene
-        // create a new id for the light visual, if we're not loading sensors
-        if (!this->dataPtr->enableSensors)
-        {
-          rendering::VisualPtr lightVisual =
-            this->dataPtr->sceneManager.CreateLightVisual(
-              std::get<0>(light) + 1, std::get<1>(light), std::get<2>(light), std::get<0>(light));
-          this->dataPtr->matchLightWithVisuals[std::get<0>(light)] = std::get<0>(light) + 1;
-          break;
-        }
+        rendering::VisualPtr lightVisual =
+          this->dataPtr->sceneManager.CreateLightVisual(
+            std::get<0>(light) + 1,
+            std::get<1>(light),
+            std::get<2>(light),
+            std::get<0>(light));
+        this->dataPtr->matchLightWithVisuals[std::get<0>(light)] =
+          std::get<0>(light) + 1;
       }
       else
       {

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -1187,27 +1187,29 @@ void RenderUtil::Update()
 
     for (const auto &light : newLights)
     {
-      this->dataPtr->sceneManager.CreateLight(std::get<0>(light),
-          std::get<1>(light), std::get<2>(light), std::get<3>(light));
+      auto newLightRendering = this->dataPtr->sceneManager.CreateLight(
+        std::get<0>(light),
+        std::get<1>(light),
+        std::get<2>(light),
+        std::get<3>(light));
 
-      // TODO(anyone) This needs to be updated for when sensors and GUI use
-      // the same scene
-      // create a new id for the light visual, if we're not loading sensors
-      if (!this->dataPtr->enableSensors)
+      if (newLightRendering)
       {
-        auto attempts = 100000u;
-        for (auto i = 0u; i < attempts; ++i)
+        // TODO(anyone) This needs to be updated for when sensors and GUI use
+        // the same scene
+        // create a new id for the light visual, if we're not loading sensors
+        if (!this->dataPtr->enableSensors)
         {
-          Entity id = std::numeric_limits<uint64_t>::min() + i;
-          if (!this->dataPtr->sceneManager.HasEntity(id))
-          {
-            rendering::VisualPtr lightVisual =
-              this->dataPtr->sceneManager.CreateLightVisual(
-                id, std::get<1>(light), std::get<2>(light), std::get<0>(light));
-            this->dataPtr->matchLightWithVisuals[std::get<0>(light)] = id;
-            break;
-          }
+          rendering::VisualPtr lightVisual =
+            this->dataPtr->sceneManager.CreateLightVisual(
+              std::get<0>(light) + 1, std::get<1>(light), std::get<2>(light), std::get<0>(light));
+          this->dataPtr->matchLightWithVisuals[std::get<0>(light)] = std::get<0>(light) + 1;
+          break;
         }
+      }
+      else
+      {
+        ignerr << "Failed to create light" << std::endl;
       }
     }
 

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -1198,6 +1198,13 @@ rendering::LightPtr SceneManager::CreateLight(Entity _id,
   if (!this->dataPtr->scene)
     return rendering::LightPtr();
 
+  if (this->HasEntity(_id))
+  {
+    ignerr << "Light with Id: [" << _id << "] can not be create there is "
+              "another entity with the same entity number" << std::endl;
+    return nullptr;
+  }
+
   if (this->dataPtr->lights.find(_id) != this->dataPtr->lights.end())
   {
     ignerr << "Light with Id: [" << _id << "] already exists in the scene"


### PR DESCRIPTION
Signed-off-by: Alejandro Hernández Cordero <ahcorde@gmail.com>

# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/1816

## Summary

When a light was created we also created a new visual, but this visual was not registered in the ECM which means that might conflict with other new entities in the world. The solution it's to create a visual entity with the light entity to register both things at the same time.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
