### PR TITLE
hydrodynamics flags test strengthening

### DIFF
--- a/test/worlds/hydrodynamics_flags.sdf
+++ b/test/worlds/hydrodynamics_flags.sdf
@@ -8,10 +8,7 @@
     <plugin filename="ignition-gazebo-physics-system"
             name="ignition::gazebo::systems::Physics">
     </plugin>
-    <plugin filename="ignition-gazebo-buoyancy-system"
-            name="ignition::gazebo::systems::Buoyancy">
-      <uniform_fluid_density>1000</uniform_fluid_density>
-    </plugin>
+    <gravity>0 0 0</gravity>
     <model name="tethys">
       <pose>0 0 1 0 0 1.57</pose>
       <link name="base_link">

--- a/test/worlds/hydrodynamics_flags.sdf
+++ b/test/worlds/hydrodynamics_flags.sdf
@@ -1,110 +1,108 @@
-<?xml version="1.0" ?>
-
+<?xml version="1.0"?>
 <sdf version="1.6">
   <world name="multi_lrauv">
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
       <real_time_factor>1.0</real_time_factor>
     </physics>
-    <plugin
-      filename="ignition-gazebo-physics-system"
-      name="ignition::gazebo::systems::Physics">
+    <plugin filename="ignition-gazebo-physics-system"
+            name="ignition::gazebo::systems::Physics">
     </plugin>
-    <plugin
-      filename="ignition-gazebo-contact-system"
-      name="ignition::gazebo::systems::Contact">
-    </plugin>
-
-    <plugin
-      filename="ignition-gazebo-buoyancy-system"
-      name="ignition::gazebo::systems::Buoyancy">
+    <plugin filename="ignition-gazebo-buoyancy-system"
+            name="ignition::gazebo::systems::Buoyancy">
       <uniform_fluid_density>1000</uniform_fluid_density>
     </plugin>
-
-    <light type="directional" name="sun">
-      <cast_shadows>true</cast_shadows>
-      <pose>0 0 10 0 0 0</pose>
-      <diffuse>1 1 1 1</diffuse>
-      <specular>0.5 0.5 0.5 1</specular>
-      <attenuation>
-        <range>1000</range>
-        <constant>0.9</constant>
-        <linear>0.01</linear>
-        <quadratic>0.001</quadratic>
-      </attenuation>
-      <direction>-0.5 0.1 -0.9</direction>
-    </light>
-
-    <include>
+    <model name="tethys">
       <pose>0 0 1 0 0 1.57</pose>
