### PR TITLE
Print an error message when trying to load SDF files that don't contain a `<world>`

### DIFF
--- a/src/Server.cc
+++ b/src/Server.cc
@@ -184,7 +184,9 @@ Server::Server(const ServerConfig &_config)
 
   if (this->dataPtr->sdfRoot.WorldCount() == 0)
   {
-    ignerr << "SDF file doesn't contain a world.\n";
+    ignerr << "SDF file doesn't contain a world. " <<
+      "If you wish to spawn a model, use the ResourceSpawner GUI plugin " <<
+      "or the 'world/<world_name>/create' service.\n";
     return;
   }
 

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -182,6 +182,12 @@ Server::Server(const ServerConfig &_config)
     return;
   }
 
+  if (this->dataPtr->sdfRoot.WorldCount() == 0)
+  {
+    ignerr << "SDF file doesn't contain a world.\n";
+    return;
+  }
+
   // Add record plugin
   if (_config.UseLogRecord())
   {

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -1114,7 +1114,10 @@ TEST_P(ServerFixture, SdfWithoutWorld)
   {
     std::string line;
     std::getline(ifs, line);
-    std::string errString = "SDF file doesn't contain a world.";
+    std::string errString = "SDF file doesn't contain a world. ";
+    errString += "If you wish to spawn a model, ";
+    errString += "use the ResourceSpawner GUI plugin ";
+    errString += "or the 'world/<world_name>/create' service.";
     errFound = (line.find(errString) != std::string::npos);
   }
   EXPECT_TRUE(errFound);

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -1099,21 +1099,23 @@ TEST_P(ServerFixture, SdfWithoutWorld)
 
   // Start server with model SDF file
   ServerConfig serverConfig;
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/models/sphere/model.sdf");
+  serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
+      "test", "worlds", "models", "sphere", "model.sdf"));
 
   gz::sim::Server server(serverConfig);
   EXPECT_FALSE(server.Running());
   EXPECT_FALSE(*server.Running(0));
 
   // Check error message in log file
-  std::ifstream ifs(common::joinPaths(logBasePath, path, "test.log").c_str(), std::ios::in);
+  std::string logFullPath = common::joinPaths(logBasePath, path, "test.log");
+  std::ifstream ifs(logFullPath.c_str(), std::ios::in);
   bool errFound = false;
   while ((!errFound) && (!ifs.eof()))
   {
     std::string line;
     std::getline(ifs, line);
-    errFound = (line.find("SDF file doesn't contain a world.") != std::string::npos);
+    std::string errString = "SDF file doesn't contain a world.";
+    errFound = (line.find(errString) != std::string::npos);
   }
   EXPECT_TRUE(errFound);
 
@@ -1121,7 +1123,6 @@ TEST_P(ServerFixture, SdfWithoutWorld)
   ignLogClose();
   common::removeAll(logBasePath);
 }
-
 
 // Run multiple times. We want to make sure that static globals don't cause
 // problems.


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #1941

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
Added an error message when attempting to load an SDF file that doesn't contain a world.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.