### PR TITLE
Partial backport of #1728

### DIFF
--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -656,6 +656,7 @@ TEST_P(SceneBroadcasterTest,
       // remove a component from an entity
       if (_info.iterations == 2)
       {
+        std::vector<gazebo::Entity> entitiesToRemoveFrom;
         _ecm.Each<ignition::gazebo::components::Model,
                   ignition::gazebo::components::Name,
                   ignition::gazebo::components::Pose>(
@@ -666,10 +667,14 @@ TEST_P(SceneBroadcasterTest,
           {
             if (_name->Data() == "box")
             {
-              _ecm.RemoveComponent<ignition::gazebo::components::Pose>(_entity);
+              entitiesToRemoveFrom.push_back(_entity);
             }
             return true;
           });
+        for (const auto &entity : entitiesToRemoveFrom)
+        {
+          _ecm.RemoveComponent<gazebo::components::Pose>(entity);
+        }
       }
       // add a component to an entity
       else if (_info.iterations == 3)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This could fix the flaky test `ServerRepeat/SceneBroadcasterTest.AddRemoveEntitiesComponents/0`.
A better fix would be to make it possible to remove components within an `Each` call as it is for creating components.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.