### PR TITLE
Improve realtime factor (RTF) calculation

### DIFF
--- a/examples/worlds/camera_sensor.sdf
+++ b/examples/worlds/camera_sensor.sdf
@@ -15,7 +15,7 @@
     <plugin
       filename="gz-sim-sensors-system"
       name="gz::sim::systems::Sensors">
-      <render_engine>ogre</render_engine>
+      <render_engine>ogre2</render_engine>
     </plugin>
     <plugin
       filename="gz-sim-user-commands-system"

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -278,8 +278,8 @@ void SimulationRunner::UpdateCurrentInfo()
   if (this->requestedRewind)
   {
     gzdbg << "Rewinding simulation back to initial time." << std::endl;
-    this->realTimes.clear();
-    this->simTimes.clear();
+    this->simTimeDelayed.reset();
+    this->realTimeDelayed.reset();
     this->realTimeFactor = 0;
 
     this->currentInfo.dt = this->simTimeEpoch - this->currentInfo.simTime;
@@ -301,8 +301,8 @@ void SimulationRunner::UpdateCurrentInfo()
     gzdbg << "Seeking to " << std::chrono::duration_cast<std::chrono::seconds>(
         this->requestedSeek.value()).count() << "s." << std::endl;
 
-    this->realTimes.clear();
-    this->simTimes.clear();
+    this->simTimeDelayed.reset();
+    this->realTimeDelayed.reset();
     this->realTimeFactor = 0;
 
     this->currentInfo.dt = this->requestedSeek.value() -
@@ -319,40 +319,34 @@ void SimulationRunner::UpdateCurrentInfo()
 
   // Regular time flow
 
-  // Store the real time and sim time only if not paused.
-  if (this->realTimeWatch.Running())
+  const double simTimeCount =
+      static_cast<double>(this->currentInfo.simTime.count());
+  const double realTimeCount =
+      static_cast<double>(this->currentInfo.realTime.count());
+
+  if (realTimeCount > 0)
   {
-    this->realTimes.push_back(this->realTimeWatch.ElapsedRunTime());
-    this->simTimes.push_back(this->currentInfo.simTime);
-  }
+    // Store the real time and sim time only if not paused.
+    constexpr double kAlpha = 0.999;
+    this->simTimeDelayed =
+        kAlpha * this->simTimeDelayed.value_or(simTimeCount) +
+        (1.0 - kAlpha) * simTimeCount;
 
-  // Maintain a window size of 20 for realtime and simtime.
-  if (this->realTimes.size() > 20)
-    this->realTimes.pop_front();
-  if (this->simTimes.size() > 20)
-    this->simTimes.pop_front();
+    this->realTimeDelayed =
+        kAlpha * this->realTimeDelayed.value_or(realTimeCount) +
+        (1.0 - kAlpha) * realTimeCount;
 
-  // Compute the average sim and real times.
-  std::chrono::steady_clock::duration simAvg{0}, realAvg{0};
-  std::list<std::chrono::steady_clock::duration>::iterator simIter,
-    realIter;
+    // Compute the average sim and real times.
+    const double realTimeFiltered = realTimeCount - (*this->realTimeDelayed);
+    const double simTimeFiltered = simTimeCount - (*this->simTimeDelayed);
 
-  simIter = ++(this->simTimes.begin());
-  realIter = ++(this->realTimes.begin());
-  while (simIter != this->simTimes.end() && realIter != this->realTimes.end())
-  {
-    simAvg += ((*simIter) - this->simTimes.front());
-    realAvg += ((*realIter) - this->realTimes.front());
-    ++simIter;
-    ++realIter;
-  }
-
-  // RTF, only compute this if the realTime count is greater than zero. The
-  // realtTime count could be zero if simulation was started paused.
-  if (realAvg.count() > 0)
-  {
-    this->realTimeFactor = math::precision(
-          static_cast<double>(simAvg.count()) / realAvg.count(), 4);
+    // RTF, only compute this if the realTime count is greater than zero. The
+    // realtTime count could be zero if simulation was started paused.
+    if (realTimeFiltered > 0)
+    {
+      this->realTimeFactor =
+          math::precision(simTimeFiltered / realTimeFiltered, 4);
+    }
   }
 
   // Fill the current update info
@@ -413,8 +407,8 @@ void SimulationRunner::UpdatePhysicsParams()
     }
     if (updated)
     {
-      this->simTimes.clear();
-      this->realTimes.clear();
+      this->simTimeDelayed.reset();
+      this->realTimeDelayed.reset();
       // Set as OneTimeChange to make sure the update is not missed
       this->entityCompMgr.SetChanged(worldEntity, components::Physics::typeId,
           ComponentState::OneTimeChange);

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -440,11 +440,13 @@ namespace gz
       /// All simulation times will be larger than the epoch. It defaults to 0.
       private: std::chrono::steady_clock::duration simTimeEpoch{0};
 
-      /// \brief List of simulation times used to compute averages.
-      private: std::list<std::chrono::steady_clock::duration> simTimes;
+      /// \brief Holds the delayed simTime which is used to compute a filter
+      /// real time factor
+      private: std::optional<double> simTimeDelayed;
 
-      /// \brief List of real times used to compute averages.
-      private: std::list<std::chrono::steady_clock::duration> realTimes;
+      /// \brief Holds the delayed realTime which is used to compute a filter
+      /// real time factor
+      private: std::optional<double> realTimeDelayed;
 
       /// \brief Node for communication.
       private: std::unique_ptr<transport::Node> node{nullptr};


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The current RTF calculation uses a moving window of 20 iterations for smoothing. This apparently is not enough and the RTF displayed in the GUI fluctuates a lot.  The fluctuation also gives an inflated sense of RTF when used with sensors that don't need to update every time step compared to the RTF obtained by simply doing `totalSimTime/totalRealTime`.

The approach in this PR essentially increases the moving window, but uses low pass filtered simTime and realTime as delayed versions of the same. The delayed times are then subtracted from the corresponding current time to get a larger window of time with which to compute the RTF.

The result is best demonstrated in this plot. Here, I'm running `examples/worlds/camera_sensor.sdf` and plotting the RTF. After 30 seconds, I remove the image subscriber to show the change in RTF.

![Figure_1](https://user-images.githubusercontent.com/206116/227373702-18fd84ff-12d9-499f-8e41-fa3910a4b552.png)

It's interesting that even after the subscriber is removed, the RTF doesn't go to 1.0.  #1938 might help, but we might also be sleeping too much in the update loop as shown in the figure below of running `empty.sdf`. 
Hopefully, we can figure out why down the road.

![image](https://user-images.githubusercontent.com/206116/227375341-efa57af8-86e1-4cd5-8c68-615b17a5c692.png)



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