### PR TITLE
Optimize render updates and use of thread mutexes in Sensors system

### DIFF
--- a/include/gz/sim/EventManager.hh
+++ b/include/gz/sim/EventManager.hh
@@ -118,6 +118,31 @@ namespace gz
                 }
               }
 
+      /// \brief Get connection count for a particular event
+      /// Connection count for the event
+      public: template <typename E>
+              unsigned int
+              ConnectionCount()
+              {
+                if (this->events.find(typeid(E)) == this->events.end())
+                {
+                  return 0u;
+                }
+
+                E *eventPtr = dynamic_cast<E *>(this->events[typeid(E)].get());
+                // All values in the map should be derived from Event,
+                // so this shouldn't be an issue, but it doesn't hurt to check.
+                if (eventPtr != nullptr)
+                {
+                  return eventPtr->ConnectionCount();
+                }
+                else
+                {
+                  gzerr << "Failed to get connection count for event: "
+                    << typeid(E).name() << std::endl;
+                  return 0u;
+                }
+              }
 
       /// \brief Convenience type for storing typeinfo references.
       private: using TypeInfoRef = std::reference_wrapper<const std::type_info>;

--- a/src/EventManager_TEST.cc
+++ b/src/EventManager_TEST.cc
@@ -29,11 +29,15 @@ TEST(EventManager, EmitConnectTest)
 {
   EventManager eventManager;
 
+  EXPECT_EQ(0u, eventManager.ConnectionCount<events::Pause>());
+
   bool paused1 = false;
   auto connection1 = eventManager.Connect<events::Pause>(
     [&paused1](bool _paused) {
       paused1 = _paused;
     });
+
+  EXPECT_EQ(1u, eventManager.ConnectionCount<events::Pause>());
 
   // Emitting events causes connection callbacks to be fired.
   eventManager.Emit<events::Pause>(true);
@@ -47,6 +51,8 @@ TEST(EventManager, EmitConnectTest)
       paused2 = _paused;
     });
 
+  EXPECT_EQ(2u, eventManager.ConnectionCount<events::Pause>());
+
   // Multiple connections should each be fired.
   eventManager.Emit<events::Pause>(true);
   EXPECT_EQ(true, paused1);
@@ -58,9 +64,12 @@ TEST(EventManager, EmitConnectTest)
 
   // Clearing the ConnectionPtr will cause it to no longer fire.
   connection1.reset();
+
   eventManager.Emit<events::Pause>(true);
   EXPECT_EQ(false, paused1);
   EXPECT_EQ(true, paused2);
+
+  EXPECT_EQ(1u, eventManager.ConnectionCount<events::Pause>());
 }
 
 /// Test that we are able to connect arbitrary events and signal them.

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -31,6 +31,8 @@
 
 #include <gz/math/Helpers.hh>
 
+#include <gz/common/Timer.hh>
+
 #include <gz/rendering/Scene.hh>
 #include <gz/sensors/BoundingBoxCameraSensor.hh>
 #include <gz/sensors/CameraSensor.hh>
@@ -280,6 +282,9 @@ void SensorsPrivate::RunOnce()
   if (!this->scene)
     return;
 
+  std::cerr << " ====" << std::endl;
+  common::Timer t;
+  t.Start();
   GZ_PROFILE("SensorsPrivate::RunOnce");
   {
     GZ_PROFILE("Update");
@@ -333,7 +338,11 @@ void SensorsPrivate::RunOnce()
       // We only need to do this once per frame It is important to call
       // sensors::RenderingSensor::SetManualSceneUpdate and set it to true
       // so we don't waste cycles doing one scene graph update per sensor
+      common::Timer t2;
+      t2.Start();
       this->scene->PreRender();
+      t2.Stop();
+      std::cerr << "t2 " << t2.ElapsedTime().count() << std::endl;
     }
 
     // disable sensors that have no subscribers to prevent doing unnecessary
@@ -355,7 +364,12 @@ void SensorsPrivate::RunOnce()
     {
       // publish data
       GZ_PROFILE("RunOnce");
+      common::Timer t3;
+      t3.Start();
       this->sensorManager.RunOnce(this->updateTime);
+      t3.Stop();
+      std::cerr << "t3 " << t3.ElapsedTime().count() << std::endl;
+
       this->eventManager->Emit<events::Render>();
     }
 
@@ -382,6 +396,8 @@ void SensorsPrivate::RunOnce()
   this->forceUpdate = false;
   lock.unlock();
   this->renderCv.notify_one();
+  t.Stop();
+  std::cerr << "t " << t.ElapsedTime().count() << std::endl;
 }
 
 //////////////////////////////////////////////////

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -17,7 +17,6 @@
 
 #include "Sensors.hh"
 
-#include <map>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
@@ -98,7 +97,7 @@ class gz::sim::systems::SensorsPrivate
   /// \brief Keep track of cameras, in case we need to handle stereo cameras.
   /// Key: Camera's parent scoped name
   /// Value: Pointer to camera
-  public: std::map<std::string, sensors::CameraSensor *> cameras;
+  public: std::unordered_map<std::string, sensors::CameraSensor *> cameras;
 
   /// \brief Maps gazebo entity to its matching sensor ID
   ///
@@ -124,9 +123,6 @@ class gz::sim::systems::SensorsPrivate
   /// \brief Mutex to protect rendering data
   public: std::mutex renderMutex;
 
-  /// \brief Mutex to protect renderCv
-  public: std::mutex cvMutex;
-
   /// \brief Condition variable to signal rendering thread
   ///
   /// This variable is used to block/unblock operations in the rendering
