### PR TITLE
Fix flaky RF comms test by relaxing the check for msg counter

### DIFF
--- a/test/integration/rf_comms.cc
+++ b/test/integration/rf_comms.cc
@@ -61,12 +61,11 @@ TEST_F(RFCommsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(RFComms))
   {
     // Verify msg content
     std::lock_guard<std::mutex> lock(mutex);
-    std::string expected = "hello world " + std::to_string(msgCounter);
 
     ignition::msgs::StringMsg receivedMsg;
     receivedMsg.ParseFromString(_msg.data());
 
-    EXPECT_EQ(expected, receivedMsg.data());
+    EXPECT_NE(std::string::npos, receivedMsg.data().find("hello world"));
     ASSERT_GT(_msg.header().data_size(), 0);
     EXPECT_EQ("rssi", _msg.header().data(0).key());
     msgCounter++;
@@ -106,14 +105,16 @@ TEST_F(RFCommsTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(RFComms))
     server.Run(true, 100, false);
   }
 
-  // Verify subscriber received all msgs.
+  // there is a non-zero probability that the packet may be lost
+  // Verify subscriber received most of the msgs.
+  unsigned int expectedMsgCount = static_cast<unsigned int>(pubCount * 0.5);
   int sleep = 0;
   bool done = false;
   while (!done && sleep++ < 10)
   {
     std::lock_guard<std::mutex> lock(mutex);
-    done = msgCounter == pubCount;
+    done = msgCounter > expectedMsgCount;
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
-  EXPECT_EQ(pubCount, msgCounter);
+  EXPECT_LT(expectedMsgCount, msgCounter);
 }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The `INTEGRATION_rf_comms` test occasionally fails on CI and is reproducible locally. The test publishes 10 msgs and expect all of them to be received. I believe it should not be the case since there is non-zero probability that msgs do get dropped (because `rf_comms` system is doing its job).  There is some [normal distribution used](https://github.com/gazebosim/gz-sim/blob/ign-gazebo6/src/systems/rf_comms/RFComms.cc#L286) when computing the Rx power, and I noticed that when the Rx values fall below ~ -80 dBm, there is a chance that msgs get dropped.

I updated the integration test to pass if majority of the msgs (>50%) are received instead of all msgs. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