-      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
-
-      <!-- Joint controllers -->
-      <plugin
-        filename="ignition-gazebo-joint-position-controller-system"
-        name="ignition::gazebo::systems::JointPositionController">
-        <joint_name>horizontal_fins_joint</joint_name>
-        <p_gain>0.1</p_gain>
-      </plugin>
-
-      <plugin
-        filename="ignition-gazebo-joint-position-controller-system"
-        name="ignition::gazebo::systems::JointPositionController">
-        <joint_name>vertical_fins_joint</joint_name>
-        <p_gain>0.1</p_gain>
-      </plugin>
-
-      <plugin
-        filename="ignition-gazebo-thruster-system"
-        name="ignition::gazebo::systems::Thruster">
-        <namespace>tethys</namespace>
-        <joint_name>propeller_joint</joint_name>
-        <thrust_coefficient>0.004422</thrust_coefficient>
-        <fluid_density>1000</fluid_density>
-        <propeller_diameter>0.2</propeller_diameter>
-      </plugin>
-
-      <!-- Lift and drag -->
-
-      <!-- Vertical fin -->
-      <plugin
-        filename="ignition-gazebo-lift-drag-system"
-        name="ignition::gazebo::systems::LiftDrag">
-        <air_density>1000</air_density>
-        <cla>4.13</cla>
-        <cla_stall>-1.1</cla_stall>
-        <cda>0.2</cda>
-        <cda_stall>0.03</cda_stall>
-        <alpha_stall>0.17</alpha_stall>
-        <a0>0</a0>
-        <area>0.0244</area>
-        <upward>0 1 0</upward>
-        <forward>1 0 0</forward>
-        <link_name>vertical_fins</link_name>
-        <cp>0 0 0</cp>
-      </plugin>
-
-      <!-- Horizontal fin -->
-      <plugin
-        filename="ignition-gazebo-lift-drag-system"
-        name="ignition::gazebo::systems::LiftDrag">
-        <air_density>1000</air_density>
-        <cla>4.13</cla>
-        <cla_stall>-1.1</cla_stall>
-        <cda>0.2</cda>
-        <cda_stall>0.03</cda_stall>
-        <alpha_stall>0.17</alpha_stall>
-        <a0>0</a0>
-        <area>0.0244</area>
-        <upward>0 0 1</upward>
-        <forward>1 0 0</forward>
-        <link_name>horizontal_fins</link_name>
-        <cp>0 0 0</cp>
-      </plugin>
-
-      <plugin
-        filename="ignition-gazebo-hydrodynamics-system"
-        name="ignition::gazebo::systems::Hydrodynamics">
+      <link name="base_link">
+        <inertial>
+          <mass>147.8671</mass>
+          <inertia>
+            <ixx>3.000000</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>41.980233</iyy>
+            <iyz>0</iyz>
+            <izz>41.980233</izz>
+          </inertia>
+        </inertial>
+        <collision name="main_body_buoyancy">
+          <geometry>
+            <box>
+              <size>2 0.3 0.246445166667</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='body_visual'>
+          <geometry>
+            <box>
+              <size>2 0.3 0.246445166667</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+      <!-- Horizontal fins -->
+      <link name="horizontal_fins">
+        <pose>1.05 0 0 0 0 0</pose>
+        <inertial>
+          <pose>0 0 0 1.57 0 0.5</pose>
+          <mass>0.2</mass>
+          <inertia>
+            <ixx>0.0007924568755</ixx>
+            <ixy>-0.0000000002674</ixy>
+            <ixz>0.0003978158176</ixz>
+            <iyy>0.0010546736475</iyy>
+            <iyz>-0.0000000006729</iyz>
+            <izz>0.0002633558262</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.02</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <!-- Vertical fins -->
+      <link name="vertical_fins">
+        <pose>1.05 0 0 0 0 0</pose>
+        <inertial>
+          <mass>0.2</mass>
+          <inertia>
+            <ixx>0.0007924568755</ixx>
+            <ixy>-0.0000000002674</ixy>
+            <ixz>0.0003978158176</ixz>
+            <iyy>0.0010546736475</iyy>
+            <iyz>-0.0000000006729</iyz>
+            <izz>0.0002633558262</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.02</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <!-- Joints -->
+      <joint name="horizontal_fins_joint" type="revolute">
+        <pose>0 0 0 0 0 0</pose>
+        <parent>base_link</parent>
+        <child>horizontal_fins</child>
+        <axis>
+          <xyz>0 1 0</xyz>
+          <limit>
+            <lower>-0.261799</lower>
+            <upper>0.261799</upper>
+            <effort>-1</effort>
+            <velocity>-1</velocity>
+          </limit>
+        </axis>
+      </joint>
+      <plugin filename="ignition-gazebo-hydrodynamics-system"
+              name="ignition::gazebo::systems::Hydrodynamics">
         <link_name>base_link</link_name>
         <xDotU>-4.876161</xDotU>
         <yDotV>-126.324739</yDotV>
@@ -127,80 +125,99 @@
         <disable_added_mass>true</disable_added_mass>
         <disable_coriolis>true</disable_coriolis>
       </plugin>
+    </model>
 
-    </include>
-
-    <include>
+    <model name="triton">
       <pose>5 0 1 0 0 1.57</pose>
