### PR TITLE
Use GzSpinBox instead of IgnSpinBox in ViewAngle plugin

### DIFF
--- a/src/gui/plugins/view_angle/ViewAngle.qml
+++ b/src/gui/plugins/view_angle/ViewAngle.qml
@@ -347,7 +347,7 @@ ColumnLayout {
       Layout.column: 0
       leftPadding: 5
     }
-    IgnSpinBox {
+    GzSpinBox {
       id: horizontalFOV
       Layout.fillWidth: true
       Layout.row: 0


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

I'm getting this error in a downstream project (VRX) while trying to load the `ViewAngle` GUI plugin:

```
[GUI] [Err] [Plugin.cc:147] Failed to instantiate QML file [:/ViewAngle/ViewAngle.qml].
[ruby $(which gz) sim-1] * file::/ViewAngle/ViewAngle.qml:350:5: IgnSpinBox is not a type
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.