### PR TITLE
Actuators message input for JointController.

### DIFF
--- a/src/systems/joint_controller/JointController.cc
+++ b/src/systems/joint_controller/JointController.cc
@@ -18,6 +18,7 @@
 
 #include "JointController.hh"
 
+#include <gz/msgs/actuators.pb.h>
 #include <gz/msgs/double.pb.h>
 
 #include <string>
@@ -28,6 +29,7 @@
 #include <gz/plugin/Register.hh>
 #include <gz/transport/Node.hh>
 
+#include "gz/sim/components/Actuators.hh"
 #include "gz/sim/components/JointForceCmd.hh"
 #include "gz/sim/components/JointVelocity.hh"
 #include "gz/sim/components/JointVelocityCmd.hh"
@@ -43,6 +45,10 @@ class gz::sim::systems::JointControllerPrivate
   /// \param[in] _msg Velocity message
   public: void OnCmdVel(const msgs::Double &_msg);
 
+  /// \brief Callback for actuator velocity subscription
+  /// \param[in] _msg Velocity message
+  public: void OnActuatorVel(const msgs::Actuators &_msg);
+
   /// \brief Gazebo communication node.
   public: transport::Node node;
 
@@ -55,11 +61,17 @@ class gz::sim::systems::JointControllerPrivate
   /// \brief Commanded joint velocity
   public: double jointVelCmd{0.0};
 
+  /// \brief Index of velocity actuator.
+  public: int actuatorNumber = 0;
+
   /// \brief mutex to protect jointVelCmd
   public: std::mutex jointVelCmdMutex;
 
   /// \brief Model interface
   public: Model model{kNullEntity};
+
+  /// \brief True if using Actuator msg to control joint velocity.
+  public: bool useActuatorMsg{false};
 
   /// \brief True if force commands are internally used to keep the target
   /// velocity.
@@ -149,9 +161,26 @@ void JointController::Configure(const Entity &_entity,
     gzdbg << "[JointController] Velocity mode" << std::endl;
   }
 
+  if (_sdf->HasElement("use_actuator_msg") &&
+    _sdf->Get<bool>("use_actuator_msg"))
+  {
+    if (_sdf->HasElement("actuatorNumber"))
+    {
+      this->dataPtr->actuatorNumber =
+        _sdf->Get<int>("actuatorNumber");
+      this->dataPtr->useActuatorMsg = true;
+    }
+    else
+    {
+      gzerr << "Please specify an actuatorNumber" <<
+        "to use Actuator velocity message control." << std::endl;
+    }
+  }
+
   // Subscribe to commands
   std::string topic;
