### PR TITLE
Add Joint class

### DIFF
--- a/include/ignition/gazebo/Joint.hh
+++ b/include/ignition/gazebo/Joint.hh
@@ -22,19 +22,20 @@
 #include <string>
 #include <vector>
 
-#include <sdf/Joint.hh>
-#include <sdf/JointAxis.hh>
+#include <gz/msgs/wrench.pb.h>
+#include <gz/utils/ImplPtr.hh>
 
 #include <ignition/math/Pose3.hh>
 #include <ignition/math/Vector2.hh>
 #include <ignition/math/Vector3.hh>
 
-#include <ignition/gazebo/config.hh>
-#include <ignition/gazebo/EntityComponentManager.hh>
-#include <ignition/gazebo/Export.hh>
-// #include <ignition/gazebo/Model.hh>
-#include <ignition/gazebo/Types.hh>
-#include <ignition/utils/ImplPtr.hh>
+#include <sdf/Joint.hh>
+#include <sdf/JointAxis.hh>
+
+#include "ignition/gazebo/config.hh"
+#include "ignition/gazebo/EntityComponentManager.hh"
+#include "ignition/gazebo/Export.hh"
+#include "ignition/gazebo/Types.hh"
 
 namespace ignition
 {
@@ -42,8 +43,6 @@ namespace ignition
   {
     // Inline bracket to help doxygen filtering.
     inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
-    // Forward declarations.
-    class IGNITION_GAZEBO_HIDDEN JointPrivate;
     //
     /// \class Joint Joint.hh ignition/gazebo/Joint.hh
     /// \brief This class provides wrappers around entities and components
@@ -69,9 +68,6 @@ namespace ignition
       /// \brief Constructor
       /// \param[in] _entity Joint entity
       public: explicit Joint(gazebo::Entity _entity = kNullEntity);
-
-      /// \brief Destructor
-      public: ~Joint();
 
       /// \brief Get the entity which this Joint is related to.
       /// \return Joint entity.
@@ -124,17 +120,16 @@ namespace ignition
 
       /// \brief Get the joint axis
       /// \param[in] _ecm Entity-component manager.
-      /// \param[in] _index Index of the joint. Supported values are: 0 and 1.
       /// \return Axis of the joint or nullopt if the entity does not
       /// have a components::JointAxis or components::JointAxis2 component.
-      public: std::optional<sdf::JointAxis> JointAxis(
-          const EntityComponentManager &_ecm, unsigned int _index = 0u) const;
+      public: std::optional<std::vector<sdf::JointAxis>> Axis(
+          const EntityComponentManager &_ecm) const;
 
       /// \brief Get the joint type
       /// \param[in] _ecm Entity-component manager.
-      /// \return Axis of the joint or nullopt if the entity does not
+      /// \return Type of the joint or nullopt if the entity does not
       /// have a components::JointType component.
-      public: std::optional<sdf::JointType> JointType(
+      public: std::optional<sdf::JointType> Type(
           const EntityComponentManager &_ecm) const;
 
       /// \brief Get the ID of a sensor entity which is an immediate child of
@@ -159,18 +154,21 @@ namespace ignition
 
       /// \brief Set velocity on this joint. Only applied if no forces are set
       /// \param[in] _ecm Entity Component manager.
-      /// \param[in] _velocities Joint velocities to be applied.
-      /// The vector of velocities should have the same size as the degrees of
-      /// freedom of the joint.
+      /// \param[in] _velocities Joint velocities commands (target velocities).
+      /// This is different from ResetVelocity in that this does not modify the
+      /// internal state of the joint. Instead, the physics engine is expected
+      /// to compute the necessary joint torque for the commanded velocity and
+      /// apply it in the next simulation step. The vector of velocities should
+      /// have the same size as the degrees of freedom of the joint.
       public: void SetVelocity(EntityComponentManager &_ecm,
           const std::vector<double> &_velocities);
 
       /// \brief Set force on this joint. If both forces and velocities are set,
       /// only forces are applied
       /// \param[in] _ecm Entity Component manager.
-      /// \param[in] _forces Joint forces (or torques) to be applied
-      /// The vector of forces should have the same size as the degrees of
-      /// freedom of the joint.
+      /// \param[in] _forces Joint force or torque commands (target forces
+      /// or toruqes). The vector of forces should have the same size as the
+      ///  degrees of freedom of the joint.
       public: void SetForce(EntityComponentManager &_ecm,
           const std::vector<double> &_forces);
 
@@ -180,7 +178,7 @@ namespace ignition
       /// Vector2 specifies the minimum velocity limit, the Y() component stands
       /// for maximum limit. The vector of limits should have the same size as
       /// the degrees of freedom of the joint.
-      public: void SetVelocityLimit(EntityComponentManager &_ecm,
+      public: void SetVelocityLimits(EntityComponentManager &_ecm,
           const std::vector<math::Vector2d> &_limits);
 
       /// \brief Set the effort limits on a joint axis.
@@ -189,7 +187,7 @@ namespace ignition
       /// Vector2 specifies the minimum effort limit, the Y() component stands
       /// for maximum limit. The vector of limits should have the same size as
       /// the degrees of freedom of the joint.
-      public: void SetEffortLimit(EntityComponentManager &_ecm,
+      public: void SetEffortLimits(EntityComponentManager &_ecm,
           const std::vector<math::Vector2d> &_limits);
 
       /// \brief Set the position limits on a joint axis.
@@ -198,11 +196,79 @@ namespace ignition
       /// Vector2 specifies the minimum position limit, the Y() component stands
       /// for maximum limit. The vector of limits should have the same size as
       /// the degrees of freedom of the joint.
-      public: void SetPositionLimit(EntityComponentManager &_ecm,
+      public: void SetPositionLimits(EntityComponentManager &_ecm,
           const std::vector<math::Vector2d> &_limits);
 
+      /// \brief Reset the joint positions
+      /// \param[in] _ecm Entity Component manager.
+      /// \param[in] _positions Joint positions to reset to.
+      /// The vector of positions should have the same size as the degrees of
+      /// freedom of the joint.
+      public: void ResetPosition(EntityComponentManager &_ecm,
+          const std::vector<double> &_positions);
+
+      /// \brief Reset the joint velocities
+      /// \param[in] _ecm Entity Component manager.
+      /// \param[in] _velocities Joint velocities to reset to. This is different
+      /// from SetVelocity as this modifies the internal state of the joint.
+      /// The vector of velocities should have the same size as the degrees of
+      /// freedom of the joint.
+      public: void ResetVelocity(EntityComponentManager &_ecm,
+          const std::vector<double> &_velocities);
+
+      /// \brief By default, Gazebo will not report velocities for a joint, so
+      /// functions like `Velocity` will return nullopt. This
+      /// function can be used to enable joint velocity check.
+      /// \param[in] _ecm Mutable reference to the ECM.
+      /// \param[in] _enable True to enable checks, false to disable. Defaults
+      /// to true.
+      public: void EnableVelocityCheck(EntityComponentManager &_ecm,
+          bool _enable = true) const;
+
+      /// \brief By default, Gazebo will not report positions for a joint, so
+      /// functions like `Position` will return nullopt. This
+      /// function can be used to enable joint position check.
+      /// \param[in] _ecm Mutable reference to the ECM.
+      /// \param[in] _enable True to enable checks, false to disable. Defaults
+      /// to true.
+      public: void EnablePositionCheck(EntityComponentManager &_ecm,
+          bool _enable = true) const;
+
+      /// \brief By default, Gazebo will not report transmitted wrench for a
+      /// joint, so functions like `TransmittedWrench` will return nullopt. This
+      /// function can be used to enable joint transmitted wrench check.
+      /// \param[in] _ecm Mutable reference to the ECM.
+      /// \param[in] _enable True to enable checks, false to disable. Defaults
+      /// to true.
+      public: void EnableTransmittedWrenchCheck(EntityComponentManager &_ecm,
+          bool _enable = true) const;
+
+      /// \brief Get the velocity of the joint
+      /// \param[in] _ecm Entity-component manager.
+      /// \return Velocity of the joint or nullopt if velocity check
+      /// is not enabled.
+      /// \sa EnableVelocityCheck
+      public: std::optional<std::vector<double>> Velocity(
+          const EntityComponentManager &_ecm) const;
+
+      /// \brief Get the position of the joint
+      /// \param[in] _ecm Entity-component manager.
+      /// \return Position of the joint or nullopt if position check
+      /// is not enabled.
+      /// \sa EnablePositionCheck
+      public: std::optional<std::vector<double>> Position(
+          const EntityComponentManager &_ecm) const;
+
+      /// \brief Get the position of the joint
+      /// \param[in] _ecm Entity-component manager.
+      /// \return Transmitted wrench of the joint or nullopt if transmitted
+      /// wrench check is not enabled.
+      /// \sa EnableTransmittedWrenchCheck
+      public: std::optional<std::vector<msgs::Wrench>> TransmittedWrench(
+          const EntityComponentManager &_ecm) const;
+
       /// \brief Private data pointer.
-      IGN_UTILS_UNIQUE_IMPL_PTR(dataPtr)
+      IGN_UTILS_IMPL_PTR(dataPtr)
     };
     }
   }

--- a/include/ignition/gazebo/Joint.hh
+++ b/include/ignition/gazebo/Joint.hh
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef IGNITION_GAZEBO_JOINT_HH_
+#define IGNITION_GAZEBO_JOINT_HH_
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <sdf/Joint.hh>
+#include <sdf/JointAxis.hh>
+
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Vector2.hh>
+#include <ignition/math/Vector3.hh>
+
+#include <ignition/gazebo/config.hh>
+#include <ignition/gazebo/EntityComponentManager.hh>
+#include <ignition/gazebo/Export.hh>
+// #include <ignition/gazebo/Model.hh>
+#include <ignition/gazebo/Types.hh>
+#include <ignition/utils/ImplPtr.hh>
+
+namespace ignition
+{
+  namespace gazebo
+  {
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
+    // Forward declarations.
+    class IGNITION_GAZEBO_HIDDEN JointPrivate;
+    //
+    /// \class Joint Joint.hh ignition/gazebo/Joint.hh
+    /// \brief This class provides wrappers around entities and components
+    /// which are more convenient and straight-forward to use than dealing
+    /// with the `EntityComponentManager` directly.
+    /// All the functions provided here are meant to be used with a joint
+    /// entity.
+    ///
+    /// For example, given a joint's entity, find the value of its
+    /// name component, one could use the entity-component manager (`ecm`)
+    /// directly as follows:
+    ///
+    ///     std::string name = ecm.Component<components::Name>(entity)->Data();
+    ///
+    /// Using this class however, the same information can be obtained with
+    /// a simpler function call:
+    ///
+    ///    Joint joint(entity);
+    ///    std::string name = joint.Name(ecm);
+    ///
+    class IGNITION_GAZEBO_VISIBLE Joint
+    {
+      /// \brief Constructor
+      /// \param[in] _entity Joint entity
+      public: explicit Joint(gazebo::Entity _entity = kNullEntity);
+
+      /// \brief Destructor
+      public: ~Joint();
+
+      /// \brief Get the entity which this Joint is related to.
+      /// \return Joint entity.
+      public: gazebo::Entity Entity() const;
+
+      /// \brief Reset Entity to a new one
+      /// \param[in] _newEntity New joint entity.
+      public: void ResetEntity(gazebo::Entity _newEntity);
+
+      /// \brief Check whether this joint correctly refers to an entity that
+      /// has a components::Joint.
+      /// \param[in] _ecm Entity-component manager.
+      /// \return True if it's a valid joint in the manager.
+      public: bool Valid(const EntityComponentManager &_ecm) const;
+
+      /// \brief Get the joint's unscoped name.
+      /// \param[in] _ecm Entity-component manager.
+      /// \return Joint's name or nullopt if the entity does not have a
+      /// components::Name component
+      public: std::optional<std::string> Name(
+          const EntityComponentManager &_ecm) const;
+
+      /// \brief Get the parent link name
+      /// \param[in] _ecm Entity-component manager.
+      /// \return Parent link name or nullopt if the entity does not have a
+      /// components::ParentLinkName component.
+      public: std::optional<std::string> ParentLinkName(
+          const EntityComponentManager &_ecm) const;
+
+      /// \brief Get the child link name
+      /// \param[in] _ecm Entity-component manager.
+      /// \return Child link name or nullopt if the entity does not have a
+      /// components::ChildLinkName component.
+      public: std::optional<std::string> ChildLinkName(
+          const EntityComponentManager &_ecm) const;
+
+      /// \brief Get the pose of the joint
+      /// \param[in] _ecm Entity-component manager.
+      /// \return Pose of the joint or nullopt if the entity does not
+      /// have a components::Pose component.
+      public: std::optional<math::Pose3d> Pose(
+          const EntityComponentManager &_ecm) const;
+
+      /// \brief Get the thread pitch of the joint
+      /// \param[in] _ecm Entity-component manager.
+      /// \return Thread pitch of the joint or nullopt if the entity does not
+      /// have a components::ThreadPitch component.
+      public: std::optional<double> ThreadPitch(
+          const EntityComponentManager &_ecm) const;
+
+      /// \brief Get the joint axis
+      /// \param[in] _ecm Entity-component manager.
+      /// \param[in] _index Index of the joint. Supported values are: 0 and 1.
+      /// \return Axis of the joint or nullopt if the entity does not
+      /// have a components::JointAxis or components::JointAxis2 component.
+      public: std::optional<sdf::JointAxis> JointAxis(
+          const EntityComponentManager &_ecm, unsigned int _index = 0u) const;
+
+      /// \brief Get the joint type
+      /// \param[in] _ecm Entity-component manager.
+      /// \return Axis of the joint or nullopt if the entity does not
+      /// have a components::JointType component.
+      public: std::optional<sdf::JointType> JointType(
+          const EntityComponentManager &_ecm) const;
+
+      /// \brief Get the ID of a sensor entity which is an immediate child of
+      /// this joint.
+      /// \param[in] _ecm Entity-component manager.
+      /// \param[in] _name Sensor name.
+      /// \return Sensor entity.
+      public: gazebo::Entity SensorByName(const EntityComponentManager &_ecm,
+          const std::string &_name) const;
+
+      /// \brief Get all sensors which are immediate children of this joint.
+      /// \param[in] _ecm Entity-component manager.
+      /// \return All sensors in this joint.
+      public: std::vector<gazebo::Entity> Sensors(
+          const EntityComponentManager &_ecm) const;
+
+      /// \brief Get the number of sensors which are immediate children of this
+      /// joint.
+      /// \param[in] _ecm Entity-component manager.
+      /// \return Number of sensors in this joint.
+      public: uint64_t SensorCount(const EntityComponentManager &_ecm) const;
+
+      /// \brief Set velocity on this joint. Only applied if no forces are set
+      /// \param[in] _ecm Entity Component manager.
+      /// \param[in] _velocities Joint velocities to be applied.
+      /// The vector of velocities should have the same size as the degrees of
+      /// freedom of the joint.
+      public: void SetVelocity(EntityComponentManager &_ecm,
+          const std::vector<double> &_velocities);
+
+      /// \brief Set force on this joint. If both forces and velocities are set,
+      /// only forces are applied
+      /// \param[in] _ecm Entity Component manager.
+      /// \param[in] _forces Joint forces (or torques) to be applied
+      /// The vector of forces should have the same size as the degrees of
+      /// freedom of the joint.
+      public: void SetForce(EntityComponentManager &_ecm,
+          const std::vector<double> &_forces);
+
+      /// \brief Set the velocity limits on a joint axis.
+      /// \param[in] _ecm Entity Component manager.
+      /// \param[in] _limits Joint limits to set to. The X() component of the
+      /// Vector2 specifies the minimum velocity limit, the Y() component stands
+      /// for maximum limit. The vector of limits should have the same size as
+      /// the degrees of freedom of the joint.
+      public: void SetVelocityLimit(EntityComponentManager &_ecm,
+          const std::vector<math::Vector2d> &_limits);
+
+      /// \brief Set the effort limits on a joint axis.
+      /// \param[in] _ecm Entity Component manager.
+      /// \param[in] _limits Joint limits to set to. The X() component of the
+      /// Vector2 specifies the minimum effort limit, the Y() component stands
+      /// for maximum limit. The vector of limits should have the same size as
+      /// the degrees of freedom of the joint.
+      public: void SetEffortLimit(EntityComponentManager &_ecm,
+          const std::vector<math::Vector2d> &_limits);
+
+      /// \brief Set the position limits on a joint axis.
+      /// \param[in] _ecm Entity Component manager.
+      /// \param[in] _limits Joint limits to set to. The X() component of the
+      /// Vector2 specifies the minimum position limit, the Y() component stands
+      /// for maximum limit. The vector of limits should have the same size as
+      /// the degrees of freedom of the joint.
+      public: void SetPositionLimit(EntityComponentManager &_ecm,
+          const std::vector<math::Vector2d> &_limits);
+
+      /// \brief Private data pointer.
+      IGN_UTILS_UNIQUE_IMPL_PTR(dataPtr)
+    };
+    }
+  }
+}
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,6 +48,7 @@ set (sources
   Conversions.cc
   ComponentFactory.cc
   EntityComponentManager.cc
+  Joint.cc
   LevelManager.cc
   Link.cc
   Model.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,6 +80,7 @@ set (gtest_sources
   Conversions_TEST.cc
   EntityComponentManager_TEST.cc
   EventManager_TEST.cc
+  Joint_TEST.cc
   Link_TEST.cc
   Model_TEST.cc
   Primitives_TEST.cc

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -1,0 +1,281 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <ignition/msgs/Utility.hh>
+
+#include "ignition/gazebo/components/ChildLinkName.hh"
+#include "ignition/gazebo/components/Joint.hh"
+#include "ignition/gazebo/components/JointAxis.hh"
+#include "ignition/gazebo/components/JointEffortLimitsCmd.hh"
+#include "ignition/gazebo/components/JointForceCmd.hh"
+#include "ignition/gazebo/components/JointPositionLimitsCmd.hh"
+#include "ignition/gazebo/components/JointType.hh"
+#include "ignition/gazebo/components/JointVelocityCmd.hh"
+#include "ignition/gazebo/components/JointVelocityLimitsCmd.hh"
+#include "ignition/gazebo/components/Name.hh"
+#include "ignition/gazebo/components/ParentEntity.hh"
+#include "ignition/gazebo/components/ParentLinkName.hh"
+#include "ignition/gazebo/components/Pose.hh"
+#include "ignition/gazebo/components/Sensor.hh"
+#include "ignition/gazebo/components/ThreadPitch.hh"
+// #include "ignition/gazebo/Util.hh"
+
+#include "ignition/gazebo/Joint.hh"
+
+class ignition::gazebo::Joint::Implementation
+{
+  /// \brief Id of joint entity.
+  public: gazebo::Entity id{kNullEntity};
+};
+
+using namespace ignition;
+using namespace gazebo;
+
+//////////////////////////////////////////////////
+Joint::Joint(gazebo::Entity _entity)
+  : dataPtr(ignition::utils::MakeUniqueImpl<Implementation>())
+{
+  this->dataPtr->id = _entity;
+}
+
+//////////////////////////////////////////////////
+gazebo::Entity Joint::Entity() const
+{
+  return this->dataPtr->id;
+}
+
+//////////////////////////////////////////////////
+void Joint::ResetEntity(gazebo::Entity _newEntity)
+{
+  this->dataPtr->id = _newEntity;
+}
+
+//////////////////////////////////////////////////
+bool Joint::Valid(const EntityComponentManager &_ecm) const
+{
+  return nullptr != _ecm.Component<components::Joint>(this->dataPtr->id);
+}
+
+//////////////////////////////////////////////////
+std::optional<std::string> Joint::Name(const EntityComponentManager &_ecm) const
+{
+  return _ecm.ComponentData<components::Name>(this->dataPtr->id);
+}
+
+//////////////////////////////////////////////////
+std::optional<std::string> Joint::ParentLinkName(
+    const EntityComponentManager &_ecm) const
+{
+  auto parent = _ecm.Component<components::ParentLinkName>(this->dataPtr->id);
+
+  if (!parent)
+    return std::nullopt;
+
+  return std::optional<std::string>(parent->Data());
+}
+
+//////////////////////////////////////////////////
+std::optional<std::string> Joint::ChildLinkName(
+    const EntityComponentManager &_ecm) const
+{
+  auto child = _ecm.Component<components::ChildLinkName>(this->dataPtr->id);
+
+  if (!child)
+    return std::nullopt;
+
+  return std::optional<std::string>(child->Data());
+}
+
+//////////////////////////////////////////////////
+std::optional<math::Pose3d> Joint::Pose(
+    const EntityComponentManager &_ecm) const
+{
+  auto pose = _ecm.Component<components::Pose>(this->dataPtr->id);
+
+  if (!pose)
+    return std::nullopt;
+
+  return std::optional<math::Pose3d>(pose->Data());
+}
+
+//////////////////////////////////////////////////
+std::optional<double> Joint::ThreadPitch(
+    const EntityComponentManager &_ecm) const
+{
+  auto threadPitch = _ecm.Component<components::ThreadPitch>(this->dataPtr->id);
+
+  if (!threadPitch)
+    return std::nullopt;
+
+  return std::optional<double>(threadPitch->Data());
+}
+
+//////////////////////////////////////////////////
+std::optional<sdf::JointAxis> Joint::JointAxis(
+    const EntityComponentManager &_ecm, unsigned int _index) const
+{
+  if (_index == 0u)
+  {
+    auto axis = _ecm.Component<components::JointAxis>(this->dataPtr->id);
+    if (!axis)
+      return std::nullopt;
+    return std::optional<sdf::JointAxis>(axis->Data());
+  }
+  else if (_index == 1u)
+  {
+    auto axis = _ecm.Component<components::JointAxis2>(this->dataPtr->id);
+    if (!axis)
+      return std::nullopt;
+    return std::optional<sdf::JointAxis>(axis->Data());
+  }
+  else
+  {
+    ignwarn << "Axis index: [" << _index << "] is not supported" << std::endl;
+    return std::nullopt;
+  }
+}
+
+//////////////////////////////////////////////////
+std::optional<sdf::JointType> Joint::JointType(
+    const EntityComponentManager &_ecm) const
+{
+  auto jointType = _ecm.Component<components::JointType>(this->dataPtr->id);
+
+  if (!jointType)
+    return std::nullopt;
+
+  return std::optional<sdf::JointType>(jointType->Data());
+}
+
+//////////////////////////////////////////////////
+Entity Joint::SensorByName(const EntityComponentManager &_ecm,
+    const std::string &_name) const
+{
+  return _ecm.EntityByComponents(
+      components::ParentEntity(this->dataPtr->id),
+      components::Name(_name),
+      components::Sensor());
+}
+
+//////////////////////////////////////////////////
+std::vector<Entity> Joint::Sensors(const EntityComponentManager &_ecm) const
+{
+  return _ecm.EntitiesByComponents(
+      components::ParentEntity(this->dataPtr->id),
+      components::Sensor());
+}
+
+//////////////////////////////////////////////////
+uint64_t Joint::SensorCount(const EntityComponentManager &_ecm) const
+{
+  return this->Sensors(_ecm).size();
+}
+
+//////////////////////////////////////////////////
+void Joint::SetVelocity(EntityComponentManager &_ecm,
+    const std::vector<double> &_velocities)
+{
+  auto jointVelocityCmd =
+    _ecm.Component<components::JointVelocityCmd>(this->dataPtr->id);
+
+  if (!jointVelocityCmd)
+  {
+    _ecm.CreateComponent(
+        this->dataPtr->id,
+        components::JointVelocityCmd(_velocities));
+  }
+  else
+  {
+    jointVelocityCmd->Data() = _velocities;
+  }
+}
+
+//////////////////////////////////////////////////
+void Joint::SetForce(EntityComponentManager &_ecm,
+    const std::vector<double> &_forces)
+{
+  auto jointForceCmd =
+    _ecm.Component<components::JointForceCmd>(this->dataPtr->id);
+
+  if (!jointForceCmd)
+  {
+    _ecm.CreateComponent(
+        this->dataPtr->id,
+        components::JointForceCmd(_forces));
+  }
+  else
+  {
+    jointForceCmd->Data() = _forces;
+  }
+}
+
+//////////////////////////////////////////////////
+void Joint::SetVelocityLimit(EntityComponentManager &_ecm,
+    const std::vector<math::Vector2d> &_limits)
+{
+  auto jointVelocityLimitsCmd =
+    _ecm.Component<components::JointVelocityLimitsCmd>(this->dataPtr->id);
+
+  if (!jointVelocityLimitsCmd)
+  {
+    _ecm.CreateComponent(
+        this->dataPtr->id,
+        components::JointVelocityLimitsCmd(_limits));
+  }
+  else
+  {
+    jointVelocityLimitsCmd->Data() = _limits;
+  }
+}
+
+//////////////////////////////////////////////////
+void Joint::SetEffortLimit(EntityComponentManager &_ecm,
+    const std::vector<math::Vector2d> &_limits)
+{
+  auto jointEffortLimitsCmd =
+    _ecm.Component<components::JointEffortLimitsCmd>(this->dataPtr->id);
+
+  if (!jointEffortLimitsCmd)
+  {
+    _ecm.CreateComponent(
+        this->dataPtr->id,
+        components::JointEffortLimitsCmd(_limits));
+  }
+  else
+  {
+    jointEffortLimitsCmd->Data() = _limits;
+  }
+}
+
+//////////////////////////////////////////////////
+void Joint::SetPositionLimit(EntityComponentManager &_ecm,
+    const std::vector<math::Vector2d> &_limits)
+{
+  auto jointPosLimitsCmd =
+    _ecm.Component<components::JointPositionLimitsCmd>(this->dataPtr->id);
+
+  if (!jointPosLimitsCmd)
+  {
+    _ecm.CreateComponent(
+        this->dataPtr->id,
+        components::JointPositionLimitsCmd(_limits));
+  }
+  else
+  {
+    jointPosLimitsCmd->Data() = _limits;
+  }
+}

--- a/src/Joint_TEST.cc
+++ b/src/Joint_TEST.cc
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+
+#include "ignition/gazebo/EntityComponentManager.hh"
+#include "ignition/gazebo/Joint.hh"
+#include "ignition/gazebo/components/Joint.hh"
+#include "ignition/gazebo/components/Name.hh"
+#include "ignition/gazebo/components/ParentEntity.hh"
+#include "ignition/gazebo/components/Sensor.hh"
+
+/////////////////////////////////////////////////
+TEST(JointTest, Constructor)
+{
+  ignition::gazebo::Joint jointNull;
+  EXPECT_EQ(ignition::gazebo::kNullEntity, jointNull.Entity());
+
+  ignition::gazebo::Entity id(3);
+  ignition::gazebo::Joint joint(id);
+
+  EXPECT_EQ(id, joint.Entity());
+}
+
+/////////////////////////////////////////////////
+TEST(JointTest, CopyConstructor)
+{
+  ignition::gazebo::Entity id(3);
+  ignition::gazebo::Joint joint(id);
+
+  // Marked nolint because we are specifically testing copy
+  // constructor here (clang wants unnecessary copies removed)
+  ignition::gazebo::Joint jointCopy(joint); // NOLINT
+  EXPECT_EQ(joint.Entity(), jointCopy.Entity());
+}
+
+/////////////////////////////////////////////////
+TEST(JointTest, CopyAssignmentOperator)
+{
+  ignition::gazebo::Entity id(3);
+  ignition::gazebo::Joint joint(id);
+
+  ignition::gazebo::Joint jointCopy;
+  jointCopy = joint;
+  EXPECT_EQ(joint.Entity(), jointCopy.Entity());
+}
+
+/////////////////////////////////////////////////
+TEST(JointTest, MoveConstructor)
+{
+  ignition::gazebo::Entity id(3);
+  ignition::gazebo::Joint joint(id);
+
+  ignition::gazebo::Joint jointMoved(std::move(joint));
+  EXPECT_EQ(id, jointMoved.Entity());
+}
+
+/////////////////////////////////////////////////
+TEST(JointTest, MoveAssignmentOperator)
+{
+  ignition::gazebo::Entity id(3);
+  ignition::gazebo::Joint joint(id);
+
+  ignition::gazebo::Joint jointMoved;
+  jointMoved = std::move(joint);
+  EXPECT_EQ(id, jointMoved.Entity());
+}
+
+/////////////////////////////////////////////////
+TEST(JointTest, Sensors)
+{
+  // jointA
+  //  - sensorAA
+  //  - sensorAB
+  //
+  // jointC
+
+  ignition::gazebo::EntityComponentManager ecm;
+
+  // Joint A
+  auto jointAEntity = ecm.CreateEntity();
+  ecm.CreateComponent(jointAEntity, ignition::gazebo::components::Joint());
+  ecm.CreateComponent(jointAEntity,
+      ignition::gazebo::components::Name("jointA_name"));
+
+  // Sensor AA - Child of Joint A
+  auto sensorAAEntity = ecm.CreateEntity();
+  ecm.CreateComponent(sensorAAEntity, ignition::gazebo::components::Sensor());
+  ecm.CreateComponent(sensorAAEntity,
+      ignition::gazebo::components::Name("sensorAA_name"));
+  ecm.CreateComponent(sensorAAEntity,
+      ignition::gazebo::components::ParentEntity(jointAEntity));
+
+  // Sensor AB - Child of Joint A
+  auto sensorABEntity = ecm.CreateEntity();
+  ecm.CreateComponent(sensorABEntity, ignition::gazebo::components::Sensor());
+  ecm.CreateComponent(sensorABEntity,
+      ignition::gazebo::components::Name("sensorAB_name"));
+  ecm.CreateComponent(sensorABEntity,
+      ignition::gazebo::components::ParentEntity(jointAEntity));
+
+  // Joint C
+  auto jointCEntity = ecm.CreateEntity();
+  ecm.CreateComponent(jointCEntity, ignition::gazebo::components::Joint());
+  ecm.CreateComponent(jointCEntity,
+      ignition::gazebo::components::Name("jointC_name"));
+
+  std::size_t foundSensors = 0;
+
+  ignition::gazebo::Joint jointA(jointAEntity);
+  auto sensors = jointA.Sensors(ecm);
+  EXPECT_EQ(2u, sensors.size());
+  for (const auto &sensor : sensors)
+  {
+    if (sensor == sensorAAEntity || sensor == sensorABEntity)
+      foundSensors++;
+  }
+  EXPECT_EQ(foundSensors, sensors.size());
+
+  ignition::gazebo::Joint jointC(jointCEntity);
+  EXPECT_EQ(0u, jointC.Sensors(ecm).size());
+}

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -27,6 +27,7 @@ set(tests
   hydrodynamics.cc
   hydrodynamics_flags.cc
   imu_system.cc
+  joint.cc
   joint_controller_system.cc
   joint_position_controller_system.cc
   joint_state_publisher_system.cc

--- a/test/integration/joint.cc
+++ b/test/integration/joint.cc
@@ -42,7 +42,6 @@
 #include <ignition/gazebo/components/ParentLinkName.hh>
 #include <ignition/gazebo/components/Pose.hh>
 #include <ignition/gazebo/components/Sensor.hh>
-#include <ignition/gazebo/components/SourceFilePath.hh>
 #include <ignition/gazebo/components/ThreadPitch.hh>
 
 #include "../helpers/EnvTestFixture.hh"

--- a/test/integration/joint.cc
+++ b/test/integration/joint.cc
@@ -122,7 +122,6 @@ TEST_F(JointIntegrationTest, JointNames)
   ecm.CreateComponent<components::ChildLinkName>(id,
     components::ChildLinkName("child_joint_name"));
   EXPECT_EQ("child_joint_name", joint.ChildLinkName(ecm));
-
 }
 
 //////////////////////////////////////////////////
@@ -547,8 +546,8 @@ TEST_F(JointIntegrationTest, TransmittedWrench)
   std::vector<msgs::Wrench> wrenchOut = *joint.TransmittedWrench(ecm);
   // todo(anyone) Unlike Velocity and Position functions that return an
   // empty vector if it has not been populated yet, the wrench vector
-  // will contain one empty wrench msg. This is because the TransmittedAPI
-  // workarounds the fact that the TransmittedWrench component contains
+  // will contain one empty wrench msg. This is because the TransmittedWrench
+  // API workarounds the fact that the TransmittedWrench component contains
   // only one wrench reading instead of a wrench vector like positions and
   // velocities.
   // EXPECT_TRUE(wrenchOut.empty());

--- a/test/integration/joint.cc
+++ b/test/integration/joint.cc
@@ -1,0 +1,574 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
+#include <ignition/math/Pose3.hh>
+
+#include <ignition/gazebo/EntityComponentManager.hh>
+#include <ignition/gazebo/Joint.hh>
+#include <ignition/gazebo/components/ChildLinkName.hh>
+#include <ignition/gazebo/components/Joint.hh>
+#include <ignition/gazebo/components/JointAxis.hh>
+#include <ignition/gazebo/components/JointEffortLimitsCmd.hh>
+#include <ignition/gazebo/components/JointForceCmd.hh>
+#include <ignition/gazebo/components/JointPosition.hh>
+#include <ignition/gazebo/components/JointPositionLimitsCmd.hh>
+#include <ignition/gazebo/components/JointPositionReset.hh>
+#include <ignition/gazebo/components/JointTransmittedWrench.hh>
+#include <ignition/gazebo/components/JointType.hh>
+#include <ignition/gazebo/components/JointVelocity.hh>
+#include <ignition/gazebo/components/JointVelocityCmd.hh>
+#include <ignition/gazebo/components/JointVelocityLimitsCmd.hh>
+#include <ignition/gazebo/components/JointVelocityReset.hh>
+#include <ignition/gazebo/components/Name.hh>
+#include <ignition/gazebo/components/ParentEntity.hh>
+#include <ignition/gazebo/components/ParentLinkName.hh>
+#include <ignition/gazebo/components/Pose.hh>
+#include <ignition/gazebo/components/Sensor.hh>
+#include <ignition/gazebo/components/SourceFilePath.hh>
+#include <ignition/gazebo/components/ThreadPitch.hh>
+
+#include "../helpers/EnvTestFixture.hh"
+
+using namespace ignition;
+using namespace gazebo;
+
+class JointIntegrationTest : public InternalFixture<::testing::Test>
+{
+};
+
+//////////////////////////////////////////////////
+TEST_F(JointIntegrationTest, Valid)
+{
+  EntityComponentManager ecm;
+
+  // No ID
+  {
+    Joint joint;
+    EXPECT_FALSE(joint.Valid(ecm));
+  }
+
+  // Missing joint component
+  {
+    auto id = ecm.CreateEntity();
+    Joint joint(id);
+    EXPECT_FALSE(joint.Valid(ecm));
+  }
+
+  // Valid
+  {
+    auto id = ecm.CreateEntity();
+    ecm.CreateComponent<components::Joint>(id, components::Joint());
+
+    Joint joint(id);
+    EXPECT_TRUE(joint.Valid(ecm));
+  }
+}
+
+//////////////////////////////////////////////////
+TEST_F(JointIntegrationTest, Name)
+{
+  EntityComponentManager ecm;
+
+  auto id = ecm.CreateEntity();
+  ecm.CreateComponent<components::Joint>(id, components::Joint());
+
+  Joint joint(id);
+
+  // No name
+  EXPECT_EQ(std::nullopt, joint.Name(ecm));
+
+  // Add name
+  ecm.CreateComponent<components::Name>(id, components::Name("joint_name"));
+  EXPECT_EQ("joint_name", joint.Name(ecm));
+}
+
+//////////////////////////////////////////////////
+TEST_F(JointIntegrationTest, JointNames)
+{
+  EntityComponentManager ecm;
+
+  auto id = ecm.CreateEntity();
+  ecm.CreateComponent<components::Joint>(id, components::Joint());
+
+  Joint joint(id);
+
+  // No parent or child joint names
+  EXPECT_EQ(std::nullopt, joint.ParentLinkName(ecm));
+  EXPECT_EQ(std::nullopt, joint.ChildLinkName(ecm));
+
+  // Add parent joint name
+  ecm.CreateComponent<components::ParentLinkName>(id,
+    components::ParentLinkName("parent_joint_name"));
+  EXPECT_EQ("parent_joint_name", joint.ParentLinkName(ecm));
+
+  // Add child joint name
+  ecm.CreateComponent<components::ChildLinkName>(id,
+    components::ChildLinkName("child_joint_name"));
+  EXPECT_EQ("child_joint_name", joint.ChildLinkName(ecm));
+
+}
+
+//////////////////////////////////////////////////
+TEST_F(JointIntegrationTest, Pose)
+{
+  EntityComponentManager ecm;
+
+  auto id = ecm.CreateEntity();
+  ecm.CreateComponent<components::Joint>(id, components::Joint());
+
+  Joint joint(id);
+
+  // No pose
+  EXPECT_EQ(std::nullopt, joint.Pose(ecm));
+
+  // Add pose
+  math::Pose3d pose(1, 2, 3, 0.1, 0.2, 0.3);
+  ecm.CreateComponent<components::Pose>(id,
+      components::Pose(pose));
+  EXPECT_EQ(pose, joint.Pose(ecm));
+}
+
+//////////////////////////////////////////////////
+TEST_F(JointIntegrationTest, Type)
+{
+  EntityComponentManager ecm;
+
+  auto id = ecm.CreateEntity();
+  ecm.CreateComponent<components::Joint>(id, components::Joint());
+
+  Joint joint(id);
+
+  // No joint type
+  EXPECT_EQ(std::nullopt, joint.Type(ecm));
+
+  // Add type
+  sdf::JointType jointType = sdf::JointType::PRISMATIC;
+  ecm.CreateComponent<components::JointType>(id,
+      components::JointType(jointType));
+  EXPECT_EQ(jointType, joint.Type(ecm));
+}
+
+//////////////////////////////////////////////////
+TEST_F(JointIntegrationTest, Axis)
+{
+  EntityComponentManager ecm;
+
+  auto id = ecm.CreateEntity();
+  ecm.CreateComponent<components::Joint>(id, components::Joint());
+
+  Joint joint(id);
+
+  // No joint axis
+  EXPECT_EQ(std::nullopt, joint.Axis(ecm));
+
+  // Add axis
+  sdf::JointAxis jointAxis;
+  auto errors = jointAxis.SetXyz(math::Vector3d(0, 1, 1));
+  EXPECT_TRUE(errors.empty());
+  ecm.CreateComponent<components::JointAxis>(id,
+      components::JointAxis(jointAxis));
+  EXPECT_EQ(jointAxis.Xyz(), (*joint.Axis(ecm))[0].Xyz());
+}
+
+//////////////////////////////////////////////////
+TEST_F(JointIntegrationTest, ThreadPitch)
+{
+  EntityComponentManager ecm;
+
+  auto id = ecm.CreateEntity();
+  ecm.CreateComponent<components::Joint>(id, components::Joint());
+
+  Joint joint(id);
+
+  // No name
+  EXPECT_EQ(std::nullopt, joint.ThreadPitch(ecm));
+
+  // Add name
+  ecm.CreateComponent<components::ThreadPitch>(id,
+      components::ThreadPitch(1.23));
+  EXPECT_DOUBLE_EQ(1.23, *joint.ThreadPitch(ecm));
+}
+
+//////////////////////////////////////////////////
+TEST_F(JointIntegrationTest, SensorByName)
+{
+  EntityComponentManager ecm;
+
+  // Joint
+  auto eJoint = ecm.CreateEntity();
+  Joint joint(eJoint);
+  EXPECT_EQ(eJoint, joint.Entity());
+  EXPECT_EQ(0u, joint.SensorCount(ecm));
+
+  // Sensor
+  auto eSensor = ecm.CreateEntity();
+  ecm.CreateComponent<components::Sensor>(eSensor, components::Sensor());
+  ecm.CreateComponent<components::ParentEntity>(eSensor,
+      components::ParentEntity(eJoint));
+  ecm.CreateComponent<components::Name>(eSensor,
+      components::Name("sensor_name"));
+
+  // Check joint
+  EXPECT_EQ(eSensor, joint.SensorByName(ecm, "sensor_name"));
+  EXPECT_EQ(1u, joint.SensorCount(ecm));
+}
+
+//////////////////////////////////////////////////
+TEST_F(JointIntegrationTest, SetVelocity)
+{
+  EntityComponentManager ecm;
+
+  auto eJoint = ecm.CreateEntity();
+  ecm.CreateComponent(eJoint, components::Joint());
+
+  Joint joint(eJoint);
+  EXPECT_EQ(eJoint, joint.Entity());
+
+  ASSERT_TRUE(joint.Valid(ecm));
+
+  // No JointVelocityCmd should exist by default
+  EXPECT_EQ(nullptr, ecm.Component<components::JointVelocityCmd>(eJoint));
+
+  std::vector<double> velCmd{1};
+  joint.SetVelocity(ecm, velCmd);
+
+  // velocity cmd should exist
+  EXPECT_NE(nullptr, ecm.Component<components::JointVelocityCmd>(eJoint));
+  EXPECT_EQ(velCmd,
+    ecm.Component<components::JointVelocityCmd>(eJoint)->Data());
+
+  // Make sure the velocity cmd is updated
+  std::vector<double> velCmd2{0};
+  joint.SetVelocity(ecm, velCmd2);
+  EXPECT_EQ(velCmd2,
+    ecm.Component<components::JointVelocityCmd>(eJoint)->Data());
+}
+
+//////////////////////////////////////////////////
+TEST_F(JointIntegrationTest, SetForce)
+{
+  EntityComponentManager ecm;
+
+  auto eJoint = ecm.CreateEntity();
+  ecm.CreateComponent(eJoint, components::Joint());
+
+  Joint joint(eJoint);
+  EXPECT_EQ(eJoint, joint.Entity());
+
+  ASSERT_TRUE(joint.Valid(ecm));
+
+  // No JointForceCmd should exist by default
+  EXPECT_EQ(nullptr, ecm.Component<components::JointForceCmd>(eJoint));
+
+  std::vector<double> forceCmd{10};
+  joint.SetForce(ecm, forceCmd);
+
+  // velocity cmd should exist
+  EXPECT_NE(nullptr, ecm.Component<components::JointForceCmd>(eJoint));
+  EXPECT_EQ(forceCmd,
+    ecm.Component<components::JointForceCmd>(eJoint)->Data());
+
+  // Make sure the force cmd is updated
+  std::vector<double> forceCmd2{1};
+  joint.SetForce(ecm, forceCmd2);
+  EXPECT_EQ(forceCmd2,
+    ecm.Component<components::JointForceCmd>(eJoint)->Data());
+}
+
+//////////////////////////////////////////////////
+TEST_F(JointIntegrationTest, SetVelocityLimits)
+{
+  EntityComponentManager ecm;
+
+  auto eJoint = ecm.CreateEntity();
+  ecm.CreateComponent(eJoint, components::Joint());
+
+  Joint joint(eJoint);
+  EXPECT_EQ(eJoint, joint.Entity());
+
+  ASSERT_TRUE(joint.Valid(ecm));
+
+  // No JointVelocityLimitsCmd should exist by default
+  EXPECT_EQ(nullptr, ecm.Component<components::JointVelocityLimitsCmd>(eJoint));
+
+  std::vector<math::Vector2d> velLimitsCmd{math::Vector2d(0.1, 1.1)};
+  joint.SetVelocityLimits(ecm, velLimitsCmd);
+
+  // velocity limits cmd should exist
+  EXPECT_NE(nullptr, ecm.Component<components::JointVelocityLimitsCmd>(eJoint));
+  EXPECT_EQ(velLimitsCmd,
+    ecm.Component<components::JointVelocityLimitsCmd>(eJoint)->Data());
+
+  // Make sure the velocity limits cmd is updated
+  std::vector<math::Vector2d> velLimitsCmd2{math::Vector2d(-0.2, 2.4)};
+  joint.SetVelocityLimits(ecm, velLimitsCmd2);
+  EXPECT_EQ(velLimitsCmd2,
+    ecm.Component<components::JointVelocityLimitsCmd>(eJoint)->Data());
+}
+
+//////////////////////////////////////////////////
+TEST_F(JointIntegrationTest, SetEffortLimits)
+{
+  EntityComponentManager ecm;
+
+  auto eJoint = ecm.CreateEntity();
+  ecm.CreateComponent(eJoint, components::Joint());
+
+  Joint joint(eJoint);
+  EXPECT_EQ(eJoint, joint.Entity());
+
+  ASSERT_TRUE(joint.Valid(ecm));
+
+  // No JointEffortLimitsCmd should exist by default
+  EXPECT_EQ(nullptr, ecm.Component<components::JointEffortLimitsCmd>(eJoint));
+
+  std::vector<math::Vector2d> effortLimitsCmd{math::Vector2d(9, 9.9)};
+  joint.SetEffortLimits(ecm, effortLimitsCmd);
+
+  // effort limits cmd should exist
+  EXPECT_NE(nullptr, ecm.Component<components::JointEffortLimitsCmd>(eJoint));
+  EXPECT_EQ(effortLimitsCmd,
+    ecm.Component<components::JointEffortLimitsCmd>(eJoint)->Data());
+
+  // Make sure the effort limits cmd is updated
+  std::vector<math::Vector2d> effortLimitsCmd2{math::Vector2d(5.2, 5.4)};
+  joint.SetEffortLimits(ecm, effortLimitsCmd2);
+  EXPECT_EQ(effortLimitsCmd2,
+    ecm.Component<components::JointEffortLimitsCmd>(eJoint)->Data());
+}
+
+//////////////////////////////////////////////////
+TEST_F(JointIntegrationTest, SetPositionLimits)
+{
+  EntityComponentManager ecm;
+
+  auto eJoint = ecm.CreateEntity();
+  ecm.CreateComponent(eJoint, components::Joint());
+
+  Joint joint(eJoint);
+  EXPECT_EQ(eJoint, joint.Entity());
+
+  ASSERT_TRUE(joint.Valid(ecm));
+
+  // No JointPositionLimitsCmd should exist by default
+  EXPECT_EQ(nullptr, ecm.Component<components::JointPositionLimitsCmd>(eJoint));
+
+  std::vector<math::Vector2d> positionLimitsCmd{math::Vector2d(-0.1, 0.1)};
+  joint.SetPositionLimits(ecm, positionLimitsCmd);
+
+  // position limits cmd should exist
+  EXPECT_NE(nullptr, ecm.Component<components::JointPositionLimitsCmd>(eJoint));
+  EXPECT_EQ(positionLimitsCmd,
+    ecm.Component<components::JointPositionLimitsCmd>(eJoint)->Data());
+
+  // Make sure the position limits cmd is updated
+  std::vector<math::Vector2d> positionLimitsCmd2{math::Vector2d(-0.2, 0.4)};
+  joint.SetPositionLimits(ecm, positionLimitsCmd2);
+  EXPECT_EQ(positionLimitsCmd2,
+    ecm.Component<components::JointPositionLimitsCmd>(eJoint)->Data());
+}
+
+//////////////////////////////////////////////////
+TEST_F(JointIntegrationTest, ResetVelocity)
+{
+  EntityComponentManager ecm;
+
+  auto eJoint = ecm.CreateEntity();
+  ecm.CreateComponent(eJoint, components::Joint());
+
+  Joint joint(eJoint);
+  EXPECT_EQ(eJoint, joint.Entity());
+
+  ASSERT_TRUE(joint.Valid(ecm));
+
+  // No JointVelocityReset should exist by default
+  EXPECT_EQ(nullptr, ecm.Component<components::JointVelocityReset>(eJoint));
+
+  std::vector<double> vel{1};
+  joint.ResetVelocity(ecm, vel);
+
+  // velocity reset should exist
+  EXPECT_NE(nullptr, ecm.Component<components::JointVelocityReset>(eJoint));
+  EXPECT_EQ(vel,
+    ecm.Component<components::JointVelocityReset>(eJoint)->Data());
+
+  // Make sure the velocity reset is updated
+  std::vector<double> vel2{0};
+  joint.ResetVelocity(ecm, vel2);
+  EXPECT_EQ(vel2,
+    ecm.Component<components::JointVelocityReset>(eJoint)->Data());
+}
+
+//////////////////////////////////////////////////
+TEST_F(JointIntegrationTest, ResetPosition)
+{
+  EntityComponentManager ecm;
+
+  auto eJoint = ecm.CreateEntity();
+  ecm.CreateComponent(eJoint, components::Joint());
+
+  Joint joint(eJoint);
+  EXPECT_EQ(eJoint, joint.Entity());
+
+  ASSERT_TRUE(joint.Valid(ecm));
+
+  // No JointPositionReset should exist by default
+  EXPECT_EQ(nullptr, ecm.Component<components::JointPositionReset>(eJoint));
+
+  std::vector<double> pos{1};
+  joint.ResetPosition(ecm, pos);
+
+  // position reset should exist
+  EXPECT_NE(nullptr, ecm.Component<components::JointPositionReset>(eJoint));
+  EXPECT_EQ(pos,
+    ecm.Component<components::JointPositionReset>(eJoint)->Data());
+
+  // Make sure the position reset is updated
+  std::vector<double> pos2{0};
+  joint.ResetPosition(ecm, pos2);
+  EXPECT_EQ(pos2,
+    ecm.Component<components::JointPositionReset>(eJoint)->Data());
+}
+
+//////////////////////////////////////////////////
+TEST_F(JointIntegrationTest, Velocity)
+{
+  EntityComponentManager ecm;
+
+  auto eJoint = ecm.CreateEntity();
+  ecm.CreateComponent(eJoint, components::Joint());
+
+  Joint joint(eJoint);
+  EXPECT_EQ(eJoint, joint.Entity());
+
+  ASSERT_TRUE(joint.Valid(ecm));
+
+  // Before enabling, velocity should return nullopt
+  EXPECT_EQ(std::nullopt, joint.Velocity(ecm));
+
+  // After enabling, velocity should return default values
+  joint.EnableVelocityCheck(ecm);
+
+  EXPECT_NE(nullptr, ecm.Component<components::JointVelocity>(eJoint));
+
+  std::vector<double> velOut = *joint.Velocity(ecm);
+  EXPECT_TRUE(velOut.empty());
+
+  // With custom velocities
+  std::vector<double> vel{0.3, 0.4};
+  ecm.SetComponentData<components::JointVelocity>(eJoint, vel);
+  velOut = *joint.Velocity(ecm);
+  EXPECT_EQ(2u, velOut.size());
+  EXPECT_DOUBLE_EQ(vel[0], velOut[0]);
+  EXPECT_DOUBLE_EQ(vel[1], velOut[1]);
+
+  // Disabling velocities goes back to nullopt
+  joint.EnableVelocityCheck(ecm, false);
+  EXPECT_EQ(std::nullopt, joint.Velocity(ecm));
+  EXPECT_EQ(nullptr, ecm.Component<components::JointVelocity>(eJoint));
+}
+
+//////////////////////////////////////////////////
+TEST_F(JointIntegrationTest, Position)
+{
+  EntityComponentManager ecm;
+
+  auto eJoint = ecm.CreateEntity();
+  ecm.CreateComponent(eJoint, components::Joint());
+
+  Joint joint(eJoint);
+  EXPECT_EQ(eJoint, joint.Entity());
+
+  ASSERT_TRUE(joint.Valid(ecm));
+
+  // Before enabling, position should return nullopt
+  EXPECT_EQ(std::nullopt, joint.Position(ecm));
+
+  // After enabling, position should return default values
+  joint.EnablePositionCheck(ecm);
+
+  EXPECT_NE(nullptr, ecm.Component<components::JointPosition>(eJoint));
+
+  std::vector<double> posOut = *joint.Position(ecm);
+  EXPECT_TRUE(posOut.empty());
+
+  // With custom positions
+  std::vector<double> pos{-0.3, -0.4};
+  ecm.SetComponentData<components::JointPosition>(eJoint, pos);
+  posOut = *joint.Position(ecm);
+  EXPECT_EQ(2u, posOut.size());
+  EXPECT_DOUBLE_EQ(pos[0], posOut[0]);
+  EXPECT_DOUBLE_EQ(pos[1], posOut[1]);
+
+  // Disabling positions goes back to nullopt
+  joint.EnablePositionCheck(ecm, false);
+  EXPECT_EQ(std::nullopt, joint.Position(ecm));
+  EXPECT_EQ(nullptr, ecm.Component<components::JointPosition>(eJoint));
+}
+
+//////////////////////////////////////////////////
+TEST_F(JointIntegrationTest, TransmittedWrench)
+{
+  EntityComponentManager ecm;
+
+  auto eJoint = ecm.CreateEntity();
+  ecm.CreateComponent(eJoint, components::Joint());
+
+  Joint joint(eJoint);
+  EXPECT_EQ(eJoint, joint.Entity());
+
+  ASSERT_TRUE(joint.Valid(ecm));
+
+  // Before enabling, wrench should return nullopt
+  EXPECT_EQ(std::nullopt, joint.TransmittedWrench(ecm));
+
+  // After enabling, wrench should return default values
+  joint.EnableTransmittedWrenchCheck(ecm);
+
+  EXPECT_NE(nullptr, ecm.Component<components::JointTransmittedWrench>(eJoint));
+
+  std::vector<msgs::Wrench> wrenchOut = *joint.TransmittedWrench(ecm);
+  // todo(anyone) Unlike Velocity and Position functions that return an
+  // empty vector if it has not been populated yet, the wrench vector
+  // will contain one empty wrench msg. This is because the TransmittedAPI
+  // workarounds the fact that the TransmittedWrench component contains
+  // only one wrench reading instead of a wrench vector like positions and
+  // velocities.
+  // EXPECT_TRUE(wrenchOut.empty());
+
+  // With custom wrench
+  msgs::Wrench wrenchMsg;
+  msgs::Set(wrenchMsg.mutable_force(),
+      math::Vector3d(0.2, 3.2, 0.1));
+
+  std::vector<msgs::Wrench> wrench{wrenchMsg};
+  ecm.SetComponentData<components::JointTransmittedWrench>(eJoint, wrench[0]);
+  wrenchOut = *joint.TransmittedWrench(ecm);
+  EXPECT_EQ(1u, wrenchOut.size());
+  EXPECT_DOUBLE_EQ(wrench[0].force().x(), wrenchOut[0].force().x());
+  EXPECT_DOUBLE_EQ(wrench[0].force().y(), wrenchOut[0].force().y());
+  EXPECT_DOUBLE_EQ(wrench[0].force().z(), wrenchOut[0].force().z());
+
+  // Disabling wrench goes back to nullopt
+  joint.EnableTransmittedWrenchCheck(ecm, false);
+  EXPECT_EQ(std::nullopt, joint.TransmittedWrench(ecm));
+  EXPECT_EQ(nullptr, ecm.Component<components::JointTransmittedWrench>(eJoint));
+}


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebosim/gz-sim/issues/325

## Summary

Add Joint APIs that help ease migration from gazebo-classic.

Note that I kept the API names somewhat consistent with classic but there are a few things to note:
* The `Set*` functions now take a vector of doubles as arg (consistent with as the `JointVelocity` component) instead of a scalar value and joint index, e.g.
    * gz-sim: `SetVelocity(const std::vector<double> &_vel)` 
    * classic: `SetVelocity(unsigned int _index, double _vel)`
* The getter and setter function names use singular nouns instead of plural, .e.g. `SetVelocity` instead of `SetVelocities`, also done to be consistent with the naming convention in the joint component, e.g. `JointVelocity` 
* `Enable*Check` must be called before reading velocity/position/wrench data

## Test it

Run the `UNIT_Joint_TEST` and INTEGRATION_joint tests:

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

