### PR TITLE
Fix QML warnings regarding binding loops

### DIFF
--- a/src/gui/resources/GazeboDrawer.qml
+++ b/src/gui/resources/GazeboDrawer.qml
@@ -183,6 +183,7 @@ Rectangle {
     focus: true
     parent: ApplicationWindow.overlay
     width: parent.width / 3 > 500 ? 500 : parent.width / 3
+    height: 300
     x: (parent.width - width) / 2
     y: (parent.height - height) / 2
     closePolicy: Popup.CloseOnEscape
@@ -292,6 +293,7 @@ Rectangle {
     modal: true
     focus: true
     parent: ApplicationWindow.overlay
+    width: messageText.implicitWidth
     x: (parent.width - width) / 2
     y: (parent.height - height) / 2
     closePolicy: Popup.CloseOnEscape


### PR DESCRIPTION

# 🦟 Bug fix

## Summary
In `aboutDialog` (line 178), the binding loop was created because the height of `aboutDialog` wasn't set. It was dependent on the height of its child (`aboutMessage`). But `aboutMessage` had `anchor.fill : parent` set which binds its height to the height of its parent. 

Similar reasoning applies to `fileSaveFailure`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
