### PR TITLE
Fix SdfGenerator unit test

### DIFF
--- a/src/SdfGenerator_TEST.cc
+++ b/src/SdfGenerator_TEST.cc
@@ -642,13 +642,13 @@ TEST_F(ElementUpdateFixture, WorldWithModelsIncludedNotExpanded)
 TEST_F(ElementUpdateFixture, WorldWithModelsIncludedWithInvalidUris)
 {
   const std::string goodUri =
-      "https://fuel.gazebosim.org/1.0/openroboticstest/models/backpack/2";
+      "https://fuel.gazebosim.org/1.0/openroboticstest/models/backpack/3";
 
   // These are URIs that are potentially problematic.
   const std::vector<std::string> fuelUris = {
       // Thes following two URIs are valid, but have a trailing '/'
       "https://fuel.gazebosim.org/1.0/openroboticstest/models/backpack/",
-      "https://fuel.gazebosim.org/1.0/openroboticstest/models/backpack/2/",
+      "https://fuel.gazebosim.org/1.0/openroboticstest/models/backpack/3/",
       // Thes following two URIs are invalid, and will not be saved
       "https://fuel.gazebosim.org/1.0/openroboticstest/models/backpack/"
       "notInt",


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/1852

## Summary

The [backpack](https://app.gazebosim.org/OpenRoboticsTest/fuel/models/Backpack) model was updated in December. I believe that's when the test started failing. This is [fixed](https://github.com/gazebosim/gz-sim/blob/main/src/SdfGenerator_TEST.cc#L644-L657) in `main` branch


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
