### PR TITLE
Header guard fix for battery power load component

### DIFF
--- a/include/ignition/gazebo/components/BatteryPowerLoad.hh
+++ b/include/ignition/gazebo/components/BatteryPowerLoad.hh
@@ -15,7 +15,7 @@
  *
 */
 #ifndef IGNITION_GAZEBO_COMPONENTS_BATTERYPOWERLOAD_HH_
-#define IGNITION_GAZEBO_COMPONENTS_BATTERYCONSUMPTION_HH_
+#define IGNITION_GAZEBO_COMPONENTS_BATTERYPOWERLOAD_HH_
 
 #include <ignition/gazebo/components/Factory.hh>
 #include <ignition/gazebo/components/Component.hh>


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

# 🦟 Bug fix

Related to https://github.com/gazebosim/gz-sim/pull/1811.

## Summary
Fix to the header guard for the battery power load component where the `#ifndef` was not matching the following `#define`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.