@@ -143,15 +139,17 @@ class gz::sim::systems::SensorsPrivate
   /// \brief Update time for the next rendering iteration
   public: std::chrono::steady_clock::duration updateTime;
 
+  /// \brief Next sensors update time
+  public: std::chrono::steady_clock::duration nextUpdateTime;
+
   /// \brief Sensors to include in the next rendering iteration
-  public: std::vector<sensors::RenderingSensor *> activeSensors;
+  public: std::set<sensors::SensorId> activeSensors;
+
+  /// \brief Sensors to be updated next
+  public: std::set<sensors::SensorId> sensorsToUpdate;
 
   /// \brief Mutex to protect sensorMask
-  public: std::mutex sensorMaskMutex;
-
-  /// \brief Mask sensor updates for sensors currently being rendered
-  public: std::map<sensors::SensorId,
-    std::chrono::steady_clock::duration> sensorMask;
+  public: std::mutex sensorsMutex;
 
   /// \brief Pointer to the event manager
   public: EventManager *eventManager{nullptr};
@@ -203,6 +201,14 @@ class gz::sim::systems::SensorsPrivate
   /// \param[in] _ecm Entity component manager
   public: void UpdateBatteryState(const EntityComponentManager &_ecm);
 
+  /// \brief Get the next closest sensor update time
+  public: std::chrono::steady_clock::duration NextUpdateTime(
+      std::set<sensors::SensorId> &_sensorsToUpdate,
+      const std::chrono::steady_clock::duration &_currentTime);
+
+  /// \brief Check if any of the sensors have connections
+  public: bool SensorsHaveConnections();
+
   /// \brief Use to optionally set the background color.
   public: std::optional<math::Color> backgroundColor;
 
@@ -219,7 +225,7 @@ class gz::sim::systems::SensorsPrivate
   public: std::unordered_map<Entity, bool> modelBatteryStateChanged;
 
   /// \brief A map of sensor ids to their active state
-  public: std::map<sensors::SensorId, bool> sensorStateChanged;
+  public: std::unordered_map<sensors::SensorId, bool> sensorStateChanged;
 
   /// \brief Disable sensors if parent model's battery is drained
   /// Affects sensors that are in nested models
@@ -272,8 +278,8 @@ void SensorsPrivate::WaitForInit()
 void SensorsPrivate::RunOnce()
 {
   {
-    std::unique_lock<std::mutex> lock(this->cvMutex);
-    this->renderCv.wait(lock, [this]()
+    std::unique_lock<std::mutex> cvLock(this->renderMutex);
+    this->renderCv.wait(cvLock, [this]()
     {
       return !this->running || this->updateAvailable;
     });
@@ -291,9 +297,10 @@ void SensorsPrivate::RunOnce()
     this->renderUtil.Update();
   }
 
+
   bool activeSensorsEmpty = true;
   {
-    std::unique_lock<std::mutex> lk(this->sensorMaskMutex);
+    std::unique_lock<std::mutex> lk(this->sensorsMutex);
     activeSensorsEmpty = this->activeSensors.empty();
   }
 
@@ -316,26 +323,6 @@ void SensorsPrivate::RunOnce()
       this->sensorStateChanged.clear();
     }
 
-    // Check the active sensors against masked sensors.
-    //
-    // The internal state of a rendering sensor is not updated until the
-    // rendering operation is complete, which can leave us in a position
-    // where the sensor is falsely indicating that an update is needed.
-    //
-    // To prevent this, add sensors that are currently being rendered to
-    // a mask. Sensors are removed from the mask when 90% of the update
-    // delta has passed, which will allow rendering to proceed.
-    {
-      std::unique_lock<std::mutex> lockMask(this->sensorMaskMutex);
-      for (const auto & sensor : this->activeSensors)
-      {
-        // 90% of update delta (1/UpdateRate());
-        auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(
-          std::chrono::duration< double >(0.9 / sensor->UpdateRate()));
-        this->sensorMask[sensor->Id()] = this->updateTime + delta;
-      }
-    }
-
     {
       GZ_PROFILE("PreRender");
       this->eventManager->Emit<events::PreRender>();
@@ -350,7 +337,7 @@ void SensorsPrivate::RunOnce()
     // disable sensors that have no subscribers to prevent doing unnecessary
     // work
     std::unordered_set<sensors::RenderingSensor *> tmpDisabledSensors;
-    this->sensorMaskMutex.lock();
+    this->sensorsMutex.lock();
     for (auto id : this->sensorIds)
     {
       sensors::Sensor *s = this->sensorManager.Sensor(id);
@@ -361,7 +348,7 @@ void SensorsPrivate::RunOnce()
         tmpDisabledSensors.insert(rs);
       }
     }
-    this->sensorMaskMutex.unlock();
+    this->sensorsMutex.unlock();
 
     {
       // publish data
@@ -382,11 +369,15 @@ void SensorsPrivate::RunOnce()
       // We only need to do this once per frame It is important to call
       // sensors::RenderingSensor::SetManualSceneUpdate and set it to true
       // so we don't waste cycles doing one scene graph update per sensor
+
+      int64_t sec, nsec;
+      std::tie(sec, nsec) = math::durationToSecNsec(this->updateTime);
+
       this->scene->PostRender();
       this->eventManager->Emit<events::PostRender>();
     }
 
-    std::unique_lock<std::mutex> lk(this->sensorMaskMutex);
+    std::unique_lock<std::mutex> lk(this->sensorsMutex);
     this->activeSensors.clear();
   }
 
