### PR TITLE
Fix Ackermann plugin zero linVel turningRadius bug

### DIFF
--- a/src/systems/ackermann_steering/AckermannSteering.cc
+++ b/src/systems/ackermann_steering/AckermannSteering.cc
@@ -729,14 +729,23 @@ void AckermannSteeringPrivate::UpdateVelocity(
   // Convert the target velocities to joint velocities and angles
   double turningRadius = linVel / angVel;
   double minimumTurningRadius = this->wheelBase / sin(this->steeringLimit);
-  if ((turningRadius >= 0.0) && (turningRadius < minimumTurningRadius))
+  if (fabs(linVel) > 0.0)
   {
-    turningRadius = minimumTurningRadius;
+    if ((turningRadius >= 0.0) && (turningRadius < minimumTurningRadius))
+    {
+      turningRadius = minimumTurningRadius;
+    }
+    if ((turningRadius <= 0.0) && (turningRadius > -minimumTurningRadius))
+    {
+      turningRadius = -minimumTurningRadius;
+    }
   }
-  if ((turningRadius <= 0.0) && (turningRadius > -minimumTurningRadius))
+  // special case for angVel not zero and linVel zero
+  else if (fabs(angVel) >= 0.001)
   {
-    turningRadius = -minimumTurningRadius;
+    turningRadius = (angVel / fabs(angVel)) * minimumTurningRadius;
   }
+
   // special case for angVel of zero
   if (fabs(angVel) < 0.001)
   {


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #1848

## Summary
Fix for handling Ackermann wheel steering angle bug where wheel always points same direction when linVel is zero and abs(angVel) > 0.001. This results in an always positive evaluated turningRadius. This solution fixes it by handling linVel zero properly. Allowing it to get past the first conditional that it is otherwise stuck on.

Now the wheels can rotate both directions when the vehicle has no linVel:


https://user-images.githubusercontent.com/10233412/209774462-ac17dd19-f537-4075-a1e4-c3b313a310fc.mp4


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
