### PR TITLE
Add tutorial on migrating the Light class from gazebo classic

### DIFF
--- a/tutorials.md.in
+++ b/tutorials.md.in
@@ -49,6 +49,7 @@ Ignition @IGN_DESIGNATION_CAP@ library and how to use the library effectively.
 * \subpage migrationsdf "SDF": Migrating SDF files from Gazebo classic to Ignition Gazebo
 * \subpage migrationworldapi "World API": Guide on what World C++ functions to call in Ignition Gazebo when migrating from Gazebo classic
 * \subpage migrationmodelapi "Model API": Guide on what Model C++ functions to call in Ignition Gazebo when migrating from Gazebo classic
+* \subpage migrationlightapi "Light API": Guide on what Light C++ functions to call in Gazebo when migrating from Gazebo classic
 * \subpage migrationlinkapi "Link API": Guide on what Link C++ functions to call in Ignition Gazebo when migrating from Gazebo classic
 * \subpage ardupilot "Case Study": Migrating the ArduPilot ModelPlugin from Gazebo classic to Ignition Gazebo.
 

--- a/tutorials/migration_light_api.md
+++ b/tutorials/migration_light_api.md
@@ -45,7 +45,9 @@ As an example the `Light::Pose()` is a convienient function for querying the `Po
   math::Pose3d pose = _ecm.Component<components::Pose>(lightEntityId)->Data();
 ```
 
-The functions presented in the sections below exist for convenience and readability.
+The functions presented in the sections below exist for convenience and
+readability. The items marked as `TODO` means that the equivalent API is not
+implemented yet in Gazebo.
 
 ### Properties
 
@@ -122,7 +124,8 @@ These functions deal with modifying the entity tree, attaching children to new
 parents. As mentioned earlier, these APIs in Gazebo classic are provided by the
 `gazebo::physics::Light` class. Most of the APIs are inherited from the base
 `gazebo::physics::Entity` class in classic. We will only list the relevant ones
-here.
+here. As seen below, APIs for changing a Light's entity tree structure are
+currently not implemented yet.
 
 ---
 

