### PR TITLE
Add P gain value for Ackermann steering.

### DIFF
--- a/src/systems/ackermann_steering/AckermannSteering.hh
+++ b/src/systems/ackermann_steering/AckermannSteering.hh
@@ -43,6 +43,9 @@ namespace systems
   /// and wheel_separation. Uses gz::msg::Double on default topic name
   /// `/model/{name_of_model}/steer_angle`
   ///
+  /// `<steer_p_gain>`: Float used to control the steering angle P gain.
+  /// Only used for when in steering_only mode.
+  ///
   /// `<left_joint>`: Name of a joint that controls a left wheel. This
   /// element can appear multiple times, and must appear at least once.
   ///

--- a/test/worlds/ackermann_steering_only.sdf
+++ b/test/worlds/ackermann_steering_only.sdf
@@ -364,6 +364,7 @@
         <left_steering_joint>front_left_wheel_steering_joint</left_steering_joint>
         <right_steering_joint>front_right_wheel_steering_joint</right_steering_joint>
         <steering_only>true</steering_only>
+        <steer_p_gain>10.0</steer_p_gain>
         <steering_limit>0.5</steering_limit>
         <wheel_base>1.0</wheel_base>
         <wheel_separation>1.25</wheel_separation>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #1872

## Summary
Adds P gain for ackermann steering when:
```xml
 <steering_only>true</steering_only>
 ```
Set with:
```xml
<steer_p_gain>your_value</steer_p_gain>
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
