### PR TITLE
Remove duplicate Fuel server used by ResourceSpawner

### DIFF
--- a/src/gui/plugins/resource_spawner/ResourceSpawner.cc
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.cc
@@ -550,6 +550,28 @@ void ResourceSpawner::LoadConfig(const tinyxml2::XMLElement *)
   }
 
   auto servers = this->dataPtr->fuelClient->Config().Servers();
+  // Since the ign->gz rename, `servers` here returns two items for the
+  // canonical Fuel server: fuel.ignitionrobotics.org and fuel.gazebosim.org.
+  // For the purposes of the ResourceSpawner, these will be treated as the same
+  // and we will remove the ignitionrobotics server here.
+  auto urlIs = [](const std::string &_url)
+  {
+    return [_url](const fuel_tools::ServerConfig &_server)
+    { return _server.Url().Str() == _url; };
+  };
+
+  auto ignIt = std::find_if(servers.begin(), servers.end(),
+                            urlIs("https://fuel.ignitionrobotics.org"));
+  if (ignIt != servers.end())
+  {
+    auto gzsimIt = std::find_if(servers.begin(), servers.end(),
+                                urlIs("https://fuel.gazebosim.org"));
+    if (gzsimIt != servers.end())
+    {
+      servers.erase(ignIt);
+    }
+  }
+
   ignmsg << "Please wait... Loading models from Fuel.\n";
 
   // Add notice for the user that fuel resources are being loaded
@@ -570,7 +592,7 @@ void ResourceSpawner::LoadConfig(const tinyxml2::XMLElement *)
       }
 
       // Create each fuel resource and add them to the ownerModelMap
-      for (auto id : models)
+      for (const auto &id : models)
       {
         Resource resource;
         resource.name = id.Name();


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Since the ign->gz rename, two canonical Fuel servers ( fuel.ignitionrobotics.org and fuel.gazebosim.org) were being queries by ResourceSpawner. This PR removes the duplication.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.