### PR TITLE
Add Sensor class

### DIFF
--- a/include/ignition/gazebo/Joint.hh
+++ b/include/ignition/gazebo/Joint.hh
@@ -35,6 +35,7 @@
 #include "ignition/gazebo/config.hh"
 #include "ignition/gazebo/EntityComponentManager.hh"
 #include "ignition/gazebo/Export.hh"
+#include "ignition/gazebo/Model.hh"
 #include "ignition/gazebo/Types.hh"
 
 namespace ignition
@@ -265,6 +266,13 @@ namespace ignition
       /// wrench check is not enabled.
       /// \sa EnableTransmittedWrenchCheck
       public: std::optional<std::vector<msgs::Wrench>> TransmittedWrench(
+          const EntityComponentManager &_ecm) const;
+
+      /// \brief Get the parent model
+      /// \param[in] _ecm Entity-component manager.
+      /// \return Parent Model or nullopt if the entity does not have a
+      /// components::ParentEntity component.
+      public: std::optional<Model> ParentModel(
           const EntityComponentManager &_ecm) const;
 
       /// \brief Private data pointer.

--- a/include/ignition/gazebo/Sensor.hh
+++ b/include/ignition/gazebo/Sensor.hh
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef IGNITION_GAZEBO_SENSOR_HH_
+#define IGNITION_GAZEBO_SENSOR_HH_
+
+#include <memory>
+#include <optional>
+#include <string>
+
+#include <gz/utils/ImplPtr.hh>
+
+#include <ignition/math/Pose3.hh>
+
+#include <sdf/Sensor.hh>
+
+#include "ignition/gazebo/config.hh"
+#include "ignition/gazebo/EntityComponentManager.hh"
+#include "ignition/gazebo/Export.hh"
+#include "ignition/gazebo/Types.hh"
+
+namespace ignition
+{
+  namespace gazebo
+  {
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
+    //
+    /// \class Sensor Sensor.hh ignition/gazebo/Sensor.hh
+    /// \brief This class provides wrappers around entities and components
+    /// which are more convenient and straight-forward to use than dealing
+    /// with the `EntityComponentManager` directly.
+    /// All the functions provided here are meant to be used with a sensor
+    /// entity.
+    ///
+    /// For example, given a sensor's entity, find the value of its
+    /// name component, one could use the entity-component manager (`ecm`)
+    /// directly as follows:
+    ///
+    ///     std::string name = ecm.Component<components::Name>(entity)->Data();
+    ///
+    /// Using this class however, the same information can be obtained with
+    /// a simpler function call:
+    ///
+    ///    Sensor sensor(entity);
+    ///    std::string name = sensor.Name(ecm);
+    ///
+    class IGNITION_GAZEBO_VISIBLE Sensor
+    {
+      /// \brief Constructor
+      /// \param[in] _entity Sensor entity
+      public: explicit Sensor(gazebo::Entity _entity = kNullEntity);
+
+      /// \brief Get the entity which this Sensor is related to.
+      /// \return Sensor entity.
+      public: gazebo::Entity Entity() const;
+
+      /// \brief Reset Entity to a new one
+      /// \param[in] _newEntity New sensor entity.
+      public: void ResetEntity(gazebo::Entity _newEntity);
+
+      /// \brief Check whether this sensor correctly refers to an entity that
+      /// has a components::Sensor.
+      /// \param[in] _ecm Entity-component manager.
+      /// \return True if it's a valid sensor in the manager.
+      public: bool Valid(const EntityComponentManager &_ecm) const;
+
+      /// \brief Get the sensor's unscoped name.
+      /// \param[in] _ecm Entity-component manager.
+      /// \return Sensor's name or nullopt if the entity does not have a
+      /// components::Name component
+      public: std::optional<std::string> Name(
+          const EntityComponentManager &_ecm) const;
+
+      /// \brief Get the pose of the sensor
+      /// \param[in] _ecm Entity-component manager.
+      /// \return Pose of the sensor or nullopt if the entity does not
+      /// have a components::Pose component.
+      public: std::optional<math::Pose3d> Pose(
+          const EntityComponentManager &_ecm) const;
+
+      /// \brief Get the topic of the sensor
+      /// \param[in] _ecm Entity-component manager.
+      /// \return Topic of the sensor or nullopt if the entity does not
+      /// have a components::SensorTopic component.
+      public: std::optional<std::string> Topic(
+          const EntityComponentManager &_ecm) const;
+
+      /// \brief Get the parent entity. This can be a link or a joint.
+      /// \param[in] _ecm Entity-component manager.
+      /// \return Parent entity or nullopt if the entity does not have a
+      /// components::ParentEntity component.
+      public: std::optional<gazebo::Entity> Parent(
+          const EntityComponentManager &_ecm) const;
+
+      /// \brief Private data pointer.
+      IGN_UTILS_IMPL_PTR(dataPtr)
+    };
+    }
+  }
+}
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,7 @@ set (sources
   Primitives.cc
   SdfEntityCreator.cc
   SdfGenerator.cc
+  Sensor.cc
   Server.cc
   ServerConfig.cc
   ServerPrivate.cc
@@ -86,6 +87,7 @@ set (gtest_sources
   Primitives_TEST.cc
   SdfEntityCreator_TEST.cc
   SdfGenerator_TEST.cc
+  Sensor_TEST.cc
   ServerConfig_TEST.cc
   Server_TEST.cc
   SimulationRunner_TEST.cc

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -374,7 +374,8 @@ std::optional<std::vector<msgs::Wrench>> Joint::TransmittedWrench(
 }
 
 //////////////////////////////////////////////////
-std::optional<Model> Joint::ParentModel(const EntityComponentManager &_ecm) const
+std::optional<Model> Joint::ParentModel(const EntityComponentManager &_ecm)
+    const
 {
   auto parent = _ecm.Component<components::ParentEntity>(this->dataPtr->id);
 

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -372,3 +372,14 @@ std::optional<std::vector<msgs::Wrench>> Joint::TransmittedWrench(
   std::vector<msgs::Wrench> wrenchVec{comp->Data()};
   return wrenchVec;
 }
+
+//////////////////////////////////////////////////
+std::optional<Model> Joint::ParentModel(const EntityComponentManager &_ecm) const
+{
+  auto parent = _ecm.Component<components::ParentEntity>(this->dataPtr->id);
+
+  if (!parent)
+    return std::nullopt;
+
+  return std::optional<Model>(parent->Data());
+}

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "ignition/gazebo/components/Sensor.hh"
+#include "ignition/gazebo/components/Name.hh"
+#include "ignition/gazebo/components/ParentEntity.hh"
+#include "ignition/gazebo/components/Pose.hh"
+#include "ignition/gazebo/components/Sensor.hh"
+
+#include "ignition/gazebo/Sensor.hh"
+#include "ignition/gazebo/Util.hh"
+
+using namespace ignition;
+using namespace gazebo;
+
+
+class ignition::gazebo::Sensor::Implementation
+{
+  /// \brief Id of sensor entity.
+  public: gazebo::Entity id{kNullEntity};
+};
+
+//////////////////////////////////////////////////
+Sensor::Sensor(gazebo::Entity _entity)
+  : dataPtr(utils::MakeImpl<Implementation>())
+{
+  this->dataPtr->id = _entity;
+}
+
+//////////////////////////////////////////////////
+gazebo::Entity Sensor::Entity() const
+{
+  return this->dataPtr->id;
+}
+
+//////////////////////////////////////////////////
+void Sensor::ResetEntity(gazebo::Entity _newEntity)
+{
+  this->dataPtr->id = _newEntity;
+}
+
+//////////////////////////////////////////////////
+bool Sensor::Valid(const EntityComponentManager &_ecm) const
+{
+  return nullptr != _ecm.Component<components::Sensor>(this->dataPtr->id);
+}
+
+//////////////////////////////////////////////////
+std::optional<std::string> Sensor::Name(const EntityComponentManager &_ecm) const
+{
+  return _ecm.ComponentData<components::Name>(this->dataPtr->id);
+}
+
+//////////////////////////////////////////////////
+std::optional<math::Pose3d> Sensor::Pose(
+    const EntityComponentManager &_ecm) const
+{
+  auto pose = _ecm.Component<components::Pose>(this->dataPtr->id);
+
+  if (!pose)
+    return std::nullopt;
+
+  return std::optional<math::Pose3d>(pose->Data());
+}
+
+//////////////////////////////////////////////////
+std::optional<std::string> Sensor::Topic(
+    const EntityComponentManager &_ecm) const
+{
+  auto topic = _ecm.Component<components::SensorTopic>(this->dataPtr->id);
+
+  if (!topic)
+    return std::nullopt;
+
+  return std::optional<std::string>(topic->Data());
+}
+
+//////////////////////////////////////////////////
+std::optional<Entity> Sensor::Parent(const EntityComponentManager &_ecm) const
+{
+  auto parent = _ecm.Component<components::ParentEntity>(this->dataPtr->id);
+
+  if (!parent)
+    return std::nullopt;
+
+  return std::optional<gazebo::Entity>(parent->Data());
+}

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -15,7 +15,6 @@
  *
  */
 
-#include "ignition/gazebo/components/Sensor.hh"
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/ParentEntity.hh"
 #include "ignition/gazebo/components/Pose.hh"
@@ -60,7 +59,8 @@ bool Sensor::Valid(const EntityComponentManager &_ecm) const
 }
 
 //////////////////////////////////////////////////
-std::optional<std::string> Sensor::Name(const EntityComponentManager &_ecm) const
+std::optional<std::string> Sensor::Name(const EntityComponentManager &_ecm)
+    const
 {
   return _ecm.ComponentData<components::Name>(this->dataPtr->id);
 }

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+
+#include "ignition/gazebo/EntityComponentManager.hh"
+#include "ignition/gazebo/Sensor.hh"
+#include "ignition/gazebo/components/Sensor.hh"
+#include "ignition/gazebo/components/Name.hh"
+#include "ignition/gazebo/components/ParentEntity.hh"
+#include "ignition/gazebo/components/Sensor.hh"
+
+/////////////////////////////////////////////////
+TEST(SensorTest, Constructor)
+{
+  ignition::gazebo::Sensor sensorNull;
+  EXPECT_EQ(ignition::gazebo::kNullEntity, sensorNull.Entity());
+
+  ignition::gazebo::Entity id(3);
+  ignition::gazebo::Sensor sensor(id);
+
+  EXPECT_EQ(id, sensor.Entity());
+}
+
+/////////////////////////////////////////////////
+TEST(SensorTest, CopyConstructor)
+{
+  ignition::gazebo::Entity id(3);
+  ignition::gazebo::Sensor sensor(id);
+
+  // Marked nolint because we are specifically testing copy
+  // constructor here (clang wants unnecessary copies removed)
+  ignition::gazebo::Sensor sensorCopy(sensor); // NOLINT
+  EXPECT_EQ(sensor.Entity(), sensorCopy.Entity());
+}
+
+/////////////////////////////////////////////////
+TEST(SensorTest, CopyAssignmentOperator)
+{
+  ignition::gazebo::Entity id(3);
+  ignition::gazebo::Sensor sensor(id);
+
+  ignition::gazebo::Sensor sensorCopy;
+  sensorCopy = sensor;
+  EXPECT_EQ(sensor.Entity(), sensorCopy.Entity());
+}
+
+/////////////////////////////////////////////////
+TEST(SensorTest, MoveConstructor)
+{
+  ignition::gazebo::Entity id(3);
+  ignition::gazebo::Sensor sensor(id);
+
+  ignition::gazebo::Sensor sensorMoved(std::move(sensor));
+  EXPECT_EQ(id, sensorMoved.Entity());
+}
+
+/////////////////////////////////////////////////
+TEST(SensorTest, MoveAssignmentOperator)
+{
+  ignition::gazebo::Entity id(3);
+  ignition::gazebo::Sensor sensor(id);
+
+  ignition::gazebo::Sensor sensorMoved;
+  sensorMoved = std::move(sensor);
+  EXPECT_EQ(id, sensorMoved.Entity());
+}
+

--- a/src/Sensor_TEST.cc
+++ b/src/Sensor_TEST.cc
@@ -19,12 +19,11 @@
 
 #include <cstddef>
 
-#include "ignition/gazebo/EntityComponentManager.hh"
-#include "ignition/gazebo/Sensor.hh"
-#include "ignition/gazebo/components/Sensor.hh"
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/ParentEntity.hh"
 #include "ignition/gazebo/components/Sensor.hh"
+#include "ignition/gazebo/EntityComponentManager.hh"
+#include "ignition/gazebo/Sensor.hh"
 
 /////////////////////////////////////////////////
 TEST(SensorTest, Constructor)

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -62,6 +62,7 @@ set(tests
   scene_broadcaster_system.cc
   sdf_frame_semantics.cc
   sdf_include.cc
+  sensor.cc
   spherical_coordinates.cc
   thruster.cc
   touch_plugin.cc

--- a/test/integration/joint.cc
+++ b/test/integration/joint.cc
@@ -37,6 +37,7 @@
 #include <ignition/gazebo/components/JointVelocityCmd.hh>
 #include <ignition/gazebo/components/JointVelocityLimitsCmd.hh>
 #include <ignition/gazebo/components/JointVelocityReset.hh>
+#include <ignition/gazebo/components/Model.hh>
 #include <ignition/gazebo/components/Name.hh>
 #include <ignition/gazebo/components/ParentEntity.hh>
 #include <ignition/gazebo/components/ParentLinkName.hh>
@@ -569,4 +570,32 @@ TEST_F(JointIntegrationTest, TransmittedWrench)
   joint.EnableTransmittedWrenchCheck(ecm, false);
   EXPECT_EQ(std::nullopt, joint.TransmittedWrench(ecm));
   EXPECT_EQ(nullptr, ecm.Component<components::JointTransmittedWrench>(eJoint));
+}
+
+//////////////////////////////////////////////////
+TEST_F(JointIntegrationTest, ParentModel)
+{
+  EntityComponentManager ecm;
+
+  // Model
+  auto eModel = ecm.CreateEntity();
+  ecm.CreateComponent(eModel, components::Model());
+  auto eJoint = ecm.CreateEntity();
+  ecm.CreateComponent(eJoint, components::Joint());
+
+  Joint joint(eJoint);
+  EXPECT_EQ(eJoint, joint.Entity());
+  EXPECT_FALSE(joint.ParentModel(ecm).has_value());
+
+  ecm.CreateComponent<components::ParentEntity>(eJoint,
+      components::ParentEntity(eModel));
+
+  ASSERT_TRUE(joint.Valid(ecm));
+
+  // Check parent model
+  EXPECT_EQ(eModel, ecm.ParentEntity(eJoint));
+  auto parentModel = joint.ParentModel(ecm);
+  ASSERT_TRUE(parentModel.has_value());
+  EXPECT_TRUE(parentModel->Valid(ecm));
+  EXPECT_EQ(eModel, parentModel->Entity());
 }

--- a/test/integration/sensor.cc
+++ b/test/integration/sensor.cc
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
+#include <ignition/math/Pose3.hh>
+
+#include <ignition/gazebo/EntityComponentManager.hh>
+#include <ignition/gazebo/Sensor.hh>
+#include <ignition/gazebo/components/Joint.hh>
+#include <ignition/gazebo/components/Link.hh>
+#include <ignition/gazebo/components/Name.hh>
+#include <ignition/gazebo/components/ParentEntity.hh>
+#include <ignition/gazebo/components/Pose.hh>
+#include <ignition/gazebo/components/Sensor.hh>
+
+#include "../helpers/EnvTestFixture.hh"
+
+using namespace ignition;
+using namespace gazebo;
+
+class SensorIntegrationTest : public InternalFixture<::testing::Test>
+{
+};
+
+//////////////////////////////////////////////////
+TEST_F(SensorIntegrationTest, Valid)
+{
+  EntityComponentManager ecm;
+
+  // No ID
+  {
+    Sensor sensor;
+    EXPECT_FALSE(sensor.Valid(ecm));
+  }
+
+  // Missing sensor component
+  {
+    auto id = ecm.CreateEntity();
+    Sensor sensor(id);
+    EXPECT_FALSE(sensor.Valid(ecm));
+  }
+
+  // Valid
+  {
+    auto id = ecm.CreateEntity();
+    ecm.CreateComponent<components::Sensor>(id, components::Sensor());
+
+    Sensor sensor(id);
+    EXPECT_TRUE(sensor.Valid(ecm));
+  }
+}
+
+//////////////////////////////////////////////////
+TEST_F(SensorIntegrationTest, Name)
+{
+  EntityComponentManager ecm;
+
+  auto id = ecm.CreateEntity();
+  ecm.CreateComponent<components::Sensor>(id, components::Sensor());
+
+  Sensor sensor(id);
+
+  // No name
+  EXPECT_EQ(std::nullopt, sensor.Name(ecm));
+
+  // Add name
+  ecm.CreateComponent<components::Name>(id, components::Name("sensor_name"));
+  EXPECT_EQ("sensor_name", sensor.Name(ecm));
+}
+
+//////////////////////////////////////////////////
+TEST_F(SensorIntegrationTest, Pose)
+{
+  EntityComponentManager ecm;
+
+  auto id = ecm.CreateEntity();
+  ecm.CreateComponent<components::Sensor>(id, components::Sensor());
+
+  Sensor sensor(id);
+
+  // No pose
+  EXPECT_EQ(std::nullopt, sensor.Pose(ecm));
+
+  // Add pose
+  math::Pose3d pose(1, 2, 3, 0.1, 0.2, 0.3);
+  ecm.CreateComponent<components::Pose>(id,
+      components::Pose(pose));
+  EXPECT_EQ(pose, sensor.Pose(ecm));
+}
+
+//////////////////////////////////////////////////
+TEST_F(SensorIntegrationTest, Topic)
+{
+  EntityComponentManager ecm;
+
+  auto eSensor = ecm.CreateEntity();
+  ecm.CreateComponent(eSensor, components::Sensor());
+
+  Sensor sensor(eSensor);
+
+  std::string topic = "sensor_topic";
+  ecm.CreateComponent<components::SensorTopic>(eSensor,
+      components::SensorTopic(topic));
+
+  EXPECT_EQ(topic, sensor.Topic(ecm));
+}
+
+//////////////////////////////////////////////////
+TEST_F(SensorIntegrationTest, Parent)
+{
+  EntityComponentManager ecm;
+
+  {
+    // Link as parent
+    auto eLink = ecm.CreateEntity();
+    ecm.CreateComponent(eLink, components::Link());
+    auto eSensor = ecm.CreateEntity();
+    ecm.CreateComponent(eSensor, components::Sensor());
+
+    Sensor sensor(eSensor);
+    EXPECT_EQ(eSensor, sensor.Entity());
+    EXPECT_FALSE(sensor.Parent(ecm).has_value());
+
+    ecm.CreateComponent<components::ParentEntity>(eSensor,
+        components::ParentEntity(eLink));
+    ASSERT_TRUE(sensor.Valid(ecm));
+
+    // Check parent link
+    EXPECT_EQ(eLink, ecm.ParentEntity(eSensor));
+    auto parentLink = sensor.Parent(ecm);
+    EXPECT_EQ(eLink, parentLink);
+  }
+
+  {
+    // Joint tas parent
+    auto eJoint = ecm.CreateEntity();
+    ecm.CreateComponent(eJoint, components::Joint());
+    auto eSensor = ecm.CreateEntity();
+    ecm.CreateComponent(eSensor, components::Sensor());
+
+    Sensor sensor(eSensor);
+    EXPECT_EQ(eSensor, sensor.Entity());
+    EXPECT_FALSE(sensor.Parent(ecm).has_value());
+
+    ecm.CreateComponent<components::ParentEntity>(eSensor,
+        components::ParentEntity(eJoint));
+    ASSERT_TRUE(sensor.Valid(ecm));
+
+    // Check parent joint
+    EXPECT_EQ(eJoint, ecm.ParentEntity(eSensor));
+    auto parentJoint = sensor.Parent(ecm);
+    EXPECT_EQ(eJoint, parentJoint);
+  }
+}


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebosim/gz-sim/issues/325

## Summary
Add generic Sensor class. Currently there are only a small set of API functions due to limited number of sensor components available.

In order to have APIs for doing things like setting update rate or active state, etc, we'll need to create new components and make use of them in all the relevant systems (e.g. `imu`, `altimeter`, `sensors` system, etc).

I also added one more API (`ParentModel`) to the Joint class that I missed in https://github.com/gazebosim/gz-sim/pull/1910.

## Test it

Run the `UNIT_Sensor_TEST` and `INTEGRATION_sensor` tests.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