@@ -465,15 +456,9 @@ void Sensors::RemoveSensor(const Entity &_entity)
     // Locking mutex to make sure the vector is not being changed while
     // the rendering thread is iterating over it
     {
-      std::unique_lock<std::mutex> lock(this->dataPtr->sensorMaskMutex);
-      sensors::Sensor *s = this->dataPtr->sensorManager.Sensor(idIter->second);
-      auto rs = dynamic_cast<sensors::RenderingSensor *>(s);
-      auto activeSensorIt = std::find(this->dataPtr->activeSensors.begin(),
-          this->dataPtr->activeSensors.end(), rs);
-      if (activeSensorIt != this->dataPtr->activeSensors.end())
-      {
-        this->dataPtr->activeSensors.erase(activeSensorIt);
-      }
+      std::unique_lock<std::mutex> lock(this->dataPtr->sensorsMutex);
+      this->dataPtr->activeSensors.erase(idIter->second);
+      this->dataPtr->sensorsToUpdate.erase(idIter->second);
     }
 
     // update cameras list
@@ -590,8 +575,9 @@ void Sensors::Reset(const UpdateInfo &_info, EntityComponentManager &)
     gzdbg << "Resetting Sensors\n";
 
     {
-      std::unique_lock<std::mutex> lock(this->dataPtr->sensorMaskMutex);
-      this->dataPtr->sensorMask.clear();
+      std::unique_lock<std::mutex> lock(this->dataPtr->sensorsMutex);
+      this->dataPtr->activeSensors.clear();
+      this->dataPtr->sensorsToUpdate.clear();
     }
 
     for (auto id : this->dataPtr->sensorIds)
@@ -606,6 +592,7 @@ void Sensors::Reset(const UpdateInfo &_info, EntityComponentManager &)
 
       s->SetNextDataUpdateTime(_info.simTime);
     }
+    this->dataPtr->nextUpdateTime =  _info.simTime;
   }
 }
 
@@ -627,8 +614,10 @@ void Sensors::Update(const UpdateInfo &_info,
        _ecm.HasComponentType(components::SegmentationCamera::typeId) ||
        _ecm.HasComponentType(components::WideAngleCamera::typeId)))
   {
+    std::unique_lock<std::mutex> lock(this->dataPtr->renderMutex);
     igndbg << "Initialization needed" << std::endl;
     this->dataPtr->renderUtil.Init();
+    this->dataPtr->nextUpdateTime = _info.simTime;
   }
 #endif
 
