### PR TITLE
gz_TEST: improve initial sim time test reliability

### DIFF
--- a/src/gz_TEST.cc
+++ b/src/gz_TEST.cc
@@ -136,7 +136,7 @@ TEST(CmdLine, SimtimeArgument)
 {
   std::string cmd =
     kGzCommand + " -r -v 4 --iterations 500 --initial-sim-time 1000.5 " +
-    std::string(PROJECT_SOURCE_PATH) + "/test/worlds/plugins.sdf";
+    std::string(PROJECT_SOURCE_PATH) + "/test/worlds/plugins.sdf -z 1000";
 
   std::cout << "Running command [" << cmd << "]" << std::endl;
   int msgCount = 0;

--- a/src/gz_TEST.cc
+++ b/src/gz_TEST.cc
@@ -135,7 +135,7 @@ TEST(CmdLine, GazeboServer)
 TEST(CmdLine, SimtimeArgument)
 {
   std::string cmd =
-    kGzCommand + " -r -v 4 --iterations 100 --initial-sim-time 1000.5 " +
+    kGzCommand + " -r -v 4 --iterations 500 --initial-sim-time 1000.5 " +
     std::string(PROJECT_SOURCE_PATH) + "/test/worlds/plugins.sdf";
 
   std::cout << "Running command [" << cmd << "]" << std::endl;
@@ -144,7 +144,7 @@ TEST(CmdLine, SimtimeArgument)
   gz::transport::Node node;
   auto cb = [&](const gz::msgs::Clock &_msg) -> void
   {
-    EXPECT_GE(_msg.sim().sec() + _msg.sim().nsec()/1000000000.0,
+    EXPECT_GE(_msg.sim().sec() + 1e-9 * _msg.sim().nsec(),
         1000.5);
     msgCount++;
   };
@@ -153,7 +153,22 @@ TEST(CmdLine, SimtimeArgument)
   EXPECT_TRUE(node.Subscribe(std::string("/clock"), cbFcn));
 
   std::string output = customExecStr(cmd);
-  EXPECT_GT(msgCount, 0);
+
+  // Try waiting different amounts if no messages have been received
+  if (!msgCount)
+  {
+    for (auto i : {1, 10, 100, 1000})
+    {
+      std::cout << "Sleeping for " << i << " ms";
+      GZ_SLEEP_MS(i);
+      std::cout << ", recevied " << msgCount << " messages." << std::endl;
+      if (msgCount)
+      {
+        break;
+      }
+    }
+  }
+  EXPECT_GT(msgCount, 0) << output;
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

Improves reliability of a test added in #1801.

## Summary

The test added in #1801 is a little flaky:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gazebo-ci-gz-sim7-homebrew-amd64&build=66)](https://build.osrfoundation.org/job/ignition_gazebo-ci-gz-sim7-homebrew-amd64/66/) https://build.osrfoundation.org/job/ignition_gazebo-ci-gz-sim7-homebrew-amd64/66/testReport/junit/(root)/CmdLine/SimtimeArgument/

I've added delays, which wasn't enough on its own. For some reason the test subscriber on macOS doesn't get any messages for the first 100 iterations or so. Increasing to 200 iterations was enough in most cases on my machine, so I increased to 500 just to be safe. To reproduce the issue, reduce the iterations to 100 and view the console output.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
