### PR TITLE
Fix some windows warnings (C4244 and C4305)

### DIFF
--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -1032,7 +1032,8 @@ TEST(Conversions, ParticleEmitter)
   EXPECT_EQ(math::Vector3d(4, 5, 6), msgs::Convert(emitterMsg.particle_size()));
   EXPECT_EQ(math::Color(0.1f, 0.2f, 0.3f),
       msgs::Convert(emitterMsg.color_start()));
-  EXPECT_EQ(math::Color(0.4f, 0.5f, 0.6f), msgs::Convert(emitterMsg.color_end()));
+  EXPECT_EQ(math::Color(0.4f, 0.5f, 0.6f), 
+      msgs::Convert(emitterMsg.color_end()));
   EXPECT_EQ("range_image", emitterMsg.color_range_image().data());
 
   auto header = emitterMsg.header().data(0);

--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -999,8 +999,8 @@ TEST(Conversions, ParticleEmitter)
   emitter.SetMaxVelocity(0.2);
   emitter.SetSize(math::Vector3d(1, 2, 3));
   emitter.SetParticleSize(math::Vector3d(4, 5, 6));
-  emitter.SetColorStart(math::Color(0.1, 0.2, 0.3));
-  emitter.SetColorEnd(math::Color(0.4, 0.5, 0.6));
+  emitter.SetColorStart(math::Color(0.1f, 0.2f, 0.3f));
+  emitter.SetColorEnd(math::Color(0.4f, 0.5f, 0.6f));
   emitter.SetColorRangeImage("range_image");
   emitter.SetTopic("my_topic");
   emitter.SetRawPose(math::Pose3d(1, 2, 3, 0, 0, 0));
@@ -1030,9 +1030,9 @@ TEST(Conversions, ParticleEmitter)
   EXPECT_NEAR(0.2, emitterMsg.max_velocity().data(), 1e-3);
   EXPECT_EQ(math::Vector3d(1, 2, 3), msgs::Convert(emitterMsg.size()));
   EXPECT_EQ(math::Vector3d(4, 5, 6), msgs::Convert(emitterMsg.particle_size()));
