### PR TITLE
Fix image links in Blender procedural generation tutorial

### DIFF
--- a/tutorials/blender_procedural_datasets.md
+++ b/tutorials/blender_procedural_datasets.md
@@ -155,9 +155,9 @@ blender rock.blend --python-text procedural_dataset_generator.py -- -o sdf_model
 blender woodland.blend --python-text procedural_dataset_generator.py -- -o sdf_models/woodland
 ```
 
-![Example of generating a dataset of rock SDF models](https://github.com/gazebosim/gz-sim/tree/gz-sim7/tutorials/files/blender_procedural_datasets/demo_blender_rock.gif)
+![Example of generating a dataset of rock SDF models](https://raw.githubusercontent.com/gazebosim/gz-sim/gz-sim7/tutorials/files/blender_procedural_datasets/demo_blender_rock.gif)
 
-![Example of generating a dataset of woodland SDF models](https://github.com/gazebosim/gz-sim/tree/gz-sim7/tutorials/files/blender_procedural_datasets/demo_blender_woodland.gif)
+![Example of generating a dataset of woodland SDF models](https://raw.githubusercontent.com/gazebosim/gz-sim/gz-sim7/tutorials/files/blender_procedural_datasets/demo_blender_woodland.gif)
 
 You can configure the script in several ways (see
 `blender rock.blend --python-text procedural_dataset_generator.py -- -h`). For
@@ -220,9 +220,9 @@ Hereafter, you can spawn the generated models inside Gazebo with your preferred
 approach, e.g. via the Resource Spawner GUI plugin. Below are some examples of
 Gazebo environments using the rock and woodland SDF models.
 
-![Example of the generated rock SDF models in Gazebo](https://github.com/gazebosim/gz-sim/tree/gz-sim7/tutorials/files/blender_procedural_datasets/demo_gazebo_rock.png)
+![Example of the generated rock SDF models in Gazebo](https://raw.githubusercontent.com/gazebosim/gz-sim/gz-sim7/tutorials/files/blender_procedural_datasets/demo_gazebo_rock.png)
 
-![Example of the generated woodland SDF models in Gazebo](https://github.com/gazebosim/gz-sim/tree/gz-sim7/tutorials/files/blender_procedural_datasets/demo_gazebo_woodland.png)
+![Example of the generated woodland SDF models in Gazebo](https://raw.githubusercontent.com/gazebosim/gz-sim/gz-sim7/tutorials/files/blender_procedural_datasets/demo_gazebo_woodland.png)
 
 Every object that uses Geometry Nodes in these projects has several input
 attributes that can be configured. You can open the `.blend` projects again,


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Images in the Blender procedural generation tutorial are not showing up on the rendered page (they only show up in GitHub)
https://gazebosim.org/api/sim/7/blender_procedural_datasets.html

Need to use raw image links.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.