### PR TITLE
Proposal to add deadband to thruster

### DIFF
--- a/src/systems/thruster/Thruster.cc
+++ b/src/systems/thruster/Thruster.cc
@@ -14,6 +14,8 @@
  * limitations under the License.
  *
  */
+#include <cstdlib>
+#include <gz/transport/TopicUtils.hh>
 #include <memory>
 #include <mutex>
 #include <limits>
@@ -144,6 +146,15 @@ class gz::sim::systems::ThrusterPrivateData
   /// \brief Linear velocity of the vehicle.
   public: double linearVelocity = 0.0;
 
+  /// \brief deadband
+  public: double deadband = 0.0;
+
+  /// \brief Flag to enable/disable deadband
+  public: bool enableDeadband = false;
+
+  /// \brief Topic name used to enable/disable the deadband
+  public: std::string deadbandTopic = "";
+
   /// \brief Topic name used to control thrust. Optional
   public: std::string topic = "";
 
@@ -158,6 +169,9 @@ class gz::sim::systems::ThrusterPrivateData
 
   /// \brief Callback for handling thrust update
   public: void OnCmdThrust(const msgs::Double &_msg);
+
+  /// \brief Callback for handling deadband enable/disable update
+  public: void OnDeabandEnable(const msgs::Boolean &_msg);
 
   /// \brief Recalculates and updates the thrust coefficient.
   public: void UpdateThrustCoefficient();
@@ -179,6 +193,10 @@ class gz::sim::systems::ThrusterPrivateData
   /// \return True if battery is charged, false otherwise. If no battery found,
   /// returns true.
   public: bool HasSufficientBattery(const EntityComponentManager &_ecm) const;
+          
+  /// \brief Applies the deadband to the thrust and angular velocity by setting
+  /// those values to zero if their absolute value is below the deadband
+  public: void ApplyDeadband(double &_thrust, double &_angVel);
 };
 
 /////////////////////////////////////////////////
@@ -276,6 +294,13 @@ void Thruster::Configure(
               << "[thrust_coefficient] value from the SDF file." << std::endl;
     }
   }
+  
+  // Get deadband, default to 0
+  if (_sdf->HasElement("deadband"))
+  {
+    this->dataPtr->deadband = _sdf->Get<double>("deadband");
+    this->dataPtr->enableDeadband = true;
+  }
 
   // Get a custom topic.
   if (_sdf->HasElement("topic"))