-  if ((!_sdf->HasElement("sub_topic")) && (!_sdf->HasElement("topic")))
+  if ((!_sdf->HasElement("sub_topic")) && (!_sdf->HasElement("topic"))
+    && (!this->dataPtr->useActuatorMsg))
   {
     topic = transport::TopicUtils::AsValidTopic("/model/" +
         this->dataPtr->model.Name(_ecm) + "/joint/" +
@@ -159,6 +188,18 @@ void JointController::Configure(const Entity &_entity,
     if (topic.empty())
     {
       gzerr << "Failed to create topic for joint ["
+            << this->dataPtr->jointNames[0]
+            << "]" << std::endl;
+      return;
+    }
+  }
+  if ((!_sdf->HasElement("sub_topic")) && (!_sdf->HasElement("topic"))
+    && (this->dataPtr->useActuatorMsg))
+  {
+    topic = transport::TopicUtils::AsValidTopic("/actuators");
+    if (topic.empty())
+    {
+      gzerr << "Failed to create Actuator topic for joint ["
             << this->dataPtr->jointNames[0]
             << "]" << std::endl;
       return;
@@ -193,11 +234,25 @@ void JointController::Configure(const Entity &_entity,
       return;
     }
   }
-  this->dataPtr->node.Subscribe(topic, &JointControllerPrivate::OnCmdVel,
-                                this->dataPtr.get());
 
-  gzmsg << "JointController subscribing to Double messages on [" << topic
+  if (this->dataPtr->useActuatorMsg)
+  {
+    this->dataPtr->node.Subscribe(topic,
+      &JointControllerPrivate::OnActuatorVel,
+      this->dataPtr.get());
+
+    gzmsg << "JointController subscribing to Actuator messages on [" << topic
          << "]" << std::endl;
+  }
+  else
+  {
+    this->dataPtr->node.Subscribe(topic,
+      &JointControllerPrivate::OnCmdVel,
+      this->dataPtr.get());
+
+    gzmsg << "JointController subscribing to Double messages on [" << topic
+         << "]" << std::endl;
+  }
 }
 
 //////////////////////////////////////////////////
@@ -309,6 +364,20 @@ void JointControllerPrivate::OnCmdVel(const msgs::Double &_msg)
 {
   std::lock_guard<std::mutex> lock(this->jointVelCmdMutex);
   this->jointVelCmd = _msg.data();
+}
+
+void JointControllerPrivate::OnActuatorVel(const msgs::Actuators &_msg)
+{
+  std::lock_guard<std::mutex> lock(this->jointVelCmdMutex);
+  if (this->actuatorNumber > _msg.velocity_size() - 1)
+  {
+    gzerr << "You tried to access index " << this->actuatorNumber
+      << " of the Actuator velocity array which is of size "
+      << _msg.velocity_size() << std::endl;
+    return;
+  }
+
+  this->jointVelCmd = static_cast<double>(_msg.velocity(this->actuatorNumber));
 }
 
 GZ_ADD_PLUGIN(JointController,

--- a/src/systems/joint_controller/JointController.cc
+++ b/src/systems/joint_controller/JointController.cc
@@ -164,15 +164,15 @@ void JointController::Configure(const Entity &_entity,
   if (_sdf->HasElement("use_actuator_msg") &&
     _sdf->Get<bool>("use_actuator_msg"))
   {
-    if (_sdf->HasElement("actuatorNumber"))
+    if (_sdf->HasElement("actuator_number"))
     {
       this->dataPtr->actuatorNumber =
-        _sdf->Get<int>("actuatorNumber");
+        _sdf->Get<int>("actuator_number");
       this->dataPtr->useActuatorMsg = true;
     }
     else
     {
-      gzerr << "Please specify an actuatorNumber" <<
+      gzerr << "Please specify an actuator_number" <<
         "to use Actuator velocity message control." << std::endl;
     }
   }

--- a/src/systems/joint_controller/JointController.hh
+++ b/src/systems/joint_controller/JointController.hh
@@ -44,6 +44,13 @@ namespace systems
   /// using force commands. If this parameter is not set or is false, the
   /// controller will use velocity commands internally.
   ///
+  /// `<use_actuator_msg>` True to enable the use of actutor message
+  /// for velocity command. Relies on `<actuator_number>` for the
+  /// index of the velocity actuator and defaults to topic "/actuators".
+  ///
+  /// `<actuator_number>` used with `<use_actuator_commands>` to set
+  /// the index of the velocity actuator.
+  ///
   /// `<topic>` Topic to receive commands in. Defaults to
   ///     `/model/<model_name>/joint/<joint_name>/cmd_vel`.
   ///

--- a/src/systems/joint_controller/JointController.hh
+++ b/src/systems/joint_controller/JointController.hh
@@ -44,11 +44,13 @@ namespace systems
   /// using force commands. If this parameter is not set or is false, the
   /// controller will use velocity commands internally.
   ///
-  /// `<use_actuator_msg>` True to enable the use of actutor message
-  /// for velocity command. Relies on `<actuator_number>` for the
-  /// index of the velocity actuator and defaults to topic "/actuators".
+  /// `<use_actuator_msg>` True to enable the use of actuator message
+  /// for velocity command. The actuator msg is an array of floats for
+  /// position, velocity and normalized commands. Relies on
+  /// `<actuator_number>` for the index of the velocity actuator and
+  /// defaults to topic "/actuators" when `topic` or `subtopic not set.
   ///
-  /// `<actuator_number>` used with `<use_actuator_commands>` to set
+  /// `<actuator_number>` used with `<use_actuator_msg>` to set
   /// the index of the velocity actuator.
   ///
   /// `<topic>` Topic to receive commands in. Defaults to

--- a/test/worlds/joint_controller.sdf
+++ b/test/worlds/joint_controller.sdf
@@ -313,5 +313,84 @@
         <i_gain>0.01</i_gain>
       </plugin>
     </model>
+
+    <model name="joint_controller_test3">
+      <pose>0 0 0.005 0 0 0</pose>
+      <link name="base_link">
+        <pose>0.0 0.0 0.0 0 0 0</pose>
+        <inertial>
+          <inertia>
+            <ixx>2.501</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>2.501</iyy>
+            <iyz>0</iyz>
+            <izz>5</izz>
+          </inertia>
+          <mass>120.0</mass>
+        </inertial>
+        <visual name="base_visual">
+          <pose>0.0 0.0 0.0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.01</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name="base_collision">
+          <pose>0.0 0.0 0.0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.01</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <link name="rotor4">
+        <pose>0.0 0.5 1.0 0.0 0 0</pose>
+        <inertial>
+          <pose>0.0 0.0 0.0 0 0 0</pose>
+          <inertia>
+            <ixx>0.032</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.032</iyy>
+            <iyz>0</iyz>
+            <izz>0.00012</izz>
+          </inertia>
+          <mass>0.6</mass>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.05</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.05</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+
+      <joint name="j4" type="revolute">
+        <pose>0 0 -0.5 0 0 0</pose>
+        <parent>base_link</parent>
+        <child>rotor4</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+      <plugin
+        filename="gz-sim-joint-controller-system"
+        name="gz::sim::systems::JointController">
+        <joint_name>j4</joint_name>
+        <use_actuator_msg>true</use_actuator_msg>
+        <actuator_number>0</actuator_number>
+      </plugin>
+    </model>
   </world>
 </sdf>

--- a/test/worlds/joint_controller.sdf
+++ b/test/worlds/joint_controller.sdf
@@ -315,7 +315,7 @@
     </model>
 
     <model name="joint_controller_test3">
-      <pose>0 0 0.005 0 0 0</pose>
+      <pose>-3 -3 0.005 0 0 0</pose>
       <link name="base_link">
         <pose>0.0 0.0 0.0 0 0 0</pose>
         <inertial>


### PR DESCRIPTION
# 🎉 New feature

Adds ability to control the velocity of joints with the velocity field of the actuators message.

Closes: #1973 

As seen in the Gazebo community meeting:
https://vimeo.com/812911652#t=39m58s

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.