### PR TITLE
Fix off-by-one error in physics test

### DIFF
--- a/test/integration/physics_system.cc
+++ b/test/integration/physics_system.cc
@@ -2433,7 +2433,7 @@ TEST_F(PhysicsSystemFixture,
 
   // Make sure the position is updated every time step
   // (here, the model is falling down, so only z should be updated)
-  for (size_t i = 1; i <= nIters; i++)
+  for (size_t i = 1; i < nIters; i++)
   {
     EXPECT_GT(collisionPoses[i - 1].Pos().Z(), collisionPoses[i].Pos().Z())
         << "Model should be falling down.";


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The error was introduced in #1868. This should fix the flakiness on macOS.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
