### PR TITLE
Sync View Angle GUI with view controller

### DIFF
--- a/src/gui/plugins/view_angle/ViewAngle.cc
+++ b/src/gui/plugins/view_angle/ViewAngle.cc
@@ -90,6 +90,14 @@ namespace ignition::gazebo
     /// \return True if there is a new clipping distance from gui camera
     public: bool UpdateQtCamClipDist();
 
+    /// \brief View Control type
+    public: rendering::CameraProjectionType viewControlType =
+              rendering::CameraProjectionType::CPT_PERSPECTIVE;
+
+    /// \brief Checks if there is a new view controller, used to update qml side
+    /// \return True if there is a new view controller from gui camera
+    public: bool UpdateQtViewControl();
+
     /// \brief User camera
     public: rendering::CameraPtr camera{nullptr};
 
@@ -185,6 +193,11 @@ bool ViewAngle::eventFilter(QObject *_obj, QEvent *_event)
     if (this->dataPtr->UpdateQtCamClipDist())
     {
       this->CamClipDistChanged();
+    }
+
+    if (this->dataPtr->UpdateQtViewControl())
+    {
+      this->ViewControlIndexChanged();
     }
   }
   else if (_event->type() ==
@@ -606,6 +619,31 @@ bool ViewAnglePrivate::UpdateQtCamClipDist()
     updated = true;
   }
   return updated;
+}
+
+/////////////////////////////////////////////////
+int ViewAngle::ViewControlIndex() const
+{
+  if (this->dataPtr->viewControlType ==
+        rendering::CameraProjectionType::CPT_PERSPECTIVE)
+    return 0;
+
+  return 1;
+}
+
+/////////////////////////////////////////////////
+bool ViewAnglePrivate::UpdateQtViewControl()
+{
+  if (!this->camera)
+    return false;
+
+  if (this->camera->ProjectionType() != this->viewControlType)
+  {
+    this->viewControlType = this->camera->ProjectionType();
+    return true;
+  }
+
+  return false;
 }
 
 // Register this plugin

--- a/src/gui/plugins/view_angle/ViewAngle.hh
+++ b/src/gui/plugins/view_angle/ViewAngle.hh
@@ -56,6 +56,13 @@ namespace gazebo
       NOTIFY CamClipDistChanged
     )
 
+    /// \brief view controller index for qml side (0: orbit; 1: ortho)
+    Q_PROPERTY(
+      int viewControlIndex
+      READ ViewControlIndex
+      NOTIFY ViewControlIndexChanged
+    )
+
     /// \brief Constructor
     public: ViewAngle();
 
@@ -119,6 +126,12 @@ namespace gazebo
     /// \param[in] _near Near clipping plane distance
     /// \param[in] _far Far clipping plane distance
     public slots: void SetCamClipDist(double _near, double _far);
+
+    /// \brief Get the current index for view controller (on qml side)
+    public: int ViewControlIndex() const;
+
+    /// \brief Notify that the camera's view controller has changed
+    signals: void ViewControlIndexChanged();
 
     /// \internal
     /// \brief Pointer to private data.

--- a/src/gui/plugins/view_angle/ViewAngle.qml
+++ b/src/gui/plugins/view_angle/ViewAngle.qml
@@ -193,7 +193,7 @@ ColumnLayout {
 
   // Projection
   ComboBox {
-    currentIndex: 0
+    currentIndex: ViewAngle.viewControlIndex
     model: ListModel {
         id: controller
         ListElement {text: "Orbit View Control"}


### PR DESCRIPTION
# 🎉 New feature

Requires https://github.com/gazebosim/gz-gui/pull/506

## Summary
Syncs the View Angle GUI when the view controller may be set elsewhere (e.g., in the plugin configuration)

## Test it
1. Add `<view_controller>ortho</view_controller>` to:
https://github.com/gazebosim/gz-sim/blob/7ba7377ca0a4c0ca17a34e9238004f245bbcc5fb/examples/worlds/minimal_scene.sdf#L30-L46

2. Run:
```bash
ign gazebo /path/to/minimal_scene.sdf
```
3. Expand the `View Angle` plugin and you should see `Orthographic View Control` selected

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
