### PR TITLE
Enable the JointController and JointPositionController to use sub_topics and control multiple joints.

### DIFF
--- a/src/systems/joint_controller/JointController.cc
+++ b/src/systems/joint_controller/JointController.cc
@@ -90,19 +90,25 @@ void JointController::Configure(const Entity &_entity,
     return;
   }
 
-  // Ugly, but needed because the sdf::Element::GetElement is not a const
-  // function and _sdf is a const shared pointer to a const sdf::Element.
-  auto ptr = const_cast<sdf::Element *>(_sdf.get());
-
   // Get params from SDF
-  sdf::ElementPtr sdfElem = ptr->GetElement("joint_name");
+  auto sdfElem = _sdf->FindElement("joint_name");
   while (sdfElem)
   {
-    this->dataPtr->jointNames.push_back(sdfElem->Get<std::string>());
+    if (!sdfElem->Get<std::string>().empty())
+    {
+      this->dataPtr->jointNames.push_back(sdfElem->Get<std::string>());
+    }
+    else
+    {
+      gzerr << "<joint_name> provided but is empty." << std::endl;
+    }
     sdfElem = sdfElem->GetNextElement("joint_name");
   }
-
-
+  if (this->dataPtr->jointNames.empty())
+  {
+    gzerr << "Failed to get any <joint_name>." << std::endl;
+    return;
+  }
 
   if (_sdf->HasElement("initial_velocity"))
   {

--- a/src/systems/joint_controller/JointController.hh
+++ b/src/systems/joint_controller/JointController.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2019 Open Source Robotics Foundation
+ * Copyright (C) 2023 Benjamin Perseghetti, Rudis Laboratories
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +38,7 @@ namespace systems
   /// ## System Parameters
   ///
   /// `<joint_name>` The name of the joint to control. Required parameter.
+  ///  Can also include multiple `<joint_name>` for identical joints.
   ///
   /// `<use_force_commands>` True to enable the controller implementation
   /// using force commands. If this parameter is not set or is false, the
@@ -44,6 +46,9 @@ namespace systems
   ///
   /// `<topic>` Topic to receive commands in. Defaults to
   ///     `/model/<model_name>/joint/<joint_name>/cmd_vel`.
+  ///
+  /// `<sub_topic>` Sub topic to receive commands in.
+  ///  Defaults to "/model/<model_name>/<sub_topic>".
   ///
   /// `<initial_velocity>` Velocity to start with.
   ///

--- a/src/systems/joint_position_controller/JointPositionController.cc
+++ b/src/systems/joint_position_controller/JointPositionController.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Open Source Robotics Foundation
+ * Copyright (C) 2023 Benjamin Perseghetti, Rudis Laboratories
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +22,7 @@
 
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 #include <gz/common/Profiler.hh>
 #include <gz/math/PID.hh>
@@ -46,10 +48,10 @@ class gz::sim::systems::JointPositionControllerPrivate
   public: transport::Node node;
 
   /// \brief Joint Entity
-  public: Entity jointEntity{kNullEntity};
+  public: std::vector<Entity> jointEntities;
 
   /// \brief Joint name
-  public: std::string jointName;
+  public: std::vector<std::string> jointNames;
 
   /// \brief Commanded joint position
   public: double jointPosCmd{0.0};
@@ -101,14 +103,16 @@ void JointPositionController::Configure(const Entity &_entity,
     return;
   }
 
-  // Get params from SDF
-  this->dataPtr->jointName = _sdf->Get<std::string>("joint_name");
+  // Ugly, but needed because the sdf::Element::GetElement is not a const
+  // function and _sdf is a const shared pointer to a const sdf::Element.
+  auto ptr = const_cast<sdf::Element *>(_sdf.get());
 
-  if (this->dataPtr->jointName == "")
+  // Get params from SDF
+  sdf::ElementPtr sdfElem = ptr->GetElement("joint_name");
+  while (sdfElem)
   {
-    gzerr << "JointPositionController found an empty jointName parameter. "
-           << "Failed to initialize.";
-    return;
+    this->dataPtr->jointNames.push_back(sdfElem->Get<std::string>());
+    sdfElem = sdfElem->GetNextElement("joint_name");
   }
 
   if (_sdf->HasElement("joint_index"))
@@ -177,14 +181,36 @@ void JointPositionController::Configure(const Entity &_entity,
   }
 
   // Subscribe to commands
-  std::string topic = transport::TopicUtils::AsValidTopic("/model/" +
-      this->dataPtr->model.Name(_ecm) + "/joint/" + this->dataPtr->jointName +
-      "/" + std::to_string(this->dataPtr->jointIndex) + "/cmd_pos");
-  if (topic.empty())
+  std::string topic;
+  if ((!_sdf->HasElement("sub_topic")) && (!_sdf->HasElement("topic")))
   {
-    gzerr << "Failed to create topic for joint [" << this->dataPtr->jointName
-           << "]" << std::endl;
-    return;
+    topic = transport::TopicUtils::AsValidTopic("/model/" +
+        this->dataPtr->model.Name(_ecm) + "/joint/" +
+        this->dataPtr->jointNames[0] + "/" +
+        std::to_string(this->dataPtr->jointIndex) + "/cmd_pos");
+    if (topic.empty())
+    {
+      gzerr << "Failed to create topic for joint ["
+            << this->dataPtr->jointNames[0]
+            << "]" << std::endl;
+      return;
+    }
+  }
+  if (_sdf->HasElement("sub_topic"))
+  {
+    topic = transport::TopicUtils::AsValidTopic("/model/" +
+      this->dataPtr->model.Name(_ecm) + "/" +
+        _sdf->Get<std::string>("sub_topic"));
+
+    if (topic.empty())
+    {
+      gzerr << "Failed to create topic from sub_topic [/model/"
+             << this->dataPtr->model.Name(_ecm) << "/"
+             << _sdf->Get<std::string>("sub_topic")
+             << "]" << " for joint [" << this->dataPtr->jointNames[0]
+             << "]" << std::endl;
+      return;
+    }
   }
   if (_sdf->HasElement("topic"))
   {
@@ -194,7 +220,7 @@ void JointPositionController::Configure(const Entity &_entity,
     if (topic.empty())
     {
       gzerr << "Failed to create topic [" << _sdf->Get<std::string>("topic")
-             << "]" << " for joint [" << this->dataPtr->jointName
+             << "]" << " for joint [" << this->dataPtr->jointNames[0]
              << "]" << std::endl;
       return;
     }
@@ -231,37 +257,40 @@ void JointPositionController::PreUpdate(
         << "s]. System may not work properly." << std::endl;
   }
 
-  // If the joint hasn't been identified yet, look for it
-  if (this->dataPtr->jointEntity == kNullEntity)
+  // If the joints haven't been identified yet, look for them
+  if (this->dataPtr->jointEntities.empty())
   {
-    this->dataPtr->jointEntity =
-        this->dataPtr->model.JointByName(_ecm, this->dataPtr->jointName);
+    bool warned{false};
+    for (const std::string &name : this->dataPtr->jointNames)
+    {
+      Entity joint = this->dataPtr->model.JointByName(_ecm, name);
+      if (joint != kNullEntity)
+      {
+        this->dataPtr->jointEntities.push_back(joint);
+      }
+      else if (!warned)
+      {
+        gzwarn << "Failed to find joint [" << name << "]" << std::endl;
+        warned = true;
+      }
+    }
   }
-
-  // If the joint is still not found then warn the user, they may have entered
-  // the wrong joint name.
-  if (this->dataPtr->jointEntity == kNullEntity)
-  {
-    static bool warned = false;
-    if(!warned)
-      gzerr << "Could not find joint with name ["
-        << this->dataPtr->jointName <<"]\n";
-    warned = true;
+  if (this->dataPtr->jointEntities.empty())
     return;
-  }
 
   // Nothing left to do if paused.
   if (_info.paused)
     return;
 
   // Create joint position component if one doesn't exist
-  auto jointPosComp =
-      _ecm.Component<components::JointPosition>(this->dataPtr->jointEntity);
-  if (jointPosComp == nullptr)
+  auto jointPosComp = _ecm.Component<components::JointPosition>(
+      this->dataPtr->jointEntities[0]);
+  if (!jointPosComp)
   {
-    _ecm.CreateComponent(
-        this->dataPtr->jointEntity, components::JointPosition());
+    _ecm.CreateComponent(this->dataPtr->jointEntities[0],
+        components::JointPosition());
   }
+
   // We just created the joint position component, give one iteration for the
   // physics system to update its size
   if (jointPosComp == nullptr || jointPosComp->Data().empty())
@@ -271,15 +300,15 @@ void JointPositionController::PreUpdate(
   if (this->dataPtr->jointIndex >= jointPosComp->Data().size())
   {
     static std::unordered_set<Entity> reported;
-    if (reported.find(this->dataPtr->jointEntity) == reported.end())
+    if (reported.find(this->dataPtr->jointEntities[0]) == reported.end())
     {
       gzerr << "[JointPositionController]: Detected an invalid <joint_index> "
              << "parameter. The index specified is ["
              << this->dataPtr->jointIndex << "] but joint ["
-             << this->dataPtr->jointName << "] only has ["
+             << this->dataPtr->jointNames[0] << "] only has ["
              << jointPosComp->Data().size() << "] index[es]. "
              << "This controller will be ignored" << std::endl;
-      reported.insert(this->dataPtr->jointEntity);
+      reported.insert(this->dataPtr->jointEntities[0]);
     }
     return;
   }
@@ -315,37 +344,40 @@ void JointPositionController::PreUpdate(
     {
       targetVel = -error;
     }
-
-    // Set velocity and return
-    auto vel =
-      _ecm.Component<components::JointVelocityCmd>(this->dataPtr->jointEntity);
-
-    if (vel == nullptr)
+    for (Entity joint : this->dataPtr->jointEntities)
     {
-      _ecm.CreateComponent(
-          this->dataPtr->jointEntity,
-          components::JointVelocityCmd({targetVel}));
-    }
-    else if (!vel->Data().empty())
-    {
-      vel->Data()[0] = targetVel;
+      // Update velocity command.
+      auto vel = _ecm.Component<components::JointVelocityCmd>(joint);
+
+      if (vel == nullptr)
+      {
+        _ecm.CreateComponent(
+            joint, components::JointVelocityCmd({targetVel}));
+      }
+      else
+      {
+        *vel = components::JointVelocityCmd({targetVel});
+      }
     }
     return;
   }
 
-  // Update force command.
-  double force = this->dataPtr->posPid.Update(error, _info.dt);
+  for (Entity joint : this->dataPtr->jointEntities)
+  {
+    // Update force command.
+    double force = this->dataPtr->posPid.Update(error, _info.dt);
 
-  auto forceComp =
-      _ecm.Component<components::JointForceCmd>(this->dataPtr->jointEntity);
-  if (forceComp == nullptr)
-  {
-    _ecm.CreateComponent(this->dataPtr->jointEntity,
-                         components::JointForceCmd({force}));
-  }
-  else
-  {
-    forceComp->Data()[this->dataPtr->jointIndex] = force;
+    auto forceComp =
+        _ecm.Component<components::JointForceCmd>(joint);
+    if (forceComp == nullptr)
+    {
+      _ecm.CreateComponent(joint,
+                          components::JointForceCmd({force}));
+    }
+    else
+    {
+      *forceComp = components::JointForceCmd({force});
+    }
   }
 }
 

--- a/src/systems/joint_position_controller/JointPositionController.cc
+++ b/src/systems/joint_position_controller/JointPositionController.cc
@@ -103,16 +103,24 @@ void JointPositionController::Configure(const Entity &_entity,
     return;
   }
 
-  // Ugly, but needed because the sdf::Element::GetElement is not a const
-  // function and _sdf is a const shared pointer to a const sdf::Element.
-  auto ptr = const_cast<sdf::Element *>(_sdf.get());
-
   // Get params from SDF
-  sdf::ElementPtr sdfElem = ptr->GetElement("joint_name");
+  auto sdfElem = _sdf->FindElement("joint_name");
   while (sdfElem)
   {
-    this->dataPtr->jointNames.push_back(sdfElem->Get<std::string>());
+    if (!sdfElem->Get<std::string>().empty())
+    {
+      this->dataPtr->jointNames.push_back(sdfElem->Get<std::string>());
+    }
+    else
+    {
+      gzerr << "<joint_name> provided but is empty." << std::endl;
+    }
     sdfElem = sdfElem->GetNextElement("joint_name");
+  }
+  if (this->dataPtr->jointNames.empty())
+  {
+    gzerr << "Failed to get any <joint_name>." << std::endl;
+    return;
   }
 
   if (_sdf->HasElement("joint_index"))

--- a/src/systems/joint_position_controller/JointPositionController.hh
+++ b/src/systems/joint_position_controller/JointPositionController.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Open Source Robotics Foundation
+ * Copyright (C) 2023 Benjamin Perseghetti, Rudis Laboratories
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +36,7 @@ namespace systems
   /// reference to a single joint.
   ///
   /// A new Gazebo Transport topic is created to send target joint positions.
-  /// The topic name is
+  /// The default topic name is
   /// "/model/<model_name>/joint/<joint_name>/<joint_index>/cmd_pos".
   ///
   /// This topic accepts gz::msgs::Double values representing the target
@@ -46,6 +47,7 @@ namespace systems
   /// ## System Parameters
   ///
   /// `<joint_name>` The name of the joint to control. Required parameter.
+  ///  Can also include multiple `<joint_name>` for identical joints.
   ///
   /// `<joint_index>` Axis of the joint to control. Optional parameter.
   ///  The default value is 0.
@@ -81,6 +83,9 @@ namespace systems
   /// `<topic>` If you wish to listen on a non-default topic you may specify it
   /// here, otherwise the controller defaults to listening on
   /// "/model/<model_name>/joint/<joint_name>/<joint_index>/cmd_pos".
+  ///
+  /// `<sub_topic>` If you wish to listen on a sub_topic you may specify it
+  /// here "/model/<model_name>/<sub_topic>".
   ///
   /// `<initial_position>` Initial position of a joint. Optional parameter.
   ///  The default value is 0.

--- a/test/integration/joint_controller_system.cc
+++ b/test/integration/joint_controller_system.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2019 Open Source Robotics Foundation
+ * Copyright (C) 2023 Benjamin Perseghetti, Rudis Laboratories
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,9 +56,9 @@ TEST_F(JointControllerTestFixture,
 
   // Start server
   ServerConfig serverConfig;
-  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
-    "/test/worlds/joint_controller.sdf";
-  serverConfig.SetSdfFile(sdfFile);
+  serverConfig.SetSdfFile(common::joinPaths(
+      PROJECT_SOURCE_PATH, "test", "worlds",
+      "joint_controller.sdf"));
 
   Server server(serverConfig);
   EXPECT_FALSE(server.Running());
@@ -155,9 +156,9 @@ TEST_F(JointControllerTestFixture,
 
   // Start server
   ServerConfig serverConfig;
-  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
-    "/test/worlds/joint_controller.sdf";
-  serverConfig.SetSdfFile(sdfFile);
+  serverConfig.SetSdfFile(common::joinPaths(
+      PROJECT_SOURCE_PATH, "test", "worlds",
+      "joint_controller.sdf"));
 
   Server server(serverConfig);
   EXPECT_FALSE(server.Running());
@@ -186,9 +187,10 @@ TEST_F(JointControllerTestFixture,
 
   // Start server
   ServerConfig serverConfig;
-  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
-    "/test/worlds/joint_controller.sdf";
-  serverConfig.SetSdfFile(sdfFile);
+  serverConfig.SetSdfFile(common::joinPaths(
+      PROJECT_SOURCE_PATH, "test", "worlds",
+      "joint_controller.sdf"));
+
 
   Server server(serverConfig);
   EXPECT_FALSE(server.Running());
@@ -263,9 +265,9 @@ TEST_F(JointControllerTestFixture, InexistentJoint)
 
   // Start server
   ServerConfig serverConfig;
-  const auto sdfFile = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
-    "test", "worlds", "joint_controller_invalid.sdf");
-  serverConfig.SetSdfFile(sdfFile);
+  serverConfig.SetSdfFile(common::joinPaths(
+      PROJECT_SOURCE_PATH, "test", "worlds",
+      "joint_controller_invalid.sdf"));
 
   Server server(serverConfig);
   EXPECT_FALSE(server.Running());

--- a/test/integration/joint_controller_system.cc
+++ b/test/integration/joint_controller_system.cc
@@ -145,6 +145,39 @@ TEST_F(JointControllerTestFixture,
 }
 
 /////////////////////////////////////////////////
+// Tests that the JointController accepts joint velocity commands
+// See https://github.com/gazebosim/gz-sim/issues/1175
+TEST_F(JointControllerTestFixture,
+       GZ_UTILS_TEST_DISABLED_ON_WIN32(
+        JointVelocityMultipleJointsSubTopicCommand))
+{
+  using namespace std::chrono_literals;
+
+  // Start server
+  ServerConfig serverConfig;
+  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
+    "/test/worlds/joint_controller.sdf";
+  serverConfig.SetSdfFile(sdfFile);
+
+  Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  server.SetUpdatePeriod(0ns);
+
+  // Publish command and check that the joint velocity is set
+  transport::Node node;
+  auto pub = node.Advertise<msgs::Double>(
+      "/model/joint_controller_test/joints");
+
+  const double testAngVel{10.0};
+  msgs::Double msg;
+  msg.set_data(testAngVel);
+
+  pub.Publish(msg);
+}
+
+/////////////////////////////////////////////////
 // Tests the JointController using joint force commands
 TEST_F(JointControllerTestFixture,
        GZ_UTILS_TEST_DISABLED_ON_WIN32(JointVelocityCommandWithForce))
@@ -163,7 +196,7 @@ TEST_F(JointControllerTestFixture,
 
   server.SetUpdatePeriod(0ns);
 
-  const std::string linkName = "rotor2";
+  const std::string linkName = "rotor3";
 
   test::Relay testSystem;
   math::Vector3d angularVelocity;

--- a/test/integration/joint_position_controller_system.cc
+++ b/test/integration/joint_position_controller_system.cc
@@ -207,3 +207,80 @@ TEST_F(JointPositionControllerTestFixture,
 
   EXPECT_NEAR(targetPosition, currentPosition.at(0), TOL);
 }
+// Tests that the JointPositionController accepts joint position
+// sub_topic commands
+TEST_F(JointPositionControllerTestFixture,
+       GZ_UTILS_TEST_DISABLED_ON_WIN32(
+        JointPositonMultipleJointsSubTopicCommand))
+{
+  using namespace std::chrono_literals;
+
+  // Start server
+  ServerConfig serverConfig;
+  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
+    "/test/worlds/joint_position_controller_multiple_joints_subtopic.sdf";
+  serverConfig.SetSdfFile(sdfFile);
+
+  Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  server.SetUpdatePeriod(0ns);
+
+  const std::string jointName = "j1";
+
+  test::Relay testSystem;
+  std::vector<double> currentPosition;
+  testSystem.OnPreUpdate(
+      [&](const UpdateInfo &, EntityComponentManager &_ecm)
+      {
+        auto joint = _ecm.EntityByComponents(components::Joint(),
+                                             components::Name(jointName));
+        // Create a JointPosition component if it doesn't exist. This signals
+        // physics system to populate the component
+        if (nullptr == _ecm.Component<components::JointPosition>(joint))
+        {
+          _ecm.CreateComponent(joint, components::JointPosition());
+        }
+      });
+
+  testSystem.OnPostUpdate([&](const UpdateInfo &,
+                              const EntityComponentManager &_ecm)
+      {
+        _ecm.Each<components::Joint, components::Name,
+                  components::JointPosition>(
+            [&](const Entity &,
+                const components::Joint *,
+                const components::Name *_name,
+                const components::JointPosition *_position) -> bool
+            {
+              EXPECT_EQ(_name->Data(), jointName);
+              currentPosition = _position->Data();
+              return true;
+            });
+      });
+
+  server.AddSystem(testSystem.systemPtr);
+
+  const std::size_t initIters = 10;
+  server.Run(true, initIters, false);
+  EXPECT_NEAR(0, currentPosition.at(0), TOL);
+
+  // Publish command and check that the joint position is set
+  transport::Node node;
+  auto pub = node.Advertise<msgs::Double>(
+      "/model/joint_position_controller_test/joints");
+
+  const double targetPosition{2.0};
+  msgs::Double msg;
+  msg.set_data(targetPosition);
+
+  pub.Publish(msg);
+  // Wait for the message to be published
+  std::this_thread::sleep_for(100ms);
+
+  const std::size_t testIters = 1000;
+  server.Run(true, testIters , false);
+
+  EXPECT_NEAR(targetPosition, currentPosition.at(0), TOL);
+}

--- a/test/integration/joint_position_controller_system.cc
+++ b/test/integration/joint_position_controller_system.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Open Source Robotics Foundation
+ * Copyright (C) 2023 Benjamin Perseghetti, Rudis Laboratories
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,9 +57,9 @@ TEST_F(JointPositionControllerTestFixture,
 
   // Start server
   ServerConfig serverConfig;
-  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
-    "/test/worlds/joint_position_controller.sdf";
-  serverConfig.SetSdfFile(sdfFile);
+  serverConfig.SetSdfFile(common::joinPaths(
+      PROJECT_SOURCE_PATH, "test", "worlds",
+      "joint_position_controller.sdf"));
 
   Server server(serverConfig);
   EXPECT_FALSE(server.Running());
@@ -133,9 +134,9 @@ TEST_F(JointPositionControllerTestFixture,
 
   // Start server
   ServerConfig serverConfig;
-  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
-    "/test/worlds/joint_position_controller_velocity.sdf";
-  serverConfig.SetSdfFile(sdfFile);
+  serverConfig.SetSdfFile(common::joinPaths(
+      PROJECT_SOURCE_PATH, "test", "worlds",
+      "joint_position_controller_velocity.sdf"));
 
   Server server(serverConfig);
   EXPECT_FALSE(server.Running());
@@ -217,9 +218,9 @@ TEST_F(JointPositionControllerTestFixture,
 
   // Start server
   ServerConfig serverConfig;
-  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
-    "/test/worlds/joint_position_controller_multiple_joints_subtopic.sdf";
-  serverConfig.SetSdfFile(sdfFile);
+  serverConfig.SetSdfFile(common::joinPaths(
+      PROJECT_SOURCE_PATH, "test", "worlds",
+      "joint_position_controller_multiple_joints_subtopic.sdf"));
 
   Server server(serverConfig);
   EXPECT_FALSE(server.Running());

--- a/test/worlds/joint_controller.sdf
+++ b/test/worlds/joint_controller.sdf
@@ -117,6 +117,123 @@
       </plugin>
     </model>
 
+    <model name="joint_controller_test1">
+      <pose>0 0 0.005 0 0 0</pose>
+      <link name="base_link">
+        <pose>0.0 0.0 0.0 0 0 0</pose>
+        <inertial>
+          <inertia>
+            <ixx>2.501</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>2.501</iyy>
+            <iyz>0</iyz>
+            <izz>5</izz>
+          </inertia>
+          <mass>120.0</mass>
+        </inertial>
+        <visual name="base_visual">
+          <pose>0.0 0.0 0.0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.01</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name="base_collision">
+          <pose>0.0 0.0 0.0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.01</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <link name="rotor1">
+        <pose>0.0 0.5 1.0 0.0 0 0</pose>
+        <inertial>
+          <pose>0.0 0.0 0.0 0 0 0</pose>
+          <inertia>
+            <ixx>0.032</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.032</iyy>
+            <iyz>0</iyz>
+            <izz>0.00012</izz>
+          </inertia>
+          <mass>0.6</mass>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.05</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.05</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <link name="rotor2">
+        <pose>0.0 -0.5 1.0 0.0 0 0</pose>
+        <inertial>
+          <pose>0.0 0.0 0.0 0 0 0</pose>
+          <inertia>
+            <ixx>0.032</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.032</iyy>
+            <iyz>0</iyz>
+            <izz>0.00012</izz>
+          </inertia>
+          <mass>0.6</mass>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.05</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.05</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+
+      <joint name="j1" type="revolute">
+        <pose>0 0 -0.5 0 0 0</pose>
+        <parent>base_link</parent>
+        <child>rotor1</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+      <joint name="j2" type="revolute">
+        <pose>0 0 -0.5 0 0 0</pose>
+        <parent>base_link</parent>
+        <child>rotor2</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+      <plugin
+        filename="gz-sim-joint-controller-system"
+        name="gz::sim::systems::JointController">
+        <initial_velocity>5.0</initial_velocity>
+        <sub_topic>joints</sub_topic>
+        <joint_name>j1</joint_name>
+        <joint_name>j2</joint_name>
+      </plugin>
+    </model>
+
     <model name="joint_controller_test_2">
       <pose>3 3 0.005 0 0 0</pose>
       <link name="base_link">
@@ -149,7 +266,7 @@
           </geometry>
         </collision>
       </link>
-      <link name="rotor2">
+      <link name="rotor3">
         <pose>0.0 0.0 1.0 0.0 0 0</pose>
         <inertial>
           <pose>0.0 0.0 0.0 0 0 0</pose>
@@ -182,7 +299,7 @@
       <joint name="j1" type="revolute">
         <pose>0 0 -0.5 0 0 0</pose>
         <parent>base_link</parent>
-        <child>rotor2</child>
+        <child>rotor3</child>
         <axis>
           <xyz>0 0 1</xyz>
         </axis>

--- a/test/worlds/joint_position_controller_multiple_joints_subtopic.sdf
+++ b/test/worlds/joint_position_controller_multiple_joints_subtopic.sdf
@@ -1,0 +1,166 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
+    <plugin
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+    <model name="joint_position_controller_test">
+      <pose>0 0 0.005 0 0 0</pose>
+      <link name="base_link">
+        <pose>0.0 0.0 0.0 0 0 0</pose>
+        <inertial>
+          <inertia>
+            <ixx>2.501</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>2.501</iyy>
+            <iyz>0</iyz>
+            <izz>5</izz>
+          </inertia>
+          <mass>120.0</mass>
+        </inertial>
+        <visual name="base_visual">
+          <pose>0.0 0.0 0.0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.01</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name="base_collision">
+          <pose>0.0 0.0 0.0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.01</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <link name="rotor1">
+        <pose>0.0 0.5 1.0 0.0 0 0</pose>
+        <inertial>
+          <pose>0.0 0.0 0.0 0 0 0</pose>
+          <inertia>
+            <ixx>0.032</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.032</iyy>
+            <iyz>0</iyz>
+            <izz>0.00012</izz>
+          </inertia>
+          <mass>0.6</mass>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.05</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.05</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <link name="rotor2">
+        <pose>0.0 -0.5 1.0 0.0 0 0</pose>
+        <inertial>
+          <pose>0.0 0.0 0.0 0 0 0</pose>
+          <inertia>
+            <ixx>0.032</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.032</iyy>
+            <iyz>0</iyz>
+            <izz>0.00012</izz>
+          </inertia>
+          <mass>0.6</mass>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.05</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.05</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+
+      <joint name="j1" type="revolute">
+        <pose>0 0 -0.5 0 0 0</pose>
+        <parent>base_link</parent>
+        <child>rotor1</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+      <joint name="j2" type="revolute">
+        <pose>0 0 -0.5 0 0 0</pose>
+        <parent>base_link</parent>
+        <child>rotor2</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>j1</joint_name>
+        <joint_name>j2</joint_name>
+        <sub_topic>joints</sub_topic>
+        <p_gain>1</p_gain>
+        <i_gain>0.1</i_gain>
+        <d_gain>0.01</d_gain>
+        <i_max>1</i_max>
+        <i_min>-1</i_min>
+        <cmd_max>1000</cmd_max>
+        <cmd_min>-1000</cmd_min>
+      </plugin>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
# 🎉 New feature

Closes #1862 

## Summary
Enable the JointController and JointPositionController to use sub_topics based on
/model/<model_name>/<sub_topic>. Furthermore enable grouping of similar
joints controlled by the same topic. Now you can have multiple
<joint_name> that will be controlled together.


## Test it
Example use (one of many):
```xml
<plugin
    filename="gz-sim-joint-controller-system"
    name="gz::sim::systems::JointController">
  <joint_name>MR_Buggy3/FrontLeftWheelJoint</joint_name>
  <joint_name>MR_Buggy3/FrontRightWheelJoint</joint_name>
  <joint_name>MR_Buggy3/RearRightWheelJoint</joint_name>
  <joint_name>MR_Buggy3/RearLeftWheelJoint</joint_name>
  <sub_topic>drive</sub_topic>
</plugin>
<plugin
    filename="gz-sim-joint-position-controller-system"
    name="gz::sim::systems::JointPositionController">
  <joint_name>MR_Buggy3/FrontRightWheelSteeringJoint</joint_name>
  <joint_name>MR_Buggy3/FrontLeftWheelSteeringJoint</joint_name>
  <sub_topic>steer_angle</sub_topic>
</plugin>
```

https://user-images.githubusercontent.com/10233412/212588290-bd13f565-1f80-4dcf-991e-592f40b4bed9.mp4




## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
