### PR TITLE
Update workflow triggers to avoid duplicates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: Ubuntu CI
 
-on: [push, pull_request]
+on: 
+  pull_request:
+  push:
+    branches:
+      - 'ign-gazebo3'
 
 jobs:
   bionic-ci:


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Pull requests created from a branch on gazebosim/gz-sim cause both the `push` and `pull_request` events to trigger a job.
![image](https://github.com/gazebosim/gz-sim/assets/206116/f1b27703-b9b0-497b-929d-2aa97bb60cd1)

Other than being a waste of resources, the duplicate jobs cause weird behaviors with codecov results. This PR updates the triggers so that the job runs only on `pull_request`. The `push` event should be triggered when we actually merge to the base branch.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
