### PR TITLE
Fix TopicInfo deprecation warnings in Harmonic

### DIFF
--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -674,7 +674,8 @@ bool SimulationRunner::Run(const uint64_t _iterations)
   {
     // Check for the existence of other publishers on `/stats`
     std::vector<transport::MessagePublisher> publishers;
-    this->node->TopicInfo("/stats", publishers);
+    std::vector<transport::MessagePublisher> subscribers;
+    this->node->TopicInfo("/stats", publishers, subscribers);
 
     if (!publishers.empty())
     {
@@ -707,7 +708,8 @@ bool SimulationRunner::Run(const uint64_t _iterations)
   {
     // Check for the existence of other publishers on `/clock`
     std::vector<transport::MessagePublisher> publishers;
-    this->node->TopicInfo("/clock", publishers);
+    std::vector<transport::MessagePublisher> subscribers;
+    this->node->TopicInfo("/clock", publishers, subscribers);
 
     if (!publishers.empty())
     {

--- a/src/gui/plugins/visualize_lidar/VisualizeLidar.cc
+++ b/src/gui/plugins/visualize_lidar/VisualizeLidar.cc
@@ -433,7 +433,8 @@ void VisualizeLidar::OnRefresh()
   for (auto topic : allTopics)
   {
     std::vector<transport::MessagePublisher> publishers;
-    this->dataPtr->node.TopicInfo(topic, publishers);
+    std::vector<transport::MessagePublisher> subscribers;
+    this->dataPtr->node.TopicInfo(topic, publishers, subscribers);
     for (auto pub : publishers)
     {
       if (pub.MsgTypeName() == "gz.msgs.LaserScan")

--- a/test/integration/sensors_system.cc
+++ b/test/integration/sensors_system.cc
@@ -133,13 +133,15 @@ void testDefaultTopics()
   };
 
   std::vector<transport::MessagePublisher> publishers;
+  std::vector<transport::MessagePublisher> subscribers;
   transport::Node node;
 
   // Sensors are created in a separate thread, so we sleep here to give them
   // time
   int sleep{0};
   int maxSleep{30};
-  for (; sleep < maxSleep && !node.TopicInfo(topics.front(), publishers);
+  for (; sleep < maxSleep &&
+      !node.TopicInfo(topics.front(), publishers, subscribers);
       ++sleep)
   {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -148,7 +150,7 @@ void testDefaultTopics()
 
   for (const std::string &topic : topics)
   {
-    bool result = node.TopicInfo(topic, publishers);
+    bool result = node.TopicInfo(topic, publishers, subscribers);
 
     EXPECT_TRUE(result) << "Could not get topic info for " << topic;
     EXPECT_EQ(1u, publishers.size());


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Updated code to use the new `TopicInfo` function introduced in https://github.com/gazebosim/gz-transport/pull/384. The existing one is deprecated.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