@@ -655,6 +644,7 @@ void Sensors::PostUpdate(const UpdateInfo &_info,
          _ecm.HasComponentType(components::SegmentationCamera::typeId) ||
          _ecm.HasComponentType(components::WideAngleCamera::typeId)))
     {
+      std::unique_lock<std::mutex> lock(this->dataPtr->renderMutex);
       gzdbg << "Initialization needed" << std::endl;
       this->dataPtr->doInit = true;
       this->dataPtr->renderCv.notify_one();
@@ -665,47 +655,31 @@ void Sensors::PostUpdate(const UpdateInfo &_info,
   {
     this->dataPtr->renderUtil.UpdateFromECM(_info, _ecm);
 
-    std::vector<sensors::RenderingSensor *> activeSensors;
+    // check connections to render events
+    // we will need to perform render updates if there are event subscribers
+    // \todo(anyone) This currently forces scene tree updates at the sim update
+    // rate which can be too frequent and causes a performance hit.
+    // We should look into throttling render updates
+    bool hasRenderConnections =
+      (this->dataPtr->eventManager->ConnectionCount<events::PreRender>() > 0u ||
+      this->dataPtr->eventManager->ConnectionCount<events::Render>() > 0u ||
+      this->dataPtr->eventManager->ConnectionCount<events::PostRender>() > 0u);
 
+    // if nextUpdateTime is max, it probably means there are previously
+    // no active sensors or sensors with connections.
+    // In this case, check if sensors have connections now. If so, we need to
+    // set the nextUpdateTime
+    if (this->dataPtr->nextUpdateTime ==
+        std::chrono::steady_clock::duration::max() &&
+        this->dataPtr->SensorsHaveConnections())
     {
-      std::unique_lock<std::mutex> lk(this->dataPtr->sensorMaskMutex);
-      for (auto id : this->dataPtr->sensorIds)
-      {
-        sensors::Sensor *s = this->dataPtr->sensorManager.Sensor(id);
-
-        if (nullptr == s)
-        {
-          continue;
-        }
-
-        auto rs = dynamic_cast<sensors::RenderingSensor *>(s);
-
-        if (nullptr == rs)
-        {
-          continue;
-        }
-
-        auto it = this->dataPtr->sensorMask.find(id);
-        if (it != this->dataPtr->sensorMask.end())
-        {
-          if (it->second <= _info.simTime)
-          {
-            this->dataPtr->sensorMask.erase(it);
-          }
-          else
-          {
-            continue;
-          }
-        }
-
-        if (rs && rs->NextDataUpdateTime() <= _info.simTime)
-        {
-          activeSensors.push_back(rs);
-        }
-      }
+      this->dataPtr->nextUpdateTime = this->dataPtr->NextUpdateTime(
+          this->dataPtr->sensorsToUpdate, _info.simTime);
     }
 
-    if (!activeSensors.empty() ||
+    // notify the render thread if updates are available
+    if (hasRenderConnections ||
+        this->dataPtr->nextUpdateTime <= _info.simTime ||
         this->dataPtr->renderUtil.PendingSensors() > 0 ||
         this->dataPtr->forceUpdate)
     {
@@ -713,8 +687,8 @@ void Sensors::PostUpdate(const UpdateInfo &_info,
         this->dataPtr->UpdateBatteryState(_ecm);
 
       {
-        std::unique_lock<std::mutex> lock(this->dataPtr->cvMutex);
-        this->dataPtr->renderCv.wait(lock, [this] {
+        std::unique_lock<std::mutex> cvLock(this->dataPtr->renderMutex);
+        this->dataPtr->renderCv.wait(cvLock, [this] {
           return !this->dataPtr->running || !this->dataPtr->updateAvailable; });
       }
 
@@ -724,8 +698,19 @@ void Sensors::PostUpdate(const UpdateInfo &_info,
       }
 
       {
-        std::unique_lock<std::mutex> lockMask(this->dataPtr->sensorMaskMutex);
-        this->dataPtr->activeSensors = std::move(activeSensors);
+        std::unique_lock<std::mutex> lockSensors(this->dataPtr->sensorsMutex);
+        this->dataPtr->activeSensors = std::move(this->dataPtr->sensorsToUpdate);
+
+        this->dataPtr->nextUpdateTime = this->dataPtr->NextUpdateTime(
+            this->dataPtr->sensorsToUpdate, _info.simTime);
+
+        // Force scene tree update if there are sensors to be created or
+        // subscribes to the render events. This does not necessary force
+        // sensors to update. Only active sensors will be updated
+        this->dataPtr->forceUpdate =
+            (this->dataPtr->renderUtil.PendingSensors() > 0) ||
+            hasRenderConnections;
+
         this->dataPtr->updateTime = _info.simTime;
         this->dataPtr->updateAvailable = true;
       }
@@ -932,6 +917,86 @@ std::string Sensors::CreateSensor(const Entity &_entity,
   }
 
   return sensor->Name();
+}
+
+//////////////////////////////////////////////////
+std::chrono::steady_clock::duration SensorsPrivate::NextUpdateTime(
+    std::set<sensors::SensorId> &_sensorsToUpdate,
+    const std::chrono::steady_clock::duration &_currentTime)
+{
+  _sensorsToUpdate.clear();
+  std::chrono::steady_clock::duration minNextUpdateTime =
+      std::chrono::steady_clock::duration::max();
+  for (auto id : this->sensorIds)
+  {
+    sensors::Sensor *s = this->sensorManager.Sensor(id);
+
+    if (nullptr == s)
+    {
+      continue;
+    }
+
+    auto rs = dynamic_cast<sensors::RenderingSensor *>(s);
+
+    if (nullptr == rs)
+    {
+      continue;
+    }
+
+    if (!rs->HasConnections())
+    {
+      continue;
+    }
+
+    std::chrono::steady_clock::duration time;
+    // if sensor's next update tims is less or equal to current sim time then
+    // it's in the process of being updated by the render loop
+    // Set their next update time  to be current time + update period
+    if (rs->NextDataUpdateTime() <= _currentTime)
+    {
+      time = rs->NextDataUpdateTime() +
+          std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+          std::chrono::duration<double>(1.0 / rs->UpdateRate()));
+    }
+    else
+    {
+      time = rs->NextDataUpdateTime();
+    }
+
+    if (time <= minNextUpdateTime)
+    {
+      _sensorsToUpdate.clear();
+      minNextUpdateTime = time;
+    }
+    _sensorsToUpdate.insert(id);
+  }
+  return minNextUpdateTime;
+}
+
+//////////////////////////////////////////////////
+bool SensorsPrivate::SensorsHaveConnections()
+{
+  for (auto id : this->sensorIds)
+  {
+    sensors::Sensor *s = this->sensorManager.Sensor(id);
+    if (nullptr == s)
+    {
+      continue;
+    }
+
+    auto rs = dynamic_cast<sensors::RenderingSensor *>(s);
+
+    if (nullptr == rs)
+    {
+      continue;
+    }
+
+    if (rs->HasConnections())
+    {
+      return true;
+    }
+  }
+  return false;
 }
 
 GZ_ADD_PLUGIN(Sensors, System,

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -99,6 +99,7 @@ set(tests_needing_display
   rgbd_camera.cc
   sensors_system.cc
   sensors_system_battery.cc
+  sensors_system_update_rate.cc
   shader_param_system.cc
   thermal_sensor_system.cc
   thermal_system.cc

--- a/test/integration/reset_sensors.cc
+++ b/test/integration/reset_sensors.cc
@@ -201,7 +201,7 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
   // Run until a sensor measurement
   pressureReceiver.Start(topic);
   imageReceiver.Start("camera");
-  while (!(pressureReceiver.msgReceived && imageReceiver.msgReceived))
+  while (!pressureReceiver.msgReceived)
   {
     // Step once to get sensor to output measurement
     server.Run(true, 1, false);
@@ -209,6 +209,12 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
 
   EXPECT_GE(server.IterationCount().value(), current);
   EXPECT_FLOAT_EQ(kStartingPressure, pressureReceiver.Last().pressure());
+
+  while (!imageReceiver.msgReceived)
+  {
+    // Step once to get sensor to output measurement
+    server.Run(true, 1, false);
+  }
 
   // Mostly green box
   {
@@ -218,7 +224,6 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
     EXPECT_FLOAT_EQ(0.0, centerPix.R());
     EXPECT_FLOAT_EQ(0.0, centerPix.B());
   }
-
   // Run until 2000 steps
   pressureReceiver.msgReceived = false;
   imageReceiver.msgReceived = false;
@@ -284,13 +289,19 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
   current = 2001;
   target = 4001;
 
-  while (!(pressureReceiver.msgReceived && imageReceiver.msgReceived))
+  while (!pressureReceiver.msgReceived)
   {
     // Step once to get sensor to output measurement
     server.Run(true, 1, false);
   }
   EXPECT_GE(server.IterationCount().value(), 1u);
   EXPECT_FLOAT_EQ(kStartingPressure, pressureReceiver.Last().pressure());
+
+  while (!imageReceiver.msgReceived)
+  {
+    // Step once to get sensor to output measurement
+    server.Run(true, 1, false);
+  }
 
   // Mostly green box
   {
@@ -304,6 +315,7 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
   // Run until target steps
   pressureReceiver.msgReceived = false;
   imageReceiver.msgReceived = false;
+
   server.Run(true, 2000 - server.IterationCount().value(), false);
 
   // Check iterator state

--- a/test/integration/sensors_system_update_rate.cc
+++ b/test/integration/sensors_system_update_rate.cc
@@ -1,0 +1,311 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include <gz/transport/Node.hh>
+#include <gz/utils/ExtraTestMacros.hh>
+
+#include "gz/sim/components/Camera.hh"
+#include "gz/sim/components/DepthCamera.hh"
+#include "gz/sim/components/GpuLidar.hh"
+#include "gz/sim/components/Name.hh"
+#include "gz/sim/components/ParentEntity.hh"
+#include "gz/sim/components/Physics.hh"
+#include "gz/sim/components/RgbdCamera.hh"
+#include "gz/sim/components/Sensor.hh"
+#include "gz/sim/components/SegmentationCamera.hh"
+#include "gz/sim/components/ThermalCamera.hh"
+#include "gz/sim/components/World.hh"
+
+#include "gz/sim/EntityComponentManager.hh"
+#include "gz/sim/EventManager.hh"
+#include "gz/sim/Server.hh"
+#include "gz/sim/SystemLoader.hh"
+#include "gz/sim/Types.hh"
+#include "test_config.hh"
+
+#include "plugins/MockSystem.hh"
+#include "../helpers/EnvTestFixture.hh"
+
+using namespace gz;
+using namespace std::chrono_literals;
+namespace components = gz::sim::components;
+
+//////////////////////////////////////////////////
+class SensorsFixture : public InternalFixture<InternalFixture<::testing::Test>>
+{
+  protected: void SetUp() override
+  {
+    InternalFixture::SetUp();
+
+    sdf::Plugin sdfPlugin;
+    sdfPlugin.SetFilename("libMockSystem.so");
+    sdfPlugin.SetName("gz::sim::MockSystem");
+    auto plugin = sm.LoadPlugin(sdfPlugin);
+    EXPECT_TRUE(plugin.has_value());
+    this->systemPtr = plugin.value();
+    this->mockSystem = static_cast<sim::MockSystem *>(
+        systemPtr->QueryInterface<sim::System>());
+  }
+
+  public: gz::sim::SystemPluginPtr systemPtr;
+  public: sim::MockSystem *mockSystem;
+
+  private: sim::SystemLoader sm;
+};
+
+/////////////////////////////////////////////////
+TEST_F(SensorsFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(UpdateRate))
+{
+  gz::sim::ServerConfig serverConfig;
+
+  const std::string sdfFile = std::string(PROJECT_SOURCE_PATH) +
+    "/test/worlds/sensor.sdf";
+
+  serverConfig.SetSdfFile(sdfFile);
+
+  sim::Server server(serverConfig);
+
+  // A pointer to the ecm. This will be valid once we run the mock system
+  sim::EntityComponentManager *ecm = nullptr;
+  this->mockSystem->configureCallback =
+    [&](const sim::Entity &,
+           const std::shared_ptr<const sdf::Element> &,
+           sim::EntityComponentManager &_ecm,
+           sim::EventManager &)
+    {
+      ecm = &_ecm;
+    };
+
+  server.AddSystem(this->systemPtr);
+  transport::Node node;
+  std::string prefix{"/world/camera_sensor/model/default_topics/"};
+
+  std::vector<double> imageTimestamps;
+  unsigned int imageCount = 0u;
+  auto cameraCb = std::function<void(const msgs::Image &)>(
+      [&](const auto &_msg)
+      {
+        double t = _msg.header().stamp().sec() + 
+            _msg.header().stamp().nsec() * 1e-9;
+        imageTimestamps.push_back(t);
+        ++imageCount;
+      });
+  node.Subscribe(prefix + "link/camera_link/sensor/camera/image", cameraCb);
+
+  std::vector<double> lidarTimestamps;
+  unsigned int lidarCount = 0u;
+  auto lidarCb = std::function<void(const msgs::LaserScan &)>(
+      [&](const auto &_msg)
+      {
+        double t = _msg.header().stamp().sec() + 
+            _msg.header().stamp().nsec() * 1e-9;
+        lidarTimestamps.push_back(t);
+        ++lidarCount;
+      });
+  node.Subscribe(prefix + "link/gpu_lidar_link/sensor/gpu_lidar/scan", lidarCb);
+
+  std::vector<double> depthTimestamps;
+  unsigned int depthCount = 0u;
+  auto depthCb = std::function<void(const msgs::Image &)>(
+      [&](const auto &_msg)
+      {
+        double t = _msg.header().stamp().sec() + 
+            _msg.header().stamp().nsec() * 1e-9;
+        depthTimestamps.push_back(t);
+        ++depthCount;
+      });
+  node.Subscribe(
+      prefix + "link/depth_camera_link/sensor/depth_camera/depth_image",
+      depthCb);
+
+  std::vector<double> rgbdTimestamps;
+  unsigned int rgbdCount = 0u;
+  auto rgbdCb = std::function<void(const msgs::Image &)>(
+      [&](const auto &_msg)
+      {
+        double t = _msg.header().stamp().sec() + 
+            _msg.header().stamp().nsec() * 1e-9;
+        rgbdTimestamps.push_back(t);
+        ++rgbdCount;
+      });
+  node.Subscribe(
+      prefix + "link/rgbd_camera_link/sensor/rgbd_camera/image",
+      rgbdCb);
+
+  std::vector<double> thermalTimestamps;
+  unsigned int thermalCount = 0u;
+  auto thermalCb = std::function<void(const msgs::Image &)>(
+      [&](const auto &_msg)
+      {
+        double t = _msg.header().stamp().sec() + 
+            _msg.header().stamp().nsec() * 1e-9;
+        thermalTimestamps.push_back(t);
+        ++thermalCount;
+      });
+  node.Subscribe(
+      prefix + "link/thermal_camera_link/sensor/thermal_camera/image",
+      thermalCb);
+
+  std::vector<double> segmentationTimestamps;
+  unsigned int segmentationCount = 0u;
+  auto segmentationCb = std::function<void(const msgs::Image &)>(
+      [&](const auto &_msg)
+      {
+        double t = _msg.header().stamp().sec() + 
+            _msg.header().stamp().nsec() * 1e-9;
+        segmentationTimestamps.push_back(t);
+        ++segmentationCount;
+      });
+  node.Subscribe(
+      prefix + "link/segmentation_camera_link/sensor/segmentation_camera/" +
+      "segmentation/colored_map",
+      segmentationCb);
+
+  unsigned int iterations = 2000u;
+  server.Run(true, iterations, false);
+
+  EXPECT_NE(nullptr, ecm);
+
+  // get the world step size
+  auto worldEntity = ecm->EntityByComponents(components::World());
+  EXPECT_NE(sim::kNullEntity, worldEntity);
+  auto physicsSdf = ecm->Component<components::Physics>(worldEntity)->Data();
+  double stepSize = physicsSdf.MaxStepSize();
+  EXPECT_LT(0, stepSize);
+
+  // get the sensors update rates
+  auto camLinkEntity = ecm->EntityByComponents(components::Name("camera_link"));
+  EXPECT_NE(sim::kNullEntity, camLinkEntity);
+  auto camEntity = ecm->EntityByComponents(components::Name("camera"),
+      components::ParentEntity(camLinkEntity));
+  EXPECT_NE(sim::kNullEntity, camEntity);
+  auto sensorSdf = ecm->Component<components::Camera>(camEntity)->Data();
+  unsigned int camRate = sensorSdf.UpdateRate();
+  EXPECT_LT(0u, camRate);
+
+  auto lidarEntity = ecm->EntityByComponents(components::Name("gpu_lidar"));
+  EXPECT_NE(sim::kNullEntity, lidarEntity);
+  sensorSdf = ecm->Component<components::GpuLidar>(lidarEntity)->Data();
+  unsigned int lidarRate = sensorSdf.UpdateRate();
+  EXPECT_LT(0u, lidarRate);
+
+  auto depthEntity = ecm->EntityByComponents(components::Name("depth_camera"));
+  EXPECT_NE(sim::kNullEntity, depthEntity);
+  sensorSdf = ecm->Component<components::DepthCamera>(depthEntity)->Data();
+  unsigned int depthRate = sensorSdf.UpdateRate();
+  EXPECT_LT(0u, depthRate);
+
+  auto rgbdEntity = ecm->EntityByComponents(components::Name("rgbd_camera"));
+  EXPECT_NE(sim::kNullEntity, rgbdEntity);
+  sensorSdf = ecm->Component<components::RgbdCamera>(rgbdEntity)->Data();
+  unsigned int rgbdRate = sensorSdf.UpdateRate();
+  EXPECT_LT(0u, rgbdRate);
+
+  auto thermalEntity = ecm->EntityByComponents(
+      components::Name("thermal_camera"));
+  EXPECT_NE(sim::kNullEntity, thermalEntity);
+  sensorSdf = ecm->Component<components::ThermalCamera>(thermalEntity)->Data();
+  unsigned int thermalRate = sensorSdf.UpdateRate();
+  EXPECT_LT(0u, thermalRate);
+
+  auto segmentationEntity = ecm->EntityByComponents(
+      components::Name("segmentation_camera"));
+  EXPECT_NE(sim::kNullEntity, segmentationEntity);
+  sensorSdf = ecm->Component<components::SegmentationCamera>(
+      segmentationEntity)->Data();
+  unsigned int segmentationRate = sensorSdf.UpdateRate();
+  EXPECT_LT(0u, segmentationRate);
+
+  // compute and verify expected msg count based on update rate and sim time
+  double timeRan = iterations * stepSize;
+
+  unsigned int expectedCamMsgCount = timeRan / (1.0 / camRate) + 1;
+  unsigned int expectedDepthMsgCount = timeRan / (1.0 / depthRate) + 1;
+  unsigned int expectedLidarMsgCount = timeRan / (1.0 / lidarRate) + 1;
+  unsigned int expectedRgbdMsgCount = timeRan / (1.0 / rgbdRate) + 1;
+  unsigned int expectedThermalMsgCount = timeRan / (1.0 / thermalRate) + 1;
+  unsigned int expectedSegmentationMsgCount =
+      timeRan / (1.0 / segmentationRate) + 1;
+
+  unsigned int sleep = 0;
+  unsigned int maxSleep = 100;
+  while (sleep++ < maxSleep &&
+         (imageCount < expectedCamMsgCount ||
+         lidarCount < expectedLidarMsgCount ||  
+         depthCount < expectedDepthMsgCount ||
+         rgbdCount < expectedRgbdMsgCount || 
+         thermalCount < expectedThermalMsgCount || 
+         segmentationCount < expectedSegmentationMsgCount))
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  EXPECT_EQ(expectedCamMsgCount, imageCount);
+  EXPECT_EQ(expectedDepthMsgCount, depthCount);
+  EXPECT_EQ(expectedLidarMsgCount, lidarCount);
+  EXPECT_EQ(expectedRgbdMsgCount, rgbdCount);
+  EXPECT_EQ(expectedThermalMsgCount, thermalCount);
+  EXPECT_EQ(expectedSegmentationMsgCount, segmentationCount);
+
+  // verify timestamps
+  // The first timestamp may not be 0 because the rendering
+  // may take some time to start and it does not block the main thread
+  // so start with index = 1
+  // \todo(anyone) Make the sensors system thread block so we always
+  // generate data at t = 0?
+  EXPECT_FALSE(imageTimestamps.empty());
+  EXPECT_FALSE(lidarTimestamps.empty());
+  EXPECT_FALSE(depthTimestamps.empty());
+  EXPECT_FALSE(rgbdTimestamps.empty());
+  EXPECT_FALSE(thermalTimestamps.empty());
+  EXPECT_FALSE(segmentationTimestamps.empty());
+  for (unsigned int i = 1; i < imageTimestamps.size()-1; ++i)
+  {
+    double dt = imageTimestamps[i+1] - imageTimestamps[i];
+    EXPECT_FLOAT_EQ(1.0 / camRate, dt);
+  }
+  for (unsigned int i = 1; i < lidarTimestamps.size()-1; ++i)
+  {
+    double dt = lidarTimestamps[i+1] - lidarTimestamps[i];
+    EXPECT_FLOAT_EQ(1.0 / lidarRate, dt);
+  }
+  for (unsigned int i = 1; i < depthTimestamps.size()-1; ++i)
+  {
+    double dt = depthTimestamps[i+1] - depthTimestamps[i];
+    EXPECT_FLOAT_EQ(1.0 / depthRate, dt);
+  }
+  for (unsigned int i = 1; i < rgbdTimestamps.size()-1; ++i)
+  {
+    double dt = rgbdTimestamps[i+1] - rgbdTimestamps[i];
+    EXPECT_FLOAT_EQ(1.0 / rgbdRate, dt);
+  }
+  for (unsigned int i = 1; i < thermalTimestamps.size()-1; ++i)
+  {
+    double dt = thermalTimestamps[i+1] - thermalTimestamps[i];
+    EXPECT_FLOAT_EQ(1.0 / thermalRate, dt);
+  }
+  for (unsigned int i = 1; i < segmentationTimestamps.size()-1; ++i)
+  {
+    double dt = segmentationTimestamps[i+1] - segmentationTimestamps[i];
+    EXPECT_FLOAT_EQ(1.0 / segmentationRate, dt);
+  }
+}

--- a/test/integration/sensors_system_update_rate.cc
+++ b/test/integration/sensors_system_update_rate.cc
@@ -104,7 +104,7 @@ TEST_F(SensorsFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(UpdateRate))
   auto cameraCb = std::function<void(const msgs::Image &)>(
       [&](const auto &_msg)
       {
-        double t = _msg.header().stamp().sec() + 
+        double t = _msg.header().stamp().sec() +
             _msg.header().stamp().nsec() * 1e-9;
         imageTimestamps.push_back(t);
         ++imageCount;
@@ -116,7 +116,7 @@ TEST_F(SensorsFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(UpdateRate))
   auto lidarCb = std::function<void(const msgs::LaserScan &)>(
       [&](const auto &_msg)
       {
-        double t = _msg.header().stamp().sec() + 
+        double t = _msg.header().stamp().sec() +
             _msg.header().stamp().nsec() * 1e-9;
         lidarTimestamps.push_back(t);
         ++lidarCount;
@@ -128,7 +128,7 @@ TEST_F(SensorsFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(UpdateRate))
   auto depthCb = std::function<void(const msgs::Image &)>(
       [&](const auto &_msg)
       {
-        double t = _msg.header().stamp().sec() + 
+        double t = _msg.header().stamp().sec() +
             _msg.header().stamp().nsec() * 1e-9;
         depthTimestamps.push_back(t);
         ++depthCount;
@@ -142,7 +142,7 @@ TEST_F(SensorsFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(UpdateRate))
   auto rgbdCb = std::function<void(const msgs::Image &)>(
       [&](const auto &_msg)
       {
-        double t = _msg.header().stamp().sec() + 
+        double t = _msg.header().stamp().sec() +
             _msg.header().stamp().nsec() * 1e-9;
         rgbdTimestamps.push_back(t);
         ++rgbdCount;
@@ -156,7 +156,7 @@ TEST_F(SensorsFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(UpdateRate))
   auto thermalCb = std::function<void(const msgs::Image &)>(
       [&](const auto &_msg)
       {
-        double t = _msg.header().stamp().sec() + 
+        double t = _msg.header().stamp().sec() +
             _msg.header().stamp().nsec() * 1e-9;
         thermalTimestamps.push_back(t);
         ++thermalCount;
@@ -170,7 +170,7 @@ TEST_F(SensorsFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(UpdateRate))
   auto segmentationCb = std::function<void(const msgs::Image &)>(
       [&](const auto &_msg)
       {
-        double t = _msg.header().stamp().sec() + 
+        double t = _msg.header().stamp().sec() +
             _msg.header().stamp().nsec() * 1e-9;
         segmentationTimestamps.push_back(t);
         ++segmentationCount;
@@ -250,10 +250,10 @@ TEST_F(SensorsFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(UpdateRate))
   unsigned int maxSleep = 100;
   while (sleep++ < maxSleep &&
          (imageCount < expectedCamMsgCount ||
-         lidarCount < expectedLidarMsgCount ||  
+         lidarCount < expectedLidarMsgCount ||
          depthCount < expectedDepthMsgCount ||
-         rgbdCount < expectedRgbdMsgCount || 
-         thermalCount < expectedThermalMsgCount || 
+         rgbdCount < expectedRgbdMsgCount ||
+         thermalCount < expectedThermalMsgCount ||
          segmentationCount < expectedSegmentationMsgCount))
   {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/test/worlds/sensor.sdf
+++ b/test/worlds/sensor.sdf
@@ -2,7 +2,8 @@
 <sdf version="1.6">
   <world name="camera_sensor">
     <physics name="fast" type="ignored">
-      <real_time_factor>0</real_time_factor>
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
     </physics>
 
     <plugin
@@ -87,6 +88,7 @@
       <static>true</static>
       <link name="camera_link">
         <sensor name="camera" type="camera">
+          <update_rate>50</update_rate>
           <camera>
             <horizontal_fov>1.047</horizontal_fov>
             <image>
@@ -103,6 +105,7 @@
 
       <link name="gpu_lidar_link">
         <sensor name='gpu_lidar' type='gpu_lidar'>"
+          <update_rate>40</update_rate>
           <ray>
             <scan>
               <horizontal>
@@ -129,6 +132,7 @@
 
       <link name="depth_camera_link">
         <sensor name="depth_camera" type="depth_camera">
+          <update_rate>25</update_rate>
           <camera>
             <horizontal_fov>1.05</horizontal_fov>
             <image>
@@ -152,6 +156,7 @@
 
       <link name="rgbd_camera_link">
         <sensor name="rgbd_camera" type="rgbd_camera">
+          <update_rate>10</update_rate>
           <camera>
             <horizontal_fov>1.05</horizontal_fov>
             <image>
@@ -168,6 +173,7 @@
 
       <link name="thermal_camera_link">
         <sensor name="thermal_camera" type="thermal_camera">
+          <update_rate>40</update_rate>
           <camera>
             <horizontal_fov>1.15</horizontal_fov>
             <image>
@@ -184,6 +190,7 @@
 
       <link name="segmentation_camera_link">
         <sensor name="segmentation_camera" type="segmentation_camera">
+          <update_rate>25</update_rate>
           <camera>
             <horizontal_fov>1.0</horizontal_fov>
             <image>


### PR DESCRIPTION
~**Marked as draft to debug test failures**~ Fixed

# 🦟 Bug fix

Related to: https://github.com/gazebosim/gz-sensors/issues/332

## Summary

While profiling the sensors system, I noticed that it spends a quite bit of time
* waiting in the [Sensors::Update](https://github.com/gazebosim/gz-sim/blob/gz-sim7/src/systems/sensors/Sensors.cc#L602-L606) function for rendering operation to finish and release the [renderMutex](https://github.com/gazebosim/gz-sim/blob/gz-sim7/src/systems/sensors/Sensors.cc#L606). This is not necessary since the `RenderUtil` calls inside the `Update` function should be thread-safe (protected by mutex inside RenderUtil).
* doing scene tree updates (`scene->PreRender()`, `scene->PostRender`, `renderUtil.Update()`) when there are no sensor or render event subscribers

This PR optimizes the threading and render updates in the sensors system by:
* ~removing~ reducing the scope of the `renderMutex` lock in `Sensors::Update` function
~* use a separate mutex for the render condition variable to reduce places that need to lock the `renderMutex`~
* changing a few bool variables to atomic, also to reduce the need to lock mutexes
* performing scene tree updates only when necessary

## Test results

Here are the RTF changes that I got from running different worlds (i7 3.4GHz 32GB RAM, NVIDIA GeForce GTX 1070 8GB VRAM). I added a best fit line to the RTF values. There is an improvement in RTF and noticeably less jitter.

*  `sensors_demo.sdf` world (with lidar visualization on)

    * **Before**
![sensors_demo_before](https://user-images.githubusercontent.com/4000684/226712599-6128d2bb-5424-4057-b2a3-da723cad4e3f.png)

    * **After**
![sensors_demo_after](https://user-images.githubusercontent.com/4000684/226805298-87fbd558-3e3d-4077-8323-fec9da5694f8.png)





*  [`profile_lidar.sdf`](https://gist.github.com/iche033/2b3aa693687ed8f1742720bfd1fbb6a0) world (5 lidars inside [Depot](https://app.gazebosim.org/OpenRobotics/fuel/models/Depot) model. All lidars are subscribed)

    * **Before**
![profile_lidar_before](https://user-images.githubusercontent.com/4000684/226713179-0afcf978-38e6-4459-8102-dbc8a26315fd.png)


    * **After**
![profile_lidar_after](https://user-images.githubusercontent.com/4000684/226805280-fa5a6d85-822d-4f53-ba73-c66d11c64e93.png)





## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
