### PR TITLE
Support loading mesh by mesh name in <mesh><uri>

### DIFF
--- a/include/gz/sim/Util.hh
+++ b/include/gz/sim/Util.hh
@@ -24,7 +24,9 @@
 #include <unordered_set>
 #include <vector>
 
+#include <gz/common/Mesh.hh>
 #include <gz/math/Pose3.hh>
+#include <sdf/Mesh.hh>
 
 #include "gz/sim/components/Environment.hh"
 #include "gz/sim/config.hh"
@@ -308,6 +310,11 @@ namespace gz
       const EntityComponentManager &_ecm,
       const math::Vector3d& _worldPosition,
       const std::shared_ptr<components::EnvironmentalData>& _gridField);
+
+    /// \brief Load a mesh from a Mesh SDF DOM
+    /// \param[in] _meshSdf Mesh SDF DOM
+    /// \return The loaded mesh or null if the mesh can not be loaded.
+    GZ_SIM_VISIBLE const common::Mesh *loadMesh(const sdf::Mesh *_meshSdf);
 
     /// \brief Environment variable holding resource paths.
     const std::string kResourcePathEnv{"GZ_SIM_RESOURCE_PATH"};

--- a/include/gz/sim/Util.hh
+++ b/include/gz/sim/Util.hh
@@ -314,7 +314,7 @@ namespace gz
     /// \brief Load a mesh from a Mesh SDF DOM
     /// \param[in] _meshSdf Mesh SDF DOM
     /// \return The loaded mesh or null if the mesh can not be loaded.
-    GZ_SIM_VISIBLE const common::Mesh *loadMesh(const sdf::Mesh *_meshSdf);
+    GZ_SIM_VISIBLE const common::Mesh *loadMesh(const sdf::Mesh &_meshSdf);
 
     /// \brief Environment variable holding resource paths.
     const std::string kResourcePathEnv{"GZ_SIM_RESOURCE_PATH"};

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -840,15 +840,15 @@ std::string resolveSdfWorldFile(const std::string &_sdfFile,
   return filePath;
 }
 
-const common::Mesh *loadMesh(const sdf::Mesh *_meshSdf)
+const common::Mesh *loadMesh(const sdf::Mesh &_meshSdf)
 {
   const common::Mesh *mesh = nullptr;
   auto &meshManager = *common::MeshManager::Instance();
-  if (common::URI(_meshSdf->Uri()).Scheme() == "name")
+  if (common::URI(_meshSdf.Uri()).Scheme() == "name")
   {
     // if it has a name:// scheme, see if the mesh
     // exists in the mesh manager and load it by name
-    const std::string basename = common::basename(_meshSdf->Uri());
+    const std::string basename = common::basename(_meshSdf.Uri());
     mesh = meshManager.MeshByName(basename);
     if (nullptr == mesh)
     {
@@ -857,10 +857,10 @@ const common::Mesh *loadMesh(const sdf::Mesh *_meshSdf)
       return nullptr;
     }
   }
-  else if (meshManager.IsValidFilename(_meshSdf->Uri()))
+  else if (meshManager.IsValidFilename(_meshSdf.Uri()))
   {
     // load mesh by file path
-    auto fullPath = asFullPath(_meshSdf->Uri(), _meshSdf->FilePath());
+    auto fullPath = asFullPath(_meshSdf.Uri(), _meshSdf.FilePath());
     mesh = meshManager.Load(fullPath);
     if (nullptr == mesh)
     {
@@ -871,7 +871,7 @@ const common::Mesh *loadMesh(const sdf::Mesh *_meshSdf)
   }
   else
   {
-    gzwarn << "Failed to load mesh [" << _meshSdf->Uri()
+    gzwarn << "Failed to load mesh [" << _meshSdf.Uri()
            << "]." << std::endl;
     return nullptr;
   }

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -18,7 +18,10 @@
 #include <gz/msgs/entity.pb.h>
 
 #include <gz/common/Filesystem.hh>
+#include <gz/common/Mesh.hh>
+#include <gz/common/MeshManager.hh>
 #include <gz/common/StringUtils.hh>
+#include <gz/common/URI.hh>
 #include <gz/common/Util.hh>
 #include <gz/math/Helpers.hh>
 #include <gz/math/Pose3.hh>
@@ -835,6 +838,44 @@ std::string resolveSdfWorldFile(const std::string &_sdfFile,
   }
 
   return filePath;
+}
+
+const common::Mesh *loadMesh(const sdf::Mesh *_meshSdf)
+{
+  const common::Mesh *mesh = nullptr;
+  auto &meshManager = *common::MeshManager::Instance();
+  if (common::URI(_meshSdf->Uri()).Scheme() == "name")
+  {
+    // if it has a name:// scheme, see if the mesh
+    // exists in the mesh manager and load it by name
+    const std::string basename = common::basename(_meshSdf->Uri());
+    mesh = meshManager.MeshByName(basename);
+    if (nullptr == mesh)
+    {
+      gzwarn << "Failed to load mesh by name [" << basename
+             << "]." << std::endl;
+      return nullptr;
+    }
+  }
+  else if (meshManager.IsValidFilename(_meshSdf->Uri()))
+  {
+    // load mesh by file path
+    auto fullPath = asFullPath(_meshSdf->Uri(), _meshSdf->FilePath());
+    mesh = meshManager.Load(fullPath);
+    if (nullptr == mesh)
+    {
+      gzwarn << "Failed to load mesh from [" << fullPath
+             << "]." << std::endl;
+      return nullptr;
+    }
+  }
+  else
+  {
+    gzwarn << "Failed to load mesh [" << _meshSdf->Uri()
+           << "]." << std::endl;
+    return nullptr;
+  }
+  return mesh;
 }
 }
 }

