### PR TITLE
Ackermann steering with steering angle and sub_topic.

### DIFF
--- a/src/systems/ackermann_steering/AckermannSteering.cc
+++ b/src/systems/ackermann_steering/AckermannSteering.cc
@@ -342,18 +342,25 @@ void AckermannSteering::Configure(const Entity &_entity,
   }
   // Subscribe to commands
   std::vector<std::string> topics;
-  if (_sdf->HasElement("topic"))
+
+  if (_sdf->HasElement("sub_topic"))
   {
-    topics.push_back(_sdf->Get<std::string>("topic"));
+    topics.push_back("/model/" + this->dataPtr->model.Name(_ecm) +
+      _sdf->Get<std::string>("sub_topic"));
   }
-  if (this->dataPtr->steeringOnly)
+  else if (this->dataPtr->steeringOnly)
   {
     topics.push_back("/model/" + this->dataPtr->model.Name(_ecm) +
       "/steer_angle");
   }
-  else
+  else if (!this->dataPtr->steeringOnly)
   {
     topics.push_back("/model/" + this->dataPtr->model.Name(_ecm) + "/cmd_vel");
+  }
+
+  if (_sdf->HasElement("topic"))
+  {
+    topics.push_back(_sdf->Get<std::string>("topic"));
   }
 
   auto topic = validTopic(topics);

--- a/src/systems/ackermann_steering/AckermannSteering.cc
+++ b/src/systems/ackermann_steering/AckermannSteering.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Open Source Robotics Foundation
+ * Copyright (C) 2023 Benjamin Perseghetti, Rudis Laboratories
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +61,10 @@ class gz::sim::systems::AckermannSteeringPrivate
   /// \param[in] _msg Velocity message
   public: void OnCmdVel(const msgs::Twist &_msg);
 
+    /// \brief Callback for angle subscription
+  /// \param[in] _msg angle message
+  public: void OnCmdAng(const msgs::Double &_msg);
+
   /// \brief Update odometry and publish an odometry message.
   /// \param[in] _info System update information.
   /// \param[in] _ecm The EntityComponentManager of the given simulation
@@ -74,8 +79,18 @@ class gz::sim::systems::AckermannSteeringPrivate
   public: void UpdateVelocity(const UpdateInfo &_info,
     const EntityComponentManager &_ecm);
 
+  /// \brief Update the angle.
+  /// \param[in] _info System update information.
+  /// \param[in] _ecm The EntityComponentManager of the given simulation
+  /// instance.
+  public: void UpdateAngle(const UpdateInfo &_info,
+    const EntityComponentManager &_ecm);
+
   /// \brief Gazebo communication node.
   public: transport::Node node;
+
+  /// \brief Use angle steer only mode.
+  public: bool steeringOnly{false};
 
   /// \brief Entity of the left joint
   public: std::vector<Entity> leftJoints;
@@ -179,6 +194,9 @@ class gz::sim::systems::AckermannSteeringPrivate
   /// \brief Last target velocity requested.
   public: msgs::Twist targetVel;
 
+  /// \brief Last target angle requested.
+  public: msgs::Double targetAng;
+
   /// \brief A mutex to protect the target velocity command.
   public: std::mutex mutex;
 
