### PR TITLE
Use a queue to track component registration from mulitiple sources

### DIFF
--- a/include/ignition/gazebo/components/Component.hh
+++ b/include/ignition/gazebo/components/Component.hh
@@ -387,6 +387,8 @@ namespace components
 
     /// \brief Unique name for this component type. This is set through the
     /// Factory registration.
+    // TODO(azeey) Change to const char* in Harmonic to prevent static
+    // initialization order fiasco.
     public: inline static std::string typeName;
   };
 
@@ -433,6 +435,8 @@ namespace components
 
     /// \brief Unique name for this component type. This is set through the
     /// Factory registration.
+    // TODO(azeey) Change to const char* in Harmonic to prevent static
+    // initialization order fiasco.
     public: inline static std::string typeName;
   };
 

--- a/include/ignition/gazebo/components/Factory.hh
+++ b/include/ignition/gazebo/components/Factory.hh
@@ -224,9 +224,18 @@ namespace components
   };
 
   /// \brief A factory that generates a component based on a string type.
+  // TODO(azeey) Do not inherit from common::SingletonT in Harmonic
   class Factory
       : public ignition::common::SingletonT<Factory>
   {
+    // Deleted copy constructors to make the ABI checker happy
+    public: Factory(Factory &) = delete;
+    public: Factory(const Factory &) = delete;
+    // Since the copy constructors are deleted, we need to explicitly declare a
+    // default constructor.
+    // TODO(azeey) Make this private in Harmonic
+    public: Factory() = default;
+
     /// \brief Get an instance of the singleton
     public: IGNITION_GAZEBO_VISIBLE static Factory *Instance();
 
@@ -505,6 +514,10 @@ namespace components
       gazebo::components::Factory::Instance()->Register<_classname>(\
         _compType, new Desc(), gazebo::components::RegistrationObjectId(this));\
     } \
+    public: IgnGazeboComponents##_classname( \
+                const IgnGazeboComponents##_classname&) = delete; \
+    public: IgnGazeboComponents##_classname( \
+                IgnGazeboComponents##_classname&) = delete; \
     public: ~IgnGazeboComponents##_classname() \
     { \
       using namespace ignition; \

--- a/include/ignition/gazebo/components/Factory.hh
+++ b/include/ignition/gazebo/components/Factory.hh
@@ -204,34 +204,26 @@ namespace components
     public: void Unregister(ComponentTypeId _typeId,
                             ComponentDescriptorBase *_compDesc = nullptr)
     {
-      // Not registered
-      if (_typeId == 0)
+      auto it = this->compsById.find(_typeId);
+      if (it != this->compsById.end())
       {
-        return;
-      }
-
-      {
-        auto it = this->compsById.find(_typeId);
-        if (it != this->compsById.end() && !it->second.empty())
+        if (!it->second.empty())
         {
-          if (nullptr == _compDesc)
+          auto compIt = std::prev(it->second.end());
+          if (nullptr != _compDesc)
           {
-            ComponentDescriptorBase *compDesc = it->second.back();
-            it->second.pop_back();
+            compIt =
+              std::find(it->second.begin(), it->second.end(), _compDesc);
+          }
+
+          if (compIt != it->second.end())
+          {
+            ComponentDescriptorBase *compDesc = *compIt;
+            it->second.erase(compIt);
             delete compDesc;
           }
-          else
-          {
-            auto compIt =
-              std::find(it->second.begin(), it->second.end(), _compDesc);
-            if (compIt != it->second.end())
-            {
-              ComponentDescriptorBase* compDesc = *compIt;
-              it->second.erase(compIt);
-              delete compDesc;
-            }
-          }
         }
+
         // Check again since we may have updated the list
         if (it->second.empty())
         {

--- a/include/ignition/gazebo/components/Factory.hh
+++ b/include/ignition/gazebo/components/Factory.hh
@@ -121,12 +121,14 @@ namespace components
         : id(reinterpret_cast<std::uintptr_t>(_ptr))
     {
     }
+
     /// \brief Construct object from a uintptr_t.
     /// \param[in] _ptr Arbitrary pointer address.
     explicit RegistrationObjectId(std::uintptr_t _ptrAddress)
         : id(_ptrAddress)
     {
     }
+
     /// \brief Equality comparison.
     /// \param[in] _other Other RegistrationObjectId object to compare against.
     bool operator==(const RegistrationObjectId &_other) const
@@ -147,7 +149,7 @@ namespace components
   ///  2. Plugin P1 gets unloaded.
   ///  3. Plugin P2 registers a component descriptor for component C1 and tries
   ///     to create an instance of C1.
-  /// When P1 gets unloaded, the desctructor of the static component
+  /// When P1 gets unloaded, the destructor of the static component
   /// registration object calls Factory::Unregister which removes the component
   /// descriptor from the queue. Without this step, P2 would attempt to use
   /// the component descriptor created by P1 in step 3 and likely segfault

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,7 @@ set (sources
   Barrier.cc
   BaseView.cc
   Conversions.cc
+  ComponentFactory.cc
   EntityComponentManager.cc
   LevelManager.cc
   Link.cc

--- a/src/ComponentFactory.cc
+++ b/src/ComponentFactory.cc
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "ignition/gazebo/components/Factory.hh"
+
+
+namespace ignition
+{
+namespace gazebo
+{
+namespace components
+{
+Factory * Factory::Instance()
+{
+  return common::SingletonT<Factory>::Instance();
+}
+}
+}
+}

--- a/src/ComponentFactory.cc
+++ b/src/ComponentFactory.cc
@@ -17,17 +17,9 @@
 
 #include "ignition/gazebo/components/Factory.hh"
 
+using Factory = ignition::gazebo::components::Factory;
 
-namespace ignition
-{
-namespace gazebo
-{
-namespace components
-{
-Factory * Factory::Instance()
+Factory *Factory::Instance()
 {
   return common::SingletonT<Factory>::Instance();
-}
-}
-}
 }

--- a/src/ComponentFactory_TEST.cc
+++ b/src/ComponentFactory_TEST.cc
@@ -68,7 +68,7 @@ TEST_F(ComponentFactoryTest, Register)
   EXPECT_EQ(registeredCount + 1, ids.size());
   EXPECT_NE(ids.end(), std::find(ids.begin(), ids.end(), MyCustom::typeId));
 
-  // Fail to register same component twice
+  // Registering the component twice doesn't change the number of type ids.
   factory->Register<MyCustom>("ign_gazebo_components.MyCustom",
       new components::ComponentDescriptor<MyCustom>());
 
@@ -85,11 +85,8 @@ TEST_F(ComponentFactoryTest, Register)
   // Unregister
   factory->Unregister<MyCustom>();
 
-  // Check it has no type id yet
   ids = factory->TypeIds();
-  EXPECT_EQ(registeredCount, ids.size());
-  EXPECT_EQ(0u, MyCustom::typeId);
-  EXPECT_EQ("", factory->Name(MyCustom::typeId));
+  EXPECT_EQ(registeredCount + 1, ids.size());
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #1780, #806

## Summary

When a plugin gets unloaded, the component types it registered will have invalid component descriptors. Attempting to create new components of those types will result in a segfault. This PR is an attempt to fix that by keeping track all component registrations and removing invalid ones when plugins get unloaded.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
