### PR TITLE
Fix Hydrodyanmics parameter names in auv_controls.sdf

### DIFF
--- a/examples/worlds/auv_controls.sdf
+++ b/examples/worlds/auv_controls.sdf
@@ -141,24 +141,31 @@
         filename="gz-sim-hydrodynamics-system"
         name="gz::sim::systems::Hydrodynamics">
         <link_name>base_link</link_name>
+        <!-- Added mass -->
         <xDotU>-4.876161</xDotU>
         <yDotV>-126.324739</yDotV>
         <zDotW>-126.324739</zDotW>
         <kDotP>0</kDotP>
         <mDotQ>-33.46</mDotQ>
         <nDotR>-33.46</nDotR>
-        <xUU>-6.2282</xUU>
+
+        <!-- Linear drag -->
         <xU>0</xU>
-        <yVV>-601.27</yVV>
         <yV>0</yV>
-        <zWW>-601.27</zWW>
         <zW>0</zW>
-        <kPP>-0.1916</kPP>
         <kP>0</kP>
-        <mQQ>-632.698957</mQQ>
         <mQ>0</mQ>
-        <nRR>-632.698957</nRR>
         <nR>0</nR>
+        <nR>0</nR>
+
+        <!-- Quadratic drag -->
+        <xUabsU>-6.2282</xUabsU>
+        <yVabsV>-601.27</yVabsV>
+        <zWabsW>-601.27</zWabsW>
+        <kPabsP>-0.1916</kPabsP>
+        <mQabsQ>-632.69</mQabsQ>
+        <nRabsR>-632.69</nRabsR>
+
       </plugin>
 
     </include>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<[1923](https://github.com/gazebosim/gz-sim/issues/1923)>

## Summary
Re-named SDF parameters to match what is expected by Hydrodynamics plugin. Un-patched SDF exhibits unbounded velocity growth as described in https://github.com/gazebosim/gz-sim/issues/1923

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.