-      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
-      <name>triton</name>
-
-      <!-- Joint controllers -->
-      <plugin
-        filename="ignition-gazebo-joint-position-controller-system"
-        name="ignition::gazebo::systems::JointPositionController">
-        <joint_name>horizontal_fins_joint</joint_name>
-        <p_gain>0.1</p_gain>
-      </plugin>
-
-      <plugin
-        filename="ignition-gazebo-joint-position-controller-system"
-        name="ignition::gazebo::systems::JointPositionController">
-        <joint_name>vertical_fins_joint</joint_name>
-        <p_gain>0.1</p_gain>
-      </plugin>
-
-      <plugin
-        filename="ignition-gazebo-thruster-system"
-        name="ignition::gazebo::systems::Thruster">
-        <namespace>triton</namespace>
-        <joint_name>propeller_joint</joint_name>
-        <thrust_coefficient>0.004422</thrust_coefficient>
-        <fluid_density>1000</fluid_density>
-        <propeller_diameter>0.2</propeller_diameter>
-      </plugin>
-
-      <!-- Lift and drag -->
-
-      <!-- Vertical fin -->
-      <plugin
-        filename="ignition-gazebo-lift-drag-system"
-        name="ignition::gazebo::systems::LiftDrag">
-        <air_density>1000</air_density>
-        <cla>4.13</cla>
-        <cla_stall>-1.1</cla_stall>
-        <cda>0.2</cda>
-        <cda_stall>0.03</cda_stall>
-        <alpha_stall>0.17</alpha_stall>
-        <a0>0</a0>
-        <area>0.0244</area>
-        <upward>0 1 0</upward>
-        <forward>1 0 0</forward>
-        <link_name>vertical_fins</link_name>
-        <cp>0 0 0</cp>
-      </plugin>
-
-      <!-- Horizontal fin -->
-      <plugin
-        filename="ignition-gazebo-lift-drag-system"
-        name="ignition::gazebo::systems::LiftDrag">
-        <air_density>1000</air_density>
-        <cla>4.13</cla>
-        <cla_stall>-1.1</cla_stall>
-        <cda>0.2</cda>
-        <cda_stall>0.03</cda_stall>
-        <alpha_stall>0.17</alpha_stall>
-        <a0>0</a0>
-        <area>0.0244</area>
-        <upward>0 0 1</upward>
-        <forward>1 0 0</forward>
-        <link_name>horizontal_fins</link_name>
-        <cp>0 0 0</cp>
-      </plugin>
-
-      <plugin
-        filename="ignition-gazebo-hydrodynamics-system"
-        name="ignition::gazebo::systems::Hydrodynamics">
+      <link name="base_link">
+        <inertial>
+          <mass>147.8671</mass>
+          <inertia>
+            <ixx>3.000000</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>41.980233</iyy>
+            <iyz>0</iyz>
+            <izz>41.980233</izz>
+          </inertia>
+        </inertial>
+        <collision name="main_body_buoyancy">
+          <geometry>
+            <box>
+              <size>2 0.3 0.246445166667</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='body_visual'>
+          <geometry>
+            <box>
+              <size>2 0.3 0.246445166667</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+      <!-- Horizontal fins -->
+      <link name="horizontal_fins">
+        <pose>1.05 0 0 0 0 0</pose>
+        <inertial>
+          <pose>0 0 0 1.57 0 0.5</pose>
+          <mass>0.2</mass>
+          <inertia>
+            <ixx>0.0007924568755</ixx>
+            <ixy>-0.0000000002674</ixy>
+            <ixz>0.0003978158176</ixz>
+            <iyy>0.0010546736475</iyy>
+            <iyz>-0.0000000006729</iyz>
+            <izz>0.0002633558262</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.02</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <!-- Vertical fins -->
+      <link name="vertical_fins">
+        <pose>1.05 0 0 0 0 0</pose>
+        <inertial>
+          <mass>0.2</mass>
+          <inertia>
+            <ixx>0.0007924568755</ixx>
+            <ixy>-0.0000000002674</ixy>
+            <ixz>0.0003978158176</ixz>
+            <iyy>0.0010546736475</iyy>
+            <iyz>-0.0000000006729</iyz>
+            <izz>0.0002633558262</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.02</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <!-- Joints -->
+      <joint name="horizontal_fins_joint" type="revolute">
+        <pose>0 0 0 0 0 0</pose>
+        <parent>base_link</parent>
+        <child>horizontal_fins</child>
+        <axis>
+          <xyz>0 1 0</xyz>
+          <limit>
+            <lower>-0.261799</lower>
+            <upper>0.261799</upper>
+            <effort>-1</effort>
+            <velocity>-1</velocity>
+          </limit>
+        </axis>
+      </joint>
+      <plugin filename="ignition-gazebo-hydrodynamics-system"
+              name="ignition::gazebo::systems::Hydrodynamics">
         <link_name>base_link</link_name>
         <xDotU>-4.876161</xDotU>
         <yDotV>-126.324739</yDotV>
@@ -222,80 +239,99 @@
         <nR>0</nR>
         <disable_added_mass>true</disable_added_mass>
       </plugin>
+    </model>
 
-    </include>
-
-    <include>
+    <model name="daphne">
       <pose>-5 0 1 0 0 1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
