### PR TITLE
Support nested joints in JointPositionController

### DIFF
--- a/examples/worlds/nested_model_joint_positions.sdf
+++ b/examples/worlds/nested_model_joint_positions.sdf
@@ -1,0 +1,949 @@
+<?xml version="1.0" ?>
+<!--
+  Run example
+  gz sim -v4 -r nested_model_joint_positions.sdf
+
+  Move rotor in model1
+  gz topic -t "/model1/cmd_rotor" -m gz.msgs.Double -p "data: 1"
+
+  Move rotors in model2
+  gz topic -t "/model2/cmd_rotor" -m gz.msgs.Double -p "data: 1"
+  gz topic -t "/model21/cmd_rotor" -m gz.msgs.Double -p "data: 1"
+
+  Move rotors in model3
+  gz topic -t "/model3/cmd_rotor" -m gz.msgs.Double -p "data: 1"
+  gz topic -t "/model31/cmd_rotor" -m gz.msgs.Double -p "data: 1"
+  gz topic -t "/model32/cmd_rotor" -m gz.msgs.Double -p "data: 1"
+
+  Move rotors in model4
+  gz topic -t "/model41/cmd_rotor" -m gz.msgs.Double -p "data: 1"
+  gz topic -t "/model42/cmd_rotor" -m gz.msgs.Double -p "data: 1"
+ -->
+
+<sdf version="1.6">
+  <world name="nested_model_joint_positions">
+    <physics name="1ms" type="ignore">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
+    <plugin filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin filename="gz-sim-user-commands-system"
+      name="gz::sim::systems::UserCommands">
+    </plugin>
+    <plugin filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+
+    <scene>
+      <ambient>1.0 1.0 1.0</ambient>
+      <background>0.8 0.8 0.8</background>
+    </scene>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.8 0.8 0.8 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <!--
+      1. Model with a position controlled joint.
+
+      Links:
+        model1::base_link
+        model1::rotor_link
+
+      Joints:
+        model1::rotor_joint
+    -->
+    <model name="model1">
+      <pose>0 0 0.5 0 0 0</pose>
+      <link name="base_link">
+        <inertial>
+          <mass>1.0</mass>
+          <inertia>
+            <ixx>0.166666667</ixx>
+            <ixy>0.00</ixy>
+            <ixz>0.00</ixz>
+            <iyy>0.166666667</iyy>
+            <iyz>0.00</iyz>
+            <izz>0.166666667</izz>
+          </inertia>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 1 0</ambient>
+            <diffuse>1 1 0</diffuse>
+            <specular>0.1 0.1 0 1</specular>
+          </material>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <link name="rotor_link">
+        <pose>0 0 0.6 0 0 0</pose>
+        <inertial>
+          <mass>0.01</mass>
+          <inertia>
+            <ixx>1.66667E-05</ixx>
+            <ixy>0.00</ixy>
+            <ixz>0.00</ixz>
+            <iyy>0.000841667</iyy>
+            <iyz>0.00</iyz>
+            <izz>0.000841667</izz>
+          </inertia>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 0.1 0.1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0.5 0</ambient>
+            <diffuse>1 0.5 0</diffuse>
+            <specular>0.1 0.1 0 1</specular>
+          </material>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <joint name="rotor_joint" type="revolute">
+        <parent>base_link</parent>
+        <child>rotor_link</child>
+        <axis>
+          <dynamics>
+            <damping>0.5</damping>
+          </dynamics>
+          <limit>
+            <lower>-3.14159265</lower>
+            <upper>3.14159265</upper>
+          </limit>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>rotor_joint</joint_name>
+        <topic>/model1/cmd_rotor</topic>
+        <p_gain>30</p_gain>
+        <i_gain>0.05</i_gain>
+      </plugin>
+    </model>
+
+    <!--
+      2. Model with a position controlled joint and nested model
+         with a position controlled joint
+
+      Links:
+        model2::base_link
+        model2::rotor_link
+        model2::model21::base_link
+        model2::model21::rotor_link
+
+      Joints:
+        model2::rotor_joint
+        model2::model21_joint
+        model2::model21::rotor_joint
+
+      Topics:
+        /model2/cmd_rotor   controls  model2::rotor_joint
+        /model21/cmd_rotor  controls  model2::model21::rotor_joint
+
+    -->
+    <model name="model2">
+      <pose>0 -2 0.5 0 0 0</pose>
+      <link name="base_link">
+        <inertial>
+          <mass>1.0</mass>
+          <inertia>
+            <ixx>0.166666667</ixx>
+            <ixy>0.00</ixy>
+            <ixz>0.00</ixz>
+            <iyy>0.166666667</iyy>
+            <iyz>0.00</iyz>
+            <izz>0.166666667</izz>
+          </inertia>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 1 0</ambient>
+            <diffuse>1 1 0</diffuse>
+            <specular>0.1 0.1 0 1</specular>
+          </material>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <link name="rotor_link">
+        <pose>0 0 0.6 0 0 0</pose>
+        <inertial>
+          <mass>0.01</mass>
+          <inertia>
+            <ixx>1.66667E-05</ixx>
+            <ixy>0.00</ixy>
+            <ixz>0.00</ixz>
+            <iyy>0.000841667</iyy>
+            <iyz>0.00</iyz>
+            <izz>0.000841667</izz>
+          </inertia>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 0.1 0.1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0.5 0</ambient>
+            <diffuse>1 0.5 0</diffuse>
+            <specular>0.1 0.1 0 1</specular>
+          </material>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <joint name="rotor_joint" type="revolute">
+        <parent>base_link</parent>
+        <child>rotor_link</child>
+        <axis>
+          <dynamics>
+            <damping>0.5</damping>
+          </dynamics>
+          <limit>
+            <lower>-3.14159265</lower>
+            <upper>3.14159265</upper>
+          </limit>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+      <model name="model21">
+        <pose>1 0 0 0 0 0</pose>
+        <link name="base_link">
+          <inertial>
+            <mass>1.0</mass>
+            <inertia>
+              <ixx>0.166666667</ixx>
+              <ixy>0.00</ixy>
+              <ixz>0.00</ixz>
+              <iyy>0.166666667</iyy>
+              <iyz>0.00</iyz>
+              <izz>0.166666667</izz>
+            </inertia>
+          </inertial>
+          <visual name="visual">
+            <geometry>
+              <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+            <material>
+              <ambient>0 1 1</ambient>
+              <diffuse>0 1 1</diffuse>
+              <specular>0.1 0.1 0 1</specular>
+            </material>
+          </visual>
+          <collision name="collision">
+            <geometry>
+              <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+          </collision>
+        </link>
+        <link name="rotor_link">
+          <pose>0 0 0.6 0 0 0</pose>
+          <inertial>
+            <mass>0.01</mass>
+            <inertia>
+              <ixx>1.66667E-05</ixx>
+              <ixy>0.00</ixy>
+              <ixz>0.00</ixz>
+              <iyy>0.000841667</iyy>
+              <iyz>0.00</iyz>
+              <izz>0.000841667</izz>
+            </inertia>
+          </inertial>
+          <visual name="visual">
+            <geometry>
+              <box>
+                <size>1 0.1 0.1</size>
+              </box>
+            </geometry>
+            <material>
+              <ambient>1 0.5 0</ambient>
+              <diffuse>1 0.5 0</diffuse>
+              <specular>0.1 0.1 0 1</specular>
+            </material>
+          </visual>
+          <collision name="collision">
+            <geometry>
+              <box>
+                <size>1 0.1 0.1</size>
+              </box>
+            </geometry>
+          </collision>
+        </link>
+        <joint name="rotor_joint" type="revolute">
+          <parent>base_link</parent>
+          <child>rotor_link</child>
+          <axis>
+            <dynamics>
+              <damping>0.5</damping>
+            </dynamics>
+            <limit>
+              <lower>-3.14159265</lower>
+              <upper>3.14159265</upper>
+            </limit>
+            <xyz>0 0 1</xyz>
+          </axis>
+        </joint>
+      </model>
+      <joint name="model21_joint" type="revolute">
+        <parent>base_link</parent>
+        <child>model21::base_link</child>
+        <axis>
+          <dynamics>
+            <damping>1</damping>
+          </dynamics>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+          </limit>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>rotor_joint</joint_name>
+        <topic>/model2/cmd_rotor</topic>
+        <p_gain>30</p_gain>
+        <i_gain>0.05</i_gain>
+      </plugin>
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>model21::rotor_joint</joint_name>
+        <topic>/model21/cmd_rotor</topic>
+        <p_gain>30</p_gain>
+        <i_gain>0.05</i_gain>
+      </plugin>
+    </model>
+
+    <!--
+      3. Model with a position controlled joint and two nested models,
+         both containing position controlled joints.
+
+      The top-level model contain two links and other models.
+
+      Links:
+        model3::base_link
+        model3::rotor_link
+        model3::model31::base_link
+        model3::model31::rotor_link
+        model3::model32::base_link
+        model3::model32::rotor_link
+
+      Joints:
+        model3::rotor_joint
+        model3::model31_joint
+        model3::model32_joint
+        model3::model31::rotor_joint
+        model3::model32::rotor_joint
+
+      Topics:
+        /model3/cmd_rotor   controls  model3::rotor_joint
+        /model31/cmd_rotor  controls  model3::model31::rotor_joint
+        /model32/cmd_rotor  controls  model3::model32::rotor_joint
+
+    -->
+    <model name="model3">
+      <pose>0 -4 0.5 0 0 0</pose>
+      <link name="base_link">
+        <inertial>
+          <mass>1.0</mass>
+          <inertia>
+            <ixx>0.166666667</ixx>
+            <ixy>0.00</ixy>
+            <ixz>0.00</ixz>
+            <iyy>0.166666667</iyy>
+            <iyz>0.00</iyz>
+            <izz>0.166666667</izz>
+          </inertia>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 1 0</ambient>
+            <diffuse>1 1 0</diffuse>
+            <specular>0.1 0.1 0 1</specular>
+          </material>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <link name="rotor_link">
+        <pose>0 0 0.6 0 0 0</pose>
+        <inertial>
+          <mass>0.01</mass>
+          <inertia>
+            <ixx>1.66667E-05</ixx>
+            <ixy>0.00</ixy>
+            <ixz>0.00</ixz>
+            <iyy>0.000841667</iyy>
+            <iyz>0.00</iyz>
+            <izz>0.000841667</izz>
+          </inertia>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 0.1 0.1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0.5 0</ambient>
+            <diffuse>1 0.5 0</diffuse>
+            <specular>0.1 0.1 0 1</specular>
+          </material>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <joint name="rotor_joint" type="revolute">
+        <parent>base_link</parent>
+        <child>rotor_link</child>
+        <axis>
+          <dynamics>
+            <damping>0.5</damping>
+          </dynamics>
+          <limit>
+            <lower>-3.14159265</lower>
+            <upper>3.14159265</upper>
+          </limit>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+      <model name="model31">
+        <pose>1 0 0 0 0 0</pose>
+        <link name="base_link">
+          <inertial>
+            <mass>1.0</mass>
+            <inertia>
+              <ixx>0.166666667</ixx>
+              <ixy>0.00</ixy>
+              <ixz>0.00</ixz>
+              <iyy>0.166666667</iyy>
+              <iyz>0.00</iyz>
+              <izz>0.166666667</izz>
+            </inertia>
+          </inertial>
+          <visual name="visual">
+            <geometry>
+              <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+            <material>
+              <ambient>0 1 1</ambient>
+              <diffuse>0 1 1</diffuse>
+              <specular>0.1 0.1 0 1</specular>
+            </material>
+          </visual>
+          <collision name="collision">
+            <geometry>
+              <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+          </collision>
+        </link>
+        <link name="rotor_link">
+          <pose>0 0 0.6 0 0 0</pose>
+          <inertial>
+            <mass>0.01</mass>
+            <inertia>
+              <ixx>1.66667E-05</ixx>
+              <ixy>0.00</ixy>
+              <ixz>0.00</ixz>
+              <iyy>0.000841667</iyy>
+              <iyz>0.00</iyz>
+              <izz>0.000841667</izz>
+            </inertia>
+          </inertial>
+          <visual name="visual">
+            <geometry>
+              <box>
+                <size>1 0.1 0.1</size>
+              </box>
+            </geometry>
+            <material>
+              <ambient>1 0.5 0</ambient>
+              <diffuse>1 0.5 0</diffuse>
+              <specular>0.1 0.1 0 1</specular>
+            </material>
+          </visual>
+          <collision name="collision">
+            <geometry>
+              <box>
+                <size>1 0.1 0.1</size>
+              </box>
+            </geometry>
+          </collision>
+        </link>
+        <joint name="rotor_joint" type="revolute">
+          <parent>base_link</parent>
+          <child>rotor_link</child>
+          <axis>
+            <dynamics>
+              <damping>0.5</damping>
+            </dynamics>
+            <limit>
+              <lower>-3.14159265</lower>
+              <upper>3.14159265</upper>
+            </limit>
+            <xyz>0 0 1</xyz>
+          </axis>
+        </joint>
+      </model>
+      <model name="model32">
+        <pose>2 0 0 0 0 0</pose>
+        <link name="base_link">
+          <inertial>
+            <mass>1.0</mass>
+            <inertia>
+              <ixx>0.166666667</ixx>
+              <ixy>0.00</ixy>
+              <ixz>0.00</ixz>
+              <iyy>0.166666667</iyy>
+              <iyz>0.00</iyz>
+              <izz>0.166666667</izz>
+            </inertia>
+          </inertial>
+          <visual name="visual">
+            <geometry>
+              <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+            <material>
+              <ambient>1 0 1</ambient>
+              <diffuse>1 0 1</diffuse>
+              <specular>0.1 0.1 0 1</specular>
+            </material>
+          </visual>
+          <collision name="collision">
+            <geometry>
+              <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+          </collision>
+        </link>
+        <link name="rotor_link">
+          <pose>0 0 0.6 0 0 0</pose>
+          <inertial>
+            <mass>0.01</mass>
+            <inertia>
+              <ixx>1.66667E-05</ixx>
+              <ixy>0.00</ixy>
+              <ixz>0.00</ixz>
+              <iyy>0.000841667</iyy>
+              <iyz>0.00</iyz>
+              <izz>0.000841667</izz>
+            </inertia>
+          </inertial>
+          <visual name="visual">
+            <geometry>
+              <box>
+                <size>1 0.1 0.1</size>
+              </box>
+            </geometry>
+            <material>
+              <ambient>1 0.5 0</ambient>
+              <diffuse>1 0.5 0</diffuse>
+              <specular>0.1 0.1 0 1</specular>
+            </material>
+          </visual>
+          <collision name="collision">
+            <geometry>
+              <box>
+                <size>1 0.1 0.1</size>
+              </box>
+            </geometry>
+          </collision>
+        </link>
+        <joint name="rotor_joint" type="revolute">
+          <parent>base_link</parent>
+          <child>rotor_link</child>
+          <axis>
+            <dynamics>
+              <damping>0.5</damping>
+            </dynamics>
+            <limit>
+              <lower>-3.14159265</lower>
+              <upper>3.14159265</upper>
+            </limit>
+            <xyz>0 0 1</xyz>
+          </axis>
+        </joint>
+      </model>
+      <joint name="model31_joint" type="revolute">
+        <parent>base_link</parent>
+        <child>model31::base_link</child>
+        <axis>
+          <dynamics>
+            <damping>1</damping>
+          </dynamics>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+          </limit>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+      <joint name="model32_joint" type="revolute">
+        <parent>model31::base_link</parent>
+        <child>model32::base_link</child>
+        <axis>
+          <dynamics>
+            <damping>1</damping>
+          </dynamics>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+          </limit>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>rotor_joint</joint_name>
+        <topic>/model3/cmd_rotor</topic>
+        <p_gain>30</p_gain>
+        <i_gain>0.05</i_gain>
+      </plugin>
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>model31::rotor_joint</joint_name>
+        <topic>/model31/cmd_rotor</topic>
+        <p_gain>30</p_gain>
+        <i_gain>0.05</i_gain>
+      </plugin>
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>model32::rotor_joint</joint_name>
+        <topic>/model32/cmd_rotor</topic>
+        <p_gain>30</p_gain>
+        <i_gain>0.05</i_gain>
+      </plugin>
+    </model>
+
+    <!--
+      4. Model containing two nested models with position contolled joints.
+
+      The top-level model does not contain a link, only a joint connecting
+      the two nested models.
+
+      Links:
+        model4::model41::base_link
+        model4::model41::rotor_link
+        model4::model42::base_link
+        model4::model42::rotor_link
+
+      Joints:
+        model4::model41_joint
+        model4::model42_joint
+        model4::model41::rotor_joint
+        model4::model42::rotor_joint
+
+      Topics:
+        /model41/cmd_rotor  controls  model3::model41::rotor_joint
+        /model42/cmd_rotor  controls  model3::model42::rotor_joint
+    -->
+    <model name="model4">
+      <pose>0 -6 0.5 0 0 0</pose>
+      <model name="model41">
+        <pose>1 0 0 0 0 0</pose>
+        <link name="base_link">
+          <inertial>
+            <mass>1.0</mass>
+            <inertia>
+              <ixx>0.166666667</ixx>
+              <ixy>0.00</ixy>
+              <ixz>0.00</ixz>
+              <iyy>0.166666667</iyy>
+              <iyz>0.00</iyz>
+              <izz>0.166666667</izz>
+            </inertia>
+          </inertial>
+          <visual name="visual">
+            <geometry>
+              <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+            <material>
+              <ambient>0 1 1</ambient>
+              <diffuse>0 1 1</diffuse>
+              <specular>0.1 0.1 0 1</specular>
+            </material>
+          </visual>
+          <collision name="collision">
+            <geometry>
+              <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+          </collision>
+        </link>
+        <link name="rotor_link">
+          <pose>0 0 0.6 0 0 0</pose>
+          <inertial>
+            <mass>0.01</mass>
+            <inertia>
+              <ixx>1.66667E-05</ixx>
+              <ixy>0.00</ixy>
+              <ixz>0.00</ixz>
+              <iyy>0.000841667</iyy>
+              <iyz>0.00</iyz>
+              <izz>0.000841667</izz>
+            </inertia>
+          </inertial>
+          <visual name="visual">
+            <geometry>
+              <box>
+                <size>1 0.1 0.1</size>
+              </box>
+            </geometry>
+            <material>
+              <ambient>1 0.5 0</ambient>
+              <diffuse>1 0.5 0</diffuse>
+              <specular>0.1 0.1 0 1</specular>
+            </material>
+          </visual>
+          <collision name="collision">
+            <geometry>
+              <box>
+                <size>1 0.1 0.1</size>
+              </box>
+            </geometry>
+          </collision>
+        </link>
+        <joint name="rotor_joint" type="revolute">
+          <parent>base_link</parent>
+          <child>rotor_link</child>
+          <axis>
+            <dynamics>
+              <damping>0.5</damping>
+            </dynamics>
+            <limit>
+              <lower>-3.14159265</lower>
+              <upper>3.14159265</upper>
+            </limit>
+            <xyz>0 0 1</xyz>
+          </axis>
+        </joint>
+      </model>
+      <model name="model42">
+        <pose>2 0 0 0 0 0</pose>
+        <link name="base_link">
+          <inertial>
+            <mass>1.0</mass>
+            <inertia>
+              <ixx>0.166666667</ixx>
+              <ixy>0.00</ixy>
+              <ixz>0.00</ixz>
+              <iyy>0.166666667</iyy>
+              <iyz>0.00</iyz>
+              <izz>0.166666667</izz>
+            </inertia>
+          </inertial>
+          <visual name="visual">
+            <geometry>
+              <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+            <material>
+              <ambient>1 0 1</ambient>
+              <diffuse>1 0 1</diffuse>
+              <specular>0.1 0.1 0 1</specular>
+            </material>
+          </visual>
+          <collision name="collision">
+            <geometry>
+              <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+          </collision>
+        </link>
+        <link name="rotor_link">
+          <pose>0 0 0.6 0 0 0</pose>
+          <inertial>
+            <mass>0.01</mass>
+            <inertia>
+              <ixx>1.66667E-05</ixx>
+              <ixy>0.00</ixy>
+              <ixz>0.00</ixz>
+              <iyy>0.000841667</iyy>
+              <iyz>0.00</iyz>
+              <izz>0.000841667</izz>
+            </inertia>
+          </inertial>
+          <visual name="visual">
+            <geometry>
+              <box>
+                <size>1 0.1 0.1</size>
+              </box>
+            </geometry>
+            <material>
+              <ambient>1 0.5 0</ambient>
+              <diffuse>1 0.5 0</diffuse>
+              <specular>0.1 0.1 0 1</specular>
+            </material>
+          </visual>
+          <collision name="collision">
+            <geometry>
+              <box>
+                <size>1 0.1 0.1</size>
+              </box>
+            </geometry>
+          </collision>
+        </link>
+        <joint name="rotor_joint" type="revolute">
+          <parent>base_link</parent>
+          <child>rotor_link</child>
+          <axis>
+            <dynamics>
+              <damping>0.5</damping>
+            </dynamics>
+            <limit>
+              <lower>-3.14159265</lower>
+              <upper>3.14159265</upper>
+            </limit>
+            <xyz>0 0 1</xyz>
+          </axis>
+        </joint>
+      </model>
+      <joint name="model42_joint" type="revolute">
+        <parent>model41::base_link</parent>
+        <child>model42::base_link</child>
+        <axis>
+          <dynamics>
+            <damping>1</damping>
+          </dynamics>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+          </limit>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>model41::rotor_joint</joint_name>
+        <topic>/model41/cmd_rotor</topic>
+        <p_gain>30</p_gain>
+        <i_gain>0.05</i_gain>
+      </plugin>
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>model42::rotor_joint</joint_name>
+        <topic>/model42/cmd_rotor</topic>
+        <p_gain>30</p_gain>
+        <i_gain>0.05</i_gain>
+      </plugin>
+    </model>
+
+  </world>
+</sdf>

