### PR TITLE
Initialize services in ViewAngle constructor

### DIFF
--- a/src/gui/plugins/view_angle/ViewAngle.cc
+++ b/src/gui/plugins/view_angle/ViewAngle.cc
@@ -64,7 +64,7 @@ namespace gz::sim
       "/gui/camera/view_control/reference_visual";
 
     /// \brief View Control sensitivity service name
-    public: std::string viewControlSensitivityService = 
+    public: std::string viewControlSensitivityService =
       "/gui/camera/view_control/sensitivity";
 
     /// \brief Move gui camera to pose service name

--- a/src/gui/plugins/view_angle/ViewAngle.cc
+++ b/src/gui/plugins/view_angle/ViewAngle.cc
@@ -57,19 +57,21 @@ namespace gz::sim
     public: std::mutex mutex;
 
     /// \brief View Control service name
-    public: std::string viewControlService;
+    public: std::string viewControlService = "/gui/camera/view_control";
 
     /// \brief View Control reference visual service name
-    public: std::string viewControlRefVisualService;
+    public: std::string viewControlRefVisualService =
+      "/gui/camera/view_control/reference_visual";
 
     /// \brief View Control sensitivity service name
-    public: std::string viewControlSensitivityService;
+    public: std::string viewControlSensitivityService = 
+      "/gui/camera/view_control/sensitivity";
 
     /// \brief Move gui camera to pose service name
-    public: std::string moveToPoseService;
+    public: std::string moveToPoseService = "/gui/move_to/pose";
 
     /// \brief Move gui camera to model service name
-    public: std::string moveToModelService;
+    public: std::string moveToModelService = "/gui/move_to/model";
 
     /// \brief New move to model message
     public: bool newMoveToModel = false;
@@ -144,27 +146,12 @@ void ViewAngle::LoadConfig(const tinyxml2::XMLElement *)
   if (this->title.empty())
     this->title = "View Angle";
 
-  // view control requests
-  this->dataPtr->viewControlService = "/gui/camera/view_control";
-
-  // view control reference visual requests
-  this->dataPtr->viewControlRefVisualService =
-      "/gui/camera/view_control/reference_visual";
-
-  // view control sensitivity requests
-  this->dataPtr->viewControlSensitivityService =
-      "/gui/camera/view_control/sensitivity";
-
   // Subscribe to camera pose
   std::string topic = "/gui/camera/pose";
   this->dataPtr->node.Subscribe(
     topic, &ViewAngle::CamPoseCb, this);
 
-  // Move to pose service
-  this->dataPtr->moveToPoseService = "/gui/move_to/pose";
-
   // Move to model service
-  this->dataPtr->moveToModelService = "/gui/move_to/model";
   this->dataPtr->node.Advertise(this->dataPtr->moveToModelService,
       &ViewAngle::OnMoveToModelService, this);
   gzmsg << "Move to model service on ["


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

When loading the `ViewAngle` GUI plugin, the terminal shows the following message:
```
caguero@cold:~$ gz sim /home/caguero/garden_ws/install/share/gz/gz-sim7/worlds/minimal_scene.sdf
Service [] is not valid.
```

The reason for this is that we're trying to call `Request()` before the  appropriate service name has been initialized. Before this patch, the services are initialized in `LoadConfig()`. We're now initializing the services in the constructor.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

