### PR TITLE
Actuators message input for Ackermann Steering.

### DIFF
--- a/src/systems/ackermann_steering/AckermannSteering.hh
+++ b/src/systems/ackermann_steering/AckermannSteering.hh
@@ -41,7 +41,15 @@ namespace systems
   /// `<steering_only>`: Boolean used to only control the steering angle
   /// only. Calculates the angles of wheels from steering_limit,  wheel_base,
   /// and wheel_separation. Uses gz::msg::Double on default topic name
-  /// `/model/{name_of_model}/steer_angle`
+  /// `/model/{name_of_model}/steer_angle`. Automatically set True when
+  /// `<use_actuator_msg>` is True, uses defaults topic name "/actuators".
+  ///
+  /// `<use_actuator_msg>` True to enable the use of actutor message
+  /// for steering angle command. Relies on `<actuatorNumber>` for the
+  /// index of the position actuator and defaults to topic "/actuators".
+  ///
+  /// `<actuatorNumber>` used with `<use_actuator_commands>` to set
+  /// the index of the steering angle position actuator.
   ///
   /// `<steer_p_gain>`: Float used to control the steering angle P gain.
   /// Only used for when in steering_only mode.

--- a/test/integration/ackermann_steering_system.cc
+++ b/test/integration/ackermann_steering_system.cc
@@ -20,6 +20,7 @@
 #include <gtest/gtest.h>
 #include <gz/msgs/pose.pb.h>
 #include <gz/msgs/double.pb.h>
+#include <gz/msgs/actuators.pb.h>
 
 #include <gz/common/Console.hh>
 #include <gz/common/Util.hh>
@@ -579,6 +580,32 @@ TEST_F(AckermannSteeringOnlyTest,
   msgs::Double msg;
   const double targetAngle{0.25};
   msg.set_data(targetAngle);
+  pub.Publish(msg);
+}
+
+TEST_F(AckermannSteeringOnlyTest,
+  GZ_UTILS_TEST_DISABLED_ON_WIN32(SteerPublishActuatorsCmd))
+{
+  // Start server
+  ServerConfig serverConfig;
+  serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
+      "test", "worlds", "ackermann_steering_only_actuators.sdf"));
+
+  Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  server.SetUpdatePeriod(0ns);
+
+  // Publish actuator command
+  transport::Node node;
+  auto pub = node.Advertise<msgs::Actuators>(
+          "/actuators");
+
+  const double targetAngle{0.25};
+  msgs::Actuators msg;
+  msg.add_position(targetAngle);
+
   pub.Publish(msg);
 }
 

--- a/test/worlds/ackermann_steering_only_actuators.sdf
+++ b/test/worlds/ackermann_steering_only_actuators.sdf
@@ -1,0 +1,376 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="ackermann_steering">
+
+    <physics name="1ms" type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>0</real_time_factor>
+    </physics>
+    <plugin
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>50</mu>
+              </ode>
+              <bullet>
+                <friction>1</friction>
+                <friction2>1</friction2>
+                <rolling_friction>0.1</rolling_friction>
+              </bullet>
+            </friction>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name='vehicle'>
+      <pose>0 0 0.325 0 -0 0</pose>
+
+      <link name='chassis'>
+        <pose>-0.151427 -0 0.175 0 -0 0</pose>
+        <inertial>
+          <mass>1.14395</mass>
+          <inertia>
+            <ixx>0.126164</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.416519</iyy>
+            <iyz>0</iyz>
+            <izz>0.481014</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>2.01142 1 0.568726</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.5 0.5 1.0 1</ambient>
+            <diffuse>0.5 0.5 1.0 1</diffuse>
+            <specular>0.0 0.0 1.0 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>2.01142 1 0.568726</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+
+      <link name='front_left_wheel'>
+        <pose>0.554283 0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+
+      <link name='rear_left_wheel'>
+        <pose>-0.957138 0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+
+      <link name='front_right_wheel'>
+        <pose>0.554282 -0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+
+      <link name='rear_right_wheel'>
+        <pose>-0.957138 -0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <cylinder>
+              <length>0.15</length>
+              <radius>0.3</radius>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+
+      <link name="front_left_wheel_steering_link">
+        <pose>0.554283 0.5 0.02 0 0 0</pose>
+        <inertial>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.0153</ixx>
+            <iyy>0.025</iyy>
+            <izz>0.0153</izz>
+          </inertia>
+        </inertial>
+        <visual name="steering_link_visual">
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
+          </material>
+        </visual>
+      </link>
+
+      <link name="front_right_wheel_steering_link">
+        <pose>0.554283 -0.5 0.02 0 0 0</pose>
+        <inertial>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.0153</ixx>
+            <iyy>0.025</iyy>
+            <izz>0.0153</izz>
+          </inertia>
+        </inertial>
+        <visual name="steering_link_visual">
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <length>0.1</length>
+              <radius>0.03</radius>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
+          </material>
+        </visual>
+      </link>
+
+      <joint name="front_left_wheel_steering_joint" type="revolute">
+        <child>front_left_wheel_steering_link</child>
+        <parent>chassis</parent>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-0.6</lower>
+            <upper>+0.6</upper>
+            <velocity>1.0</velocity>
+            <effort>25</effort>
+          </limit>
+          <use_parent_model_frame>1</use_parent_model_frame>
+        </axis>
+      </joint>
+
+      <joint name="front_right_wheel_steering_joint" type="revolute">
+        <parent>chassis</parent>
+        <child>front_right_wheel_steering_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-0.6</lower>
+            <upper>+0.6</upper>
+            <velocity>1.0</velocity>
+            <effort>25</effort>
+          </limit>
+        </axis>
+      </joint>
+
+      <joint name='front_left_wheel_joint' type='revolute'>
+        <parent>front_left_wheel_steering_link</parent>
+        <child>front_left_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+
+      <joint name='front_right_wheel_joint' type='revolute'>
+        <parent>front_right_wheel_steering_link</parent>
+        <child>front_right_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+
+      <joint name='rear_left_wheel_joint' type='revolute'>
+        <parent>chassis</parent>
+        <child>rear_left_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+
+      <joint name='rear_right_wheel_joint' type='revolute'>
+        <parent>chassis</parent>
+        <child>rear_right_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+
+      <plugin
+        filename="gz-sim-ackermann-steering-system"
+        name="gz::sim::systems::AckermannSteering">
+        <left_steering_joint>front_left_wheel_steering_joint</left_steering_joint>
+        <right_steering_joint>front_right_wheel_steering_joint</right_steering_joint>
+        <steering_only>true</steering_only>
+        <use_actuator_msg>true</use_actuator_msg>
+        <actuatorNumber>0</actuatorNumber>
+        <steer_p_gain>10.0</steer_p_gain>
+        <steering_limit>0.5</steering_limit>
+        <wheel_base>1.0</wheel_base>
+        <wheel_separation>1.25</wheel_separation>
+      </plugin>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
# 🎉 New feature

Adds ability to steer Ackermann vehicles with the position field of the actuator message.

As seen in the Gazebo community meeting:
https://vimeo.com/812911652#t=39m58s

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.