--- a/src/Util_TEST.cc
+++ b/src/Util_TEST.cc
@@ -1009,18 +1009,18 @@ TEST_F(UtilTest, ResolveSdfWorldFile)
 TEST_F(UtilTest, LoadMesh)
 {
   sdf::Mesh meshSdf;
-  EXPECT_EQ(nullptr, loadMesh(&meshSdf));
+  EXPECT_EQ(nullptr, loadMesh(meshSdf));
 
   meshSdf.SetUri("invalid_uri");
   meshSdf.SetFilePath("invalid_filepath");
-  EXPECT_EQ(nullptr, loadMesh(&meshSdf));
+  EXPECT_EQ(nullptr, loadMesh(meshSdf));
 
   meshSdf.SetUri("name://unit_box");
-  EXPECT_NE(nullptr, loadMesh(&meshSdf));
+  EXPECT_NE(nullptr, loadMesh(meshSdf));
 
   meshSdf.SetUri("duck.dae");
   std::string filePath = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
     "test", "media", "duck.dae");
   meshSdf.SetFilePath(filePath);
-  EXPECT_NE(nullptr, loadMesh(&meshSdf));
+  EXPECT_NE(nullptr, loadMesh(meshSdf));
 }

--- a/src/Util_TEST.cc
+++ b/src/Util_TEST.cc
@@ -40,6 +40,7 @@
 #include "gz/sim/Util.hh"
 
 #include "helpers/EnvTestFixture.hh"
+#include "test_config.hh"
 
 using namespace gz;
 using namespace sim;
@@ -1002,4 +1003,24 @@ TEST_F(UtilTest, ResolveSdfWorldFile)
 
   // A bad relative path should return an empty string
   EXPECT_TRUE(resolveSdfWorldFile("../invalid/does_not_exist.sdf").empty());
+}
+
+/////////////////////////////////////////////////
+TEST_F(UtilTest, LoadMesh)
+{
+  sdf::Mesh meshSdf;
+  EXPECT_EQ(nullptr, loadMesh(&meshSdf));
+
+  meshSdf.SetUri("invalid_uri");
+  meshSdf.SetFilePath("invalid_filepath");
+  EXPECT_EQ(nullptr, loadMesh(&meshSdf));
+
+  meshSdf.SetUri("name://unit_box");
+  EXPECT_NE(nullptr, loadMesh(&meshSdf));
+
+  meshSdf.SetUri("duck.dae");
+  std::string filePath = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+    "test", "media", "duck.dae");
+  meshSdf.SetFilePath(filePath);
+  EXPECT_NE(nullptr, loadMesh(&meshSdf));
 }

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -713,16 +713,17 @@ rendering::GeometryPtr SceneManager::LoadGeometry(const sdf::Geometry &_geom,
           _geom.MeshShape()->FilePath());
       if (fullPath.empty())
       {
-        gzerr << "Mesh geometry missing uri" << std::endl;
+        gzwarn << "Failed to load mesh from [" << fullPath
+               << "]." << std::endl;
         return geom;
       }
       meshUri = fullPath;
       descriptor.mesh = meshManager->Load(meshUri);
     }