--- a/tutorials/migration_light_api.md
+++ b/tutorials/migration_light_api.md
@@ -37,7 +37,15 @@ You'll find the APIs below on the following headers:
 It's worth remembering that most of this functionality can be performed using
 the
 [EntityComponentManager](https://gazebosim.org/api/gazebo/6/classignition_1_1gazebo_1_1EntityComponentManager.html)
-directly. The functions presented here exist for convenience and readability.
+directly.
+
+As an example the `Light::Pose()` is a convienient function for querying the `Pose` component from the `EntityComponentManager`, i.e.
+
+```
+  math::Pose3d pose = _ecm.Component<components::Pose>(lightEntityId)->Data();
+```
+
+The functions presented in the sections below exist for convenience and readability.
 
 ### Properties
 
@@ -61,8 +69,8 @@ Id | `ignition::gazebo::Light::Entity`
 LightType | `ignition::gazebo::Light::Type`
 Name | `ignition::gazebo::Light::Name`
 Position | `ignition::gazebo::Light::Pose`
-Rotation | `ignition::gazebo::Light::Pose``
-SetAttenuation | use `ignition::gazebo::Light::SetAttenuation\*`
+Rotation | `ignition::gazebo::Light::Pose`
+SetAttenuation | use `ignition::gazebo::Light::SetAttenuation*`
 SetCastShadows | `ignition::gazebo::Light::SetCastShadows`
 SetDiffuseColor | `ignition::gazebo::Light::SetDiffuseColor`
 SetDirection | `ignition::gazebo::Light::SetDirection`
@@ -74,11 +82,11 @@ SetRotation | TODO
 SetSelected |  Selection is client-specific, not porting
 SetSpecularColor | `ignition::gazebo::Light::SetSpecularColor`
 SetSpotFalloff | `ignition::gazebo::Light::SetSpotFalloff`
-SetSpotInnerAngle | ignition::gazebo::Light::SetSpotInnerAngle`
-SetSpotOuterAngle | ignition::gazebo::Light::SetSpotOuterAngle`
+SetSpotInnerAngle | `ignition::gazebo::Light::SetSpotInnerAngle`
+SetSpotOuterAngle | `ignition::gazebo::Light::SetSpotOuterAngle`
 SetVisible | TODO
 ShowVisual | TODO
-SpecularColor | ignition::gazebo::Light::SetSpecularColor`
+SpecularColor | `ignition::gazebo::Light::SetSpecularColor`
 ToggleShowVisual | TODO
 Type | `ignition::gazebo::Light::Type`
 Visible | TODO

--- a/tutorials/migration_light_api.md
+++ b/tutorials/migration_light_api.md
@@ -1,0 +1,144 @@
+\page migrationlightapi
+
+# Migration from Gazebo-classic: Light API
+
+When migrating plugins from Gazebo-classic to Gazebo, developers will
+notice that the C++ APIs for both simulators are quite different. Be sure to
+check the [plugin migration tutorial](migrationplugins.html) to get a high-level
+view of the architecture differences before using this guide.
+
+This tutorial is meant to serve as a reference guide for developers migrating
+functions from the
+[gazebo::rendering::Light](http://osrf-distributions.s3.amazonaws.com/gazebo/api/11.0.0/rendering_1_1Light.html)
+class.
+
+If you're trying to use some API which doesn't have an equivalent on Gazebo
+yet, feel free to
+[ticket an issue](https://github.com/gazebosim/gz-sim/issues/).
+
+## Light API
+
+Gazebo-classic has 2 Light classes:
+* [`gazebo::rendering::Light`](http://osrf-distributions.s3.amazonaws.com/gazebo/api/11.0.0/classgazebo_1_1rendering_1_1Light.html) - responsible for accessing and setting light properties.
+    * Example: [Light::DiffuseColor](http://osrf-distributions.s3.amazonaws.com/gazebo/api/11.0.0/classgazebo_1_1rendering_1_1Light.html#a0deb81873bee2c7bc883a10c373501d0) / [Light::SetDiffuseColor](http://osrf-distributions.s3.amazonaws.com/gazebo/api/11.0.0/classgazebo_1_1rendering_1_1Light.html#a9208ba6d4cb8e0972e046e735dc26976)
+* [`gazebo::physics::Light`](http://osrf-distributions.s3.amazonaws.com/gazebo/api/11.0.0/classgazebo_1_1physics_1_1Light.html) - responsible for accessing and setting generic entity properties, and parent / child relationship.
+    * Example: [Light::GetName](http://osrf-distributions.s3.amazonaws.com/gazebo/api/11.0.0/classgazebo_1_1physics_1_1Base.html#a9a98946a64f3893b085f650932c9dfee) / [Light::SetName](http://osrf-distributions.s3.amazonaws.com/gazebo/api/11.0.0/classgazebo_1_1physics_1_1Entity.html#a5d74ac4d7a230aed1ab4b11933b16e92)
+    * Example: [Light::GetParent](http://osrf-distributions.s3.amazonaws.com/gazebo/api/11.0.0/classgazebo_1_1physics_1_1Base.html#af87578478aeeb2b176de010d1d639fd9) / [Light::SetParent](http://osrf-distributions.s3.amazonaws.com/gazebo/api/11.0.0/classgazebo_1_1physics_1_1Base.html#a736efe8278da4ecb1640100a2857756f)
+
+In Gazebo, the light APIs has been consolidated into a single Light class with
+some of generic functions available through other utility / core classes.
+You'll find the APIs below on the following headers:
+
+* [ignition/gazebo/Light.hh](https://gazebosim.org/api/gazebo/6/Light_8hh.html)
+* [ignition/gazebo/Util.hh](https://gazebosim.org/api/gazebo/6/Util_8hh.html)
+* [ignition/gazebo/SdfEntityCreator.hh](https://gazebosim.org/api/gazebo/6/SdfEntityCreator_8hh.html)
+* [ignition/gazebo/EntityComponentManager.hh](https://gazebosim.org/api/gazebo/6/classignition_1_1gazebo_1_1EntityComponentManager.html)
+
+It's worth remembering that most of this functionality can be performed using
+the
+[EntityComponentManager](https://gazebosim.org/api/gazebo/6/classignition_1_1gazebo_1_1EntityComponentManager.html)
+directly. The functions presented here exist for convenience and readability.
+
+### Properties
+
+Most of Gazebo-classic's Light API is related to setting
+and getting properties. These functions are great candidates to have
+equivalents on Gazebo because the Entity-Component-System architecture is
+perfect for setting components (properties) into entities such as lights.
+This section focuses on migrating from APIs provided through the
+`gazebo::rendering::Light` class.
+
+---
+
+Classic | Gazebo
+-- | --
+CastShadows | `ignition::gazebo::Light::CastShadows`
+Clone | TODO
+DiffuseColor | `ignition::gazebo::Light::DiffuseColor`
+Direction | `ignition::gazebo::Light::Direction`
+FillMsg | TODO
+Id | `ignition::gazebo::Light::Entity`
+LightType | `ignition::gazebo::Light::Type`
+Name | `ignition::gazebo::Light::Name`
+Position | `ignition::gazebo::Light::Pose`
+Rotation | `ignition::gazebo::Light::Pose``
+SetAttenuation | use `ignition::gazebo::Light::SetAttenuation\*`
+SetCastShadows | `ignition::gazebo::Light::SetCastShadows`
+SetDiffuseColor | `ignition::gazebo::Light::SetDiffuseColor`
+SetDirection | `ignition::gazebo::Light::SetDirection`
+SetLightType | TODO
+SetName | TODO
+SetPosition | TODO
+SetRange | `ignition::gazebo::Light::SetAttenuationRange`
+SetRotation | TODO
+SetSelected |  Selection is client-specific, not porting
+SetSpecularColor | `ignition::gazebo::Light::SetSpecularColor`
+SetSpotFalloff | `ignition::gazebo::Light::SetSpotFalloff`
+SetSpotInnerAngle | ignition::gazebo::Light::SetSpotInnerAngle`
+SetSpotOuterAngle | ignition::gazebo::Light::SetSpotOuterAngle`
+SetVisible | TODO
+ShowVisual | TODO
+SpecularColor | ignition::gazebo::Light::SetSpecularColor`
+ToggleShowVisual | TODO
+Type | `ignition::gazebo::Light::Type`
+Visible | TODO
+WorldPose | TODO
+---
+
+
+## Read family
+
+These APIs deal with reading information related to child / parent
+relationships. As mentioned earlier, these APIs in Gazebo
+classic are provided by the `gazebo::physics::Light` class. Most of the
+APIs are inherited from the base `gazebo::physics::Entity` class in classic.
+We will only list the relevant ones here.
+
+The main difference in these APIs across Gazebo generations is that
+on classic, they deal with shared pointers to entities, while on Gazebo,
+they deal with entity IDs.
+
+---
+
+Classic | Gazebo
+-- | --
+GetParent | `ignition::gazebo::Light::Parent`
+GetParentId | `ignition::gazebo::Light::Parent`
+GetWorld | `ignition::gazebo::worldEntity`
+
+---
+
+## Write family
+
+These functions deal with modifying the entity tree, attaching children to new
+parents. As mentioned earlier, these APIs in Gazebo classic are provided by the
+`gazebo::physics::Light` class. Most of the APIs are inherited from the base
+`gazebo::physics::Entity` class in classic. We will only list the relevant ones
+here.
+
+---
+
+Classic | Gazebo
+-- | --
+AddChild | Not supported
+RemoveChild | Not supported
+RemoveChildren | Not supported
+SetParent | TODO
+SetWorld | TODO
+
+---
+
+## Lifecycle
+
+These functions are related to the light's lifecycle, like loading and updating
+its properties.
+
+---
+
+Classic | Gazebo
+-- | --
+Load | `ignition::gazebo::SdfEntityCreator::CreateEntities`
+LoadFromMsg | `ignition::gazebo::SdfEntityCreator::CreateEntities`
+UpdateFromMsg | TODO
+
+---


### PR DESCRIPTION


# 🎉 New feature

Part of https://github.com/gazebosim/gz-sim/issues/325

## Summary

Add migration tutorial for Gazebo classic's Light class.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

