### PR TITLE
Re-add namespace for GUI render event

### DIFF
--- a/src/gui/plugins/scene3d/Scene3D.cc
+++ b/src/gui/plugins/scene3d/Scene3D.cc
@@ -778,7 +778,7 @@ void IgnRenderer::Render()
 
   if (ignition::gui::App())
   {
-    gui::events::Render event;
+    ignition::gui::events::Render event;
     ignition::gui::App()->sendEvent(
         ignition::gui::App()->findChild<ignition::gui::MainWindow *>(),
         &event);


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
A required namespace was accidentally removed in https://github.com/gazebosim/gz-sim/pull/1635 , this caused the assumption that the render event was a `ignition::gazebo::gui` event when it needed to be an `ignition::gui` event.

To test: 
```bash
ign gazebo shapes.sdf
```
then use the `Screenshot` plugin.

Before PR, nothing happened when clicking the screenshot icon (no popup stating where image was saved and no image saved to `~/.ignition/gui/pictures`).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.