@@ -312,6 +337,8 @@ void Thruster::Configure(
     // Subscribe to specified topic for force commands
     thrusterTopic = gz::transport::TopicUtils::AsValidTopic(
       ns + "/" + this->dataPtr->topic);
+    this->dataPtr->deadbandTopic = gz::transport::TopicUtils::AsValidTopic(
+      ns + "/" + this->dataPtr->topic + "/enable_deadband");
     if (this->dataPtr->opmode == ThrusterPrivateData::OperationMode::ForceCmd)
     {
       this->dataPtr->node.Subscribe(
@@ -347,6 +374,9 @@ void Thruster::Configure(
 
     feedbackTopic = gz::transport::TopicUtils::AsValidTopic(
       "/model/" + ns + "/joint/" + jointName + "/ang_vel");
+    
+    this->dataPtr->deadbandTopic = gz::transport::TopicUtils::AsValidTopic(
+      "/model/" + ns + "/joint/" + jointName + "/enable_deadband");
   }
   else
   {
@@ -362,10 +392,19 @@ void Thruster::Configure(
 
     feedbackTopic = gz::transport::TopicUtils::AsValidTopic(
         "/model/" + ns + "/joint/" + jointName + "/force");
+
+    this->dataPtr->deadbandTopic = gz::transport::TopicUtils::AsValidTopic(
+      "/model/" + ns + "/joint/" + jointName + "/enable_deadband");
   }
 
   gzmsg << "Thruster listening to commands on [" << thrusterTopic << "]"
         << std::endl;
+  this->dataPtr->node.Subscribe(
+      this->dataPtr->deadbandTopic,
+      &ThrusterPrivateData::OnDeabandEnable,
+      this->dataPtr.get());
+  gzmsg << "Thruster listening to enable_deadband on [" 
+        << this->dataPtr->deadbandTopic << "]" << std::endl;
 
   this->dataPtr->pub = this->dataPtr->node.Advertise<msgs::Double>(
       feedbackTopic);
@@ -476,6 +515,19 @@ void ThrusterPrivateData::OnCmdThrust(const gz::msgs::Double &_msg)
 }
 
 /////////////////////////////////////////////////
+void ThrusterPrivateData::OnDeabandEnable(const gz::msgs::Boolean &_msg)
+{
+  if (_msg.data() != this->enableDeadband)
+  {
+    if (_msg.data()) gzmsg << "Enabling deadband." << std::endl;
+    else gzmsg << "Disabling deadband." << std::endl;
+    
+    this->enableDeadband = _msg.data();
+  }
+
+}
+
+/////////////////////////////////////////////////
 void ThrusterPrivateData::OnCmdAngVel(const gz::msgs::Double &_msg)
 {
   std::lock_guard<std::mutex> lock(mtx);
@@ -551,6 +603,16 @@ bool ThrusterPrivateData::HasSufficientBattery(
 }
 
 /////////////////////////////////////////////////
+void ThrusterPrivateData::ApplyDeadband(double &_thrust, double &_angVel)
+{
+    if (abs(_thrust) < this->deadband)
+    {
+        _thrust = 0.0;
+        _angVel = 0.0;
+    }
+}
+
+/////////////////////////////////////////////////
 void Thruster::PreUpdate(
   const gz::sim::UpdateInfo &_info,
   gz::sim::EntityComponentManager &_ecm)
@@ -560,6 +622,9 @@ void Thruster::PreUpdate(
 
   if (!this->dataPtr->enabled)
   {
+    return;
+  }
+  if (!_ecm.HasEntity(this->dataPtr->linkEntity)){
     return;
   }
 
@@ -630,6 +695,12 @@ void Thruster::PreUpdate(
         this->dataPtr->ThrustToAngularVec(this->dataPtr->thrust);
     desiredPropellerAngVel = this->dataPtr->propellerAngVel;
   }
+  
+  if (this->dataPtr->enableDeadband)
+  {
+    this->dataPtr->ApplyDeadband(desiredThrust, desiredPropellerAngVel);
+  }
+  
 
   msgs::Double angvel;
   // PID control

--- a/src/systems/thruster/Thruster.cc
+++ b/src/systems/thruster/Thruster.cc
@@ -152,6 +152,9 @@ class gz::sim::systems::ThrusterPrivateData
   /// \brief Flag to enable/disable deadband
   public: bool enableDeadband = false;
 
+  /// \brief Mutex to protect enableDeadband
+  public: std::mutex deadbandMutex;
+
   /// \brief Topic name used to enable/disable the deadband
   public: std::string deadbandTopic = "";
 
@@ -525,6 +528,7 @@ void ThrusterPrivateData::OnCmdThrust(const gz::msgs::Double &_msg)
 /////////////////////////////////////////////////
 void ThrusterPrivateData::OnDeadbandEnable(const gz::msgs::Boolean &_msg)
 {
+  std::lock_guard<std::mutex> lock(this->deadbandMutex);
   if (_msg.data() != this->enableDeadband)
   {
     if (_msg.data())

--- a/src/systems/thruster/Thruster.cc
+++ b/src/systems/thruster/Thruster.cc
@@ -171,7 +171,7 @@ class gz::sim::systems::ThrusterPrivateData
   public: void OnCmdThrust(const msgs::Double &_msg);
 
   /// \brief Callback for handling deadband enable/disable update
-  public: void OnDeabandEnable(const msgs::Boolean &_msg);
+  public: void OnDeadbandEnable(const msgs::Boolean &_msg);
 
   /// \brief Recalculates and updates the thrust coefficient.
   public: void UpdateThrustCoefficient();
@@ -401,7 +401,7 @@ void Thruster::Configure(
         << std::endl;
   this->dataPtr->node.Subscribe(
       this->dataPtr->deadbandTopic,
-      &ThrusterPrivateData::OnDeabandEnable,
+      &ThrusterPrivateData::OnDeadbandEnable,
       this->dataPtr.get());
   gzmsg << "Thruster listening to enable_deadband on [" 
         << this->dataPtr->deadbandTopic << "]" << std::endl;
@@ -515,7 +515,7 @@ void ThrusterPrivateData::OnCmdThrust(const gz::msgs::Double &_msg)
 }
 
 /////////////////////////////////////////////////
-void ThrusterPrivateData::OnDeabandEnable(const gz::msgs::Boolean &_msg)
+void ThrusterPrivateData::OnDeadbandEnable(const gz::msgs::Boolean &_msg)
 {
   if (_msg.data() != this->enableDeadband)
   {

--- a/src/systems/thruster/Thruster.cc
+++ b/src/systems/thruster/Thruster.cc
@@ -171,6 +171,8 @@ class gz::sim::systems::ThrusterPrivateData
   public: void OnCmdThrust(const msgs::Double &_msg);
 
   /// \brief Callback for handling deadband enable/disable update
+  /// \param[in] _msg boolean msg to indicate whether to enable or disable
+  ///                 the deadband
   public: void OnDeadbandEnable(const msgs::Boolean &_msg);
 
   /// \brief Recalculates and updates the thrust coefficient.
@@ -195,7 +197,9 @@ class gz::sim::systems::ThrusterPrivateData
   public: bool HasSufficientBattery(const EntityComponentManager &_ecm) const;
 
   /// \brief Applies the deadband to the thrust and angular velocity by setting
-  /// those values to zero if their absolute value is below the deadband
+  /// those values to zero if the thrust absolute value is below the deadband
+  /// \param[in] _thrust thrust in N used for check
+  /// \param[in] _angvel angular velocity in rad/s
   public: void ApplyDeadband(double &_thrust, double &_angVel);
 };
 

--- a/src/systems/thruster/Thruster.cc
+++ b/src/systems/thruster/Thruster.cc
@@ -193,7 +193,7 @@ class gz::sim::systems::ThrusterPrivateData
   /// \return True if battery is charged, false otherwise. If no battery found,
   /// returns true.
   public: bool HasSufficientBattery(const EntityComponentManager &_ecm) const;
-          
+
   /// \brief Applies the deadband to the thrust and angular velocity by setting
   /// those values to zero if their absolute value is below the deadband
   public: void ApplyDeadband(double &_thrust, double &_angVel);
@@ -294,7 +294,7 @@ void Thruster::Configure(
               << "[thrust_coefficient] value from the SDF file." << std::endl;
     }
   }
-  
+
   // Get deadband, default to 0
   if (_sdf->HasElement("deadband"))
   {
@@ -374,7 +374,7 @@ void Thruster::Configure(
 
     feedbackTopic = gz::transport::TopicUtils::AsValidTopic(
       "/model/" + ns + "/joint/" + jointName + "/ang_vel");
-    
+
     this->dataPtr->deadbandTopic = gz::transport::TopicUtils::AsValidTopic(
       "/model/" + ns + "/joint/" + jointName + "/enable_deadband");
   }
@@ -403,7 +403,7 @@ void Thruster::Configure(
       this->dataPtr->deadbandTopic,
       &ThrusterPrivateData::OnDeadbandEnable,
       this->dataPtr.get());
-  gzmsg << "Thruster listening to enable_deadband on [" 
+  gzmsg << "Thruster listening to enable_deadband on ["
         << this->dataPtr->deadbandTopic << "]" << std::endl;
 
   this->dataPtr->pub = this->dataPtr->node.Advertise<msgs::Double>(
@@ -527,7 +527,7 @@ void ThrusterPrivateData::OnDeadbandEnable(const gz::msgs::Boolean &_msg)
     {
       gzmsg << "Disabling deadband." << std::endl;
     }
-    
+
     this->enableDeadband = _msg.data();
   }
 
@@ -701,12 +701,12 @@ void Thruster::PreUpdate(
         this->dataPtr->ThrustToAngularVec(this->dataPtr->thrust);
     desiredPropellerAngVel = this->dataPtr->propellerAngVel;
   }
-  
+
   if (this->dataPtr->enableDeadband)
   {
     this->dataPtr->ApplyDeadband(desiredThrust, desiredPropellerAngVel);
   }
-  
+
 
   msgs::Double angvel;
   // PID control

--- a/src/systems/thruster/Thruster.cc
+++ b/src/systems/thruster/Thruster.cc
@@ -519,8 +519,14 @@ void ThrusterPrivateData::OnDeadbandEnable(const gz::msgs::Boolean &_msg)
 {
   if (_msg.data() != this->enableDeadband)
   {
-    if (_msg.data()) gzmsg << "Enabling deadband." << std::endl;
-    else gzmsg << "Disabling deadband." << std::endl;
+    if (_msg.data())
+    {
+      gzmsg << "Enabling deadband." << std::endl;
+    }
+    else
+    {
+      gzmsg << "Disabling deadband." << std::endl;
+    }
     
     this->enableDeadband = _msg.data();
   }

--- a/src/systems/thruster/Thruster.cc
+++ b/src/systems/thruster/Thruster.cc
@@ -146,7 +146,7 @@ class gz::sim::systems::ThrusterPrivateData
   /// \brief Linear velocity of the vehicle.
   public: double linearVelocity = 0.0;
 
-  /// \brief deadband
+  /// \brief deadband in newtons
   public: double deadband = 0.0;
 
   /// \brief Flag to enable/disable deadband

--- a/src/systems/thruster/Thruster.cc
+++ b/src/systems/thruster/Thruster.cc
@@ -714,9 +714,12 @@ void Thruster::PreUpdate(
     desiredPropellerAngVel = this->dataPtr->propellerAngVel;
   }
 
-  if (this->dataPtr->enableDeadband)
   {
-    this->dataPtr->ApplyDeadband(desiredThrust, desiredPropellerAngVel);
+    std::lock_guard<std::mutex> lock(this->dataPtr->deadbandMutex);
+    if (this->dataPtr->enableDeadband)
+    {
+      this->dataPtr->ApplyDeadband(desiredThrust, desiredPropellerAngVel);
+    }
   }
 
 

--- a/src/systems/thruster/Thruster.cc
+++ b/src/systems/thruster/Thruster.cc
@@ -403,12 +403,16 @@ void Thruster::Configure(
 
   gzmsg << "Thruster listening to commands on [" << thrusterTopic << "]"
         << std::endl;
-  this->dataPtr->node.Subscribe(
-      this->dataPtr->deadbandTopic,
-      &ThrusterPrivateData::OnDeadbandEnable,
-      this->dataPtr.get());
-  gzmsg << "Thruster listening to enable_deadband on ["
-        << this->dataPtr->deadbandTopic << "]" << std::endl;
+
+  if (!this->dataPtr->deadbandTopic.empty())
+  {
+    this->dataPtr->node.Subscribe(
+        this->dataPtr->deadbandTopic,
+        &ThrusterPrivateData::OnDeadbandEnable,
+        this->dataPtr.get());
+    gzmsg << "Thruster listening to enable_deadband on ["
+          << this->dataPtr->deadbandTopic << "]" << std::endl;
+  }
 
   this->dataPtr->pub = this->dataPtr->node.Advertise<msgs::Double>(
       feedbackTopic);

--- a/src/systems/thruster/Thruster.hh
+++ b/src/systems/thruster/Thruster.hh
@@ -85,6 +85,8 @@ namespace systems
   ///                      [Optional, defaults to 1000N or 1000rad/s]
   /// - <min_thrust_cmd> - Minimum input thrust or angular velocity command.
   ///                      [Optional, defaults to -1000N or -1000rad/s]
+  /// - <deadband> - Deadband of the thruster. Absolute value below which the 
+  ///                thruster won't spin nor generate thrust
   /// - <wake_fraction>  - Relative speed reduction between the water
   ///                      at the propeller (Va) vs behind the vessel.
   ///                      [Optional, defults to 0.2]

--- a/src/systems/thruster/Thruster.hh
+++ b/src/systems/thruster/Thruster.hh
@@ -85,10 +85,10 @@ namespace systems
   ///                      [Optional, defaults to 1000N or 1000rad/s]
   /// - <min_thrust_cmd> - Minimum input thrust or angular velocity command.
   ///                      [Optional, defaults to -1000N or -1000rad/s]
-  /// - <deadband> - Deadband of the thruster. Absolute value below which the 
-  ///                thruster won't spin nor generate thrust. This value can also
+  /// - <deadband> - Deadband of the thruster. Absolute value below which the
+  ///                thruster won't spin nor generate thrust. This value can
   ///                be changed at runtime using a topic. The topic is either
-  ///                `/model/{ns}/joint/{jointName}/enable_deadband` or 
+  ///                `/model/{ns}/joint/{jointName}/enable_deadband` or
   ///                `{ns}/{topic}/enable_deadband` depending on other params
   /// - <wake_fraction>  - Relative speed reduction between the water
   ///                      at the propeller (Va) vs behind the vessel.

--- a/src/systems/thruster/Thruster.hh
+++ b/src/systems/thruster/Thruster.hh
@@ -86,7 +86,10 @@ namespace systems
   /// - <min_thrust_cmd> - Minimum input thrust or angular velocity command.
   ///                      [Optional, defaults to -1000N or -1000rad/s]
   /// - <deadband> - Deadband of the thruster. Absolute value below which the 
-  ///                thruster won't spin nor generate thrust
+  ///                thruster won't spin nor generate thrust. This value can also
+  ///                be changed at runtime using a topic. The topic is either
+  ///                `/model/{ns}/joint/{jointName}/enable_deadband` or 
+  ///                `{ns}/{topic}/enable_deadband` depending on other params
   /// - <wake_fraction>  - Relative speed reduction between the water
   ///                      at the propeller (Va) vs behind the vessel.
   ///                      [Optional, defults to 0.2]

--- a/test/integration/thruster.cc
+++ b/test/integration/thruster.cc
@@ -24,6 +24,7 @@
 #include <gz/common/Util.hh>
 #include <gz/math/Helpers.hh>
 #include <gz/transport/Node.hh>
+#include <gz/transport/Publisher.hh>
 #include <gz/utils/ExtraTestMacros.hh>
 
 #include "gz/sim/Link.hh"
@@ -158,7 +159,12 @@ void ThrusterTest::TestWorld(const std::string &_world,
   // Publish command and check that vehicle moved
   transport::Node node;
   auto pub = node.Advertise<msgs::Double>(_topic);
-  auto db_pub = node.Advertise<msgs::Boolean>(_db_topic);
+  transport::Node::Publisher db_pub;
+  if (!_db_topic.empty()) {
+    // create publisher only if topic is not empty, otherwise tests will  which should be the case
+    // for the deadband world.
+    db_pub = node.Advertise<msgs::Boolean>(_db_topic);
+  }
 
   int sleep{0};
   int maxSleep{30};

--- a/test/integration/thruster.cc
+++ b/test/integration/thruster.cc
@@ -211,7 +211,6 @@ void ThrusterTest::TestWorld(const std::string &_world,
 
   // Check no movement because of invalid commands
   fixture.Server()->Run(true, 100, false);
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
   EXPECT_DOUBLE_EQ(0.0, modelPoses.back().Pos().X());
   EXPECT_EQ(100u, modelPoses.size());
   EXPECT_EQ(100u, propellerAngVels.size());
@@ -248,7 +247,6 @@ void ThrusterTest::TestWorld(const std::string &_world,
     for (sleep = 0; modelPoses.back().Pos().X() < 5.0 && sleep < maxSleep;
         ++sleep)
     {
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
       fixture.Server()->Run(true, 100, false);
     }
     EXPECT_LT(sleep, maxSleep);
@@ -351,7 +349,6 @@ void ThrusterTest::TestWorld(const std::string &_world,
     // When the deadband is disabled, any command value
     // (especially values below the deadband threshold) should move the model
     fixture.Server()->Run(true, 1000, false);
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     // make sure we have run a 1000 times
     EXPECT_EQ(1000u, modelPoses.size());

--- a/test/integration/thruster.cc
+++ b/test/integration/thruster.cc
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 
+#include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/double.pb.h>
 
 #include <gz/common/Console.hh>
@@ -55,12 +56,16 @@ class ThrusterTest : public InternalFixture<::testing::Test>
   /// \param[in] _useAngVelCmd Send commands in angular velocity instead of
   /// force
   /// \param[in] _mass Mass of the body being propelled.
+  /// \param[in] _deadband deadband value in newtons
+  /// \param[in] _dp_topic deadband enable topic
   public: void TestWorld(const std::string &_world,
       const std::string &_namespace, const std::string &_topic,
       double _thrustCoefficient, double _density, double _diameter,
       double _baseTol, double _wakeFraction = 0.2, double _alpha_1 = 1,
       double _alpha_2 = 0, bool _calculateCoefficient = false,
-      bool _useAngVelCmd = false, double _mass = 100.1);
+      bool _useAngVelCmd = false, double _mass = 100.1,
+      double _deadband = 0,
+      const std::string &_db_topic = std::string());
 };
 
 //////////////////////////////////////////////////
@@ -68,7 +73,8 @@ void ThrusterTest::TestWorld(const std::string &_world,
     const std::string &_namespace, const std::string &_topic,
     double _thrustCoefficient, double _density, double _diameter,
     double _baseTol, double _wakeFraction, double _alpha1, double _alpha2,
-    bool _calculateCoefficient, bool _useAngVelCmd, double _mass)
+    bool _calculateCoefficient, bool _useAngVelCmd, double _mass,
+    double _deadband, const std::string &_db_topic)
 {
   // Start server
   ServerConfig serverConfig;
@@ -152,15 +158,30 @@ void ThrusterTest::TestWorld(const std::string &_world,
   // Publish command and check that vehicle moved
   transport::Node node;
   auto pub = node.Advertise<msgs::Double>(_topic);
+  auto db_pub = node.Advertise<msgs::Boolean>(_db_topic);
 
   int sleep{0};
   int maxSleep{30};
-  for (; !pub.HasConnections() && sleep < maxSleep; ++sleep)
+  if (_namespace != "deadband")
   {
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    for (; !pub.HasConnections() && sleep < maxSleep; ++sleep) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+  }
+  else
+  {
+    for (;
+         !(pub.HasConnections() && db_pub.HasConnections()) && sleep < maxSleep;
+         ++sleep) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
   }
   EXPECT_LT(sleep, maxSleep);
   EXPECT_TRUE(pub.HasConnections());
+  if (_namespace == "deadband")
+  {
+    EXPECT_TRUE(db_pub.HasConnections());
+  }
 
   // Test the cmd limits specified in the world file. These should be:
   //    if (use_angvel_cmd && thrust_coefficient < 0):
@@ -170,11 +191,19 @@ void ThrusterTest::TestWorld(const std::string &_world,
   //        min_thrust = 0
   //        max_thrust = 300
   double invalidCmd = (_useAngVelCmd && _thrustCoefficient < 0) ? 1000 : -1000;
+  if (_namespace == "deadband")
+  {
+    // an invalid command in case the deadband is enabled is a command
+    // below the deadband threshold
+    invalidCmd = _deadband / 2.0;
+    // note that in the deadband world, deadband is enabled by default,
+    // because the deadband parameter is specified.
+  }
   msgs::Double msg;
   msg.set_data(invalidCmd);
   pub.Publish(msg);
 
-  // Check no movement
+  // Check no movement because of invalid commands
   fixture.Server()->Run(true, 100, false);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   EXPECT_DOUBLE_EQ(0.0, modelPoses.back().Pos().X());
@@ -285,14 +314,50 @@ void ThrusterTest::TestWorld(const std::string &_world,
       {
         EXPECT_NEAR(0.0, angVel.X(), _baseTol);
       }
+      else if (_namespace == "deadband")
+      {
+        continue;
+      }
       else
       {
-        EXPECT_NEAR(omega, angVel.X(), omegaTol) << i;
+        ASSERT_NEAR(omega, angVel.X(), omegaTol) << i;
       }
     }
     EXPECT_NEAR(0.0, angVel.Y(), _baseTol);
     EXPECT_NEAR(0.0, angVel.Z(), _baseTol);
   }
+
+  modelPoses.clear();
+  propellerAngVels.clear();
+  propellerLinVels.clear();
+  // Make sure that when the deadband is disabled
+  // commands below the deadband should create a movement
+  auto latest_pose = modelPoses.back();
+  msgs::Boolean db_msg;
+  if (_namespace == "deadband")
+  {
+    // disable the deadband
+    db_msg.set_data(false);
+    db_pub.Publish(db_msg);
+    // And we send a command that is still below the deadband threshold
+    msg.set_data(_deadband / 2.0);
+    pub.Publish(msg);
+    // Check movements
+    fixture.Server()->Run(true, 1000, false);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    EXPECT_LT(0.1, modelPoses.back().Pos().X());
+
+    EXPECT_EQ(1000u, modelPoses.size());
+    EXPECT_EQ(1000u, propellerAngVels.size());
+    EXPECT_EQ(1000u, propellerLinVels.size());
+    modelPoses.clear();
+    propellerAngVels.clear();
+    propellerLinVels.clear();
+  }
+  // re-enable the deadband
+  db_msg.set_data(true);
+  db_pub.Publish(db_msg);
+
 }
 
 /////////////////////////////////////////////////
@@ -307,7 +372,7 @@ TEST_F(ThrusterTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(AngVelCmdControl))
 
   //  Tolerance is high because the joint command disturbs the vehicle body
   this->TestWorld(world, ns, topic, 0.005, 950, 0.2, 1e-2, 0.2, 1, 0, false,
-      true, 100.01);
+                  true, 100.01);
 }
 
 /////////////////////////////////////////////////
@@ -372,7 +437,7 @@ TEST_F(ThrusterTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(VelocityControl))
 /////////////////////////////////////////////////
 TEST_F(ThrusterTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(BatteryIntegration))
 {
-  const std::string ns = "lowbattery";
+:string ns = "lowbattery";
   const std::string topic =  ns + "/thrust";
   auto world = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
       "test", "worlds", "thruster_battery.sdf");
@@ -392,4 +457,20 @@ TEST_F(ThrusterTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(ThrustCoefficient))
 
   // Tolerance is high because the joint command disturbs the vehicle body
   this->TestWorld(world, ns, topic, 1, 950, 0.25, 1e-2, 0.2, 0.9, 0.01, true);
+}
+
+/////////////////////////////////////////////////
+TEST_F(ThrusterTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(ThrusterDeadBand))
+{
+  const std::string ns = "deadband";
+  const std::string topic = "/model/" + ns +
+      "/joint/propeller_joint/cmd_thrust";
+  const std::string db_topic = "/model/" + ns +
+      "/joint/propeller_joint/enable_deadband";
+  auto world = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+      "test", "worlds", "thruster_deadband.sdf");
+
+  // Tolerance is high because the joint command disturbs the vehicle body
+  this->TestWorld(world, ns, topic, 0.005, 950, 0.25, 1e-2, 0.2, 0.9, 0.01,
+                  false, false, 100.1, 50.0, db_topic);
 }

--- a/test/integration/thruster.cc
+++ b/test/integration/thruster.cc
@@ -247,6 +247,7 @@ void ThrusterTest::TestWorld(const std::string &_world,
     for (sleep = 0; modelPoses.back().Pos().X() < 5.0 && sleep < maxSleep;
         ++sleep)
     {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
       fixture.Server()->Run(true, 100, false);
     }
     EXPECT_LT(sleep, maxSleep);

--- a/test/integration/thruster.cc
+++ b/test/integration/thruster.cc
@@ -340,11 +340,12 @@ void ThrusterTest::TestWorld(const std::string &_world,
   msgs::Boolean db_msg;
   if (_namespace == "deadband")
   {
+    force = _deadband / 2.0;
     // disable the deadband
     db_msg.set_data(false);
     db_pub.Publish(db_msg);
-    // And we send a command that are below the deadband threshold
-    msg.set_data(_deadband / 2.0);
+    // And we send a command that is below the deadband threshold
+    msg.set_data(force);
     pub.Publish(msg);
     // When the deadband is disabled, any command value
     // (especially values below the deadband threshold) should move the model
@@ -360,16 +361,16 @@ void ThrusterTest::TestWorld(const std::string &_world,
     EXPECT_LT(0.1, modelPoses.back().Pos().X());
 
     // Check that the propeller are rotating
-    force = _deadband / 2.0;
     omega = sqrt(abs(force / (_density * _thrustCoefficient *
         pow(_diameter, 4))));
     // Account for negative thrust and/or negative thrust coefficient
     omega *= (force * _thrustCoefficient > 0 ? 1 : -1);
 
-    // for (unsigned int i = 0; i < propellerAngVels.size(); ++i)
-    // {
-    //   EXPECT_NEAR(omega, propellerAngVels[i].X(), omegaTol) << i;
-    // }
+    // it takes a few iteration to reach the speed
+    for (unsigned int i = 25; i < propellerAngVels.size(); ++i)
+    {
+      EXPECT_NEAR(omega, propellerAngVels[i].X(), omegaTol) << i;
+    }
     modelPoses.clear();
     propellerAngVels.clear();
     propellerLinVels.clear();

--- a/test/integration/thruster.cc
+++ b/test/integration/thruster.cc
@@ -161,8 +161,8 @@ void ThrusterTest::TestWorld(const std::string &_world,
   auto pub = node.Advertise<msgs::Double>(_topic);
   transport::Node::Publisher db_pub;
   if (!_db_topic.empty()) {
-    // create publisher only if topic is not empty, otherwise tests will  which should be the case
-    // for the deadband world.
+    // create publisher only if topic is not empty, otherwise tests will get
+    // get complains
     db_pub = node.Advertise<msgs::Boolean>(_db_topic);
   }
 
@@ -348,11 +348,11 @@ void ThrusterTest::TestWorld(const std::string &_world,
     // And we send a command that are below the deadband threshold
     msg.set_data(_deadband / 2.0);
     pub.Publish(msg);
-    // When the deadband is disabled, any command value 
+    // When the deadband is disabled, any command value
     // (especially values below the deadband threshold) should move the model
     fixture.Server()->Run(true, 1000, false);
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    
+
     // make sure we have run a 1000 times
     EXPECT_EQ(1000u, modelPoses.size());
     EXPECT_EQ(1000u, propellerAngVels.size());
@@ -361,7 +361,7 @@ void ThrusterTest::TestWorld(const std::string &_world,
     // the model should have moved. Note that the distance moved is small
     // This is because we are sending small forces (deadband/2)
     EXPECT_LT(0.1, modelPoses.back().Pos().X());
-    
+
     // Check that the propeller are rotating
     force = _deadband / 2.0;
     omega = sqrt(abs(force / (_density * _thrustCoefficient *

--- a/test/worlds/thruster_deadband.sdf
+++ b/test/worlds/thruster_deadband.sdf
@@ -1,0 +1,112 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+    <world name="thruster">
+
+        <physics name="fast" type="none">
+            <!-- Zero to run as fast as possible -->
+            <real_time_factor>0</real_time_factor>
+        </physics>
+
+        <!-- prevent sinking -->
+        <gravity>0 0 0</gravity>
+
+        <plugin
+            filename="gz-sim-physics-system"
+            name="gz::sim::systems::Physics">
+        </plugin>
+        <plugin
+            filename="gz-sim-scene-broadcaster-system"
+            name="gz::sim::systems::SceneBroadcaster">
+        </plugin>
+
+        <light type="directional" name="sun">
+            <cast_shadows>true</cast_shadows>
+            <pose>0 0 10 0 0 0</pose>
+            <diffuse>1 1 1 1</diffuse>
+            <specular>0.5 0.5 0.5 1</specular>
+            <attenuation>
+                <range>1000</range>
+                <constant>0.9</constant>
+                <linear>0.01</linear>
+                <quadratic>0.001</quadratic>
+            </attenuation>
+            <direction>-0.5 0.1 -0.9</direction>
+        </light>
+
+        <model name="sub">
+
+            <link name="body">
+                <pose>0 0 0 0 1.57 0</pose>
+                <inertial>
+                    <mass>100</mass>
+                    <inertia>
+                        <ixx>33.89</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>33.89</iyy>
+                        <iyz>0</iyz>
+                        <izz>1.125</izz>
+                    </inertia>
+                </inertial>
+                <visual name="visual">
+                    <geometry>
+                        <cylinder>
+                            <length>2</length>
+                            <radius>0.15</radius>
+                        </cylinder>
+                    </geometry>
+                </visual>
+            </link>
+
+            <link name="propeller">
+                <pose>-1.05 0 0 0 0 0</pose>
+                <inertial>
+                    <mass>0.1</mass>
+                    <inertia>
+                        <ixx>0.0000354167</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.0000021667</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.0000334167</izz>
+                    </inertia>
+                </inertial>
+                <visual name="visual">
+                    <geometry>
+                        <box>
+                            <size>0.01 0.25 0.05</size>
+                        </box>
+                    </geometry>
+                </visual>
+            </link>
+
+            <joint name="propeller_joint" type="revolute">
+                <parent>body</parent>
+                <child>propeller</child>
+                <axis>
+                    <xyz>1 0 0</xyz>
+                    <limit>
+                        <lower>-1e+12</lower>
+                        <upper>1e+12</upper>
+                        <effort>1e6</effort>
+                        <velocity>1e6</velocity>
+                    </limit>
+                </axis>
+            </joint>
+
+            <plugin
+                filename="gz-sim-thruster-system"
+                name="gz::sim::systems::Thruster">
+                <namespace>deadband</namespace>
+                <joint_name>propeller_joint</joint_name>
+                <thrust_coefficient>0.005</thrust_coefficient>
+                <fluid_density>950</fluid_density>
+                <propeller_diameter>0.25</propeller_diameter>
+                <max_thrust_cmd>300</max_thrust_cmd>
+                <min_thrust_cmd>0</min_thrust_cmd>
+                <deadband>50</deadband>
+            </plugin>
+        </model>
+
+    </world>
+</sdf>

--- a/test/worlds/thruster_deadband.sdf
+++ b/test/worlds/thruster_deadband.sdf
@@ -103,8 +103,9 @@
                 <fluid_density>950</fluid_density>
                 <propeller_diameter>0.25</propeller_diameter>
                 <max_thrust_cmd>300</max_thrust_cmd>
-                <min_thrust_cmd>0</min_thrust_cmd>
+                <min_thrust_cmd>-300</min_thrust_cmd>
                 <deadband>50</deadband>
+                <p_gain>0.05</p_gain>
             </plugin>
         </model>
 


### PR DESCRIPTION
# 🎉 New feature

This PR is a proposal to add a deadband to the thruster system.
Real thrusters have a physical deadband that are not currently simulated.


## Summary

This implements a limit below which the thrusters will not spin nor generate thrust. 

It adds an additional parameter in the sdf called `<deadband>`.
 - If this tag is not present, the deadband will not be applied.
 - otherwise the value in the tag is the absolute value of thrust below which the output will be set to 0.

An additional topic called `/enable_deadband` is also created to enable or disable the deadband effect during runtime.

## Test it

Unit test are coming...

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

