### PR TITLE
Backport #2006 to citadel: Fix finding new versions of protobuf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,9 +146,7 @@ set(IGN_TOOLS_VER 1)
 
 #--------------------------------------
 # Find protobuf
-set(REQ_PROTOBUF_VER 3)
 ign_find_package(IgnProtobuf
-                 VERSION ${REQ_PROTOBUF_VER}
                  REQUIRED
                  COMPONENTS all
                  PRETTY Protobuf)

--- a/src/systems/triggered_publisher/TriggeredPublisher.cc
+++ b/src/systems/triggered_publisher/TriggeredPublisher.cc
@@ -652,14 +652,7 @@ bool TriggeredPublisher::MatchInput(const transport::ProtoMsg &_inputMsg)
   return std::all_of(this->matchers.begin(), this->matchers.end(),
                      [&](const auto &_matcher)
                      {
-                       try
-                       {
-                         return _matcher->Match(_inputMsg);
-                       } catch (const google::protobuf::FatalException &err)
-                       {
-                          ignerr << err.what() << std::endl;
-                          return false;
-                       }
+                       return _matcher->Match(_inputMsg);
                      });
 }
 


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2274. Use rebase and merge.