### PR TITLE
Increase timeout for UNIT_Gui_clean_exit_TEST

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -78,5 +78,5 @@ gz_build_tests(TYPE UNIT
 )
 
 if(TARGET UNIT_Gui_clean_exit_TEST)
-  set_test_properties(UNIT_Gui_clean_exit_TEST PROPERTIES TIMEOUT 300)
+  set_tests_properties(UNIT_Gui_clean_exit_TEST PROPERTIES TIMEOUT 300)
 endif()

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -76,3 +76,7 @@ gz_build_tests(TYPE UNIT
     gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
     gz-transport${GZ_TRANSPORT_VER}::gz-transport${GZ_TRANSPORT_VER}
 )
+
+if(TARGET UNIT_Gui_clean_exit_TEST)
+  set_test_properties(UNIT_Gui_clean_exit_TEST PROPERTIES TIMEOUT 300)
+endif()


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #1886

## Summary

This PR increases the default timeout for Gui_clean_exit_TEST (240 -> 300 seconds)

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.