### PR TITLE
cmdsim.rb: fix ruby syntax

### DIFF
--- a/src/cmd/cmdsim.rb.in
+++ b/src/cmd/cmdsim.rb.in
@@ -413,7 +413,7 @@ has properly set the DYLD_LIBRARY_PATH environment variables."
       parsed = ''
       if options['file'] != ''
         # Check if the passed in file exists.
-        if File.exists?(options['file'])
+        if File.exist?(options['file'])
           path = options['file']
         # If not, then first check the GZ_SIM_RESOURCE_PATH environment
         # variable, then the configuration path from the launch library.
@@ -434,7 +434,7 @@ Please use [GZ_SIM_RESOURCE_PATH] instead."
             resourcePaths = resourcePathEnv.split(':')
             for resourcePath in resourcePaths
               filePath = File.join(resourcePath, options['file'])
-              if File.exists?(filePath)
+              if File.exist?(filePath)
                 path = filePath
                 break
               end
@@ -444,7 +444,7 @@ Please use [GZ_SIM_RESOURCE_PATH] instead."
           if path.nil?
             Importer.extern 'char *worldInstallDir()'
             path = File.join(Importer.worldInstallDir().to_s, options['file'])
-            if !File.exists?(path)
+            if !File.exist?(path)
               path = Importer.findFuelResource(options['file']).to_s
               options['file'] = path
               if path == ""
@@ -556,10 +556,6 @@ See https://github.com/gazebosim/gz-sim/issues/168 for more info."
         Importer.runGui(options['gui_config'], options['file'],
             options['wait_gui'], options['render_engine_gui'])
       end
-    rescue
-      puts "Library error: Problem running [#{options['command']}]() "\
-        "from #{plugin}."
-    # begin
     end
   # execute
   end


### PR DESCRIPTION
# 🦟 Bug fix

Part of #1867.

## Summary

This replaces the deprecated/removed `File.exists?` calls with `File.exist?` to fix the `UNIT_gz_TEST` on macOS (which uses a very new version of ruby). It also removes a `rescue` statement that was hiding useful error messages.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
