### PR TITLE
Fix component removal in component inspector

### DIFF
--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -916,10 +916,7 @@ void ComponentInspector::Update(const UpdateInfo &,
   // Remove components in list
   for (auto typeId : itemsToRemove)
   {
-    QMetaObject::invokeMethod(&this->dataPtr->componentsModel,
-        "RemoveComponentType",
-        Qt::QueuedConnection,
-        Q_ARG(sim::ComponentTypeId, typeId));
+    this->dataPtr->componentsModel.RemoveComponentType(typeId);
   }
 }
 


### PR DESCRIPTION
# 🦟 Bug fix
## Summary

When clicking an object, the components of the previously selected objects get removed from the component inspector view. From example, if the world is currently selected, clicking on a model would remove the gravity component from the view. The mechanism that makes it work was broken when `gz` was removed from `Q_ARG(sim::ComponentTypeId, typeId));` of https://github.com/gazebosim/gz-sim/blob/60d4121036eaa2515a2c9f02afe6e1f98673bb4e/src/gui/plugins/component_inspector/ComponentInspector.cc#L922 in #1794. This was also generating the warning:

```
[GUI] [Wrn] [Application.cc:845] [QT] QMetaObject::invokeMethod: No such method gz::sim::ComponentsModel::RemoveComponentType(gz::sim::ComponentTypeId)
Candidates are:
    RemoveComponentType(sim::ComponentTypeId)
```

We used to need `invokeMethod` in `Update` functions, but this is not the case anymore, so I went ahead and changed it to a regular function call. 


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.