### PR TITLE
Cherry-Pick #1836: Use a queue to track component registration from multiple sources

### DIFF
--- a/include/gz/sim/components/Component.hh
+++ b/include/gz/sim/components/Component.hh
@@ -387,6 +387,8 @@ namespace components
 
     /// \brief Unique name for this component type. This is set through the
     /// Factory registration.
+    // TODO(azeey) Change to const char* in Harmonic to prevent static
+    // initialization order fiasco.
     public: inline static std::string typeName;
   };
 
@@ -433,6 +435,8 @@ namespace components
 
     /// \brief Unique name for this component type. This is set through the
     /// Factory registration.
+    // TODO(azeey) Change to const char* in Harmonic to prevent static
+    // initialization order fiasco.
     public: inline static std::string typeName;
   };
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,7 @@ set (sources
   Barrier.cc
   BaseView.cc
   Conversions.cc
+  ComponentFactory.cc
   EntityComponentManager.cc
   EntityComponentManagerDiff.cc
   LevelManager.cc

--- a/src/ComponentFactory.cc
+++ b/src/ComponentFactory.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/sim/components/Factory.hh"
+
+using Factory = gz::sim::components::Factory;
+
+Factory *Factory::Instance()
+{
+  return common::SingletonT<Factory>::Instance();
+}

--- a/src/ComponentFactory_TEST.cc
+++ b/src/ComponentFactory_TEST.cc
@@ -68,7 +68,7 @@ TEST_F(ComponentFactoryTest, Register)
   EXPECT_EQ(registeredCount + 1, ids.size());
   EXPECT_NE(ids.end(), std::find(ids.begin(), ids.end(), MyCustom::typeId));
 
-  // Fail to register same component twice
+  // Registering the component twice doesn't change the number of type ids.
   factory->Register<MyCustom>("gz_sim_components.MyCustom",
       new components::ComponentDescriptor<MyCustom>());
 
@@ -85,11 +85,8 @@ TEST_F(ComponentFactoryTest, Register)
   // Unregister
   factory->Unregister<MyCustom>();
 
-  // Check it has no type id yet
   ids = factory->TypeIds();
-  EXPECT_EQ(registeredCount, ids.size());
-  EXPECT_EQ(0u, MyCustom::typeId);
-  EXPECT_EQ("", factory->Name(MyCustom::typeId));
+  EXPECT_EQ(registeredCount + 1, ids.size());
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

Cherry-Pick #1836 with `ign->gz` changes.

## Summary

When a plugin gets unloaded, the component types it registered will have invalid component descriptors. Attempting to create new components of those types will result in a segfault. This PR is an attempt to fix that by keeping track of all component registrations and removing invalid ones when plugins get unloaded.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Rebase-and-merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.