--- a/src/systems/joint_position_controller/JointPositionController.cc
+++ b/src/systems/joint_position_controller/JointPositionController.cc
@@ -29,10 +29,12 @@
 #include <gz/plugin/Register.hh>
 #include <gz/transport/Node.hh>
 
+#include "gz/sim/components/Joint.hh"
 #include "gz/sim/components/JointForceCmd.hh"
 #include "gz/sim/components/JointVelocityCmd.hh"
 #include "gz/sim/components/JointPosition.hh"
 #include "gz/sim/Model.hh"
+#include "gz/sim/Util.hh"
 
 using namespace gz;
 using namespace sim;
@@ -271,14 +273,42 @@ void JointPositionController::PreUpdate(
     bool warned{false};
     for (const std::string &name : this->dataPtr->jointNames)
     {
-      Entity joint = this->dataPtr->model.JointByName(_ecm, name);
+      // First try to resolve by scoped name.
+      Entity joint = kNullEntity;
+      auto entities = entitiesFromScopedName(
+          name, _ecm, this->dataPtr->model.Entity());
+
+      if (!entities.empty())
+      {
+        if (entities.size() > 1)
+        {
+          gzwarn << "Multiple joint entities with name ["
+                << name << "] found. "
+                << "Using the first one.\n";
+        }
+        joint = *entities.begin();
+
+        // Validate
+        if (!_ecm.EntityHasComponentType(joint, components::Joint::typeId))
+        {
+          gzerr << "Entity with name[" << name
+                << "] is not a joint\n";
+          joint = kNullEntity;
+        }
+        else
+        {
+          gzdbg << "Identified joint [" << name
+                << "] as Entity [" << joint << "]\n";
+        }
+      }
+
       if (joint != kNullEntity)
       {
         this->dataPtr->jointEntities.push_back(joint);
       }
       else if (!warned)
       {
-        gzwarn << "Failed to find joint [" << name << "]" << std::endl;
+        gzwarn << "Failed to find joint [" << name << "]\n";
         warned = true;
       }
     }

--- a/test/worlds/joint_position_controller_nested_models.sdf
+++ b/test/worlds/joint_position_controller_nested_models.sdf
@@ -1,0 +1,270 @@
+<?xml version="1.0" ?>
+<!--
+  Run example
+  gz sim -v4 -r joint_position_controller_nested_models.sdf
+
+  Move rotors in model2
+  gz topic -t "/model2/cmd_rotor" -m gz.msgs.Double -p "data: 1"
+  gz topic -t "/model21/cmd_rotor" -m gz.msgs.Double -p "data: 1"
+ -->
+
+<sdf version="1.6">
+  <world name="default">
+    <physics name="1ms" type="ignore">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
+    <plugin filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin filename="gz-sim-user-commands-system"
+      name="gz::sim::systems::UserCommands">
+    </plugin>
+    <plugin filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <!--
+      2. Model with a position controlled joint and nested model
+         with a position controlled joint
+
+      Links:
+        model2::base_link
+        model2::rotor_link
+        model2::model21::base_link
+        model2::model21::rotor_link
+
+      Joints:
+        model2::rotor_joint
+        model2::model21_joint
+        model2::model21::rotor_joint
+
+      Topics:
+        /model2/cmd_rotor   controls  model2::rotor_joint
+        /model21/cmd_rotor  controls  model2::model21::rotor_joint
+
+    -->
+    <model name="model2">
+      <pose>0 -2 0.5 0 0 0</pose>
+      <link name="base_link">
+        <inertial>
+          <mass>1.0</mass>
+          <inertia>
+            <ixx>0.166666667</ixx>
+            <ixy>0.00</ixy>
+            <ixz>0.00</ixz>
+            <iyy>0.166666667</iyy>
+            <iyz>0.00</iyz>
+            <izz>0.166666667</izz>
+          </inertia>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 1 0</ambient>
+            <diffuse>1 1 0</diffuse>
+            <specular>0.1 0.1 0 1</specular>
+          </material>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <link name="rotor_link">
+        <pose>0 0 0.6 0 0 0</pose>
+        <inertial>
+          <mass>0.01</mass>
+          <inertia>
+            <ixx>1.66667E-05</ixx>
+            <ixy>0.00</ixy>
+            <ixz>0.00</ixz>
+            <iyy>0.000841667</iyy>
+            <iyz>0.00</iyz>
+            <izz>0.000841667</izz>
+          </inertia>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 0.1 0.1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0.5 0</ambient>
+            <diffuse>1 0.5 0</diffuse>
+            <specular>0.1 0.1 0 1</specular>
+          </material>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <joint name="rotor_joint" type="revolute">
+        <parent>base_link</parent>
+        <child>rotor_link</child>
+        <axis>
+          <dynamics>
+            <damping>0.5</damping>
+          </dynamics>
+          <limit>
+            <lower>-3.14159265</lower>
+            <upper>3.14159265</upper>
+          </limit>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+      <model name="model21">
+        <pose>1 0 0 0 0 0</pose>
+        <link name="base_link">
+          <inertial>
+            <mass>1.0</mass>
+            <inertia>
+              <ixx>0.166666667</ixx>
+              <ixy>0.00</ixy>
+              <ixz>0.00</ixz>
+              <iyy>0.166666667</iyy>
+              <iyz>0.00</iyz>
+              <izz>0.166666667</izz>
+            </inertia>
+          </inertial>
+          <visual name="visual">
+            <geometry>
+              <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+            <material>
+              <ambient>0 1 1</ambient>
+              <diffuse>0 1 1</diffuse>
+              <specular>0.1 0.1 0 1</specular>
+            </material>
+          </visual>
+          <collision name="collision">
+            <geometry>
+              <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+          </collision>
+        </link>
+        <link name="rotor_link">
+          <pose>0 0 0.6 0 0 0</pose>
+          <inertial>
+            <mass>0.01</mass>
+            <inertia>
+              <ixx>1.66667E-05</ixx>
+              <ixy>0.00</ixy>
+              <ixz>0.00</ixz>
+              <iyy>0.000841667</iyy>
+              <iyz>0.00</iyz>
+              <izz>0.000841667</izz>
+            </inertia>
+          </inertial>
+          <visual name="visual">
+            <geometry>
+              <box>
+                <size>1 0.1 0.1</size>
+              </box>
+            </geometry>
+            <material>
+              <ambient>1 0.5 0</ambient>
+              <diffuse>1 0.5 0</diffuse>
+              <specular>0.1 0.1 0 1</specular>
+            </material>
+          </visual>
+          <collision name="collision">
+            <geometry>
+              <box>
+                <size>1 0.1 0.1</size>
+              </box>
+            </geometry>
+          </collision>
+        </link>
+        <joint name="rotor_joint" type="revolute">
+          <parent>base_link</parent>
+          <child>rotor_link</child>
+          <axis>
+            <dynamics>
+              <damping>0.5</damping>
+            </dynamics>
+            <limit>
+              <lower>-3.14159265</lower>
+              <upper>3.14159265</upper>
+            </limit>
+            <xyz>0 0 1</xyz>
+          </axis>
+        </joint>
+      </model>
+      <joint name="model21_joint" type="revolute">
+        <parent>base_link</parent>
+        <child>model21::base_link</child>
+        <axis>
+          <dynamics>
+            <damping>1</damping>
+          </dynamics>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+          </limit>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>rotor_joint</joint_name>
+        <topic>/model2/cmd_rotor</topic>
+        <p_gain>30</p_gain>
+        <i_gain>0.05</i_gain>
+      </plugin>
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>model21::rotor_joint</joint_name>
+        <topic>/model21/cmd_rotor</topic>
+        <p_gain>30</p_gain>
+        <i_gain>0.05</i_gain>
+      </plugin>
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
# 🦟 Bug fix

Partially Fixes #1844

## Summary

The details of the bug and how to reproduce it are documented in [gz-sim: #1844](https://github.com/gazebosim/gz-sim/issues/1844).

This PR enables the `JointPositionController` plugin to search for scoped joint names as well as unscoped ones. The approach is similar to that used in the Buoyancy plugin. 

For the change to take effect the upstream change in https://github.com/gazebosim/gz-physics/pull/464 is also required.

## Context

The use case for this change is to be able to include standalone models for peripherals such as https://app.gazebosim.org/OpenRobotics/fuel/models/Gimbal%20Small%202D in a standard vehicle frame such as https://app.gazebosim.org/OpenRobotics/fuel/models/Iris%20with%20Standoffs and then configure the `JointPositionController` at the top level for joint control.

The only way the position controller will work at present is to copy the elements from gimbal model into the quadcopter model (renaming any duplicated joints and links). This is inconvenient but possible for PoC but does not scale well. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.