-  EXPECT_EQ(math::Color(0.1, 0.2, 0.3),
+  EXPECT_EQ(math::Color(0.1f, 0.2f, 0.3f),
       msgs::Convert(emitterMsg.color_start()));
-  EXPECT_EQ(math::Color(0.4, 0.5, 0.6), msgs::Convert(emitterMsg.color_end()));
+  EXPECT_EQ(math::Color(0.4f, 0.5f, 0.6f), msgs::Convert(emitterMsg.color_end()));
   EXPECT_EQ("range_image", emitterMsg.color_range_image().data());
 
   auto header = emitterMsg.header().data(0);

--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -1032,7 +1032,7 @@ TEST(Conversions, ParticleEmitter)
   EXPECT_EQ(math::Vector3d(4, 5, 6), msgs::Convert(emitterMsg.particle_size()));
   EXPECT_EQ(math::Color(0.1f, 0.2f, 0.3f),
       msgs::Convert(emitterMsg.color_start()));
-  EXPECT_EQ(math::Color(0.4f, 0.5f, 0.6f), 
+  EXPECT_EQ(math::Color(0.4f, 0.5f, 0.6f),
       msgs::Convert(emitterMsg.color_end()));
   EXPECT_EQ("range_image", emitterMsg.color_range_image().data());
 

--- a/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
+++ b/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
@@ -807,9 +807,9 @@ void OpticalTactilePluginPrivate::ComputeNormalForces(
       bufferIndex = j * (_msg.row_step() / 2) + i * (_msg.point_step() / 2);
       std::memcpy(&normalForcesBuffer.get()[bufferIndex],
                  &normalForce.X(), sizeof(float));
-      std::memcpy(&normalForcesBuffer.get()[bufferIndex] + sizeof(float),
+      std::memcpy(&normalForcesBuffer.get()[bufferIndex + sizeof(float)],
                  &normalForce.Y(), sizeof(float));
-      std::memcpy(&normalForcesBuffer.get()[bufferIndex] + 2 * sizeof(float),
+      std::memcpy(&normalForcesBuffer.get()[bufferIndex + 2 * sizeof(float)],
                  &normalForce.Z(), sizeof(float));
 
       if (!_visualizeForces)

--- a/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
+++ b/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
@@ -805,10 +805,10 @@ void OpticalTactilePluginPrivate::ComputeNormalForces(
       // Forces buffer is composed of XYZ coordinates, while _msg buffer is
       // made up of XYZRGB values
       bufferIndex = j * (_msg.row_step() / 2) + i * (_msg.point_step() / 2);
-      normalForcesBuffer.get()[bufferIndex] = normalForce.X();
-      normalForcesBuffer.get()[bufferIndex + sizeof(float)] = normalForce.Y();
+      normalForcesBuffer.get()[bufferIndex] = static_cast<char>(normalForce.X());
+      normalForcesBuffer.get()[bufferIndex + sizeof(float)] = static_cast<char>(normalForce.Y());
       normalForcesBuffer.get()[bufferIndex + 2 * sizeof(float)] =
-        normalForce.Z();
+        static_cast<char>(normalForce.Z());
 
       if (!_visualizeForces)
         continue;

--- a/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
+++ b/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
@@ -805,10 +805,10 @@ void OpticalTactilePluginPrivate::ComputeNormalForces(
       // Forces buffer is composed of XYZ coordinates, while _msg buffer is
       // made up of XYZRGB values
       bufferIndex = j * (_msg.row_step() / 2) + i * (_msg.point_step() / 2);
-      normalForcesBuffer.get()[bufferIndex] = 
-	static_cast<char>(normalForce.X());
-      normalForcesBuffer.get()[bufferIndex + sizeof(float)] = 
-	static_cast<char>(normalForce.Y());
+      normalForcesBuffer.get()[bufferIndex] =
+        static_cast<char>(normalForce.X());
+      normalForcesBuffer.get()[bufferIndex + sizeof(float)] =
+        static_cast<char>(normalForce.Y());
       normalForcesBuffer.get()[bufferIndex + 2 * sizeof(float)] =
         static_cast<char>(normalForce.Z());
 

--- a/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
+++ b/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
@@ -805,12 +805,12 @@ void OpticalTactilePluginPrivate::ComputeNormalForces(
       // Forces buffer is composed of XYZ coordinates, while _msg buffer is
       // made up of XYZRGB values
       bufferIndex = j * (_msg.row_step() / 2) + i * (_msg.point_step() / 2);
-      std::memcpy(&normalForcesBuffer.get()[bufferIndex], &normalForce.X(), sizeof(float));
-        static_cast<char>(normalForce.X());
-      normalForcesBuffer.get()[bufferIndex + sizeof(float)] =
-        static_cast<char>(normalForce.Y());
-      normalForcesBuffer.get()[bufferIndex + 2 * sizeof(float)] =
-        static_cast<char>(normalForce.Z());
+      std::memcpy(&normalForcesBuffer.get()[bufferIndex],
+                 &normalForce.X(), sizeof(float));
+      std::memcpy(&normalForcesBuffer.get()[bufferIndex] + sizeof(float),
+                 &normalForce.Y(), sizeof(float));
+      std::memcpy(&normalForcesBuffer.get()[bufferIndex] + 2 * sizeof(float),
+                 &normalForce.Z(), sizeof(float));
 
       if (!_visualizeForces)
         continue;

--- a/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
+++ b/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
@@ -767,8 +767,7 @@ void OpticalTactilePluginPrivate::ComputeNormalForces(
   normalsMsg.set_step(3 * sizeof(float) * _msg.width());
   normalsMsg.set_pixel_format_type(ignition::msgs::PixelFormatType::R_FLOAT32);
 
-  uint32_t bufferSize = 3 * sizeof(float) * _msg.width() * _msg.height();
-  std::shared_ptr<char> normalForcesBuffer(new char[bufferSize]);
+  std::vector<float> normalForcesBuffer(3 * _msg.width() * _msg.height());
   uint32_t bufferIndex;
 
   // Marker messages representing the normal forces
@@ -804,13 +803,11 @@ void OpticalTactilePluginPrivate::ComputeNormalForces(
       // Add force to buffer
       // Forces buffer is composed of XYZ coordinates, while _msg buffer is
       // made up of XYZRGB values
-      bufferIndex = j * (_msg.row_step() / 2) + i * (_msg.point_step() / 2);
-      std::memcpy(&normalForcesBuffer.get()[bufferIndex],
-                 &normalForce.X(), sizeof(float));
-      std::memcpy(&normalForcesBuffer.get()[bufferIndex + sizeof(float)],
-                 &normalForce.Y(), sizeof(float));
-      std::memcpy(&normalForcesBuffer.get()[bufferIndex + 2 * sizeof(float)],
-                 &normalForce.Z(), sizeof(float));
+
+      bufferIndex = j * (_msg.width() * 3) + i * 3;
+      normalForcesBuffer[bufferIndex] = normalForce.X();
+      normalForcesBuffer[bufferIndex+1] = normalForce.Y();
+      normalForcesBuffer[bufferIndex+2] = normalForce.Z();
 
       if (!_visualizeForces)
         continue;
@@ -822,9 +819,12 @@ void OpticalTactilePluginPrivate::ComputeNormalForces(
     }
   }
 
+  std::string *dataStr = normalsMsg.mutable_data();
+  dataStr->resize(sizeof(float) * normalForcesBuffer.size());
+  memcpy(&((*dataStr)[0]), normalForcesBuffer.data(), dataStr->size());
+
   // Publish message
-  normalsMsg.set_data(normalForcesBuffer.get(),
-    3 * sizeof(float) * _msg.width() * _msg.height());
+
   this->normalForcesPub.Publish(normalsMsg);
 
   if (_visualizeForces)

--- a/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
+++ b/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
@@ -805,8 +805,10 @@ void OpticalTactilePluginPrivate::ComputeNormalForces(
       // Forces buffer is composed of XYZ coordinates, while _msg buffer is
       // made up of XYZRGB values
       bufferIndex = j * (_msg.row_step() / 2) + i * (_msg.point_step() / 2);
-      normalForcesBuffer.get()[bufferIndex] = static_cast<char>(normalForce.X());
-      normalForcesBuffer.get()[bufferIndex + sizeof(float)] = static_cast<char>(normalForce.Y());
+      normalForcesBuffer.get()[bufferIndex] = 
+	static_cast<char>(normalForce.X());
+      normalForcesBuffer.get()[bufferIndex + sizeof(float)] = 
+	static_cast<char>(normalForce.Y());
       normalForcesBuffer.get()[bufferIndex + 2 * sizeof(float)] =
         static_cast<char>(normalForce.Z());
 

--- a/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
+++ b/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
@@ -805,7 +805,7 @@ void OpticalTactilePluginPrivate::ComputeNormalForces(
       // Forces buffer is composed of XYZ coordinates, while _msg buffer is
       // made up of XYZRGB values
       bufferIndex = j * (_msg.row_step() / 2) + i * (_msg.point_step() / 2);
-      normalForcesBuffer.get()[bufferIndex] =
+      std::memcpy(&normalForcesBuffer.get()[bufferIndex], &normalForce.X(), sizeof(float));
         static_cast<char>(normalForce.X());
       normalForcesBuffer.get()[bufferIndex + sizeof(float)] =
         static_cast<char>(normalForce.Y());

--- a/test/integration/optical_tactile_plugin.cc
+++ b/test/integration/optical_tactile_plugin.cc
@@ -67,14 +67,14 @@ class OpticalTactilePluginTest : public InternalFixture<::testing::Test>
     uint32_t msgBufferIndex =
       _j * this->normalForces.step() + _i * 3 * sizeof(float);
 
-    measuredPoint.X() = static_cast<float>(
-      msgBuffer[msgBufferIndex]);
+    measuredPoint.X() = *reinterpret_cast<float*>(
+      &msgBuffer[msgBufferIndex]);
 
-    measuredPoint.Y() = static_cast<float>(
-      msgBuffer[msgBufferIndex + sizeof(float)]);
+    measuredPoint.Y() = *reinterpret_cast<float*>(
+      &msgBuffer[msgBufferIndex + sizeof(float)]);
 
-    measuredPoint.Z() = static_cast<float>(
-      msgBuffer[msgBufferIndex + 2*sizeof(float)]);
+    measuredPoint.Z() = *reinterpret_cast<float*>(
+      &msgBuffer[msgBufferIndex + 2*sizeof(float)]);
 
     return measuredPoint;
   }

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -952,10 +952,10 @@ TEST_P(SceneBroadcasterTest,
   EXPECT_TRUE(result);
 
   ASSERT_TRUE(res.has_ambient());
-  EXPECT_EQ(math::Color(1.0, 1.0, 1.0, 1.0), msgs::Convert(res.ambient()));
+  EXPECT_EQ(math::Color(1.0f, 1.0f, 1.0f, 1.0f), msgs::Convert(res.ambient()));
 
   ASSERT_TRUE(res.has_background());
-  EXPECT_EQ(math::Color(0.8, 0.8, 0.8, 1.0), msgs::Convert(res.background()));
+  EXPECT_EQ(math::Color(0.8f, 0.8f, 0.8f, 1.0f), msgs::Convert(res.background()));
 
   EXPECT_TRUE(res.shadows());
   EXPECT_FALSE(res.grid());

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -952,10 +952,12 @@ TEST_P(SceneBroadcasterTest,
   EXPECT_TRUE(result);
 
   ASSERT_TRUE(res.has_ambient());
-  EXPECT_EQ(math::Color(1.0f, 1.0f, 1.0f, 1.0f), msgs::Convert(res.ambient()));
+  EXPECT_EQ(math::Color(1.0f, 1.0f, 1.0f, 1.0f),
+      msgs::Convert(res.ambient()));
 
   ASSERT_TRUE(res.has_background());
-  EXPECT_EQ(math::Color(0.8f, 0.8f, 0.8f, 1.0f), msgs::Convert(res.background()));
+  EXPECT_EQ(math::Color(0.8f, 0.8f, 0.8f, 1.0f),
+      msgs::Convert(res.background()));
 
   EXPECT_TRUE(res.shadows());
   EXPECT_FALSE(res.grid());


### PR DESCRIPTION
# 🦟 Bug fix

Fixes part of #1870 

## Summary
This PR fixes some warnings (C4244 and C4305) happening in ign-gazebo6 windows 
Reference build: https://build.osrfoundation.org/job/ign_gazebo-ign-6-win/166/

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.