### PR TITLE
Minor optimization to transform control tool

### DIFF
--- a/src/gui/plugins/transform_control/TransformControl.cc
+++ b/src/gui/plugins/transform_control/TransformControl.cc
@@ -586,7 +586,6 @@ void TransformControlPrivate::HandleTransform()
       &blockOrbitEvent);
 }
 
-
 /////////////////////////////////////////////////
 void TransformControlPrivate::HandleMouseEvents()
 {

--- a/src/gui/plugins/transform_control/TransformControl.cc
+++ b/src/gui/plugins/transform_control/TransformControl.cc
@@ -54,6 +54,9 @@ namespace ignition::gazebo
     /// \brief Perform transformations in the render thread.
     public: void HandleTransform();
 
+    /// \brief Handle mouse events
+    public: void HandleMouseEvents();
+
     /// \brief Snaps a point at intervals of a fixed distance. Currently used
     /// to give a snapping behavior when moving models with a mouse.
     /// \param[in] _point Input point to snap.
@@ -575,9 +578,22 @@ void TransformControlPrivate::HandleTransform()
   // update gizmo visual
   this->transformControl.Update();
 
+  this->HandleMouseEvents();
+
+  ignition::gui::events::BlockOrbit blockOrbitEvent(this->blockOrbit);
+  ignition::gui::App()->sendEvent(
+      ignition::gui::App()->findChild<ignition::gui::MainWindow *>(),
+      &blockOrbitEvent);
+}
+
+
+/////////////////////////////////////////////////
+void TransformControlPrivate::HandleMouseEvents()
+{
   // check for mouse events
   if (!this->mouseDirty)
     return;
+  this->mouseDirty = false;
 
   // handle mouse movements
   if (this->mouseEvent.Button() == ignition::common::MouseEvent::LEFT)
@@ -615,7 +631,6 @@ void TransformControlPrivate::HandleTransform()
               // It's ok to get here
             }
           }
-          this->mouseDirty = false;
         }
         else
         {
@@ -682,7 +697,6 @@ void TransformControlPrivate::HandleTransform()
         }
 
         this->transformControl.Stop();
-        this->mouseDirty = false;
       }
       // Select entity
       else if (!this->mouseEvent.Dragging())
@@ -753,7 +767,6 @@ void TransformControlPrivate::HandleTransform()
               }
             }
 
-            this->mouseDirty = false;
             return;
           }
         }
@@ -912,13 +925,7 @@ void TransformControlPrivate::HandleTransform()
       }
       this->transformControl.Scale(scale);
     }
-    this->mouseDirty = false;
   }
-
-  ignition::gui::events::BlockOrbit blockOrbitEvent(this->blockOrbit);
-  ignition::gui::App()->sendEvent(
-      ignition::gui::App()->findChild<ignition::gui::MainWindow *>(),
-      &blockOrbitEvent);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

While working on https://github.com/gazebosim/gz-rendering/pull/800, I noticed that the transform control tool does unnecessary ray queries every frame if the user mouse click does not register any models. This is because the `mouseDirtry` variable never gets reset and hence every frame the transform control tool will continue to try and handle the same mouse event and perform ray queries. 

This PR refactors the mouse event handle logic to its own function and resets the variable `mouseDirtry`.



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

