### PR TITLE
Tracks periodic changes in scene broadcaster

### DIFF
--- a/include/ignition/gazebo/EntityComponentManager.hh
+++ b/include/ignition/gazebo/EntityComponentManager.hh
@@ -602,8 +602,12 @@ namespace ignition
           ComponentTypesWithPeriodicChanges() const;
 
       /// \brief Get all components with periodic changes.
-      /// \param[in] _f Callback function to be called for each matching entity
-      /// and component that has experienced a change.
+      /// \param[in] _changes A list of components with the latest periodic
+      /// changes. If a component has a periodic change, it is added to the
+      /// hash map. It the component or entity was removed, it is removed from
+      /// the hashmap. This way the hashmap stores a list of components and
+      /// entities which have had periodic changes in the past and still
+      /// exit within the ECM.
       public: void PeriodicChangeEntityComponentMap(std::unordered_map<Entity,
                         std::unordered_set<ComponentTypeId>> &_changes) const;
 
@@ -637,10 +641,10 @@ namespace ignition
       /// \brief Get a message with the serialized state of the given entities
       /// and components.
       /// \details The header of the message will not be populated, it is the
-      /// responsibility of the caller to timestamp it before use.
-      /// \param[out] _state The serialized state message to populate.
+      /// responsibility of the caller to timestamp it before use. Additionally,
+      /// changes such as addition or removal will not be populated.
+      /// \param[inout] _state The serialized state message to populate.
       /// \param[in] _entityMap A map of entities and components to serialize.
-      /// False will get only components and entities that have changed.
       public: void State(
                   msgs::SerializedStateMap &_state,
                   const std::unordered_map<Entity,

--- a/include/ignition/gazebo/EntityComponentManager.hh
+++ b/include/ignition/gazebo/EntityComponentManager.hh
@@ -606,7 +606,7 @@ namespace ignition
       /// and component that has experienced a change.
       public: void EachPeriodicChange(const std::function<
                   void(const Entity &_entity,
-                       components::BaseComponent *_component)> _f) const; 
+                       const ComponentTypeId &_type)> _f) const; 
 
       /// \brief Set the absolute state of the ECM from a serialized message.
       /// Entities / components that are in the new state but not in the old
@@ -634,6 +634,18 @@ namespace ignition
                   const std::unordered_set<Entity> &_entities = {},
                   const std::unordered_set<ComponentTypeId> &_types = {},
                   bool _full = false) const;
+
+      /// \brief Get a message with the serialized state of the given entities
+      /// and components.
+      /// \details The header of the message will not be populated, it is the
+      /// responsibility of the caller to timestamp it before use.
+      /// \param[out] _state The serialized state message to populate.
+      /// \param[in] _entityMap A map of entities and components to serialize.
+      /// False will get only components and entities that have changed.
+      public: void State(
+                  msgs::SerializedStateMap &_state,
+                  const std::unordered_map<Entity,
+                        std::unordered_set<ComponentTypeId>> &_entityMap) const;
 
       /// \brief Get a message with the serialized state of all entities and
       /// components that are changing in the current iteration

--- a/include/ignition/gazebo/EntityComponentManager.hh
+++ b/include/ignition/gazebo/EntityComponentManager.hh
@@ -604,9 +604,8 @@ namespace ignition
       /// \brief Get all components with periodic changes.
       /// \param[in] _f Callback function to be called for each matching entity
       /// and component that has experienced a change.
-      public: void EachPeriodicChange(const std::function<
-                  void(const Entity &_entity,
-                       const ComponentTypeId &_type)> _f) const; 
+      public: void PeriodicChangeEntityComponentMap(std::unordered_map<Entity,
+                        std::unordered_set<ComponentTypeId>> &_changes) const;
 
       /// \brief Set the absolute state of the ECM from a serialized message.
       /// Entities / components that are in the new state but not in the old

--- a/include/ignition/gazebo/EntityComponentManager.hh
+++ b/include/ignition/gazebo/EntityComponentManager.hh
@@ -601,6 +601,13 @@ namespace ignition
       public: std::unordered_set<ComponentTypeId>
           ComponentTypesWithPeriodicChanges() const;
 
