### PR TITLE
Fix tracked vehicle track direction

### DIFF
--- a/src/systems/tracked_vehicle/TrackedVehicle.cc
+++ b/src/systems/tracked_vehicle/TrackedVehicle.cc
@@ -683,9 +683,9 @@ void TrackedVehiclePrivate::UpdateVelocity(
   if (sendCommandsToTracks)
   {
     // Convert the target velocities to track velocities.
-    this->rightSpeed = (linVel + angVel * this->tracksSeparation /
+    this->rightSpeed = - (linVel + angVel * this->tracksSeparation /
       (2.0 * steeringEfficiencyCopy));
-    this->leftSpeed = (linVel - angVel * this->tracksSeparation /
+    this->leftSpeed = - (linVel - angVel * this->tracksSeparation /
       (2.0 * steeringEfficiencyCopy));
 
     // radius of the turn the robot is doing


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2008

Make the tracks go the opposite direction to propel the vehicle in the correct direction.


## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

