### PR TITLE
Backport gz/sim.hh fix, add redirection header

### DIFF
--- a/include/gz/CMakeLists.txt
+++ b/include/gz/CMakeLists.txt
@@ -1,1 +1,4 @@
 add_subdirectory(sim)
+# Manually install the redirection header sim.hh
+# Do not merge this forward to gz-sim7
+install(FILES sim.hh DESTINATION ${IGN_INCLUDE_INSTALL_DIR_FULL}/gz)

--- a/include/gz/sim.hh
+++ b/include/gz/sim.hh
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef GZ_SIM_HH_
+#define GZ_SIM_HH_
+
+// Since gz-cmake derives the auto-generated header name from the cmake
+// project name, for ignition-gazebo*, the auto-generated header name
+// is <gz/gazebo.hh>.
+// This header file provides a redirection from <gz/sim.hh> to <gz/gazebo.hh>
+// for the ignition-gazebo* projects and should not be merged forward to
+// gz-sim*.
+#include <gz/gazebo.hh>
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,6 +106,8 @@ target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
   ignition-common${IGN_COMMON_VER}::profiler
   ignition-fuel_tools${IGN_FUEL_TOOLS_VER}::ignition-fuel_tools${IGN_FUEL_TOOLS_VER}
   ignition-gui${IGN_GUI_VER}::ignition-gui${IGN_GUI_VER}
+  ignition-physics${IGN_PHYSICS_VER}::core
+  ignition-rendering${IGN_RENDERING_VER}::core
   ignition-transport${IGN_TRANSPORT_VER}::ignition-transport${IGN_TRANSPORT_VER}
   sdformat${SDF_VER}::sdformat${SDF_VER}
   protobuf::libprotobuf

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -20,6 +20,7 @@ set(tests
   events.cc
   examples_build.cc
   imu_system.cc
+  include_sim_hh.cc
   joint_controller_system.cc
   joint_position_controller_system.cc
   joint_state_publisher_system.cc

--- a/test/integration/include_sim_hh.cc
+++ b/test/integration/include_sim_hh.cc
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include <gz/sim.hh>
+
+/////////////////////////////////////////////////
+// Simple test to make sure it compiles
+TEST(Compilation, sim_hh)
+{
+  gz::sim::System system;
+}


### PR DESCRIPTION
# 🦟 Bug fix

Backports #1978 and adds a missing header file

## Summary

This backports a fix for using the `gz/sim.hh` header file, but this header file does not yet exist on the `ign-gazebo3` branch as a consequence of how gz-cmake derives the auto-generated header name from the cmake project name. For ignition-gazebo*, the auto-generated header name is `gz/gazebo.hh`. Rather than try to modify gz-cmake, I've added a redirection header file from `gz/sim.hh` to `gz/gazebo.hh` for this branch. This should not be merged forward to `gz-sim*`. This is similar to the [sdf/sdf.hh](https://github.com/gazebosim/sdformat/blob/sdf13/include/sdf/sdf.hh) redirection header file used in SDFormat.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Rebase-and-merge**.
