### PR TITLE
Cherry-pick #2006 to garden: fix finding new protobuf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,12 +186,10 @@ set(GZ_UTILS_VER ${gz-utils2_VERSION_MAJOR})
 
 #--------------------------------------
 # Find protobuf
-set(REQ_PROTOBUF_VER 3)
 gz_find_package(GzProtobuf
-                 VERSION ${REQ_PROTOBUF_VER}
-                 REQUIRED
-                 COMPONENTS all
-                 PRETTY Protobuf)
+                REQUIRED
+                COMPONENTS all
+                PRETTY Protobuf)
 set(Protobuf_IMPORT_DIRS ${gz-msgs9_INCLUDE_DIRS})
 
 #--------------------------------------

--- a/src/systems/triggered_publisher/TriggeredPublisher.cc
+++ b/src/systems/triggered_publisher/TriggeredPublisher.cc
@@ -832,14 +832,7 @@ bool TriggeredPublisher::MatchInput(const transport::ProtoMsg &_inputMsg)
   return std::all_of(this->matchers.begin(), this->matchers.end(),
                      [&](const auto &_matcher)
                      {
-                       try
-                       {
-                         return _matcher->Match(_inputMsg);
-                       } catch (const google::protobuf::FatalException &err)
-                       {
-                          gzerr << err.what() << std::endl;
-                          return false;
-                       }
+                       return _matcher->Match(_inputMsg);
                      });
 }
 


### PR DESCRIPTION
Cherry-pick #2006 to Garden. Part of https://github.com/osrf/homebrew-simulation/issues/2274. Use Rebase and Merge.