-    else
+    else if (common::URI(_geom.MeshShape()->Uri()).Scheme() == "name")
     {
-      // if it's not a file, see if the mesh exists in the
-      // mesh manager and load it by name
+      // if it's not a file and has a name:// scheme, see if the mesh
+      // exists in the mesh manager and load it by name
       const std::string basename = common::basename(_geom.MeshShape()->Uri());
       descriptor.mesh = meshManager->MeshByName(basename);
       if (descriptor.mesh)
@@ -731,10 +732,16 @@ rendering::GeometryPtr SceneManager::LoadGeometry(const sdf::Geometry &_geom,
       }
       else
       {
-        gzerr << "Invalid mesh: " << _geom.MeshShape()->Uri()
-              << std::endl;
+        gzwarn << "Failed to load mesh by name [" << basename
+               << "]." << std::endl;
         return geom;
       }
+    }
+    else
+    {
+      gzwarn << "Failed to load mesh [" << _geom.MeshShape()->Uri()
+             << "]." << std::endl;
+      return geom;
     }
 
     descriptor.meshName = meshUri;

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -702,47 +702,17 @@ rendering::GeometryPtr SceneManager::LoadGeometry(const sdf::Geometry &_geom,
   }
   else if (_geom.Type() == sdf::GeometryType::MESH)
   {
-    common::MeshManager *meshManager =
-        common::MeshManager::Instance();
-    std::string meshUri;
     rendering::MeshDescriptor descriptor;
-    if (meshManager->IsValidFilename(_geom.MeshShape()->Uri()))
-    {
-      // Assume absolute path to mesh file
-      auto fullPath = asFullPath(_geom.MeshShape()->Uri(),
-          _geom.MeshShape()->FilePath());
-      if (fullPath.empty())
-      {
-        gzwarn << "Failed to load mesh from [" << fullPath
-               << "]." << std::endl;
-        return geom;
-      }
-      meshUri = fullPath;
-      descriptor.mesh = meshManager->Load(meshUri);
-    }
-    else if (common::URI(_geom.MeshShape()->Uri()).Scheme() == "name")
-    {
-      // if it's not a file and has a name:// scheme, see if the mesh
-      // exists in the mesh manager and load it by name
-      const std::string basename = common::basename(_geom.MeshShape()->Uri());
-      descriptor.mesh = meshManager->MeshByName(basename);
-      if (descriptor.mesh)
-      {
-        meshUri = basename;
-      }
-      else
-      {
-        gzwarn << "Failed to load mesh by name [" << basename
-               << "]." << std::endl;
-        return geom;
-      }
-    }
-    else
-    {
-      gzwarn << "Failed to load mesh [" << _geom.MeshShape()->Uri()
-             << "]." << std::endl;
+    descriptor.mesh = loadMesh(_geom.MeshShape());
+    if (!descriptor.mesh)
       return geom;
-    }
+    std::string meshUri =
+        (common::URI(_geom.MeshShape()->Uri()).Scheme() == "name") ?
+         common::basename(_geom.MeshShape()->Uri()) :
+         asFullPath(_geom.MeshShape()->Uri(),
+                    _geom.MeshShape()->FilePath());
+    auto a =     asFullPath(_geom.MeshShape()->Uri(),
+                    _geom.MeshShape()->FilePath());
 
     descriptor.meshName = meshUri;
     descriptor.subMeshName = _geom.MeshShape()->Submesh();

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -703,7 +703,7 @@ rendering::GeometryPtr SceneManager::LoadGeometry(const sdf::Geometry &_geom,
   else if (_geom.Type() == sdf::GeometryType::MESH)
   {
     rendering::MeshDescriptor descriptor;
-    descriptor.mesh = loadMesh(_geom.MeshShape());
+    descriptor.mesh = loadMesh(*_geom.MeshShape());
     if (!descriptor.mesh)
       return geom;
     std::string meshUri =

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -1398,7 +1398,7 @@ void PhysicsPrivate::CreateCollisionEntities(const EntityComponentManager &_ecm,
             if (nullptr == mesh)
             {
               gzwarn << "Failed to load mesh from [" << fullPath
-                      << "]." << std::endl;
+                     << "]." << std::endl;
               return true;
             }
           }
@@ -1411,7 +1411,7 @@ void PhysicsPrivate::CreateCollisionEntities(const EntityComponentManager &_ecm,
             if (nullptr == mesh)
             {
               gzwarn << "Failed to load mesh by name [" << basename
-                      << "]." << std::endl;
+                     << "]." << std::endl;
               return true;
             }
           }

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -1402,10 +1402,11 @@ void PhysicsPrivate::CreateCollisionEntities(const EntityComponentManager &_ecm,
               return true;
             }
           }
-          else
+          else if (common::URI(meshSdf->Uri()).Scheme() == "name")
           {
-            // if it's not a file, see if the mesh exists in the
-            // mesh manager and load it by name
+            // if it's not a file and has a name:// scheme, see if the mesh
+            // exists in the mesh manager and load it by name
+
             const std::string basename = common::basename(meshSdf->Uri());
             mesh = meshManager.MeshByName(basename);
             if (nullptr == mesh)
@@ -1414,6 +1415,12 @@ void PhysicsPrivate::CreateCollisionEntities(const EntityComponentManager &_ecm,
                      << "]." << std::endl;
               return true;
             }
+          }
+          else
+          {
+            gzwarn << "Failed to load mesh [" << meshSdf->Uri()
+                   << "]." << std::endl;
+            return true;
           }
           auto linkMeshFeature =
               this->entityLinkMap.EntityCast<MeshFeatureList>(_parent->Data());

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -1389,7 +1389,7 @@ void PhysicsPrivate::CreateCollisionEntities(const EntityComponentManager &_ecm,
             return true;
           }
 
-          const common::Mesh *mesh = loadMesh(meshSdf);
+          const common::Mesh *mesh = loadMesh(*meshSdf);
           if (!mesh)
             return true;
 

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -1389,39 +1389,10 @@ void PhysicsPrivate::CreateCollisionEntities(const EntityComponentManager &_ecm,
             return true;
           }
 
-          auto &meshManager = *common::MeshManager::Instance();
-          const common::Mesh *mesh = nullptr;
-          if (meshManager.IsValidFilename(meshSdf->Uri()))
-          {
-            auto fullPath = asFullPath(meshSdf->Uri(), meshSdf->FilePath());
-            mesh = meshManager.Load(fullPath);
-            if (nullptr == mesh)
-            {
-              gzwarn << "Failed to load mesh from [" << fullPath
-                     << "]." << std::endl;
-              return true;
-            }
-          }
-          else if (common::URI(meshSdf->Uri()).Scheme() == "name")
-          {
-            // if it's not a file and has a name:// scheme, see if the mesh
-            // exists in the mesh manager and load it by name
-
-            const std::string basename = common::basename(meshSdf->Uri());
-            mesh = meshManager.MeshByName(basename);
-            if (nullptr == mesh)
-            {
-              gzwarn << "Failed to load mesh by name [" << basename
-                     << "]." << std::endl;
-              return true;
-            }
-          }
-          else
-          {
-            gzwarn << "Failed to load mesh [" << meshSdf->Uri()
-                   << "]." << std::endl;
+          const common::Mesh *mesh = loadMesh(meshSdf);
+          if (!mesh)
             return true;
-          }
+
           auto linkMeshFeature =
               this->entityLinkMap.EntityCast<MeshFeatureList>(_parent->Data());
           if (!linkMeshFeature)

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -101,6 +101,7 @@ set(tests_needing_display
   depth_camera.cc
   distortion_camera.cc
   gpu_lidar.cc
+  mesh_uri.cc
   optical_tactile_plugin.cc
   reset_sensors.cc
   rgbd_camera.cc

--- a/test/integration/mesh_uri.cc
+++ b/test/integration/mesh_uri.cc
@@ -66,10 +66,10 @@ std::string meshModelStr(bool _static = false)
       "<model name='spawned_model'>" +
       "<link name='link'>" +
       "<visual name='visual'>" +
-      "<geometry><mesh><uri>unit_box</uri></mesh></geometry>" +
+      "<geometry><mesh><uri>name://unit_box</uri></mesh></geometry>" +
       "</visual>" +
       "<collision name='visual'>" +
-      "<geometry><mesh><uri>unit_box</uri></mesh></geometry>" +
+      "<geometry><mesh><uri>name://unit_box</uri></mesh></geometry>" +
       "</collision>" +
       "</link>" +
       "<static>" + std::to_string(_static) + "</static>" +

--- a/test/integration/mesh_uri.cc
+++ b/test/integration/mesh_uri.cc
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <gz/msgs/entity_factory.pb.h>
+
+#include <gz/common/Console.hh>
+#include <gz/common/Util.hh>
+#include <gz/math/Pose3.hh>
+#include <gz/transport/Node.hh>
+#include <gz/utils/ExtraTestMacros.hh>
+
+#include "gz/sim/components/Model.hh"
+#include "gz/sim/components/Name.hh"
+#include "gz/sim/components/Pose.hh"
+#include "gz/sim/Server.hh"
+#include "gz/sim/SystemLoader.hh"
+#include "test_config.hh"
+
+#include "../helpers/Relay.hh"
+#include "../helpers/EnvTestFixture.hh"
+
+using namespace gz;
+using namespace sim;
+
+std::mutex mutex;
+int g_count = 0;
+unsigned char *g_imageBuffer = nullptr;
+msgs::Image g_image;
+
+/////////////////////////////////////////////////
+void cameraCb(const msgs::Image & _msg)
+{
+  ASSERT_EQ(msgs::PixelFormatType::RGB_INT8,
+      _msg.pixel_format_type());
+
+  std::lock_guard<std::mutex> lock(mutex);
+  g_image = _msg;
+  g_count++;
+}
+
+std::string meshModelStr(bool _static = false)
+{
+  // SDF string consisting of a box mesh. Note that "unit_box"
+  // is a mesh that comes pre-registered with MeshManager so
+  // it should be able to load this as a mesh.
+  // Similarly the user can create a common::Mesh object and add that
+  // to the MeshManager by calling MeshManager::Instance()->AddMesh;
+  return std::string("<?xml version=\"1.0\" ?>") +
+      "<sdf version='1.6'>" +
+      "<model name='spawned_model'>" +
+      "<link name='link'>" +
+      "<visual name='visual'>" +
+      "<geometry><mesh><uri>unit_box</uri></mesh></geometry>" +
+      "</visual>" +
+      "<collision name='visual'>" +
+      "<geometry><mesh><uri>unit_box</uri></mesh></geometry>" +
+      "</collision>" +
+      "</link>" +
+      "<static>" + std::to_string(_static) + "</static>" +
+      "</model>" +
+      "</sdf>";
+}
+
+//////////////////////////////////////////////////
+class MeshUriTest : public InternalFixture<::testing::Test>
+{
+};
+
+/////////////////////////////////////////////////
+// Test spawning mesh by name and verify that the mesh is correctly
+// spawned in both rendering and physics. Cameras should see the spawned
+// mesh and spawend object should collide with one another on the physics
+// side.
+TEST_F(MeshUriTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(SpawnMeshByName))
+{
+  // Start server
+  ServerConfig serverConfig;
+  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
+    "/test/worlds/camera_sensor_scene_background.sdf";
+  serverConfig.SetSdfFile(sdfFile);
+
+  Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  // Create a system just to get the ECM
+  EntityComponentManager *ecm{nullptr};
+  test::Relay testSystem;
+  testSystem.OnPreUpdate([&](const UpdateInfo &,
+                             EntityComponentManager &_ecm)
+      {
+        ecm = &_ecm;
+      });
+
+  server.AddSystem(testSystem.systemPtr);
+
+  // Run server and check we have the ECM
+  EXPECT_EQ(nullptr, ecm);
+  server.Run(true, 1, false);
+  EXPECT_NE(nullptr, ecm);
+
+  auto entityCount = ecm->EntityCount();
+
+  // Subscribe to the camera topic
+  transport::Node node;
+  g_count = 0;
+  node.Subscribe("/camera", &cameraCb);
+
+  // Run and make sure we received camera images
+  server.Run(true, 100, false);
+  for (int i = 0; i < 100 && g_count <= 0; ++i)
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  EXPECT_LT(0u, g_count);
+
+  // Empty scene - camera should see just red background
+  unsigned int bufferSize = g_image.width() *g_image.height() * 3u;
+  unsigned char *imageBuffer = new unsigned char[bufferSize];
+  memcpy(imageBuffer, g_image.data().c_str(), bufferSize);
+
+  unsigned midIdx = (g_image.height() * 0.5 * g_image.width()  +
+    g_image.width() * 0.5) * 3;
+  unsigned int r = imageBuffer[midIdx];
+  unsigned int g = imageBuffer[midIdx + 1];
+  unsigned int b = imageBuffer[midIdx + 2];
+  EXPECT_EQ(255u, r);
+  EXPECT_EQ(0u, g);
+  EXPECT_EQ(0u, b);
+
+  // Spawn a static box (mesh) model in front of the camera
+  msgs::EntityFactory req;
+  req.set_sdf(meshModelStr(true));
+
+  auto pose = req.mutable_pose();
+  auto pos = pose->mutable_position();
+  pos->set_x(3);
+  pos->set_z(1);
+
+  msgs::Boolean res;
+  bool result;
+  unsigned int timeout = 5000;
+  std::string service{"/world/sensors/create"};
+
+  EXPECT_TRUE(node.Request(service, req, timeout, res, result));
+  EXPECT_TRUE(result);
+  EXPECT_TRUE(res.data());
+
+  // Check entity has not been created yet
+  EXPECT_EQ(kNullEntity, ecm->EntityByComponents(components::Model(),
+      components::Name("spawned_model")));
+
+  // Run an iteration and check it was created
+  server.Run(true, 1, false);
+  EXPECT_EQ(entityCount + 4, ecm->EntityCount());
+  entityCount = ecm->EntityCount();
+
+  auto model = ecm->EntityByComponents(components::Model(),
+      components::Name("spawned_model"));
+  EXPECT_NE(kNullEntity, model);
+  auto poseComp = ecm->Component<components::Pose>(model);
+  EXPECT_NE(nullptr, poseComp);
+  EXPECT_EQ(math::Pose3d(3, 0, 1, 0, 0, 0), poseComp->Data());
+
+  // Verify camera now sees a white box
+  g_count = 0u;
+  server.Run(true, 100, false);
+  for (int i = 0; i < 100 && g_count <= 1; ++i)
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  EXPECT_LT(0u, g_count);
+
+  memcpy(imageBuffer, g_image.data().c_str(), bufferSize);
+  r = imageBuffer[midIdx];
+  g = imageBuffer[midIdx + 1];
+  b = imageBuffer[midIdx + 2];
+  EXPECT_EQ(255u, r);
+  EXPECT_EQ(255u, g);
+  EXPECT_EQ(255u, b);
+
+  // Spawn another box over the static one
+  const std::string spawnedModel2Name = "spawned_model2";
+  req.set_sdf(meshModelStr());
+  req.set_name(spawnedModel2Name);
+  pose = req.mutable_pose();
+  pos = pose->mutable_position();
+  pos->set_x(3);
+  pos->set_z(5);
+  EXPECT_TRUE(node.Request(service, req, timeout, res, result));
+  EXPECT_TRUE(result);
+  EXPECT_TRUE(res.data());
+
+  // Check entity has not been created yet
+  EXPECT_EQ(kNullEntity, ecm->EntityByComponents(components::Model(),
+      components::Name(spawnedModel2Name)));
+
+  // Run an iteration and check it was created
+  server.Run(true, 1, false);
+  EXPECT_EQ(entityCount + 4, ecm->EntityCount());
+  entityCount = ecm->EntityCount();
+
+  auto model2 = ecm->EntityByComponents(components::Model(),
+      components::Name(spawnedModel2Name));
+  EXPECT_NE(kNullEntity, model2);
+
+  poseComp = ecm->Component<components::Pose>(model2);
+  EXPECT_NE(nullptr, poseComp);
+  EXPECT_EQ(math::Pose3d(3, 0, 5, 0, 0, 0), poseComp->Data());
+
+  // run and spawned model 2 should fall onto the previous box
+  server.Run(true, 1000, false);
+  poseComp = ecm->Component<components::Pose>(model2);
+  EXPECT_NE(nullptr, poseComp);
+  EXPECT_EQ(math::Pose3d(3, 0, 2, 0, 0, 0), poseComp->Data()) <<
+    poseComp->Data();
+
+  delete [] imageBuffer;
+  imageBuffer = nullptr;
+}

--- a/test/integration/mesh_uri.cc
+++ b/test/integration/mesh_uri.cc
@@ -40,7 +40,6 @@ using namespace sim;
 
 std::mutex mutex;
 int g_count = 0;
-unsigned char *g_imageBuffer = nullptr;
 msgs::Image g_image;
 
 /////////////////////////////////////////////////
@@ -128,13 +127,19 @@ TEST_F(MeshUriTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(SpawnMeshByName))
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   EXPECT_LT(0u, g_count);
 
+  unsigned char *imageBuffer = nullptr;
+  unsigned int midIdx = 0u;
+  unsigned int bufferSize = 0u;
   // Empty scene - camera should see just red background
-  unsigned int bufferSize = g_image.width() *g_image.height() * 3u;
-  unsigned char *imageBuffer = new unsigned char[bufferSize];
-  memcpy(imageBuffer, g_image.data().c_str(), bufferSize);
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    bufferSize = g_image.width() *g_image.height() * 3u;
+    imageBuffer = new unsigned char[bufferSize];
+    memcpy(imageBuffer, g_image.data().c_str(), bufferSize);
 
-  unsigned midIdx = (g_image.height() * 0.5 * g_image.width()  +
-    g_image.width() * 0.5) * 3;
+    midIdx = (g_image.height() * 0.5 * g_image.width()  +
+      g_image.width() * 0.5) * 3;
+  }
   unsigned int r = imageBuffer[midIdx];
   unsigned int g = imageBuffer[midIdx + 1];
   unsigned int b = imageBuffer[midIdx + 2];
@@ -183,7 +188,10 @@ TEST_F(MeshUriTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(SpawnMeshByName))
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   EXPECT_LT(0u, g_count);
 
-  memcpy(imageBuffer, g_image.data().c_str(), bufferSize);
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    memcpy(imageBuffer, g_image.data().c_str(), bufferSize);
+  }
   r = imageBuffer[midIdx];
   g = imageBuffer[midIdx + 1];
   b = imageBuffer[midIdx + 2];

--- a/test/integration/mesh_uri.cc
+++ b/test/integration/mesh_uri.cc
@@ -91,8 +91,8 @@ TEST_F(MeshUriTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(SpawnMeshByName))
 {
   // Start server
   ServerConfig serverConfig;
-  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
-    "/test/worlds/camera_sensor_scene_background.sdf";
+  const auto sdfFile = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+    "test", "worlds", "camera_sensor_scene_background.sdf");
   serverConfig.SetSdfFile(sdfFile);
 
   Server server(serverConfig);

--- a/test/worlds/camera_sensor_scene_background.sdf
+++ b/test/worlds/camera_sensor_scene_background.sdf
@@ -14,6 +14,10 @@
       name="gz::sim::systems::Sensors">
       <render_engine>ogre2</render_engine>
     </plugin>
+    <plugin
+      filename="gz-sim-user-commands-system"
+      name="gz::sim::systems::UserCommands">
+    </plugin>
 
     <scene>
       <background>1 0 0</background>

--- a/tutorials/resources.md
+++ b/tutorials/resources.md
@@ -144,6 +144,14 @@ Gazebo will look for URIs (path / URL) in the following, in order:
 \* The `GZ_FILE_PATH` environment variable also works in some scenarios, but
   it's not recommended when using Gazebo.
 
+If a <geometry><mesh><uri>` starts with the `name://` scheme,
+e.g. `name://my_mesh_name`, Gazebo will check to see if a mesh with the
+specified name exists in the Mesh Manager and load that mesh if it exists.
+This can happen when a `common::Mesh` object is created in memory and
+registered with the Mesh Manager via the
+[common::MeshManager::Instance()->AddMesh](https://gazebosim.org/api/common/5/classgz_1_1common_1_1MeshManager.html#a2eaddabc3a3109bd8757b2a8b2dd2d01)
+call.
+
 ### GUI configuration
 
 Gazebo Sim's


### PR DESCRIPTION

# 🎉 New feature

Partially addresses https://github.com/gazebosim/gz-common/issues/404, specifically https://github.com/gazebosim/gz-common/issues/404#issuecomment-1569399519 about handing over in-memory mesh data to gazebo.

## Summary

Allow users to specify name of mesh in SDF via `<mesh><uri>`. 

Addresses this use case: User has created `common:Mesh` object and added it to the MeshManager via [AddMesh](https://github.com/gazebosim/gz-common/blob/466f83fca2fba08126efe1d912d7fffb5fe03444/graphics/src/MeshManager.cc#L245) call. They now want to spawn a new model with this mesh using an SDF string that has `<mesh><uri>` set to the name of their `common::Mesh`.

Added integration test demonstrating the above use case. It uses `unit_box` (that comes with MeshManager) as an example but user should be able to supply their own mesh.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

