### PR TITLE
Document behaviour changes introduced #1784

### DIFF
--- a/examples/worlds/auv_controls.sdf
+++ b/examples/worlds/auv_controls.sdf
@@ -147,17 +147,17 @@
         <kDotP>0</kDotP>
         <mDotQ>-33.46</mDotQ>
         <nDotR>-33.46</nDotR>
-        <xUU>-6.2282</xUU>
+        <xUabsU>-6.2282</xUabsU>
         <xU>0</xU>
-        <yVV>-601.27</yVV>
+        <yVabsV>-601.27</yVabsV>
         <yV>0</yV>
-        <zWW>-601.27</zWW>
+        <zWabsW>-601.27</zWabsW>
         <zW>0</zW>
-        <kPP>-0.1916</kPP>
+        <kPabsP>-0.1916</kPabsP>
         <kP>0</kP>
-        <mQQ>-632.698957</mQQ>
+        <mQabsQ>-632.698957</mQabsQ>
         <mQ>0</mQ>
-        <nRR>-632.698957</nRR>
+        <nRabsR>-632.698957</nRabsR>
         <nR>0</nR>
       </plugin>
 

--- a/examples/worlds/multi_lrauv_race.sdf
+++ b/examples/worlds/multi_lrauv_race.sdf
@@ -145,17 +145,17 @@
         <kDotP>0</kDotP>
         <mDotQ>-33.46</mDotQ>
         <nDotR>-33.46</nDotR>
-        <xUU>-6.2282</xUU>
+        <yUabsU>-6.2282</yUabsU>
         <xU>0</xU>
-        <yVV>-601.27</yVV>
+        <yVabsV>-601.27</yVabsV>
         <yV>0</yV>
-        <zWW>-601.27</zWW>
+        <zWabsW>-601.27</zWabsW>
         <zW>0</zW>
-        <kPP>-0.1916</kPP>
+        <kPabsP>-0.1916</kPabsP>
         <kP>0</kP>
-        <mQQ>-632.698957</mQQ>
+        <mQabsQ>-632.698957</mQabsQ>
         <mQ>0</mQ>
-        <nRR>-632.698957</nRR>
+        <nRabsR>-632.698957</nRabsR>
         <nR>0</nR>
       </plugin>
 
@@ -239,17 +239,17 @@
         <kDotP>0</kDotP>
         <mDotQ>-33.46</mDotQ>
         <nDotR>-33.46</nDotR>
-        <xUU>-6.2282</xUU>
+        <yUabsU>-6.2282</yUabsU>
         <xU>0</xU>
-        <yVV>-601.27</yVV>
+        <yVabsV>-601.27</yVabsV>
         <yV>0</yV>
-        <zWW>-601.27</zWW>
+        <zWabsW>-601.27</zWabsW>
         <zW>0</zW>
-        <kPP>-0.1916</kPP>
+        <kPabsP>-0.1916</kPabsP>
         <kP>0</kP>
-        <mQQ>-632.698957</mQQ>
+        <mQabsQ>-632.698957</mQabsQ>
         <mQ>0</mQ>
-        <nRR>-632.698957</nRR>
+        <nRabsR>-632.698957</nRabsR>
         <nR>0</nR>
       </plugin>
 
@@ -333,17 +333,17 @@
         <kDotP>0</kDotP>
         <mDotQ>-33.46</mDotQ>
         <nDotR>-33.46</nDotR>
-        <xUU>-6.2282</xUU>
+        <yUabsU>-6.2282</yUabsU>
         <xU>0</xU>
-        <yVV>-601.27</yVV>
+        <yVabsV>-601.27</yVabsV>
         <yV>0</yV>
-        <zWW>-601.27</zWW>
+        <zWabsW>-601.27</zWabsW>
         <zW>0</zW>
-        <kPP>-0.1916</kPP>
+        <kPabsP>-0.1916</kPabsP>
         <kP>0</kP>
-        <mQQ>-632.698957</mQQ>
+        <mQabsQ>-632.698957</mQabsQ>
         <mQ>0</mQ>
-        <nRR>-632.698957</nRR>
+        <nRabsR>-632.698957</nRabsR>
         <nR>0</nR>
       </plugin>
 

