### PR TITLE
Fix setting cast shadows property for visuals with shader param system 

### DIFF
--- a/src/systems/shader_param/ShaderParam.cc
+++ b/src/systems/shader_param/ShaderParam.cc
@@ -330,6 +330,16 @@ void ShaderParamPrivate::OnUpdate()
         ignmsg << "Using metal shaders. " << std::endl;
     }
 #endif
+
+    // inherit cast shadows property from existing material
+    rendering::MaterialPtr oldMat;
+    if (visual->GeometryCount() >  0u)
+      oldMat = this->visual->GeometryByIndex(0u)->Material();
+    else
+      oldMat = this->visual->Material();
+    if (oldMat)
+      mat->SetCastShadows(oldMat->CastShadows());
+
     this->visual->SetMaterial(mat);
     scene->DestroyMaterial(mat);
     this->material = this->visual->Material();


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

Currently setting the `<cast_shadows>` property for visuals that uses the ShaderParam system does not have any effect. The visual will always cast shadows.  This PR fixes the issue so that users can toggle shadows on/off for these visuals.

To test:

Download the the [deformable_sphere_no_shadows.sdf](https://gist.github.com/iche033/6ffe4e1b7dc8191bfc3626165e17e895) world that consists of a [sphere model](https://app.gazebosim.org/iche033/fuel/models/deformable_sphere_no_shadows) with ShaderParam system and `<cast_shadows>` set to false. Launch it to verify that the visual does not not cast shadows on the ground plane:

```
ign gazebo -v 4 deformable_sphere_no_shadows.sdf
```

![1](https://user-images.githubusercontent.com/4000684/211123496-d67b3c97-2c59-4c6b-978d-3c0f21b4c4f3.png)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