-      <name>daphne</name>
-
-      <!-- Joint controllers -->
-      <plugin
-        filename="ignition-gazebo-joint-position-controller-system"
-        name="ignition::gazebo::systems::JointPositionController">
-        <joint_name>horizontal_fins_joint</joint_name>
-        <p_gain>0.1</p_gain>
-      </plugin>
-
-      <plugin
-        filename="ignition-gazebo-joint-position-controller-system"
-        name="ignition::gazebo::systems::JointPositionController">
-        <joint_name>vertical_fins_joint</joint_name>
-        <p_gain>0.1</p_gain>
-      </plugin>
-
-      <plugin
-        filename="ignition-gazebo-thruster-system"
-        name="ignition::gazebo::systems::Thruster">
-        <namespace>daphne</namespace>
-        <joint_name>propeller_joint</joint_name>
-        <thrust_coefficient>0.004422</thrust_coefficient>
-        <fluid_density>1000</fluid_density>
-        <propeller_diameter>0.2</propeller_diameter>
-      </plugin>
-
-      <!-- Lift and drag -->
-
-      <!-- Vertical fin -->
-      <plugin
-        filename="ignition-gazebo-lift-drag-system"
-        name="ignition::gazebo::systems::LiftDrag">
-        <air_density>1000</air_density>
-        <cla>4.13</cla>
-        <cla_stall>-1.1</cla_stall>
-        <cda>0.2</cda>
-        <cda_stall>0.03</cda_stall>
-        <alpha_stall>0.17</alpha_stall>
-        <a0>0</a0>
-        <area>0.0244</area>
-        <upward>0 1 0</upward>
-        <forward>1 0 0</forward>
-        <link_name>vertical_fins</link_name>
-        <cp>0 0 0</cp>
-      </plugin>
-
-      <!-- Horizontal fin -->
-      <plugin
-        filename="ignition-gazebo-lift-drag-system"
-        name="ignition::gazebo::systems::LiftDrag">
-        <air_density>1000</air_density>
-        <cla>4.13</cla>
-        <cla_stall>-1.1</cla_stall>
-        <cda>0.2</cda>
-        <cda_stall>0.03</cda_stall>
-        <alpha_stall>0.17</alpha_stall>
-        <a0>0</a0>
-        <area>0.0244</area>
-        <upward>0 0 1</upward>
-        <forward>1 0 0</forward>
-        <link_name>horizontal_fins</link_name>
-        <cp>0 0 0</cp>
-      </plugin>
-
-      <plugin
-        filename="ignition-gazebo-hydrodynamics-system"
-        name="ignition::gazebo::systems::Hydrodynamics">
+      <link name="base_link">
+        <inertial>
+          <mass>147.8671</mass>
+          <inertia>
+            <ixx>3.000000</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>41.980233</iyy>
+            <iyz>0</iyz>
+            <izz>41.980233</izz>
+          </inertia>
+        </inertial>
+        <collision name="main_body_buoyancy">
+          <geometry>
+            <box>
+              <size>2 0.3 0.246445166667</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='body_visual'>
+          <geometry>
+            <box>
+              <size>2 0.3 0.246445166667</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+      <!-- Horizontal fins -->
+      <link name="horizontal_fins">
+        <pose>1.05 0 0 0 0 0</pose>
+        <inertial>
+          <pose>0 0 0 1.57 0 0.5</pose>
+          <mass>0.2</mass>
+          <inertia>
+            <ixx>0.0007924568755</ixx>
+            <ixy>-0.0000000002674</ixy>
+            <ixz>0.0003978158176</ixz>
+            <iyy>0.0010546736475</iyy>
+            <iyz>-0.0000000006729</iyz>
+            <izz>0.0002633558262</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.02</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <!-- Vertical fins -->
+      <link name="vertical_fins">
+        <pose>1.05 0 0 0 0 0</pose>
+        <inertial>
+          <mass>0.2</mass>
+          <inertia>
+            <ixx>0.0007924568755</ixx>
+            <ixy>-0.0000000002674</ixy>
+            <ixz>0.0003978158176</ixz>
+            <iyy>0.0010546736475</iyy>
+            <iyz>-0.0000000006729</iyz>
+            <izz>0.0002633558262</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.02</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <!-- Joints -->
+      <joint name="horizontal_fins_joint" type="revolute">
+        <pose>0 0 0 0 0 0</pose>
+        <parent>base_link</parent>
+        <child>horizontal_fins</child>
+        <axis>
+          <xyz>0 1 0</xyz>
+          <limit>
+            <lower>-0.261799</lower>
+            <upper>0.261799</upper>
+            <effort>-1</effort>
+            <velocity>-1</velocity>
+          </limit>
+        </axis>
+      </joint>
+      <plugin filename="ignition-gazebo-hydrodynamics-system"
+              name="ignition::gazebo::systems::Hydrodynamics">
         <link_name>base_link</link_name>
         <xDotU>-4.876161</xDotU>
         <yDotV>-126.324739</yDotV>
@@ -317,6 +353,6 @@
         <nR>0</nR>
         <disable_coriolis>true</disable_coriolis>
       </plugin>
-    </include>
+    </model>
   </world>
 </sdf>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This PR tries to reduce the flakiness of the `hydrodynamics flags` test:

It removes the fuel model download as it might be causing the `timeouts`. It also makes sure the checks are not done until the body is moving and it doubles the number of steps that used to test.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