@@ -220,20 +238,11 @@ void AckermannSteering::Configure(const Entity &_entity,
   // function and _sdf is a const shared pointer to a const sdf::Element.
   auto ptr = const_cast<sdf::Element *>(_sdf.get());
 
+  this->dataPtr->steeringOnly = _sdf->Get<bool>("steering_only",
+      this->dataPtr->steeringOnly).first;
+
   // Get params from SDF
-  sdf::ElementPtr sdfElem = ptr->GetElement("left_joint");
-  while (sdfElem)
-  {
-    this->dataPtr->leftJointNames.push_back(sdfElem->Get<std::string>());
-    sdfElem = sdfElem->GetNextElement("left_joint");
-  }
-  sdfElem = ptr->GetElement("right_joint");
-  while (sdfElem)
-  {
-    this->dataPtr->rightJointNames.push_back(sdfElem->Get<std::string>());
-    sdfElem = sdfElem->GetNextElement("right_joint");
-  }
-  sdfElem = ptr->GetElement("left_steering_joint");
+  sdf::ElementPtr sdfElem = ptr->GetElement("left_steering_joint");
   while (sdfElem)
   {
     this->dataPtr->leftSteeringJointNames.push_back(
@@ -247,17 +256,36 @@ void AckermannSteering::Configure(const Entity &_entity,
                            sdfElem->Get<std::string>());
     sdfElem = sdfElem->GetNextElement("right_steering_joint");
   }
-
+  if (!this->dataPtr->steeringOnly)
+  {
+    sdfElem = ptr->GetElement("left_joint");
+    while (sdfElem)
+    {
+      this->dataPtr->leftJointNames.push_back(sdfElem->Get<std::string>());
+      sdfElem = sdfElem->GetNextElement("left_joint");
+    }
+    sdfElem = ptr->GetElement("right_joint");
+    while (sdfElem)
+    {
+      this->dataPtr->rightJointNames.push_back(sdfElem->Get<std::string>());
+      sdfElem = sdfElem->GetNextElement("right_joint");
+    }
+  }
+  if (!this->dataPtr->steeringOnly)
+  {
+    this->dataPtr->wheelRadius = _sdf->Get<double>("wheel_radius",
+      this->dataPtr->wheelRadius).first;
+    this->dataPtr->kingpinWidth = _sdf->Get<double>("kingpin_width",
+      this->dataPtr->kingpinWidth).first;
+  }
   this->dataPtr->wheelSeparation = _sdf->Get<double>("wheel_separation",
       this->dataPtr->wheelSeparation).first;
-  this->dataPtr->kingpinWidth = _sdf->Get<double>("kingpin_width",
-      this->dataPtr->kingpinWidth).first;
+
   this->dataPtr->wheelBase = _sdf->Get<double>("wheel_base",
       this->dataPtr->wheelBase).first;
   this->dataPtr->steeringLimit = _sdf->Get<double>("steering_limit",
       this->dataPtr->steeringLimit).first;
-  this->dataPtr->wheelRadius = _sdf->Get<double>("wheel_radius",
-      this->dataPtr->wheelRadius).first;
+
 
   // Instantiate the speed limiters.
   this->dataPtr->limiterLin = std::make_unique<math::SpeedLimiter>();
@@ -301,22 +329,33 @@ void AckermannSteering::Configure(const Entity &_entity,
     this->dataPtr->limiterAng->SetMaxJerk(maxJerk);
   }
 
-
-  double odomFreq = _sdf->Get<double>("odom_publish_frequency", 50).first;
-  if (odomFreq > 0)
+  if (!this->dataPtr->steeringOnly)
   {
-    std::chrono::duration<double> odomPer{1 / odomFreq};
-    this->dataPtr->odomPubPeriod =
-      std::chrono::duration_cast<std::chrono::steady_clock::duration>(odomPer);
+    double odomFreq = _sdf->Get<double>("odom_publish_frequency", 50).first;
+    if (odomFreq > 0)
+    {
+      std::chrono::duration<double> odomPer{1 / odomFreq};
+      this->dataPtr->odomPubPeriod =
+        std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+          odomPer);
+    }
   }
-
   // Subscribe to commands
   std::vector<std::string> topics;
   if (_sdf->HasElement("topic"))
   {
     topics.push_back(_sdf->Get<std::string>("topic"));
   }
-  topics.push_back("/model/" + this->dataPtr->model.Name(_ecm) + "/cmd_vel");
+  if (this->dataPtr->steeringOnly)
+  {
+    topics.push_back("/model/" + this->dataPtr->model.Name(_ecm) +
+      "/steer_angle");
+  }
+  else
+  {
+    topics.push_back("/model/" + this->dataPtr->model.Name(_ecm) + "/cmd_vel");
+  }
+
   auto topic = validTopic(topics);
   if (topic.empty())
   {
@@ -324,54 +363,64 @@ void AckermannSteering::Configure(const Entity &_entity,
            << "Failed to initialize." << std::endl;
     return;
   }
-
-  this->dataPtr->node.Subscribe(topic, &AckermannSteeringPrivate::OnCmdVel,
+  if (this->dataPtr->steeringOnly)
+  {
+    this->dataPtr->node.Subscribe(topic, &AckermannSteeringPrivate::OnCmdAng,
       this->dataPtr.get());
-
-  std::vector<std::string> odomTopics;
-  if (_sdf->HasElement("odom_topic"))
-  {
-    odomTopics.push_back(_sdf->Get<std::string>("odom_topic"));
+    gzmsg << "AckermannSteering subscribing to float messages on ["
+          << topic << "]" << std::endl;
   }
-  odomTopics.push_back("/model/" + this->dataPtr->model.Name(_ecm) +
-      "/odometry");
-  auto odomTopic = validTopic(odomTopics);
-  if (topic.empty())
+  else
   {
-    gzerr << "AckermannSteering plugin received invalid model name "
-           << "Failed to initialize." << std::endl;
-    return;
+    this->dataPtr->node.Subscribe(topic, &AckermannSteeringPrivate::OnCmdVel,
+      this->dataPtr.get());
+    gzmsg << "AckermannSteering subscribing to twist messages on ["
+          << topic << "]" << std::endl;
   }
-
-  this->dataPtr->odomPub = this->dataPtr->node.Advertise<msgs::Odometry>(
-      odomTopic);
-
-  std::vector<std::string> tfTopics;
-  if (_sdf->HasElement("tf_topic"))
+  if (!this->dataPtr->steeringOnly)
   {
-    tfTopics.push_back(_sdf->Get<std::string>("tf_topic"));
+    std::vector<std::string> odomTopics;
+    if (_sdf->HasElement("odom_topic"))
+    {
+      odomTopics.push_back(_sdf->Get<std::string>("odom_topic"));
+    }
+    odomTopics.push_back("/model/" + this->dataPtr->model.Name(_ecm) +
+        "/odometry");
+    auto odomTopic = validTopic(odomTopics);
+    if (topic.empty())
+    {
+      gzerr << "AckermannSteering plugin received invalid model name "
+            << "Failed to initialize." << std::endl;
+      return;
+    }
+
+    this->dataPtr->odomPub = this->dataPtr->node.Advertise<msgs::Odometry>(
+        odomTopic);
+
+    std::vector<std::string> tfTopics;
+    if (_sdf->HasElement("tf_topic"))
+    {
+      tfTopics.push_back(_sdf->Get<std::string>("tf_topic"));
+    }
+    tfTopics.push_back("/model/" + this->dataPtr->model.Name(_ecm) +
+      "/tf");
+    auto tfTopic = validTopic(tfTopics);
+    if (tfTopic.empty())
+    {
+      gzerr << "AckermannSteering plugin invalid tf topic name "
+            << "Failed to initialize." << std::endl;
+      return;
+    }
+
+    this->dataPtr->tfPub = this->dataPtr->node.Advertise<msgs::Pose_V>(
+        tfTopic);
+
+    if (_sdf->HasElement("frame_id"))
+      this->dataPtr->sdfFrameId = _sdf->Get<std::string>("frame_id");
+
+    if (_sdf->HasElement("child_frame_id"))
+      this->dataPtr->sdfChildFrameId = _sdf->Get<std::string>("child_frame_id");
   }
-  tfTopics.push_back("/model/" + this->dataPtr->model.Name(_ecm) +
-    "/tf");
-  auto tfTopic = validTopic(tfTopics);
-  if (tfTopic.empty())
-  {
-    gzerr << "AckermannSteering plugin invalid tf topic name "
-           << "Failed to initialize." << std::endl;
-    return;
-  }
-
-  this->dataPtr->tfPub = this->dataPtr->node.Advertise<msgs::Pose_V>(
-      tfTopic);
-
-  if (_sdf->HasElement("frame_id"))
-    this->dataPtr->sdfFrameId = _sdf->Get<std::string>("frame_id");
-
-  if (_sdf->HasElement("child_frame_id"))
-    this->dataPtr->sdfChildFrameId = _sdf->Get<std::string>("child_frame_id");
-
-  gzmsg << "AckermannSteering subscribing to twist messages on [" <<
-      topic << "]" << std::endl;
 }
 
 //////////////////////////////////////////////////
@@ -391,10 +440,9 @@ void AckermannSteering::PreUpdate(const UpdateInfo &_info,
   // If the joints haven't been identified yet, look for them
   static std::set<std::string> warnedModels;
   auto modelName = this->dataPtr->model.Name(_ecm);
-  if (this->dataPtr->leftJoints.empty() ||
-      this->dataPtr->rightJoints.empty() ||
-      this->dataPtr->leftSteeringJoints.empty() ||
-      this->dataPtr->rightSteeringJoints.empty())
+  if (!this->dataPtr->steeringOnly &&
+      (this->dataPtr->leftJoints.empty() ||
+      this->dataPtr->rightJoints.empty()))
   {
     bool warned{false};
     for (const std::string &name : this->dataPtr->leftJointNames)
@@ -422,6 +470,15 @@ void AckermannSteering::PreUpdate(const UpdateInfo &_info,
         warned = true;
       }
     }
+    if (warned)
+    {
+      warnedModels.insert(modelName);
+    }
+  }
+  if (this->dataPtr->leftSteeringJoints.empty() ||
+      this->dataPtr->rightSteeringJoints.empty())
+  {
+    bool warned{false};
     for (const std::string &name : this->dataPtr->leftSteeringJointNames)
     {
       Entity joint = this->dataPtr->model.JointByName(_ecm, name);
@@ -453,9 +510,11 @@ void AckermannSteering::PreUpdate(const UpdateInfo &_info,
       warnedModels.insert(modelName);
     }
   }
-
-  if (this->dataPtr->leftJoints.empty() || this->dataPtr->rightJoints.empty() ||
-      this->dataPtr->leftSteeringJoints.empty() ||
+  if (!this->dataPtr->steeringOnly &&
+    (this->dataPtr->leftJoints.empty() ||
+    this->dataPtr->rightJoints.empty()))
+    return;
+  else if (this->dataPtr->leftSteeringJoints.empty() ||
       this->dataPtr->rightSteeringJoints.empty())
     return;
 
@@ -469,36 +528,39 @@ void AckermannSteering::PreUpdate(const UpdateInfo &_info,
   // Nothing left to do if paused.
   if (_info.paused)
     return;
-
-  for (Entity joint : this->dataPtr->leftJoints)
+  if (!this->dataPtr->steeringOnly)
   {
-    // Update wheel velocity
-    auto vel = _ecm.Component<components::JointVelocityCmd>(joint);
+    for (Entity joint : this->dataPtr->leftJoints)
+    {
+      // Update wheel velocity
+      auto vel = _ecm.Component<components::JointVelocityCmd>(joint);
 
-    if (vel == nullptr)
-    {
-      _ecm.CreateComponent(
-          joint, components::JointVelocityCmd({this->dataPtr->leftJointSpeed}));
+      if (vel == nullptr)
+      {
+        _ecm.CreateComponent(
+            joint, components::JointVelocityCmd(
+              {this->dataPtr->leftJointSpeed}));
+      }
+      else
+      {
+        *vel = components::JointVelocityCmd({this->dataPtr->leftJointSpeed});
+      }
     }
-    else
-    {
-      *vel = components::JointVelocityCmd({this->dataPtr->leftJointSpeed});
-    }
-  }
 
-  for (Entity joint : this->dataPtr->rightJoints)
-  {
-    // Update wheel velocity
-    auto vel = _ecm.Component<components::JointVelocityCmd>(joint);
+    for (Entity joint : this->dataPtr->rightJoints)
+    {
+      // Update wheel velocity
+      auto vel = _ecm.Component<components::JointVelocityCmd>(joint);
 
-    if (vel == nullptr)
-    {
-      _ecm.CreateComponent(joint,
-          components::JointVelocityCmd({this->dataPtr->rightJointSpeed}));
-    }
-    else
-    {
-      *vel = components::JointVelocityCmd({this->dataPtr->rightJointSpeed});
+      if (vel == nullptr)
+      {
+        _ecm.CreateComponent(joint,
+            components::JointVelocityCmd({this->dataPtr->rightJointSpeed}));
+      }
+      else
+      {
+        *vel = components::JointVelocityCmd({this->dataPtr->rightJointSpeed});
+      }
     }
   }
 
@@ -536,25 +598,26 @@ void AckermannSteering::PreUpdate(const UpdateInfo &_info,
                      {this->dataPtr->rightSteeringJointSpeed});
     }
   }
-
-  // Create the left and right side joint position components if they
-  // don't exist.
-  auto leftPos = _ecm.Component<components::JointPosition>(
-      this->dataPtr->leftJoints[0]);
-  if (!leftPos)
+  if (!this->dataPtr->steeringOnly)
   {
-    _ecm.CreateComponent(this->dataPtr->leftJoints[0],
-        components::JointPosition());
-  }
+    // Create the left and right side joint position components if they
+    // don't exist.
+    auto leftPos = _ecm.Component<components::JointPosition>(
+        this->dataPtr->leftJoints[0]);
+    if (!leftPos)
+    {
+      _ecm.CreateComponent(this->dataPtr->leftJoints[0],
+          components::JointPosition());
+    }
 
-  auto rightPos = _ecm.Component<components::JointPosition>(
-      this->dataPtr->rightJoints[0]);
-  if (!rightPos)
-  {
-    _ecm.CreateComponent(this->dataPtr->rightJoints[0],
-        components::JointPosition());
+    auto rightPos = _ecm.Component<components::JointPosition>(
+        this->dataPtr->rightJoints[0]);
+    if (!rightPos)
+    {
+      _ecm.CreateComponent(this->dataPtr->rightJoints[0],
+          components::JointPosition());
+    }
   }
-
   auto leftSteeringPos = _ecm.Component<components::JointPosition>(
       this->dataPtr->leftSteeringJoints[0]);
   if (!leftSteeringPos)
@@ -580,9 +643,15 @@ void AckermannSteering::PostUpdate(const UpdateInfo &_info,
   // Nothing left to do if paused.
   if (_info.paused)
     return;
-
-  this->dataPtr->UpdateVelocity(_info, _ecm);
-  this->dataPtr->UpdateOdometry(_info, _ecm);
+  if (this->dataPtr->steeringOnly)
+  {
+    this->dataPtr->UpdateAngle(_info, _ecm);
+  }
+  else
+  {
+    this->dataPtr->UpdateVelocity(_info, _ecm);
+    this->dataPtr->UpdateOdometry(_info, _ecm);
+  }
 }
 
 //////////////////////////////////////////////////
@@ -794,6 +863,71 @@ void AckermannSteeringPrivate::OnCmdVel(const msgs::Twist &_msg)
 {
   std::lock_guard<std::mutex> lock(this->mutex);
   this->targetVel = _msg;
+}
+
+//////////////////////////////////////////////////
+void AckermannSteeringPrivate::UpdateAngle(
+    const UpdateInfo &_info,
+    const EntityComponentManager &_ecm)
+{
+  GZ_PROFILE("AckermannSteering::UpdateAngle");
+
+  double ang;
+  {
+    std::lock_guard<std::mutex> lock(this->mutex);
+    ang = this->targetAng.data();
+  }
+
+  // Limit the target angle if needed.
+  this->limiterAng->Limit(
+      ang, this->last0Cmd.ang, this->last1Cmd.ang, _info.dt);
+
+  if (fabs(ang) > this->steeringLimit)
+  {
+    ang = (ang / fabs(ang)) * this->steeringLimit;
+  }
+
+  // Update history of commands.
+  this->last1Cmd = last0Cmd;
+  this->last0Cmd.ang = ang;
+
+  double leftSteeringJointAngle =
+      atan((2.0 * this->wheelBase * sin(ang)) / \
+      ((2.0 * this->wheelBase * cos(ang)) + \
+      (1.0 * this->wheelSeparation * sin(ang))));
+  double rightSteeringJointAngle =
+      atan((2.0 * this->wheelBase * sin(ang)) / \
+      ((2.0 * this->wheelBase * cos(ang)) - \
+      (1.0 * this->wheelSeparation * sin(ang))));
+
+  auto leftSteeringPos = _ecm.Component<components::JointPosition>(
+      this->leftSteeringJoints[0]);
+  auto rightSteeringPos = _ecm.Component<components::JointPosition>(
+      this->rightSteeringJoints[0]);
+
+  // Abort if the joints were not found or just created.
+  if (!leftSteeringPos || !rightSteeringPos ||
+      leftSteeringPos->Data().empty() ||
+      rightSteeringPos->Data().empty())
+  {
+    return;
+  }
+
+  double leftDelta = leftSteeringJointAngle - leftSteeringPos->Data()[0];
+  double rightDelta = rightSteeringJointAngle - rightSteeringPos->Data()[0];
+
+  // Simple proportional control with a gain of 1
+  // Adding programmable PID values might be a future feature.
+  // Works as is for tested cases
+  this->leftSteeringJointSpeed = leftDelta;
+  this->rightSteeringJointSpeed = rightDelta;
+}
+
+//////////////////////////////////////////////////
+void AckermannSteeringPrivate::OnCmdAng(const msgs::Double &_msg)
+{
+  std::lock_guard<std::mutex> lock(this->mutex);
+  this->targetAng = _msg;
 }
 
 GZ_ADD_PLUGIN(AckermannSteering,

--- a/src/systems/ackermann_steering/AckermannSteering.hh
+++ b/src/systems/ackermann_steering/AckermannSteering.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Open Source Robotics Foundation
+ * Copyright (C) 2023 Benjamin Perseghetti, Rudis Laboratories
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +37,11 @@ namespace systems
   /// with any number of left and right wheels.
   ///
   /// # System Parameters
+  ///
+  /// `<steering_only>`: Boolean used to only control the steering angle
+  /// only. Calculates the angles of wheels from steering_limit,  wheel_base,
+  /// and wheel_separation. Uses gz::msg::Double on default topic name
+  /// `/model/{name_of_model}/steer_angle`
   ///
   /// `<left_joint>`: Name of a joint that controls a left wheel. This
   /// element can appear multiple times, and must appear at least once.
@@ -83,8 +89,9 @@ namespace systems
   /// `<max_jerk Maximum>`: jerk [m/s^3], usually >= 0.
   ///
   /// `<topic>`: Custom topic that this system will subscribe to in order to
-  /// receive command velocity messages. This element if optional, and the
-  /// default value is `/model/{name_of_model}/cmd_vel`.
+  /// receive command messages. This element is optional, and the
+  /// default value is `/model/{name_of_model}/cmd_vel` or when steering_only
+  /// is true `/model/{name_of_model}/steer_angle`.
   ///
   /// `<odom_topic>`: Custom topic on which this system will publish odometry
   /// messages. This element if optional, and the default value is

--- a/src/systems/ackermann_steering/AckermannSteering.hh
+++ b/src/systems/ackermann_steering/AckermannSteering.hh
@@ -93,6 +93,10 @@ namespace systems
   /// default value is `/model/{name_of_model}/cmd_vel` or when steering_only
   /// is true `/model/{name_of_model}/steer_angle`.
   ///
+  /// `<sub_topic>`: Custom sub_topic that this system will subscribe to in
+  /// order to receive command messages. This element is optional, and
+  /// creates a topic `/model/{name_of_model}/{sub_topic}`
+  ///
   /// `<odom_topic>`: Custom topic on which this system will publish odometry
   /// messages. This element if optional, and the default value is
   /// `/model/{name_of_model}/odometry`.

--- a/test/integration/ackermann_steering_system.cc
+++ b/test/integration/ackermann_steering_system.cc
@@ -48,6 +48,7 @@ using namespace gz;
 using namespace sim;
 using namespace std::chrono_literals;
 
+/// \brief Test AckermannSteeringOnly system
 class AckermannSteeringOnlyTest
   : public InternalFixture<::testing::Test>
 {
@@ -180,7 +181,7 @@ class AckermannSteeringTest
     EXPECT_NEAR(poses[0].Pos().Z(), poses[3999].Pos().Z(), tol);
     EXPECT_NEAR(poses[0].Rot().X(), poses[3999].Rot().X(), tol);
     EXPECT_NEAR(poses[0].Rot().Y(), poses[3999].Rot().Y(), tol);
-    // EXPECT_LT(poses[0].Rot().Z(), poses[3999].Rot().Z());
+    EXPECT_LT(poses[0].Rot().Z(), poses[3999].Rot().Z());
 
     // The value from odometry will be close, but not exactly the ground truth
     // pose of the robot model. This is partially due to throttling the
@@ -321,7 +322,7 @@ TEST_P(AckermannSteeringTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(SkidPublishCmd))
   EXPECT_NEAR(poses[0].Pos().Z(), poses[3999].Pos().Z(), tol);
   EXPECT_NEAR(poses[0].Rot().X(), poses[3999].Rot().X(), tol);
   EXPECT_NEAR(poses[0].Rot().Y(), poses[3999].Rot().Y(), tol);
-  // EXPECT_LT(poses[0].Rot().Z(), poses[3999].Rot().Z());
+  EXPECT_LT(poses[0].Rot().Z(), poses[3999].Rot().Z());
 }
 
 /////////////////////////////////////////////////
@@ -560,9 +561,8 @@ TEST_F(AckermannSteeringOnlyTest,
 {
   // Start server
   ServerConfig serverConfig;
-  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/ackermann_steering_only.sdf";
-  serverConfig.SetSdfFile(sdfFile);
+  serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
+      "test", "worlds", "ackermann_steering_only.sdf"));
 
   Server server(serverConfig);
   EXPECT_FALSE(server.Running());
@@ -580,8 +580,6 @@ TEST_F(AckermannSteeringOnlyTest,
   const double targetAngle{0.25};
   msg.set_data(targetAngle);
   pub.Publish(msg);
-
-  EXPECT_NEAR(0, 0, 0.1);
 }
 
 /////////////////////////////////////////////////
@@ -591,9 +589,8 @@ TEST_F(AckermannSteeringOnlyTest,
 {
   // Start server
   ServerConfig serverConfig;
-  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/ackermann_steering_only_custom_sub_topics.sdf";
-  serverConfig.SetSdfFile(sdfFile);
+  serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
+      "test", "worlds", "ackermann_steering_only_custom_sub_topics.sdf"));
 
   Server server(serverConfig);
   EXPECT_FALSE(server.Running());
@@ -611,8 +608,6 @@ TEST_F(AckermannSteeringOnlyTest,
   const double targetAngle{0.25};
   msg.set_data(targetAngle);
   pub.Publish(msg);
-
-  EXPECT_NEAR(0, 0, 0.1);
 }
 
 // Run multiple times

--- a/test/worlds/ackermann_steering_only.sdf
+++ b/test/worlds/ackermann_steering_only.sdf
@@ -1,0 +1,387 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="ackermann_steering">
+
+    <physics name="1ms" type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>0</real_time_factor>
+    </physics>
+    <plugin
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>1 1 1 1</diffuse>
+      <specular>0.5 0.5 0.5 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>50</mu>
+              </ode>
+              <bullet>
+                <friction>1</friction>
+                <friction2>1</friction2>
+                <rolling_friction>0.1</rolling_friction>
+              </bullet>
+            </friction>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name='vehicle'>
+      <pose>0 0 0.325 0 -0 0</pose>
+
+      <link name='chassis'>
+        <pose>-0.151427 -0 0.175 0 -0 0</pose>
+        <inertial>
+          <mass>1.14395</mass>
+          <inertia>
+            <ixx>0.126164</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.416519</iyy>
+            <iyz>0</iyz>
+            <izz>0.481014</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>2.01142 1 0.568726</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.5 0.5 1.0 1</ambient>
+            <diffuse>0.5 0.5 1.0 1</diffuse>
+            <specular>0.0 0.0 1.0 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>2.01142 1 0.568726</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+
+      <link name='front_left_wheel'>
+        <pose>0.554283 0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+
+      <link name='rear_left_wheel'>
+        <pose>-0.957138 0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+
+      <link name='front_right_wheel'>
+        <pose>0.554282 -0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+
+      <link name='rear_right_wheel'>
+        <pose>-0.957138 -0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+
+      <link name="front_left_wheel_steering_link">
+        <pose>0.554283 0.5 0.02 0 0 0</pose>
+        <inertial>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.0153</ixx>
+            <iyy>0.025</iyy>
+            <izz>0.0153</izz>
+          </inertia>
+        </inertial>
+        <visual name="steering_link_visual">
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
+          </material>
+        </visual>
+      </link>
+
+      <link name="front_right_wheel_steering_link">
+        <pose>0.554283 -0.5 0.02 0 0 0</pose>
+        <inertial>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.0153</ixx>
+            <iyy>0.025</iyy>
+            <izz>0.0153</izz>
+          </inertia>
+        </inertial>
+        <visual name="steering_link_visual">
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
+          </material>
+        </visual>
+      </link>
+
+      <joint name="front_left_wheel_steering_joint" type="revolute">
+        <child>front_left_wheel_steering_link</child>
+        <parent>chassis</parent>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-0.6</lower>
+            <upper>+0.6</upper>
+            <velocity>1.0</velocity>
+            <effort>25</effort>
+          </limit>
+          <use_parent_model_frame>1</use_parent_model_frame>
+        </axis>
+      </joint>
+
+      <joint name="front_right_wheel_steering_joint" type="revolute">
+        <parent>chassis</parent>
+        <child>front_right_wheel_steering_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-0.6</lower>
+            <upper>+0.6</upper>
+            <velocity>1.0</velocity>
+            <effort>25</effort>
+          </limit>
+        </axis>
+      </joint>
+
+      <joint name='front_left_wheel_joint' type='revolute'>
+        <parent>front_left_wheel_steering_link</parent>
+        <child>front_left_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+
+      <joint name='front_right_wheel_joint' type='revolute'>
+        <parent>front_right_wheel_steering_link</parent>
+        <child>front_right_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+
+      <joint name='rear_left_wheel_joint' type='revolute'>
+        <parent>chassis</parent>
+        <child>rear_left_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+
+      <joint name='rear_right_wheel_joint' type='revolute'>
+        <parent>chassis</parent>
+        <child>rear_right_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+
+      <plugin
+        filename="gz-sim-ackermann-steering-system"
+        name="gz::sim::systems::AckermannSteering">
+        <left_steering_joint>front_left_wheel_steering_joint</left_steering_joint>
+        <right_steering_joint>front_right_wheel_steering_joint</right_steering_joint>
+        <steering_only>true</steering_only>
+        <steering_limit>0.5</steering_limit>
+        <wheel_base>1.0</wheel_base>
+        <wheel_separation>1.25</wheel_separation>
+      </plugin>
+    </model>
+  </world>
+</sdf>

--- a/test/worlds/ackermann_steering_only.sdf
+++ b/test/worlds/ackermann_steering_only.sdf
@@ -11,20 +11,6 @@
       name="gz::sim::systems::Physics">
     </plugin>
 
-    <light type="directional" name="sun">
-      <cast_shadows>true</cast_shadows>
-      <pose>0 0 10 0 0 0</pose>
-      <diffuse>1 1 1 1</diffuse>
-      <specular>0.5 0.5 0.5 1</specular>
-      <attenuation>
-        <range>1000</range>
-        <constant>0.9</constant>
-        <linear>0.01</linear>
-        <quadratic>0.001</quadratic>
-      </attenuation>
-      <direction>-0.5 0.1 -0.9</direction>
-    </light>
-
     <model name="ground_plane">
       <static>true</static>
       <link name="link">

--- a/test/worlds/ackermann_steering_only_custom_sub_topics.sdf
+++ b/test/worlds/ackermann_steering_only_custom_sub_topics.sdf
@@ -19,20 +19,6 @@
       name="gz::sim::systems::SceneBroadcaster">
     </plugin>
 
-    <light type="directional" name="sun">
-      <cast_shadows>true</cast_shadows>
-      <pose>0 0 10 0 0 0</pose>
-      <diffuse>1 1 1 1</diffuse>
-      <specular>0.5 0.5 0.5 1</specular>
-      <attenuation>
-        <range>1000</range>
-        <constant>0.9</constant>
-        <linear>0.01</linear>
-        <quadratic>0.001</quadratic>
-      </attenuation>
-      <direction>-0.5 0.1 -0.9</direction>
-    </light>
-
     <model name="ground_plane">
       <static>true</static>
       <link name="link">

--- a/test/worlds/ackermann_steering_only_custom_sub_topics.sdf
+++ b/test/worlds/ackermann_steering_only_custom_sub_topics.sdf
@@ -1,0 +1,453 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="ackermann_steering">
+
+    <physics name="1ms" type="ignored">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>0</real_time_factor>
+    </physics>
+    <plugin
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin
+      filename="gz-sim-user-commands-system"
+      name="gz::sim::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>1 1 1 1</diffuse>
+      <specular>0.5 0.5 0.5 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>50</mu>
+              </ode>
+              <bullet>
+                <friction>1</friction>
+                <friction2>1</friction2>
+                <rolling_friction>0.1</rolling_friction>
+              </bullet>
+            </friction>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name='vehicle'>
+      <pose>0 0 0.325 0 -0 0</pose>
+
+      <link name='chassis'>
+        <pose>-0.151427 -0 0.175 0 -0 0</pose>
+        <inertial>
+          <mass>1.14395</mass>
+          <inertia>
+            <ixx>0.126164</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.416519</iyy>
+            <iyz>0</iyz>
+            <izz>0.481014</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>2.01142 1 0.568726</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.5 0.5 1.0 1</ambient>
+            <diffuse>0.5 0.5 1.0 1</diffuse>
+            <specular>0.0 0.0 1.0 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>2.01142 1 0.568726</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+
+      <link name='front_left_wheel'>
+        <pose>0.554283 0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>0.5</mu>
+                <mu2>1.0</mu2>
+                <fdir1>0 0 1</fdir1>
+              </ode>
+              <bullet>
+                <friction>0.5</friction>
+                <friction2>1</friction2>
+                <rolling_friction>0.1</rolling_friction>
+              </bullet>
+            </friction>
+          </surface>
+        </collision>
+      </link>
+
+      <link name='rear_left_wheel'>
+        <pose>-0.957138 0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>0.5</mu>
+                <mu2>1.0</mu2>
+                <fdir1>0 0 1</fdir1>
+              </ode>
+              <bullet>
+                <friction>0.5</friction>
+                <friction2>1</friction2>
+                <rolling_friction>0.1</rolling_friction>
+              </bullet>
+            </friction>
+          </surface>
+        </collision>
+      </link>
+
+      <link name='front_right_wheel'>
+        <pose>0.554282 -0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>0.5</mu>
+                <mu2>1.0</mu2>
+                <fdir1>0 0 1</fdir1>
+              </ode>
+              <bullet>
+                <friction>0.5</friction>
+                <friction2>1</friction2>
+                <rolling_friction>0.1</rolling_friction>
+              </bullet>
+            </friction>
+          </surface>
+        </collision>
+      </link>
+
+      <link name='rear_right_wheel'>
+        <pose>-0.957138 -0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>0.5</mu>
+                <mu2>1.0</mu2>
+                <fdir1>0 0 1</fdir1>
+              </ode>
+              <bullet>
+                <friction>0.5</friction>
+                <friction2>1</friction2>
+                <rolling_friction>0.1</rolling_friction>
+              </bullet>
+            </friction>
+          </surface>
+        </collision>
+      </link>
+
+      <link name="front_left_wheel_steering_link">
+        <pose>0.554283 0.5 0.02 0 0 0</pose>
+        <inertial>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.0153</ixx>
+            <iyy>0.025</iyy>
+            <izz>0.0153</izz>
+          </inertia>
+        </inertial>
+        <visual name="steering_link_visual">
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
+          </material>
+        </visual>
+      </link>
+
+      <link name="front_right_wheel_steering_link">
+        <pose>0.554283 -0.5 0.02 0 0 0</pose>
+        <inertial>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.0153</ixx>
+            <iyy>0.025</iyy>
+            <izz>0.0153</izz>
+          </inertia>
+        </inertial>
+        <visual name="steering_link_visual">
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
+          </material>
+        </visual>
+      </link>
+
+      <joint name="front_left_wheel_steering_joint" type="revolute">
+        <child>front_left_wheel_steering_link</child>
+        <parent>chassis</parent>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-0.6</lower>
+            <upper>+0.6</upper>
+            <velocity>1.0</velocity>
+            <effort>25</effort>
+          </limit>
+          <use_parent_model_frame>1</use_parent_model_frame>
+        </axis>
+      </joint>
+
+      <joint name="front_right_wheel_steering_joint" type="revolute">
+        <parent>chassis</parent>
+        <child>front_right_wheel_steering_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-0.6</lower>
+            <upper>+0.6</upper>
+            <velocity>1.0</velocity>
+            <effort>25</effort>
+          </limit>
+        </axis>
+      </joint>
+
+      <joint name='front_left_wheel_joint' type='revolute'>
+        <parent>front_left_wheel_steering_link</parent>
+        <child>front_left_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+
+      <joint name='front_right_wheel_joint' type='revolute'>
+        <parent>front_right_wheel_steering_link</parent>
+        <child>front_right_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+
+      <joint name='rear_left_wheel_joint' type='revolute'>
+        <parent>chassis</parent>
+        <child>rear_left_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+
+      <joint name='rear_right_wheel_joint' type='revolute'>
+        <parent>chassis</parent>
+        <child>rear_right_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+
+      <plugin
+        filename="gz-sim-ackermann-steering-system"
+        name="gz::sim::systems::AckermannSteering">
+        <left_steering_joint>front_left_wheel_steering_joint</left_steering_joint>
+        <right_steering_joint>front_right_wheel_steering_joint</right_steering_joint>
+        <steering_limit>0.5</steering_limit>
+        <wheel_base>1.0</wheel_base>
+        <wheel_separation>1.25</wheel_separation>
+        <sub_topic>steerangle</sub_topic>
+      </plugin>
+
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
# 🎉 New feature

Closes #1863

## Summary
Option to use <steering_only> to enable a mode that does not drive the wheels. It instead only controls the central steering angle phi in radians on a /model/{name_of_model}/steer_angle gz::msgs::Double. This is usefull for simulating the control of a real vehicle without direct cmd_vel capabilities.

## Test it
Example:
```xml
<plugin
  filename="gz-sim-ackermann-steering-system"
  name="gz::sim::systems::AckermannSteering">
  <steering_only>true</steering_only>
  <left_steering_joint>MR_Buggy3/FrontLeftWheelSteeringJoint</left_steering_joint>
  <right_steering_joint>MR_Buggy3/FrontRightWheelSteeringJoint</right_steering_joint>
  <steering_limit>0.4</steering_limit>
  <wheel_base>.2255</wheel_base>
  <wheel_separation>.2</wheel_separation>
</plugin>
```

https://user-images.githubusercontent.com/10233412/212523915-1357228c-ad57-4005-8e56-fbf31b061b82.mp4


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
