### PR TITLE
Fix loading wold with record topic

### DIFF
--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -248,7 +248,6 @@ void ServerPrivate::AddRecordPlugin(const ServerConfig &_config)
       recordPluginElem->Get<std::string>("compress_path", "");
     std::tie(sdfRecordResources, hasRecordResources) =
       recordPluginElem->Get<bool>("record_resources", false);
-
     hasRecordTopics = recordPluginElem->HasElement("record_topic");
     if (hasRecordTopics)
     {
@@ -258,9 +257,8 @@ void ServerPrivate::AddRecordPlugin(const ServerConfig &_config)
       {
         auto topic = recordTopicElem->Get<std::string>();
         sdfRecordTopics.push_back(topic);
+        recordTopicElem = recordTopicElem->GetNextElement();
       }
-
-      recordTopicElem = recordTopicElem->GetNextElement();
     }
 
     // Remove from SDF


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

fix infinite loop when loading a world with `LogRecord` plugin and additional `record_topic` cmd line arg

To test:

modify [log_record_shapes.sdf](https://github.com/gazebosim/gz-sim/blob/ign-gazebo3/examples/worlds/log_record_shapes.sdf) and add an extra sdf plugin param `<record_topic>/world/shapes/clock</record_topic>` to the the `LogRecord` plugin, i.e.

```xml
    <plugin
      filename="ignition-gazebo-log-system"
      name="ignition::gazebo::systems::LogRecord">
      <record_topic>/world/shapes/clock</record_topic>
    </plugin>
```

launch gazebo with the following cmd line arg and verify that it does not go into infinite loop

```
ign gazebo -v 4 --record_topic /clock ./log_record_shapes.sdf
```


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
