### PR TITLE
Use ignition::gazebo:: in class instantiation

### DIFF
--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -32,7 +32,7 @@
 using namespace gz;
 using namespace gz::sim;
 
-class gz::sim::EntityComponentManagerPrivate
+class ignition::gazebo::EntityComponentManagerPrivate
 {
   /// \brief Implementation of the CreateEntity function, which takes a specific
   /// entity as input.

--- a/src/Link.cc
+++ b/src/Link.cc
@@ -36,7 +36,7 @@
 
 #include "gz/sim/Link.hh"
 
-class gz::sim::LinkPrivate
+class ignition::gazebo::LinkPrivate
 {
   /// \brief Id of link entity.
   public: Entity id{kNullEntity};

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -28,7 +28,7 @@
 #include "gz/sim/components/WindMode.hh"
 #include "gz/sim/Model.hh"
 
-class gz::sim::ModelPrivate
+class ignition::gazebo::ModelPrivate
 {
   /// \brief Id of model entity.
   public: Entity id{kNullEntity};

--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -70,7 +70,7 @@
 #include "gz/sim/components/WindMode.hh"
 #include "gz/sim/components/World.hh"
 
-class gz::sim::SdfEntityCreatorPrivate
+class ignition::gazebo::SdfEntityCreatorPrivate
 {
   /// \brief Pointer to entity component manager. We don't assume ownership.
   public: EntityComponentManager *ecm{nullptr};

--- a/src/ServerConfig.cc
+++ b/src/ServerConfig.cc
@@ -31,7 +31,7 @@ using namespace gz;
 using namespace gz::sim;
 
 /// \brief Private data for PluginInfoConfig.
-class gz::sim::ServerConfig::PluginInfoPrivate
+class ignition::gazebo::ServerConfig::PluginInfoPrivate
 {
   /// \brief Default constructor.
   public: PluginInfoPrivate() = default;
@@ -192,7 +192,7 @@ void ServerConfig::PluginInfo::SetSdf(const sdf::ElementPtr &_sdf)
 }
 
 /// \brief Private data for ServerConfig.
-class gz::sim::ServerConfigPrivate
+class ignition::gazebo::ServerConfigPrivate
 {
   /// \brief Default constructor.
   public: ServerConfigPrivate()

--- a/src/SystemLoader.cc
+++ b/src/SystemLoader.cc
@@ -35,7 +35,7 @@
 
 using namespace gz::sim;
 
-class gz::sim::SystemLoaderPrivate
+class ignition::gazebo::SystemLoaderPrivate
 {
   //////////////////////////////////////////////////
   public: explicit SystemLoaderPrivate() = default;

--- a/src/TestFixture.cc
+++ b/src/TestFixture.cc
@@ -106,7 +106,7 @@ void HelperSystem::PostUpdate(const UpdateInfo &_info,
 }
 
 //////////////////////////////////////////////////
-class gz::sim::TestFixturePrivate
+class ignition::gazebo::TestFixturePrivate
 {
   /// \brief Initialize fixture
   /// \param[in] _config Server config

--- a/src/World.cc
+++ b/src/World.cc
@@ -28,7 +28,7 @@
 #include "gz/sim/components/World.hh"
 #include "gz/sim/World.hh"
 
-class gz::sim::WorldPrivate
+class ignition::gazebo::WorldPrivate
 {
   /// \brief Id of world entity.
   public: Entity id{kNullEntity};

--- a/src/rendering/MarkerManager.cc
+++ b/src/rendering/MarkerManager.cc
@@ -37,7 +37,7 @@ using namespace gz;
 using namespace gz::sim;
 
 /// Private data for the MarkerManager class
-class gz::sim::MarkerManagerPrivate
+class ignition::gazebo::MarkerManagerPrivate
 {
   /// \brief Processes a marker message.
   /// \param[in] _msg The message data.

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -75,7 +75,7 @@ using namespace gz;
 using namespace gz::sim;
 
 // Private data class.
-class gz::sim::RenderUtilPrivate
+class ignition::gazebo::RenderUtilPrivate
 {
   /// True if the rendering component is initialized
   public: bool initialized = false;

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -50,7 +50,7 @@ using namespace gz::sim;
 using namespace std::chrono_literals;
 
 /// \brief Private data class.
-class gz::sim::SceneManagerPrivate
+class ignition::gazebo::SceneManagerPrivate
 {
   /// \brief Keep track of world ID, which is equivalent to the scene's
   /// root visual.

--- a/src/systems/ackermann_steering/AckermannSteering.cc
+++ b/src/systems/ackermann_steering/AckermannSteering.cc
@@ -54,7 +54,7 @@ struct Commands
   Commands() : lin(0.0), ang(0.0) {}
 };
 
-class gz::sim::systems::AckermannSteeringPrivate
+class ignition::gazebo::systems::AckermannSteeringPrivate
 {
   /// \brief Callback for velocity subscription
   /// \param[in] _msg Velocity message

--- a/src/systems/air_pressure/AirPressure.cc
+++ b/src/systems/air_pressure/AirPressure.cc
@@ -48,7 +48,7 @@ using namespace gz::sim;
 using namespace systems;
 
 /// \brief Private AirPressure data class.
-class gz::sim::systems::AirPressurePrivate
+class ignition::gazebo::systems::AirPressurePrivate
 {
   /// \brief A map of air pressure entity to its sensor
   public: std::unordered_map<Entity,

--- a/src/systems/altimeter/Altimeter.cc
+++ b/src/systems/altimeter/Altimeter.cc
@@ -50,7 +50,7 @@ using namespace gz::sim;
 using namespace systems;
 
 /// \brief Private Altimeter data class.
-class gz::sim::systems::AltimeterPrivate
+class ignition::gazebo::systems::AltimeterPrivate
 {
   /// \brief A map of altimeter entity to its sensor
   public: std::unordered_map<Entity,

--- a/src/systems/apply_joint_force/ApplyJointForce.cc
+++ b/src/systems/apply_joint_force/ApplyJointForce.cc
@@ -30,7 +30,7 @@ using namespace gz;
 using namespace gz::sim;
 using namespace systems;
 
-class gz::sim::systems::ApplyJointForcePrivate
+class ignition::gazebo::systems::ApplyJointForcePrivate
 {
   /// \brief Callback for joint force subscription
   /// \param[in] _msg Joint force message

--- a/src/systems/apply_link_wrench/ApplyLinkWrench.cc
+++ b/src/systems/apply_link_wrench/ApplyLinkWrench.cc
@@ -41,7 +41,7 @@ using namespace gz;
 using namespace gz::sim;
 using namespace systems;
 
-class gz::sim::systems::ApplyLinkWrenchPrivate
+class ignition::gazebo::systems::ApplyLinkWrenchPrivate
 {
   /// \brief Callback for wrench subscription
   /// \param[in] _msg Wrench message

--- a/src/systems/battery_plugin/LinearBatteryPlugin.cc
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.cc
@@ -52,7 +52,7 @@ using namespace gz;
 using namespace gz::sim;
 using namespace systems;
 
-class gz::sim::systems::LinearBatteryPluginPrivate
+class ignition::gazebo::systems::LinearBatteryPluginPrivate
 {
   /// \brief Reset the plugin
   public: void Reset();

--- a/src/systems/buoyancy/Buoyancy.cc
+++ b/src/systems/buoyancy/Buoyancy.cc
@@ -52,7 +52,7 @@ using namespace gz;
 using namespace gz::sim;
 using namespace systems;
 
-class gz::sim::systems::BuoyancyPrivate
+class ignition::gazebo::systems::BuoyancyPrivate
 {
   /// \brief Get the fluid density based on a pose. This function can be
   /// used to adjust the fluid density based on the pose of an object in the

--- a/src/systems/camera_video_recorder/CameraVideoRecorder.cc
+++ b/src/systems/camera_video_recorder/CameraVideoRecorder.cc
@@ -51,7 +51,7 @@ using namespace gz::sim;
 using namespace systems;
 
 // Private data class.
-class gz::sim::systems::CameraVideoRecorderPrivate
+class ignition::gazebo::systems::CameraVideoRecorderPrivate
 {
   /// \brief Callback for the video recorder service
   public: bool OnRecordVideo(const msgs::VideoRecord &_msg,

--- a/src/systems/collada_world_exporter/ColladaWorldExporter.cc
+++ b/src/systems/collada_world_exporter/ColladaWorldExporter.cc
@@ -53,7 +53,7 @@ using namespace gz::sim;
 using namespace systems;
 
 
-class gz::sim::systems::ColladaWorldExporterPrivate
+class ignition::gazebo::systems::ColladaWorldExporterPrivate
 {
   // Default constructor
   public: ColladaWorldExporterPrivate() = default;

--- a/src/systems/contact/Contact.cc
+++ b/src/systems/contact/Contact.cc
@@ -81,7 +81,7 @@ class ContactSensor
   public: std::vector<Entity> collisionEntities;
 };
 
-class gz::sim::systems::ContactPrivate
+class ignition::gazebo::systems::ContactPrivate
 {
   /// \brief Create sensors that correspond to entities in the simulation
   /// \param[in] _ecm Mutable reference to ECM.

--- a/src/systems/diff_drive/DiffDrive.cc
+++ b/src/systems/diff_drive/DiffDrive.cc
@@ -53,7 +53,7 @@ struct Commands
   Commands() : lin(0.0), ang(0.0) {}
 };
 
-class gz::sim::systems::DiffDrivePrivate
+class ignition::gazebo::systems::DiffDrivePrivate
 {
   /// \brief Callback for velocity subscription
   /// \param[in] _msg Velocity message

--- a/src/systems/imu/Imu.cc
+++ b/src/systems/imu/Imu.cc
@@ -48,7 +48,7 @@ using namespace gz::sim;
 using namespace systems;
 
 /// \brief Private Imu data class.
-class gz::sim::systems::ImuPrivate
+class ignition::gazebo::systems::ImuPrivate
 {
   /// \brief A map of IMU entity to its IMU sensor.
   public: std::unordered_map<Entity,

--- a/src/systems/joint_controller/JointController.cc
+++ b/src/systems/joint_controller/JointController.cc
@@ -35,7 +35,7 @@ using namespace gz;
 using namespace gz::sim;
 using namespace systems;
 
-class gz::sim::systems::JointControllerPrivate
+class ignition::gazebo::systems::JointControllerPrivate
 {
   /// \brief Callback for velocity subscription
   /// \param[in] _msg Velocity message

--- a/src/systems/joint_position_controller/JointPositionController.cc
+++ b/src/systems/joint_position_controller/JointPositionController.cc
@@ -35,7 +35,7 @@ using namespace gz;
 using namespace gz::sim;
 using namespace systems;
 
-class gz::sim::systems::JointPositionControllerPrivate
+class ignition::gazebo::systems::JointPositionControllerPrivate
 {
   /// \brief Callback for position subscription
   /// \param[in] _msg Position message

--- a/src/systems/kinetic_energy_monitor/KineticEnergyMonitor.cc
+++ b/src/systems/kinetic_energy_monitor/KineticEnergyMonitor.cc
@@ -43,7 +43,7 @@ using namespace gz::sim;
 using namespace systems;
 
 /// \brief Private data class
-class gz::sim::systems::KineticEnergyMonitorPrivate
+class ignition::gazebo::systems::KineticEnergyMonitorPrivate
 {
   /// \brief Link of the model.
   public: Entity linkEntity;

--- a/src/systems/lift_drag/LiftDrag.cc
+++ b/src/systems/lift_drag/LiftDrag.cc
@@ -44,7 +44,7 @@ using namespace gz;
 using namespace gz::sim;
 using namespace systems;
 
-class gz::sim::systems::LiftDragPrivate
+class ignition::gazebo::systems::LiftDragPrivate
 {
   // Initialize the system
   public: void Load(const EntityComponentManager &_ecm,

--- a/src/systems/log/LogPlayback.cc
+++ b/src/systems/log/LogPlayback.cc
@@ -53,7 +53,7 @@ using namespace gz::sim;
 using namespace systems;
 
 /// \brief Private LogPlayback data class.
-class gz::sim::systems::LogPlaybackPrivate
+class ignition::gazebo::systems::LogPlaybackPrivate
 {
   /// \brief Extract model resource files and state file from compression.
   /// \return True if extraction was successful.

--- a/src/systems/log/LogRecord.cc
+++ b/src/systems/log/LogRecord.cc
@@ -65,7 +65,7 @@ using namespace gz;
 using namespace ignition::gazebo::systems;
 
 // Private data class.
-class gz::sim::systems::LogRecordPrivate
+class ignition::gazebo::systems::LogRecordPrivate
 {
   /// \brief Start recording
   /// \param[in] _logPath Path to record to.

--- a/src/systems/log_video_recorder/LogVideoRecorder.cc
+++ b/src/systems/log_video_recorder/LogVideoRecorder.cc
@@ -45,7 +45,7 @@ using namespace gz::sim;
 using namespace systems;
 
 // Private data class.
-class gz::sim::systems::LogVideoRecorderPrivate
+class ignition::gazebo::systems::LogVideoRecorderPrivate
 {
   /// \brief Rewind the log
   public: void Rewind();

--- a/src/systems/logical_audio_sensor_plugin/LogicalAudioSensorPlugin.cc
+++ b/src/systems/logical_audio_sensor_plugin/LogicalAudioSensorPlugin.cc
@@ -43,7 +43,7 @@ using namespace gz;
 using namespace gz::sim;
 using namespace systems;
 
-class gz::sim::systems::LogicalAudioSensorPluginPrivate
+class ignition::gazebo::systems::LogicalAudioSensorPluginPrivate
 {
   /// \brief Creates an audio source with attributes specified in an SDF file.
   /// \param[in] _elem A pointer to the source element in the SDF file.

--- a/src/systems/logical_camera/LogicalCamera.cc
+++ b/src/systems/logical_camera/LogicalCamera.cc
@@ -51,7 +51,7 @@ using namespace gz::sim;
 using namespace systems;
 
 /// \brief Private LogicalCamera data class.
-class gz::sim::systems::LogicalCameraPrivate
+class ignition::gazebo::systems::LogicalCameraPrivate
 {
   /// \brief A map of logicalCamera entities
   public: std::unordered_map<Entity,

--- a/src/systems/magnetometer/Magnetometer.cc
+++ b/src/systems/magnetometer/Magnetometer.cc
@@ -48,7 +48,7 @@ using namespace gz::sim;
 using namespace systems;
 
 /// \brief Private Magnetometer data class.
-class gz::sim::systems::MagnetometerPrivate
+class ignition::gazebo::systems::MagnetometerPrivate
 {
   /// \brief A map of magnetometer entity to its sensor.
   public: std::unordered_map<Entity,

--- a/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
+++ b/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
@@ -115,7 +115,7 @@ enum class MotorType {
   kForce
 };
 
-class gz::sim::systems::MulticopterMotorModelPrivate
+class ignition::gazebo::systems::MulticopterMotorModelPrivate
 {
   /// \brief Callback for actuator commands.
   public: void OnActuatorMsg(const msgs::Actuators &_msg);

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -137,7 +137,7 @@ namespace components = gz::sim::components;
 
 
 // Private data class.
-class gz::sim::systems::PhysicsPrivate
+class ignition::gazebo::systems::PhysicsPrivate
 {
   /// \brief This is the minimum set of features that any physics engine must
   /// implement to be supported by this system.

--- a/src/systems/pose_publisher/PosePublisher.cc
+++ b/src/systems/pose_publisher/PosePublisher.cc
@@ -56,7 +56,7 @@ using namespace gz::sim;
 using namespace systems;
 
 /// \brief Private data class for PosePublisher
-class gz::sim::systems::PosePublisherPrivate
+class ignition::gazebo::systems::PosePublisherPrivate
 {
   /// \brief Initializes internal caches for entities whose poses are to be
   /// published and their names

--- a/src/systems/scene_broadcaster/SceneBroadcaster.cc
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.cc
@@ -70,7 +70,7 @@ using namespace gz::sim;
 using namespace systems;
 
 // Private data class.
-class gz::sim::systems::SceneBroadcasterPrivate
+class ignition::gazebo::systems::SceneBroadcasterPrivate
 {
   /// \brief Type alias for the graph used to represent the scene graph.
   public: using SceneGraphType = math::graph::DirectedGraph<

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -55,7 +55,7 @@ using namespace gz::sim;
 using namespace systems;
 
 // Private data class.
-class gz::sim::systems::SensorsPrivate
+class ignition::gazebo::systems::SensorsPrivate
 {
   /// \brief Sensor manager object. This manages the lifecycle of the
   /// instantiated sensors.

--- a/src/systems/thermal/Thermal.cc
+++ b/src/systems/thermal/Thermal.cc
@@ -30,7 +30,7 @@ using namespace gz::sim;
 using namespace systems;
 
 /// \brief Private Thermal data class.
-class gz::sim::systems::ThermalPrivate
+class ignition::gazebo::systems::ThermalPrivate
 {
 };
 

--- a/src/systems/touch_plugin/TouchPlugin.cc
+++ b/src/systems/touch_plugin/TouchPlugin.cc
@@ -42,7 +42,7 @@ using namespace gz;
 using namespace gz::sim;
 using namespace systems;
 
-class gz::sim::systems::TouchPluginPrivate
+class ignition::gazebo::systems::TouchPluginPrivate
 {
   // Initialize the plugin
   public: void Load(const EntityComponentManager &_ecm,

--- a/src/systems/track_controller/TrackController.cc
+++ b/src/systems/track_controller/TrackController.cc
@@ -44,7 +44,7 @@ using namespace gz;
 using namespace gz::sim;
 using namespace systems;
 
-class gz::sim::systems::TrackControllerPrivate
+class ignition::gazebo::systems::TrackControllerPrivate
 {
   public : ~TrackControllerPrivate() {}
   /// \brief Register a collision entity to work with this system (e.g. enable

--- a/src/systems/tracked_vehicle/TrackedVehicle.cc
+++ b/src/systems/tracked_vehicle/TrackedVehicle.cc
@@ -56,7 +56,7 @@ struct Commands
   Commands() {}
 };
 
-class gz::sim::systems::TrackedVehiclePrivate
+class ignition::gazebo::systems::TrackedVehiclePrivate
 {
   /// \brief Callback for velocity subscription
   /// \param[in] _msg Velocity message

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -173,7 +173,7 @@ class PhysicsCommand : public UserCommandBase
 }
 
 /// \brief Private UserCommands data class.
-class gz::sim::systems::UserCommandsPrivate
+class ignition::gazebo::systems::UserCommandsPrivate
 {
   /// \brief Callback for create service
   /// \param[in] _req Request containing entity description.

--- a/src/systems/velocity_control/VelocityControl.cc
+++ b/src/systems/velocity_control/VelocityControl.cc
@@ -36,7 +36,7 @@ using namespace gz;
 using namespace gz::sim;
 using namespace systems;
 
-class gz::sim::systems::VelocityControlPrivate
+class ignition::gazebo::systems::VelocityControlPrivate
 {
   /// \brief Callback for model velocity subscription
   /// \param[in] _msg Velocity message

--- a/src/systems/wheel_slip/WheelSlip.cc
+++ b/src/systems/wheel_slip/WheelSlip.cc
@@ -40,7 +40,7 @@ using namespace systems;
 
 // Adapted from osrf/Gazebo WheelSlipPlugin
 // https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-requests/2950/
-class gz::sim::systems::WheelSlipPrivate
+class ignition::gazebo::systems::WheelSlipPrivate
 {
   /// \brief Initialize the plugin
   public: bool Load(const EntityComponentManager &_ecm, sdf::ElementPtr _sdf);

--- a/src/systems/wind_effects/WindEffects.cc
+++ b/src/systems/wind_effects/WindEffects.cc
@@ -54,7 +54,7 @@ using namespace gz::sim;
 using namespace systems;
 
 /// \brief Private WindEffects data class.
-class gz::sim::systems::WindEffectsPrivate
+class ignition::gazebo::systems::WindEffectsPrivate
 {
   /// \brief Initialize the system.
   /// \param[in] _ecm Mutable reference to the EntityComponentManager.


### PR DESCRIPTION
# 🦟 Bug fix

Fixes macOS build.

## Summary

The macOS build has been broken since https://github.com/gazebosim/gz-sim/pull/1646:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gazebo-ci-ign-gazebo3-homebrew-amd64&build=282)](https://build.osrfoundation.org/view/ign-citadel/job/ignition_gazebo-ci-ign-gazebo3-homebrew-amd64/282/) https://build.osrfoundation.org/view/ign-citadel/job/ignition_gazebo-ci-ign-gazebo3-homebrew-amd64/282/

In other packages, I have avoided using the `gz::sim` namespace when implementing classes, so doing it here seems to fix the macOS build. The ABI build is broken too, but that needs a different fix.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