--- a/src/systems/hydrodynamics/Hydrodynamics.cc
+++ b/src/systems/hydrodynamics/Hydrodynamics.cc
@@ -195,16 +195,16 @@ void Hydrodynamics::Configure(
         SdfParamDouble(_sdf, prefix, 0);
       for(auto k = 0; k < 6; k++)
       {
-        // TODO(arjo): 
         auto fieldName = prefix + snameConventionVel[k];
         this->dataPtr->stabilityQuadraticDerivative[i*36 + j*6 + k] =
           SdfParamDouble(
             _sdf,
             fieldName,
             0);
+
         if (_sdf->HasElement(fieldName)) {
           warnBehaviourChange = true;
-        } 
+        }
 
         this->dataPtr->stabilityQuadraticAbsDerivative[i*36 + j*6 + k] =
           SdfParamDouble(
@@ -220,9 +220,9 @@ void Hydrodynamics::Configure(
   {
     ignwarn << "You are using parameters that may cause instabilities"
       << "in your simulation. If your simulation crashes we recommend"
-      << "renaming <xUU> -> <xUabsU> and likewise for other information"
+      << "renaming <xUU> -> <xUabsU> and likewise for other axis"
       << "for more information see:"
-      << "\t<INSERT LINK HERE>\n";
+      << "\thttps://github.com/gazebosim/gz-sim/pull/1888\n";
   }
 
   // Added mass according to Fossen's equations (p 37)

--- a/src/systems/hydrodynamics/Hydrodynamics.cc
+++ b/src/systems/hydrodynamics/Hydrodynamics.cc
@@ -183,6 +183,8 @@ void Hydrodynamics::Configure(
   // Use SNAME 1950 convention to load the coeffecients.
   const auto snameConventionVel = "UVWPQR";
   const auto snameConventionMoment = "xyzkmn";
+
+  bool warnBehaviourChange = false;
   for(auto i = 0; i < 6; i++)
   {
     for(auto j = 0; j < 6; j++)
@@ -193,11 +195,17 @@ void Hydrodynamics::Configure(
         SdfParamDouble(_sdf, prefix, 0);
       for(auto k = 0; k < 6; k++)
       {
+        // TODO(arjo): 
+        auto fieldName = prefix + snameConventionVel[k];
         this->dataPtr->stabilityQuadraticDerivative[i*36 + j*6 + k] =
           SdfParamDouble(
             _sdf,
-            prefix + snameConventionVel[k],
+            fieldName,
             0);
+        if (_sdf->HasElement(fieldName)) {
+          warnBehaviourChange = true;
+        } 
+
         this->dataPtr->stabilityQuadraticAbsDerivative[i*36 + j*6 + k] =
           SdfParamDouble(
             _sdf,
@@ -205,6 +213,16 @@ void Hydrodynamics::Configure(
             0);
       }
     }
+  }
+
+
+  if (warnBehaviourChange)
+  {
+    ignwarn << "You are using parameters that may cause instabilities"
+      << "in your simulation. If your simulation crashes we recommend"
+      << "renaming <xUU> -> <xUabsU> and likewise for other information"
+      << "for more information see:"
+      << "\t<INSERT LINK HERE>\n";
   }
 
   // Added mass according to Fossen's equations (p 37)

--- a/src/systems/hydrodynamics/Hydrodynamics.cc
+++ b/src/systems/hydrodynamics/Hydrodynamics.cc
@@ -218,11 +218,11 @@ void Hydrodynamics::Configure(
 
   if (warnBehaviourChange)
   {
-    ignwarn << "You are using parameters that may cause instabilities"
-      << "in your simulation. If your simulation crashes we recommend"
-      << "renaming <xUU> -> <xUabsU> and likewise for other axis"
-      << "for more information see:"
-      << "\thttps://github.com/gazebosim/gz-sim/pull/1888\n";
+    ignwarn << "You are using parameters that may cause instabilities "
+      << "in your simulation. If your simulation crashes we recommend "
+      << "renaming <xUU> -> <xUabsU> and likewise for other axis "
+      << "for more information see:" << std::endl
+      << "\thttps://github.com/gazebosim/gz-sim/pull/1888" << std::endl;
   }
 
   // Added mass according to Fossen's equations (p 37)

--- a/src/systems/hydrodynamics/Hydrodynamics.hh
+++ b/src/systems/hydrodynamics/Hydrodynamics.hh
@@ -72,7 +72,7 @@ namespace systems
   /// and yaw axis respectively.
   ///   * Added Mass: <{x|y|z|k|m|n}Dot{U|V|W|P|Q|R}> e.g. <xDotR>
   ///       Units are either kg or kgm^2 depending on the choice of terms.
-  ///   * Quadratic Damping With abs term (this is probably what you want): 
+  ///   * Quadratic Damping With abs term (this is probably what you want):
   ///       <{x|y|z|k|m|n}{U|V|W|P|Q|R}abs{U|V|W|P|Q|R}>
   ///       e.g. <xRabsQ>
   ///       Units are either kg/m or kg/m^2.

--- a/src/systems/hydrodynamics/Hydrodynamics.hh
+++ b/src/systems/hydrodynamics/Hydrodynamics.hh
@@ -51,17 +51,17 @@ namespace systems
   ///   * <kDotP> - Added mass in roll direction [kgm^2]
   ///   * <mDotQ> - Added mass in pitch direction [kgm^2]
   ///   * <nDotR> - Added mass in yaw direction [kgm^2]
-  ///   * <xUU>   - Quadratic damping, 2nd order, x component [kg/m]
+  ///   * <xUabsU>   - Quadratic damping, 2nd order, x component [kg/m]
   ///   * <xU>    - Linear damping, 1st order, x component [kg]
-  ///   * <yVV>   - Quadratic damping, 2nd order, y component [kg/m]
+  ///   * <yVabsV>   - Quadratic damping, 2nd order, y component [kg/m]
   ///   * <yV>    - Linear damping, 1st order, y component [kg]
-  ///   * <zWW>   - Quadratic damping, 2nd order, z component [kg/m]
+  ///   * <zWabsW>   - Quadratic damping, 2nd order, z component [kg/m]
   ///   * <zW>    - Linear damping, 1st order, z component [kg]
-  ///   * <kPP>   - Quadratic damping, 2nd order, roll component [kg/m^2]
+  ///   * <kPabsP>   - Quadratic damping, 2nd order, roll component [kg/m^2]
   ///   * <kP>    - Linear damping, 1st order, roll component [kg/m]
-  ///   * <mQQ>   - Quadratic damping, 2nd order, pitch component [kg/m^2]
+  ///   * <mQabsQ>   - Quadratic damping, 2nd order, pitch component [kg/m^2]
   ///   * <mQ>    - Linear damping, 1st order, pitch component [kg/m]
-  ///   * <nRR>   - Quadratic damping, 2nd order, yaw component [kg/m^2]
+  ///   * <nRabsR>   - Quadratic damping, 2nd order, yaw component [kg/m^2]
   ///   * <nR>    - Linear damping, 1st order, yaw component [kg/m]
   /// ### Cross terms
   /// In general we support cross terms as well. These are terms which act on
@@ -72,7 +72,12 @@ namespace systems
   /// and yaw axis respectively.
   ///   * Added Mass: <{x|y|z|k|m|n}Dot{U|V|W|P|Q|R}> e.g. <xDotR>
   ///       Units are either kg or kgm^2 depending on the choice of terms.
-  ///   * Quadratic Damping:  <{x|y|z|k|m|n}{U|V|W|P|Q|R}{U|V|W|P|Q|R}>
+  ///   * Quadratic Damping With abs term (this is probably what you want): 
+  ///       <{x|y|z|k|m|n}{U|V|W|P|Q|R}abs{U|V|W|P|Q|R}>
+  ///       e.g. <xRabsQ>
+  ///       Units are either kg/m or kg/m^2.
+  ///   * Quadratic Damping (could lead to unwanted oscillations):
+  ///       <{x|y|z|k|m|n}{U|V|W|P|Q|R}{U|V|W|P|Q|R}>
   ///       e.g. <xRQ>
   ///       Units are either kg/m or kg/m^2.
   ///   * Linear Damping: <{x|y|z|k|m|n}{U|V|W|P|Q|R}>. e.g. <xR>

--- a/test/worlds/hydrodynamics.sdf
+++ b/test/worlds/hydrodynamics.sdf
@@ -104,17 +104,17 @@
         <kDotP>0</kDotP>
         <mDotQ>0</mDotQ>
         <nDotR>0</nDotR>
-        <xUU>0</xUU>
+        <xUabsU>0</xUabsU>
         <xU>0</xU>
-        <yVV>0</yVV>
+        <yVabsV>0</yVabsV>
         <yV>0</yV>
-        <zWW>11.5359</zWW>
+        <zWabsW>11.5359</zWabsW>
         <zW>0.211869</zW>
-        <kPP>0</kPP>
+        <kPabsP>0</kPabsP>
         <kP>0</kP>
-        <mQQ>0</mQQ>
+        <mQabsQ>0</mQabsQ>
         <mQ>0</mQ>
-        <nRR>0</nRR>
+        <nRabsR>0</nRabsR>
         <nR>0</nR>
       </plugin>
     </model>
@@ -163,17 +163,17 @@
         <kDotP>0</kDotP>
         <mDotQ>0</mDotQ>
         <nDotR>0</nDotR>
-        <xUU>0</xUU>
+        <xUabsU>0</xUabsU>
         <xU>0</xU>
-        <yVV>0</yVV>
+        <yVabsV>0</yVabsV>
         <yV>0</yV>
-        <zWW>94.2475</zWW>
+        <zWabsW>94.2475</zWabsW>
         <zW>0.0037699</zW>
-        <kPP>0</kPP>
+        <kPabsP>0</kPabsP>
         <kP>0</kP>
-        <mQQ>0</mQQ>
+        <mQabsQ>0</mQabsQ>
         <mQ>0</mQ>
-        <nRR>0</nRR>
+        <nRabsR>0</nRabsR>
         <nR>0</nR>
       </plugin>
     </model>
@@ -222,17 +222,17 @@
         <kDotP>0</kDotP>
         <mDotQ>0</mDotQ>
         <nDotR>0</nDotR>
-        <xUU>0</xUU>
+        <xUabsU>0</xUabsU>
         <xU>0</xU>
-        <yVV>0</yVV>
+        <yVabsV>0</yVabsV>
         <yV>0</yV>
-        <zWW>94.2475</zWW>
+        <zWabsW>94.2475</zWabsW>
         <zW>0.0037699</zW>
-        <kPP>0</kPP>
+        <kPabsP>0</kPabsP>
         <kP>0</kP>
-        <mQQ>0</mQQ>
+        <mQabsQ>0</mQabsQ>
         <mQ>0</mQ>
-        <nRR>0</nRR>
+        <nRabsR>0</nRabsR>
         <nR>0</nR>
       </plugin>
     </model>
@@ -281,17 +281,17 @@
         <kDotP>0</kDotP>
         <mDotQ>0</mDotQ>
         <nDotR>0</nDotR>
-        <xUU>0</xUU>
+        <xUabsU>0</xUabsU>
         <xU>0</xU>
-        <yVV>0</yVV>
+        <yVabsV>0</yVabsV>
         <yV>0</yV>
-        <zWW>94.2475</zWW>
+        <zWabsW>94.2475</zWabsW>
         <zW>0.0037699</zW>
-        <kPP>0</kPP>
+        <kPabsP>0</kPabsP>
         <kP>0</kP>
-        <mQQ>0</mQQ>
+        <mQabsQ>0</mQabsQ>
         <mQ>0</mQ>
-        <nRR>0</nRR>
+        <nRabsR>0</nRabsR>
         <nR>0</nR>
       </plugin>
     </model>

--- a/test/worlds/hydrodynamics_flags.sdf
+++ b/test/worlds/hydrodynamics_flags.sdf
@@ -107,17 +107,17 @@
         <kDotP>0</kDotP>
         <mDotQ>-33.46</mDotQ>
         <nDotR>-33.46</nDotR>
-        <xUU>-6.2282</xUU>
+        <xUabsU>-6.2282</xUabsU>
         <xU>0</xU>
-        <yVV>-601.27</yVV>
+        <yVabsV>-601.27</yVabsV>
         <yV>0</yV>
-        <zWW>-601.27</zWW>
+        <zWabsW>-601.27</zWabsW>
         <zW>0</zW>
-        <kPP>-0.1916</kPP>
+        <kPabsP>-0.1916</kPabsP>
         <kP>0</kP>
-        <mQQ>-632.698957</mQQ>
+        <mQabsQ>-632.698957</mQabsQ>
         <mQ>0</mQ>
-        <nRR>-632.698957</nRR>
+        <nRabsR>-632.698957</nRabsR>
         <nR>0</nR>
         <disable_added_mass>true</disable_added_mass>
         <disable_coriolis>true</disable_coriolis>
@@ -222,17 +222,17 @@
         <kDotP>0</kDotP>
         <mDotQ>-33.46</mDotQ>
         <nDotR>-33.46</nDotR>
-        <xUU>-6.2282</xUU>
+        <xUabsU>-6.2282</xUabsU>
         <xU>0</xU>
-        <yVV>-601.27</yVV>
+        <yVabsV>-601.27</yVabsV>
         <yV>0</yV>
-        <zWW>-601.27</zWW>
+        <zWabsW>-601.27</zWabsW>
         <zW>0</zW>
-        <kPP>-0.1916</kPP>
+        <kPabsP>-0.1916</kPabsP>
         <kP>0</kP>
-        <mQQ>-632.698957</mQQ>
+        <mQabsQ>-632.698957</mQabsQ>
         <mQ>0</mQ>
-        <nRR>-632.698957</nRR>
+        <nRabsR>-632.698957</nRabsR>
         <nR>0</nR>
         <disable_added_mass>true</disable_added_mass>
       </plugin>
@@ -336,17 +336,17 @@
         <kDotP>0</kDotP>
         <mDotQ>-33.46</mDotQ>
         <nDotR>-33.46</nDotR>
-        <xUU>-6.2282</xUU>
+        <xUabsU>-6.2282</xUabsU>
         <xU>0</xU>
-        <yVV>-601.27</yVV>
+        <yVabsV>-601.27</yVabsV>
         <yV>0</yV>
-        <zWW>-601.27</zWW>
+        <zWabsW>-601.27</zWabsW>
         <zW>0</zW>
-        <kPP>-0.1916</kPP>
+        <kPabsP>-0.1916</kPabsP>
         <kP>0</kP>
-        <mQQ>-632.698957</mQQ>
+        <mQabsQ>-632.698957</mQabsQ>
         <mQ>0</mQ>
-        <nRR>-632.698957</nRR>
+        <nRabsR>-632.698957</nRabsR>
         <nR>0</nR>
         <disable_coriolis>true</disable_coriolis>
       </plugin>

--- a/tutorials/underwater_vehicles.md
+++ b/tutorials/underwater_vehicles.md
@@ -78,17 +78,17 @@ name="ignition::gazebo::systems::Hydrodynamics">
     <kDotP>0</kDotP>
     <mDotQ>-33.46</mDotQ>
     <nDotR>-33.46</nDotR>
-    <xUU>-6.2282</xUU>
+    <xUabsU>-6.2282</xUabsU>
     <xU>0</xU>
-    <yVV>-601.27</yVV>
+    <yVabsV>-601.27</yVabsV>
     <yV>0</yV>
-    <zWW>-601.27</zWW>
+    <zWabsW>-601.27</zWabsW>
     <zW>0</zW>
-    <kPP>-0.1916</kPP>
+    <kPabsP>-0.1916</kPabsP>
     <kP>0</kP>
-    <mQQ>-632.698957</mQQ>
+    <mQabsQ>-632.698957</mQabsQ>
     <mQ>0</mQ>
-    <nRR>-632.698957</nRR>
+    <nRabsR>-632.698957</nRabsR>
     <nR>0</nR>
 </plugin>
 ```


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The PR in #1784 claimed not to introduce behavior changes, but actually ended up introducing behavior changes. Specifically, it would break a lot of marine simulation code that runs on our tools. The issue in question is a matter of naming parameters. In the past `<xUU>` used to refer to the quadratic drag term in the diagonal axis. This term would be multiplied by the absolute velocity. After #1784 this term was multiplied by the velocity (no absolute). An equivalent term of `<xUabsU>` This behavior change likely breaks all previous maritime simulations that rely on our hydrodynamics plugin.

There are several options:
1. Revert #1784
2. Make `<xUU>` mirror `<xUabsU>`
3. Document the change and mark it as breaking.

This PR goes with option 3 as there are already code bases using `<xUabsU>` nota tion instead of `<xUU>`. We also add a warning if someone does use the `<xUU>` term that points to this PR for details.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.