### PR TITLE
Disable pybind11 on Windows by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ else()
   set (EXTRA_TEST_LIB_DEPS)
 endif()
 
+# We're disabling pybind11 by default on Windows because they
+# don't have active CI on them for now.
 set(skip_pybind11_default_value OFF)
 if (MSVC)
   set(skip_pybind11_default_value ON)
@@ -211,9 +213,9 @@ else()
 
     if (${pybind11_FOUND})
       message (STATUS "Searching for pybind11 - found version ${pybind11_VERSION}.")
-  	else()
-  		IGN_BUILD_WARNING("pybind11 is missing: Python interfaces are disabled.")
-  		message (STATUS "Searching for pybind11 - not found.")
+    else()
+      IGN_BUILD_WARNING("pybind11 is missing: Python interfaces are disabled.")
+      message (STATUS "Searching for pybind11 - not found.")
     endif()
   endif()
 endif()
@@ -237,7 +239,7 @@ add_subdirectory(examples)
 #============================================================================
 ign_create_packages()
 
-if (pybind11_FOUND AND NOT SKIP_PYBIND11)
+if (pybind11_FOUND)
 	add_subdirectory(python)
 endif()
 #============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,11 +53,11 @@ FindDRI()
 
 option(USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION
       "Install python modules in standard system paths in the system"
-      OFF "NOT SKIP_PYBIND11" OFF)
+      ${skip_pybind11_default_value})
 
 option(USE_DIST_PACKAGES_FOR_PYTHON
       "Use dist-packages instead of site-package to install python modules"
-      OFF "NOT SKIP_PYBIND11" OFF)
+      ${skip_pybind11_default_value})
 
 #============================================================================
 # Search for project-specific dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,11 +53,11 @@ FindDRI()
 
 option(USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION
       "Install python modules in standard system paths in the system"
-      OFF)
+      OFF "NOT SKIP_PYBIND11" OFF)
 
 option(USE_DIST_PACKAGES_FOR_PYTHON
       "Use dist-packages instead of site-package to install python modules"
-      OFF)
+      OFF "NOT SKIP_PYBIND11" OFF)
 
 #============================================================================
 # Search for project-specific dependencies
@@ -234,7 +234,7 @@ add_subdirectory(examples)
 #============================================================================
 ign_create_packages()
 
-if (${pybind11_FOUND})
+if (pybind11_FOUND AND NOT SKIP_PYBIND11)
 	add_subdirectory(python)
 endif()
 #============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,15 @@ else()
   set (EXTRA_TEST_LIB_DEPS)
 endif()
 
+set(skip_pybind11_default_value OFF)
+if (MSVC)
+  set(skip_pybind11_default_value ON)
+endif()
+
+option(SKIP_PYBIND11
+      "Skip generating Python bindings via pybind11"
+      ${skip_pybind11_default_value})
+
 include(test/find_dri.cmake)
 FindDRI()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,11 +53,11 @@ FindDRI()
 
 option(USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION
       "Install python modules in standard system paths in the system"
-      ${skip_pybind11_default_value})
+      OFF)
 
 option(USE_DIST_PACKAGES_FOR_PYTHON
       "Use dist-packages instead of site-package to install python modules"
-      ${skip_pybind11_default_value})
+      OFF)
 
 #============================================================================
 # Search for project-specific dependencies
@@ -205,14 +205,17 @@ else()
 
   set(PYBIND11_PYTHON_VERSION 3)
   find_package(Python3 QUIET COMPONENTS Interpreter Development)
-  find_package(pybind11 2.2 QUIET)
 
-  if (${pybind11_FOUND})
-    message (STATUS "Searching for pybind11 - found version ${pybind11_VERSION}.")
-	else()
-		IGN_BUILD_WARNING("pybind11 is missing: Python interfaces are disabled.")
-		message (STATUS "Searching for pybind11 - not found.")
-	endif()
+  if (NOT SKIP_PYBIND11)
+    find_package(pybind11 2.2 QUIET)
+
+    if (${pybind11_FOUND})
+      message (STATUS "Searching for pybind11 - found version ${pybind11_VERSION}.")
+  	else()
+  		IGN_BUILD_WARNING("pybind11 is missing: Python interfaces are disabled.")
+  		message (STATUS "Searching for pybind11 - not found.")
+    endif()
+  endif()
 endif()
 # Plugin install dirs
 set(IGNITION_GAZEBO_PLUGIN_INSTALL_DIR


### PR DESCRIPTION
# 🦟 Bug fix

(Copied from https://github.com/gazebosim/gz-math/pull/529)

Fixes part of #2003 (discussion on https://github.com/gazebosim/gz-launch/issues/220)

## Summary
This PR disabled pybind11 on windows by default until we fix the Windows build regressions that are related to #2003

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
