### PR TITLE
Fix use of actors that only has trajectory animation

### DIFF
--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -508,6 +508,19 @@ Entity SdfEntityCreator::CreateEntities(const sdf::Actor *_actor)
   this->dataPtr->ecm->CreateComponent(actorEntity,
       components::Name(_actor->Name()));
 
+  // Links
+  for (uint64_t linkIndex = 0; linkIndex < _actor->LinkCount();
+      ++linkIndex)
+  {
+    auto link = _actor->LinkByIndex(linkIndex);
+    auto linkEntity = this->CreateEntities(link);
+
+    this->SetParent(linkEntity, actorEntity);
+  }
+
+  // \todo(anyone) Load Joints, Nested Models, and set canonical link
+  // Need to update Actor SDF DOM to include APIs for nested models
+
   // Actor plugins
   this->dataPtr->eventManager->Emit<events::LoadSdfPlugins>(actorEntity,
         _actor->Plugins());

--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -518,9 +518,6 @@ Entity SdfEntityCreator::CreateEntities(const sdf::Actor *_actor)
     this->SetParent(linkEntity, actorEntity);
   }
 
-  // \todo(anyone) Load Joints, Nested Models, and set canonical link
-  // Need to update Actor SDF DOM to include APIs for nested models
-
   // Actor plugins
   this->dataPtr->eventManager->Emit<events::LoadSdfPlugins>(actorEntity,
         _actor->Plugins());

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -2367,7 +2367,8 @@ SceneManagerPrivate::LoadTrajectories(const sdf::Actor &_actor,
 
         if (_meshSkel)
         {
-          // Animations are offset by 1 because index 0 is taken by the mesh name
+          // Animations are offset by 1 because index 0 is taken by the mesh
+          // name
           auto animation = _actor.AnimationByIndex(trajInfo.AnimIndex() - 1);
 
           if (animation && animation->InterpolateX() && _meshSkel)

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -115,6 +115,16 @@ class ignition::gazebo::SceneManagerPrivate
   /// also sets the time point in which the animation should be played
   public: AnimationUpdateData ActorTrajectoryAt(
       Entity _id, const std::chrono::steady_clock::duration &_time) const;
+
+  /// \brief Load Actor trajectories
+  /// \param[in] _actor Actor
+  /// \param[in] _mapAnimNameId  Animation name to id map
+  /// \param[in] _skel Mesh skeleton
+  /// \return Trajectory vector
+  public: std::vector<common::TrajectoryInfo>
+      LoadTrajectories(const sdf::Actor &_actor,
+      std::unordered_map<std::string, unsigned int> &_mapAnimNameId,
+      common::SkeletonPtr _skel);
 };
 
 
@@ -964,113 +974,38 @@ rendering::VisualPtr SceneManager::CreateActor(Entity _id,
   descriptor.meshName = asFullPath(_actor.SkinFilename(), _actor.FilePath());
   common::MeshManager *meshManager = common::MeshManager::Instance();
   descriptor.mesh = meshManager->Load(descriptor.meshName);
+  std::unordered_map<std::string, unsigned int> mapAnimNameId;
+  common::SkeletonPtr meshSkel;
   if (nullptr == descriptor.mesh)
   {
-    ignerr << "Actor skin mesh [" << descriptor.meshName << "] not found."
-           << std::endl;
-    return rendering::VisualPtr();
+    ignwarn << "Actor skin mesh [" << descriptor.meshName << "] not found."
+            << std::endl;
   }
-
-  // todo(anyone) create a copy of meshSkel so we don't modify the original
-  // when adding animations!
-  common::SkeletonPtr meshSkel = descriptor.mesh->MeshSkeleton();
-  if (nullptr == meshSkel)
-  {
-    ignerr << "Mesh skeleton in [" << descriptor.meshName << "] not found."
-           << std::endl;
-    return rendering::VisualPtr();
-  }
-
-  // Load all animations
-  auto mapAnimNameId = this->LoadAnimations(_actor);
-  if (mapAnimNameId.size() == 0)
-    return nullptr;
-
-  this->dataPtr->actorSkeletons[_id] = meshSkel;
-
-  std::vector<common::TrajectoryInfo> trajectories;
-  if (_actor.TrajectoryCount() != 0)
-  {
-    // Load all trajectories specified in sdf
-    for (unsigned i = 0; i < _actor.TrajectoryCount(); i++)
-    {
-      const sdf::Trajectory *trajSdf = _actor.TrajectoryByIndex(i);
-      if (nullptr == trajSdf)
-      {
-        ignerr << "Null trajectory SDF for [" << _actor.Name() << "]"
-               << std::endl;
-        continue;
-      }
-
-      common::TrajectoryInfo trajInfo;
-      trajInfo.SetId(trajSdf->Id());
-      trajInfo.SetAnimIndex(mapAnimNameId[trajSdf->Type()]);
-
-      if (trajSdf->WaypointCount() != 0)
-      {
-        std::map<TP, math::Pose3d> waypoints;
-        for (unsigned j = 0; j < trajSdf->WaypointCount(); j++)
-        {
-          auto point = trajSdf->WaypointByIndex(j);
-          TP pointTp(std::chrono::milliseconds(
-                    static_cast<int>(point->Time()*1000)));
-          waypoints[pointTp] = point->Pose();
-        }
-        trajInfo.SetWaypoints(waypoints, trajSdf->Tension());
-        // Animations are offset by 1 because index 0 is taken by the mesh name
-        auto animation = _actor.AnimationByIndex(trajInfo.AnimIndex()-1);
-
-        if (animation && animation->InterpolateX())
-        {
-          // warn if no x displacement can be interpolated
-          // warn only once per mesh
-          static std::unordered_set<std::string> animInterpolateCheck;
-          if (animInterpolateCheck.count(animation->Filename()) == 0)
-          {
-            std::string rootNodeName = meshSkel->RootNode()->Name();
-            common::SkeletonAnimation *skelAnim =
-                meshSkel->Animation(trajInfo.AnimIndex());
-            common::NodeAnimation *rootNode = skelAnim->NodeAnimationByName(
-                rootNodeName);
-            math::Matrix4d lastPos = rootNode->KeyFrame(
-                rootNode->FrameCount() - 1).second;
-            math::Matrix4d firstPos = rootNode->KeyFrame(0).second;
-            if (!math::equal(firstPos.Translation().X(),
-                lastPos.Translation().X()))
-            {
-              trajInfo.Waypoints()->SetInterpolateX(animation->InterpolateX());
-            }
-            else
-            {
-              ignwarn << "Animation has no x displacement. "
-                      << "Ignoring <interpolate_x> for the animation in '"
-                      << animation->Filename() << "'." << std::endl;
-            }
-            animInterpolateCheck.insert(animation->Filename());
-          }
-        }
-      }
-      else
-      {
-        trajInfo.SetTranslated(false);
-      }
-      trajectories.push_back(trajInfo);
-    }
-  }
-  // if there are no trajectories, but there are animations, add a trajectory
   else
   {
-    auto skel = this->dataPtr->actorSkeletons[_id];
-    common::TrajectoryInfo trajInfo;
-    trajInfo.SetId(0);
-    trajInfo.SetAnimIndex(0);
-    trajInfo.SetStartTime(TP(0ms));
-    auto timepoint = std::chrono::milliseconds(
-                  static_cast<int>(skel->Animation(0)->Length() * 1000));
-    trajInfo.SetEndTime(TP(timepoint));
-    trajInfo.SetTranslated(false);
-    trajectories.push_back(trajInfo);
+    // todo(anyone) create a copy of meshSkel so we don't modify the original
+    // when adding animations!
+    meshSkel = descriptor.mesh->MeshSkeleton();
+    if (nullptr == meshSkel)
+    {
+      ignwarn << "Mesh skeleton in [" << descriptor.meshName << "] not found."
+              << std::endl;
+    }
+    else
+    {
+      this->dataPtr->actorSkeletons[_id] = meshSkel;
+      // Load all animations
+      mapAnimNameId = this->LoadAnimations(_actor);
+      if (mapAnimNameId.size() == 0)
+        return nullptr;
+    }
   }
+
+  // load trajectories regardless of whether the mesh skeleton exists
+  // or not. If there is no mesh skeleon, we can still do trajectory
+  // animation
+  auto trajectories = this->dataPtr->LoadTrajectories(_actor, mapAnimNameId,
+                      meshSkel);
 
   // sequencing all trajectories
   auto delayStartTime = std::chrono::milliseconds(
@@ -1093,25 +1028,27 @@ rendering::VisualPtr SceneManager::CreateActor(Entity _id,
 
   this->dataPtr->actorTrajectories[_id] = trajectories;
 
+  rendering::VisualPtr actorVisual = this->dataPtr->scene->CreateVisual(name);
+  rendering::MeshPtr actorMesh;
   // create mesh with animations
-  rendering::MeshPtr actorMesh = this->dataPtr->scene->CreateMesh(
-      descriptor);
-  if (nullptr == actorMesh)
+  if (descriptor.mesh)
   {
-    ignerr << "Actor skin file [" << descriptor.meshName << "] not found."
-           << std::endl;
-    return rendering::VisualPtr();
+    actorMesh = this->dataPtr->scene->CreateMesh(descriptor);
+    if (nullptr == actorMesh)
+    {
+      ignerr << "Actor skin file [" << descriptor.meshName << "] not found."
+             << std::endl;
+      return rendering::VisualPtr();
+    }
+    actorVisual->AddGeometry(actorMesh);
   }
 
-  rendering::VisualPtr actorVisual = this->dataPtr->scene->CreateVisual(name);
   actorVisual->SetLocalPose(_actor.RawPose());
-  actorVisual->AddGeometry(actorMesh);
   actorVisual->SetUserData("gazebo-entity", static_cast<int>(_id));
   actorVisual->SetUserData("pause-update", static_cast<int>(0));
 
   this->dataPtr->visuals[_id] = actorVisual;
   this->dataPtr->actors[_id] = actorMesh;
-
 
   if (parent)
     parent->AddChild(actorVisual);
@@ -1796,11 +1733,11 @@ AnimationUpdateData SceneManager::ActorAnimationAt(
   if (trajIt == this->dataPtr->actorTrajectories.end())
     return animData;
 
+  animData = this->dataPtr->ActorTrajectoryAt(_id, _time);
+
   auto skelIt = this->dataPtr->actorSkeletons.find(_id);
   if (skelIt == this->dataPtr->actorSkeletons.end())
     return animData;
-
-  animData = this->dataPtr->ActorTrajectoryAt(_id, _time);
 
   auto skel = skelIt->second;
   unsigned int animIndex = animData.trajectory.AnimIndex();
@@ -2389,4 +2326,103 @@ SceneManager::LoadAnimations(const sdf::Actor &_actor)
     }
   }
   return mapAnimNameId;
+}
+
+/////////////////////////////////////////////////
+std::vector<common::TrajectoryInfo>
+SceneManagerPrivate::LoadTrajectories(const sdf::Actor &_actor,
+  std::unordered_map<std::string, unsigned int> &_mapAnimNameId,
+  common::SkeletonPtr _meshSkel)
+{
+  std::vector<common::TrajectoryInfo> trajectories;
+  if (_actor.TrajectoryCount() != 0)
+  {
+    // Load all trajectories specified in sdf
+    for (unsigned i = 0; i < _actor.TrajectoryCount(); ++i)
+    {
+      const sdf::Trajectory *trajSdf = _actor.TrajectoryByIndex(i);
+      if (nullptr == trajSdf)
+      {
+        ignerr << "Null trajectory SDF for [" << _actor.Name() << "]"
+               << std::endl;
+        continue;
+      }
+      common::TrajectoryInfo trajInfo;
+      trajInfo.SetId(trajSdf->Id());
+
+      if (!_mapAnimNameId.empty())
+        trajInfo.SetAnimIndex(_mapAnimNameId[trajSdf->Type()]);
+
+      if (trajSdf->WaypointCount() != 0)
+      {
+        std::map<TP, math::Pose3d> waypoints;
+        for (unsigned j = 0; j < trajSdf->WaypointCount(); ++j)
+        {
+          auto point = trajSdf->WaypointByIndex(j);
+          TP pointTp(std::chrono::milliseconds(
+                    static_cast<int>(point->Time() * 1000)));
+          waypoints[pointTp] = point->Pose();
+        }
+        trajInfo.SetWaypoints(waypoints, trajSdf->Tension());
+
+        if (_meshSkel)
+        {
+          // Animations are offset by 1 because index 0 is taken by the mesh name
+          auto animation = _actor.AnimationByIndex(trajInfo.AnimIndex() - 1);
+
+          if (animation && animation->InterpolateX() && _meshSkel)
+          {
+            // warn if no x displacement can be interpolated
+            // warn only once per mesh
+            static std::unordered_set<std::string> animInterpolateCheck;
+            if (animInterpolateCheck.count(animation->Filename()) == 0)
+            {
+              std::string rootNodeName = _meshSkel->RootNode()->Name();
+              common::SkeletonAnimation *skelAnim =
+                  _meshSkel->Animation(trajInfo.AnimIndex());
+              common::NodeAnimation *rootNode = skelAnim->NodeAnimationByName(
+                  rootNodeName);
+              math::Matrix4d lastPos = rootNode->KeyFrame(
+                  rootNode->FrameCount() - 1).second;
+              math::Matrix4d firstPos = rootNode->KeyFrame(0).second;
+              if (!math::equal(firstPos.Translation().X(),
+                  lastPos.Translation().X()))
+              {
+                trajInfo.Waypoints()->SetInterpolateX(
+                    animation->InterpolateX());
+              }
+              else
+              {
+                ignwarn << "Animation has no x displacement. "
+                        << "Ignoring <interpolate_x> for the animation in '"
+                        << animation->Filename() << "'." << std::endl;
+              }
+              animInterpolateCheck.insert(animation->Filename());
+            }
+          }
+        }
+      }
+      else
+      {
+        trajInfo.SetTranslated(false);
+      }
+      trajectories.push_back(trajInfo);
+    }
+  }
+  // if there are no trajectories, but there are animations, add a trajectory
+  else
+  {
+    common::TrajectoryInfo trajInfo;
+    trajInfo.SetId(0);
+    trajInfo.SetAnimIndex(0);
+    trajInfo.SetStartTime(TP(0ms));
+
+    double animLength = (_meshSkel) ? _meshSkel->Animation(0)->Length() : 0.0;
+    auto timepoint = std::chrono::milliseconds(
+                  static_cast<int>(animLength * 1000));
+    trajInfo.SetEndTime(TP(timepoint));
+    trajInfo.SetTranslated(false);
+    trajectories.push_back(trajInfo);
+  }
+  return trajectories;
 }

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -90,6 +90,7 @@
 #include "ignition/gazebo/Util.hh"
 
 // Components
+#include "ignition/gazebo/components/Actor.hh"
 #include "ignition/gazebo/components/AngularAcceleration.hh"
 #include "ignition/gazebo/components/AngularVelocity.hh"
 #include "ignition/gazebo/components/AngularVelocityCmd.hh"
@@ -2526,8 +2527,14 @@ std::map<Entity, physics::FrameData3d> PhysicsPrivate::ChangedLinks(
           if (this->linkAddedToModel.find(_entity) ==
               this->linkAddedToModel.end())
           {
-            ignerr << "Internal error: link [" << _entity
-              << "] not in entity map" << std::endl;
+            // ignore links from actors for now
+            auto parentId =
+                _ecm.Component<components::ParentEntity>(_entity)->Data();
+            if (!_ecm.Component<components::Actor>(parentId))
+            {
+              ignerr << "Internal error: link [" << _entity
+                << "] not in entity map" << std::endl;
+            }
           }
           return true;
         }

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -1,8 +1,8 @@
 set(TEST_TYPE "INTEGRATION")
 
 set(tests
-  actor.cc
   ackermann_steering_system.cc
+  actor.cc
   air_pressure_system.cc
   altimeter_system.cc
   apply_joint_force_system.cc
@@ -86,6 +86,7 @@ endif()
 
 # Tests that require a valid display
 set(tests_needing_display
+  actor_trajectory.cc
   camera_sensor_background.cc
   camera_sensor_background_from_scene.cc
   camera_video_record_system.cc
@@ -171,6 +172,9 @@ endif()
 
 if(VALID_DISPLAY AND VALID_DRI_DISPLAY)
   target_link_libraries(INTEGRATION_sensors_system
+    ignition-rendering${IGN_RENDERING_VER}::ignition-rendering${IGN_RENDERING_VER}
+  )
+  target_link_libraries(INTEGRATION_actor_trajectory
     ignition-rendering${IGN_RENDERING_VER}::ignition-rendering${IGN_RENDERING_VER}
   )
 endif()

--- a/test/integration/actor_trajectory.cc
+++ b/test/integration/actor_trajectory.cc
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <ignition/utilities/ExtraTestMacros.hh>
+
+#include <ignition/rendering/RenderingIface.hh>
+#include <ignition/rendering/Scene.hh>
+
+#include "ignition/gazebo/EntityComponentManager.hh"
+#include "ignition/gazebo/EventManager.hh"
+#include "ignition/gazebo/Server.hh"
+#include "ignition/gazebo/SystemLoader.hh"
+#include "ignition/gazebo/Types.hh"
+#include "ignition/gazebo/test_config.hh"
+
+#include "ignition/gazebo/rendering/Events.hh"
+
+#include "plugins/MockSystem.hh"
+#include "../helpers/EnvTestFixture.hh"
+
+using namespace ignition;
+using namespace std::chrono_literals;
+
+// Pointer to scene
+rendering::ScenePtr g_scene;
+
+// Map of model names to their poses
+std::unordered_map<std::string, std::vector<math::Pose3d>> g_modelPoses;
+
+// mutex to project model poses
+std::mutex g_mutex;
+
+/////////////////////////////////////////////////
+void OnPostRender()
+{
+  if (!g_scene)
+  {
+    g_scene = rendering::sceneFromFirstRenderEngine();
+  }
+  ASSERT_TRUE(g_scene);
+
+  auto rootVis = g_scene->RootVisual();
+  ASSERT_TRUE(rootVis);
+
+  // store all the model poses
+  std::lock_guard<std::mutex> lock(g_mutex);
+  for (unsigned int i = 0; i < rootVis->ChildCount(); ++i)
+  {
+    auto vis = rootVis->ChildByIndex(i);
+    ASSERT_TRUE(vis);
+    g_modelPoses[vis->Name()].push_back(vis->WorldPose());
+  }
+}
+
+//////////////////////////////////////////////////
+class ActorFixture : public InternalFixture<InternalFixture<::testing::Test>>
+{
+  protected: void SetUp() override
+  {
+    InternalFixture::SetUp();
+
+    sdf::Plugin sdfPlugin;
+    sdfPlugin.SetFilename("libMockSystem.so");
+    sdfPlugin.SetName("ignition::gazebo::MockSystem");
+    auto plugin = sm.LoadPlugin(sdfPlugin);
+    EXPECT_TRUE(plugin.has_value());
+    this->systemPtr = plugin.value();
+    this->mockSystem = static_cast<gazebo::MockSystem *>(
+        systemPtr->QueryInterface<gazebo::System>());
+  }
+
+  public: gazebo::SystemPluginPtr systemPtr;
+  public: gazebo::MockSystem *mockSystem;
+
+  private: gazebo::SystemLoader sm;
+};
+
+/////////////////////////////////////////////////
+// Load the actor_trajectory.sdf world that animates a box (actor) to follow
+// a trajectory. Verify that the box pose changes over time on the rendering
+// side.
+TEST_F(ActorFixture, IGN_UTILS_TEST_DISABLED_ON_MAC(ActorTrajectoryNoMesh))
+{
+  gazebo::ServerConfig serverConfig;
+
+  const std::string sdfFile = std::string(PROJECT_SOURCE_PATH) +
+    "/test/worlds/actor_trajectory.sdf";
+
+  serverConfig.SetSdfFile(sdfFile);
+  gazebo::Server server(serverConfig);
+
+  common::ConnectionPtr postRenderConn;
+
+  // A pointer to the ecm. This will be valid once we run the mock system
+  gazebo::EntityComponentManager *ecm = nullptr;
+  this->mockSystem->preUpdateCallback =
+    [&ecm](const gazebo::UpdateInfo &, gazebo::EntityComponentManager &_ecm)
+    {
+      ecm = &_ecm;
+    };
+  this->mockSystem->configureCallback =
+    [&](const gazebo::Entity &,
+           const std::shared_ptr<const sdf::Element> &,
+           gazebo::EntityComponentManager &,
+           gazebo::EventManager &_eventMgr)
+    {
+      postRenderConn = _eventMgr.Connect<gazebo::events::PostRender>(
+          std::bind(&::OnPostRender));
+    };
+
+  server.AddSystem(this->systemPtr);
+  server.Run(true, 500, false);
+  ASSERT_NE(nullptr, ecm);
+
+  // verify that pose of the animated box exists
+  bool hasBoxPose = false;
+  int sleep = 0;
+  int maxSleep = 50;
+  const std::string boxName = "animated_box";
+  unsigned int boxPoseCount = 0u;
+  while (!hasBoxPose && sleep++ < maxSleep)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::lock_guard<std::mutex> lock(g_mutex);
+    if (g_modelPoses.find(boxName) != g_modelPoses.end())
+    {
+      hasBoxPose = true;
+      boxPoseCount = g_modelPoses.size();
+    }
+  }
+  EXPECT_TRUE(hasBoxPose);
+  EXPECT_LT(1u, boxPoseCount);
+
+  // check that box is animated, i.e. pose changes over time
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    auto it = g_modelPoses.find(boxName);
+    auto &poses = it->second;
+    for (unsigned int i = 0; i < poses.size()-1; ++i)
+    {
+      EXPECT_NE(poses[i], poses[i+1]);
+    }
+  }
+
+  g_scene.reset();
+}

--- a/test/worlds/actor_trajectory.sdf
+++ b/test/worlds/actor_trajectory.sdf
@@ -1,0 +1,83 @@
+<?xml version="1.0" ?>
+<sdf version="1.7">
+  <world name="actors">
+
+    <!-- add sensors system for rendering to run on server -->
+    <plugin
+      filename="ignition-gazebo-sensors-system"
+      name="ignition::gazebo::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+
+    <!-- box actor with no skin mesh but follows a trajectory -->
+    <actor name="animated_box">
+      <link name="box_link">
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>.2 .2 .2</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+      <script>
+        <loop>true</loop>
+        <auto_start>true</auto_start>
+        <trajectory id="0" type="square">
+           <waypoint>
+              <time>0.0</time>
+              <pose>-1 -1 1 0 0 0</pose>
+           </waypoint>
+           <waypoint>
+              <time>1.0</time>
+              <pose>-1 1 1 0 0 0</pose>
+           </waypoint>
+           <waypoint>
+              <time>2.0</time>
+              <pose>1 1 1 0 0 0</pose>
+           </waypoint>
+           <waypoint>
+              <time>3.0</time>
+              <pose>1 -1 1 0 0 0</pose>
+           </waypoint>
+           <waypoint>
+              <time>4.0</time>
+              <pose>-1 -1 1 0 0 0</pose>
+           </waypoint>
+        </trajectory>
+      </script>
+    </actor>
+
+    <!-- add camera or any rendering sensor for rendering to run on server -->
+    <model name="camera">
+      <static>true</static>
+      <pose>-5 0 0 0 0.5 0</pose>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name="camera" type="camera">
+          <pose>0 0 0.0 0 0 0</pose>
+          <camera>
+            <horizontal_fov>1.047</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+          </camera>
+          <update_rate>30</update_rate>
+          <topic>camera</topic>
+        </sensor>
+      </link>
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/1932

## Summary
Fixes the case when actors are used without a mesh with animations

More info:
Actor support in gz assumes that actors are always used with a skin mesh and a mesh with skeleton animations. It was found in https://github.com/gazebosim/gz-sim/issues/1932 that this is not the case in gazebo-classic. Trajectory animation should still work without any meshes or built-in animations. This PR makes the use of skin mesh and animations optional in gz so that users can use actors with just trajectory animation. 

To Test:

Run the `test/actor_trajectory.sdf world`  and `INTEGRATION_actor_trajectory` test.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

