### PR TITLE
Actuators message for JointPositionController.

### DIFF
--- a/src/systems/joint_position_controller/JointPositionController.cc
+++ b/src/systems/joint_position_controller/JointPositionController.cc
@@ -18,6 +18,7 @@
 
 #include "JointPositionController.hh"
 
+#include <gz/msgs/actuators.pb.h>
 #include <gz/msgs/double.pb.h>
 
 #include <string>
@@ -29,6 +30,7 @@
 #include <gz/plugin/Register.hh>
 #include <gz/transport/Node.hh>
 
+#include "gz/sim/components/Actuators.hh"
 #include "gz/sim/components/Joint.hh"
 #include "gz/sim/components/JointForceCmd.hh"
 #include "gz/sim/components/JointVelocityCmd.hh"
@@ -46,6 +48,10 @@ class gz::sim::systems::JointPositionControllerPrivate
   /// \param[in] _msg Position message
   public: void OnCmdPos(const msgs::Double &_msg);
 
+  /// \brief Callback for actuator position subscription
+  /// \param[in] _msg Position message
+  public: void OnActuatorPos(const msgs::Actuators &_msg);
+
   /// \brief Gazebo communication node.
   public: transport::Node node;
 
@@ -58,11 +64,17 @@ class gz::sim::systems::JointPositionControllerPrivate
   /// \brief Commanded joint position
   public: double jointPosCmd{0.0};
 
+  /// \brief Index of position actuator.
+  public: int actuatorNumber = 0;
+
   /// \brief mutex to protect joint commands
   public: std::mutex jointCmdMutex;
 
   /// \brief Model interface
   public: Model model{kNullEntity};
+
+  /// \brief True if using Actuator msg to control joint position.
+  public: bool useActuatorMsg{false};
 
   /// \brief Position PID controller.
   public: math::PID posPid;
@@ -190,9 +202,26 @@ void JointPositionController::Configure(const Entity &_entity,
     this->dataPtr->jointPosCmd = _sdf->Get<double>("initial_position");
   }
 
+  if (_sdf->HasElement("use_actuator_msg") &&
+    _sdf->Get<bool>("use_actuator_msg"))
+  {
+    if (_sdf->HasElement("actuatorNumber"))
+    {
+      this->dataPtr->actuatorNumber =
+        _sdf->Get<int>("actuatorNumber");
+      this->dataPtr->useActuatorMsg = true;
+    }
+    else
+    {
+      gzerr << "Please specify an actuatorNumber" <<
+        "to use Actuator position message control." << std::endl;
+    }
+  }
+
   // Subscribe to commands
   std::string topic;