+      /// \brief Get all components with periodic changes.
+      /// \param[in] _f Callback function to be called for each matching entity
+      /// and component that has experienced a change.
+      public: void EachPeriodicChange(const std::function<
+                  void(const Entity &_entity,
+                       components::BaseComponent *_component)> _f) const; 
+
       /// \brief Set the absolute state of the ECM from a serialized message.
       /// Entities / components that are in the new state but not in the old
       /// one will be created.

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -964,6 +964,27 @@ std::unordered_set<ComponentTypeId>
 }
 
 /////////////////////////////////////////////////
+void EntityComponentManager::EachPeriodicChange(const std::function<
+                  void(const Entity &_entity,
+                       components::BaseComponent *_type)> _f) const
+{
+  for (const auto &[componentType, entities] : this->dataPtr->periodicChangedComponents)
+  {
+    
+    for (const auto entity: entities) {
+
+      const components::BaseComponent* implementation =  
+        this->ComponentImplementation(entity, componentType);
+      
+      if(!implementation)
+        continue;
+      
+      _f(entity, const_cast<components::BaseComponent*>(implementation));
+    }
+  }
+}
+
+/////////////////////////////////////////////////
 bool EntityComponentManager::HasEntity(const Entity _entity) const
 {
   auto vertex = this->dataPtr->entities.VertexFromId(_entity);

--- a/src/systems/scene_broadcaster/SceneBroadcaster.cc
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.cc
@@ -395,15 +395,8 @@ void SceneBroadcaster::PostUpdate(const UpdateInfo &_info,
     {
       IGN_PROFILE("SceneBroadcast::PostUpdate UpdateState");
 
-      if (_manager.HasPeriodicComponentChanges())
-      {
-        // TODO(arjo): We probably don't need this with the new cache method?
-        auto periodicComponents = _manager.ComponentTypesWithPeriodicChanges();
-        _manager.State(*this->dataPtr->stepMsg.mutable_state(),
-             {}, periodicComponents);
-        this->dataPtr->pubPeriodicChanges = false;
-      }
-      else
+      // TODO(arjo): We may not need this.
+      if (!_manager.HasPeriodicComponentChanges())
       {
         // log files may be recorded at lower rate than sim time step. So in
         // playback mode, the scene broadcaster may not see any periodic
@@ -428,13 +421,13 @@ void SceneBroadcaster::PostUpdate(const UpdateInfo &_info,
         // we may be able to remove this in the future and update tests
         this->dataPtr->stepMsg.mutable_state();
       }
-    }
 
-    // Apply changes that were caught by the periodic state tracker and then
-    // clear the change tracker.
-    _manager.State(*this->dataPtr->stepMsg.mutable_state(),
-      this->dataPtr->changedComponents);
-    this->dataPtr->changedComponents.clear();
+      // Apply changes that were caught by the periodic state tracker and then
+      // clear the change tracker.
+      _manager.State(*this->dataPtr->stepMsg.mutable_state(),
+        this->dataPtr->changedComponents);
+      this->dataPtr->changedComponents.clear();
+    }
 
     // Full state on demand
     if (this->dataPtr->stateServiceRequest)

--- a/src/systems/scene_broadcaster/SceneBroadcaster.cc
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.cc
@@ -257,7 +257,53 @@ class ignition::gazebo::systems::SceneBroadcasterPrivate
   /// \brief Flag used to indicate if periodic changes need to be published
   /// This is currently only used in playback mode.
   public: bool pubPeriodicChanges{false};
+
+  /// \brief Stores a cache of components that are changed. (This prevents dropping of
+  /// periodic change components which may not be frequent enough)
+  public: std::unordered_map<Entity,
+    std::unordered_map<ComponentTypeId,
+    std::unique_ptr<components::BaseComponent>>> changedComponents;
+
+  void ApplyPeriodicCacheChanges(msgs::SerializedStateMap &_stateMsg) {
+    for (auto &[entity, components] : changedComponents) {
+
+      // Add entity to message if it does not exist
+      auto entIter = _stateMsg.mutable_entities()->find(entity);
+      if (entIter == _stateMsg.mutable_entities()->end())
+      {
+        msgs::SerializedEntityMap ent;
+        ent.set_id(entity);
+        (*_stateMsg.mutable_entities())[static_cast<uint64_t>(entity)] = ent;
+        entIter = _stateMsg.mutable_entities()->find(entity);
+      }
+
+      // Serialize components that have changed
+      for (auto &[typeId, comp]: components) {
+
+        // Find the component in the message
+        auto compIter = entIter->second.mutable_components()->find(typeId);
+        
+        if (compIter != entIter->second.mutable_components()->end())
+        {
+          // If the component is present we don't need to update it.
+          continue;
+        }
+
+        // Add the component to the message
+        msgs::SerializedComponent cmp;
+        cmp.set_type(comp->TypeId());
+        std::ostringstream ostr;
+        comp->Serialize(ostr);
+        cmp.set_component(ostr.str());
+        (*(entIter->second.mutable_components()))[
+        static_cast<int64_t>(typeId)] = cmp;
+      }  
+    }
+    this->changedComponents.clear();
+  }
+
 };
+
 
 //////////////////////////////////////////////////
 SceneBroadcaster::SceneBroadcaster()
@@ -341,6 +387,16 @@ void SceneBroadcaster::PostUpdate(const UpdateInfo &_info,
   // removed entities are removed from the scene graph for the next update cycle
   this->dataPtr->SceneGraphRemoveEntities(_manager);
 
+  // Iterate through entities and their changes to cache them.
+  _manager.EachPeriodicChange([&](const Entity &_entity,
+                      components::BaseComponent *_component) {
+    //ignerr << "got change" <<"\n";
+    this->dataPtr->changedComponents[_entity].emplace(_component->TypeId(),
+      _component->Clone());
+  });
+  // TODO(arjo): Remove items in the periodic change cache that have been removed.
+  
+
   // Publish state only if there are subscribers and
   // * throttle rate to 60 Hz
   // * also publish off-rate if there are change events:
@@ -386,6 +442,7 @@ void SceneBroadcaster::PostUpdate(const UpdateInfo &_info,
 
       if (_manager.HasPeriodicComponentChanges())
       {
+        // TODO(arjo): We probably don't need this with the new cache method?
         auto periodicComponents = _manager.ComponentTypesWithPeriodicChanges();
         _manager.State(*this->dataPtr->stepMsg.mutable_state(),
              {}, periodicComponents);
@@ -417,6 +474,10 @@ void SceneBroadcaster::PostUpdate(const UpdateInfo &_info,
         this->dataPtr->stepMsg.mutable_state();
       }
     }
+
+    // Apply changes that were caught by the periodic state tracker
+    this->dataPtr->ApplyPeriodicCacheChanges(
+      *this->dataPtr->stepMsg.mutable_state());
 
     // Full state on demand
     if (this->dataPtr->stateServiceRequest)

--- a/src/systems/scene_broadcaster/SceneBroadcaster.cc
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.cc
@@ -394,8 +394,6 @@ void SceneBroadcaster::PostUpdate(const UpdateInfo &_info,
     else if (!_info.paused)
     {
       IGN_PROFILE("SceneBroadcast::PostUpdate UpdateState");
-
-      // TODO(arjo): We may not need this.
       if (!_manager.HasPeriodicComponentChanges())
       {
         // log files may be recorded at lower rate than sim time step. So in


### PR DESCRIPTION
This commit proposes a change to the scene broadcaster which enables tracking of all components with periodic changes. This way if a component has a periodic change the scene broadcaster does not miss it.

For more info see this discussion https://github.com/gazebosim/gz-sim/pull/2001#issuecomment-1581573728 where @azeey proposes this solution.

This commit is WIP (Work In Progress) and I still need to handle entity/component removal and add tests.