### PR TITLE
Add ignition alias back

### DIFF
--- a/src/systems/thruster/Thruster.cc
+++ b/src/systems/thruster/Thruster.cc
@@ -623,4 +623,4 @@ GZ_ADD_PLUGIN(
 GZ_ADD_PLUGIN_ALIAS(Thruster, "gz::sim::systems::Thruster")
 
 // TODO(CH3): Deprecated, remove on version 8
-GZ_ADD_PLUGIN_ALIAS(Thruster, "gz::sim::systems::Thruster")
+GZ_ADD_PLUGIN_ALIAS(Thruster, "ignition::gazebo::systems::Thruster")


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
Till we fully move over to gzsim 8 we are supposed to retain an alias to ignition so users have time to migrate their codebase. Our plugin happily eliminated this option.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