-  if ((!_sdf->HasElement("sub_topic")) && (!_sdf->HasElement("topic")))
+  if ((!_sdf->HasElement("sub_topic")) && (!_sdf->HasElement("topic"))
+    && (!this->dataPtr->useActuatorMsg))
   {
     topic = transport::TopicUtils::AsValidTopic("/model/" +
         this->dataPtr->model.Name(_ecm) + "/joint/" +
@@ -201,6 +230,18 @@ void JointPositionController::Configure(const Entity &_entity,
     if (topic.empty())
     {
       gzerr << "Failed to create topic for joint ["
+            << this->dataPtr->jointNames[0]
+            << "]" << std::endl;
+      return;
+    }
+  }
+  if ((!_sdf->HasElement("sub_topic")) && (!_sdf->HasElement("topic"))
+    && (this->dataPtr->useActuatorMsg))
+  {
+    topic = transport::TopicUtils::AsValidTopic("/actuators");
+    if (topic.empty())
+    {
+      gzerr << "Failed to create Actuator topic for joint ["
             << this->dataPtr->jointNames[0]
             << "]" << std::endl;
       return;
@@ -235,8 +276,24 @@ void JointPositionController::Configure(const Entity &_entity,
       return;
     }
   }
-  this->dataPtr->node.Subscribe(
-      topic, &JointPositionControllerPrivate::OnCmdPos, this->dataPtr.get());
+  if (this->dataPtr->useActuatorMsg)
+  {
+    this->dataPtr->node.Subscribe(topic,
+      &JointPositionControllerPrivate::OnActuatorPos,
+      this->dataPtr.get());
+
+    gzmsg << "JointPositionController subscribing to Actuator messages on ["
+      << topic << "]" << std::endl;
+  }
+  else
+  {
+    this->dataPtr->node.Subscribe(topic,
+      &JointPositionControllerPrivate::OnCmdPos,
+      this->dataPtr.get());
+
+    gzmsg << "JointPositionController subscribing to Double messages on ["
+      << topic << "]" << std::endl;
+  }
 
   gzdbg << "[JointPositionController] system parameters:" << std::endl;
   gzdbg << "p_gain: ["     << p         << "]"            << std::endl;
@@ -424,6 +481,20 @@ void JointPositionControllerPrivate::OnCmdPos(const msgs::Double &_msg)
 {
   std::lock_guard<std::mutex> lock(this->jointCmdMutex);
   this->jointPosCmd = _msg.data();
+}
+
+void JointPositionControllerPrivate::OnActuatorPos(const msgs::Actuators &_msg)
+{
+  std::lock_guard<std::mutex> lock(this->jointCmdMutex);
+  if (this->actuatorNumber > _msg.position_size() - 1)
+  {
+    gzerr << "You tried to access index " << this->actuatorNumber
+      << " of the Actuator position array which is of size "
+      << _msg.position_size() << std::endl;
+    return;
+  }
+
+  this->jointPosCmd = static_cast<double>(_msg.position(this->actuatorNumber));
 }
 
 GZ_ADD_PLUGIN(JointPositionController,

--- a/src/systems/joint_position_controller/JointPositionController.cc
+++ b/src/systems/joint_position_controller/JointPositionController.cc
@@ -205,15 +205,15 @@ void JointPositionController::Configure(const Entity &_entity,
   if (_sdf->HasElement("use_actuator_msg") &&
     _sdf->Get<bool>("use_actuator_msg"))
   {
-    if (_sdf->HasElement("actuatorNumber"))
+    if (_sdf->HasElement("actuator_number"))
     {
       this->dataPtr->actuatorNumber =
-        _sdf->Get<int>("actuatorNumber");
+        _sdf->Get<int>("actuator_number");
       this->dataPtr->useActuatorMsg = true;
     }
     else
     {
-      gzerr << "Please specify an actuatorNumber" <<
+      gzerr << "Please specify an actuator_number" <<
         "to use Actuator position message control." << std::endl;
     }
   }

--- a/src/systems/joint_position_controller/JointPositionController.hh
+++ b/src/systems/joint_position_controller/JointPositionController.hh
@@ -52,6 +52,13 @@ namespace systems
   /// `<joint_index>` Axis of the joint to control. Optional parameter.
   ///  The default value is 0.
   ///
+  /// `<use_actuator_msg>` True to enable the use of actutor message
+  /// for position command. Relies on `<actuatorNumber>` for the
+  /// index of the position actuator and defaults to topic "/actuators".
+  ///
+  /// `<actuatorNumber>` used with `<use_actuator_commands>` to set
+  /// the index of the position actuator.
+  ///
   /// `<p_gain>` The proportional gain of the PID. Optional parameter.
   ///  The default value is 1.
   ///

--- a/src/systems/joint_position_controller/JointPositionController.hh
+++ b/src/systems/joint_position_controller/JointPositionController.hh
@@ -53,10 +53,10 @@ namespace systems
   ///  The default value is 0.
   ///
   /// `<use_actuator_msg>` True to enable the use of actutor message
-  /// for position command. Relies on `<actuatorNumber>` for the
+  /// for position command. Relies on `<actuator_number>` for the
   /// index of the position actuator and defaults to topic "/actuators".
   ///
-  /// `<actuatorNumber>` used with `<use_actuator_commands>` to set
+  /// `<actuator_number>` used with `<use_actuator_commands>` to set
   /// the index of the position actuator.
   ///
   /// `<p_gain>` The proportional gain of the PID. Optional parameter.

--- a/test/worlds/joint_position_controller_actuators.sdf
+++ b/test/worlds/joint_position_controller_actuators.sdf
@@ -116,7 +116,7 @@
         name="gz::sim::systems::JointPositionController">
         <joint_name>j1</joint_name>
         <use_actuator_msg>true</use_actuator_msg>
-        <actuatorNumber>0</actuatorNumber>
+        <actuator_number>0</actuator_number>
       </plugin>
     </model>
   </world>

--- a/test/worlds/joint_position_controller_actuators.sdf
+++ b/test/worlds/joint_position_controller_actuators.sdf
@@ -1,0 +1,123 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="default">
+    <physics name="fast" type="ignored">
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
+    <plugin
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="joint_position_controller_test">
+      <pose>0 0 0.005 0 0 0</pose>
+      <link name="base_link">
+        <pose>0.0 0.0 0.0 0 0 0</pose>
+        <inertial>
+          <inertia>
+            <ixx>2.501</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>2.501</iyy>
+            <iyz>0</iyz>
+            <izz>5</izz>
+          </inertia>
+          <mass>120.0</mass>
+        </inertial>
+        <visual name="base_visual">
+          <pose>0.0 0.0 0.0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.01</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name="base_collision">
+          <pose>0.0 0.0 0.0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.01</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <link name="rotor">
+        <pose>0.0 0.0 1.0 0.0 0 0</pose>
+        <inertial>
+          <pose>0.0 0.0 0.0 0 0 0</pose>
+          <inertia>
+            <ixx>0.032</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.032</iyy>
+            <iyz>0</iyz>
+            <izz>0.00012</izz>
+          </inertia>
+          <mass>0.6</mass>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.05</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.05</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+
+      <joint name="j1" type="revolute">
+        <pose>0 0 -0.5 0 0 0</pose>
+        <parent>base_link</parent>
+        <child>rotor</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>j1</joint_name>
+        <use_actuator_msg>true</use_actuator_msg>
+        <actuatorNumber>0</actuatorNumber>
+      </plugin>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
# 🎉 New feature

Adds ability to control the position of joints with the position field of the actuators message.

Closes: #1974 

As seen in the Gazebo community meeting:
https://vimeo.com/812911652#t=39m58s

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.