### PR TITLE
Odometry topic for the track controller system

### DIFF
--- a/examples/worlds/conveyor.sdf
+++ b/examples/worlds/conveyor.sdf
@@ -162,7 +162,7 @@
             <plugin filename="gz-sim-track-controller-system"
                     name="gz::sim::systems::TrackController">
                 <link>base_link</link>
-                <kinematic_state_publish_frequency>1</kinematic_state_publish_frequency>
+                <odometry_publish_frequency>1</odometry_publish_frequency>
                 <!--debug>true</debug-->
             </plugin>
 

--- a/examples/worlds/conveyor.sdf
+++ b/examples/worlds/conveyor.sdf
@@ -121,6 +121,11 @@
                             <size>5 0.2 0.1</size>
                         </box>
                     </geometry>
+                    <material>
+                        <ambient>0.05 0.05 0.70 1</ambient>
+                        <diffuse>0.05 0.05 0.70 1</diffuse>
+                        <specular>0.8 0.8 0.8 1</specular>
+                    </material>
                 </visual>
                 <visual name='visual_1'>
                     <pose relative_to='base_link'>2.5 0 0 -1.570796327 0 0</pose>
@@ -130,6 +135,11 @@
                             <radius>0.05</radius>
                         </cylinder>
                     </geometry>
+                    <material>
+                        <ambient>0.05 0.05 0.70 1</ambient>
+                        <diffuse>0.05 0.05 0.70 1</diffuse>
+                        <specular>0.8 0.8 0.8 1</specular>
+                    </material>
                 </visual>
                 <visual name='visual_2'>
                     <pose relative_to='base_link'>-2.5 0 0 -1.570796327 0 0</pose>
@@ -139,6 +149,11 @@
                             <radius>0.05</radius>
                         </cylinder>
                     </geometry>
+                    <material>
+                        <ambient>0.05 0.05 0.70 1</ambient>
+                        <diffuse>0.05 0.05 0.70 1</diffuse>
+                        <specular>0.8 0.8 0.8 1</specular>
+                    </material>
                 </visual>
                 <gravity>1</gravity>
                 <kinematic>0</kinematic>
@@ -147,6 +162,7 @@
             <plugin filename="gz-sim-track-controller-system"
                     name="gz::sim::systems::TrackController">
                 <link>base_link</link>
+                <kinematic_state_publish_frequency>1</kinematic_state_publish_frequency>
                 <!--debug>true</debug-->
             </plugin>
 
@@ -157,7 +173,7 @@
                     <match field="data">87</match>
                 </input>
                 <output type="gz.msgs.Double" topic="/model/conveyor/link/base_link/track_cmd_vel">
-                    data: 10.0
+                    data: 1.0
                 </output>
             </plugin>
 
@@ -185,7 +201,7 @@
         </model>
 
         <model name='box'>
-            <pose frame=''>0 0 1 0 0 0</pose>
+            <pose>0 0 1 0 0 0</pose>
             <link name='base_link'>
                 <inertial>
                     <mass>1.06</mass>
@@ -206,7 +222,9 @@
                         </box>
                     </geometry>
                     <material>
-                        <ambient>1 1 1 1</ambient>
+                        <ambient>0.60 0.0 0.0 1</ambient>
+                        <diffuse>0.60 0.0 0.0 1</diffuse>
+                        <specular>0.8 0.8 0.8 1</specular>
                     </material>
                 </visual>
                 <collision name='main_collision'>
@@ -271,6 +289,25 @@
                 <property key="state" type="string">floating</property>
                 <property key="showTitleBar" type="bool">false</property>
               </gz-gui>
+            </plugin>
+
+            <plugin name='World control' filename='WorldControl'>
+                <gz-gui>
+                    <title>World control</title>
+                    <property type='bool' key='showTitleBar'>0</property>
+                    <property type='bool' key='resizable'>0</property>
+                    <property type='double' key='height'>72</property>
+                    <property type='double' key='width'>150</property>
+                    <property type='double' key='z'>1</property>
+                    <property type='string' key='state'>floating</property>
+                    <anchors target='3D View'>
+                        <line own='left' target='left'/>
+                        <line own='bottom' target='bottom'/>
+                    </anchors>
+                </gz-gui>
+                <play_pause>1</play_pause>
+                <step>1</step>
+                <start_paused>0</start_paused>
             </plugin>
 
             <!-- World statistics -->

--- a/src/systems/track_controller/TrackController.cc
+++ b/src/systems/track_controller/TrackController.cc
@@ -528,7 +528,7 @@ void TrackController::PostUpdate(const UpdateInfo &_info,
 
   // Set position and velocity
   msg.mutable_pose()->mutable_position()->set_x(this->dataPtr->position);
-  msg.mutable_twist()->mutable_linear()->set_x(this->dataPtr->velocity);
+  msg.mutable_twist()->mutable_linear()->set_x(this->dataPtr->limitedVelocity);
 
   this->dataPtr->odometryPub.Publish(msg);
 }

--- a/src/systems/track_controller/TrackController.cc
+++ b/src/systems/track_controller/TrackController.cc
@@ -17,8 +17,6 @@
 
 #include "TrackController.hh"
 
-#include <gz/msgs/odometry.pb.h>
-
 #include <limits>
 #include <mutex>
 #include <string>
@@ -27,6 +25,7 @@
 
 #include <gz/msgs/double.pb.h>
 #include <gz/msgs/marker.pb.h>
+#include <gz/msgs/odometry.pb.h>
 #include <gz/msgs/Utility.hh>
 
 #include <gz/math/eigen3.hh>

--- a/src/systems/track_controller/TrackController.cc
+++ b/src/systems/track_controller/TrackController.cc
@@ -288,7 +288,8 @@ void TrackController::Configure(const Entity &_entity,
   this->dataPtr->kinematicStatePub =
     this->dataPtr->node.Advertise<msgs::KinematicState1D>(kinTopic);
 
-  double kinFreq = _sdf->Get<double>("kinematic_state_publish_frequency", 50).first;
+  double kinFreq = _sdf->Get<double>(
+    "kinematic_state_publish_frequency", 50).first;
   std::chrono::duration<double> kinPer{0.0};
   if (kinFreq > 0)
   {
@@ -296,8 +297,8 @@ void TrackController::Configure(const Entity &_entity,
     this->dataPtr->kinStatePubPeriod =
       std::chrono::duration_cast<std::chrono::steady_clock::duration>(kinPer);
   }
-  gzdbg << "Publishing kinematic state to " << kinTopic << " with period " << kinPer.count()
-    << " seconds." << std::endl;
+  gzdbg << "Publishing kinematic state to " << kinTopic
+    << " with period " << kinPer.count() << " seconds." << std::endl;
 
 
   this->dataPtr->trackOrientation = _sdf->Get<math::Quaterniond>(
@@ -490,31 +491,34 @@ void TrackController::PostUpdate(const UpdateInfo &_info,
   //
   // Only the position and velocity fields of the message are populated, as
   // these are the only known values. E.g. at timestep 'k':
-  // - Given an ideal system: (position k) = (position k-1) + (velocity k-1) * dt,
-  // - And (velocity k) is known from the velocity command (possibly limited by the SpeedLimiter).
-  // However, since this is a velocity-resolved controler, (acceleration k) and (jerk k)
-  // are unknown, e.g.:
+  // - For an ideal system: (position k) = (position k-1) + (velocity k-1) * dt,
+  // - And (velocity k) is known from the velocity command (possibly limited by
+  // the SpeedLimiter).
+  // However, since this is a velocity-resolved controler, (acceleration k)
+  // and (jerk k) are unknown, e.g.:
   //   (acceleration k) = ( (velocity k+1) - (velocity k) ) / dt
   //   in which (velocity k+1) is unknown in timestep k.
   //
-  // Note that, in case of a lower publish frequency than the simulation frequency, a similar issue
-  // exists for the velocity, since only the instantaneous velocity is known at each time step,
-  // and not the average velocity. E.g. consider:
+  // Note that, in case of a lower publish frequency than the simulation
+  // frequency, a similar issue exists for the velocity, since only the
+  // instantaneous velocity is known at each time step, and not the average
+  // velocity. E.g. consider:
   //
   //    Time        0    1    2    3    4    5
   //    Velocity   10   10   10   10    0    0
   //    Position    0   10   20   30   40   40
   //
   // with publish at:
-  // - time 0: position 10 and velocity 10
+  // - time 0: position 0 and velocity 10
   // - time 5: position 40 and velocity 0
   //
-  // For '(pos k) = (pos k-1) + (vel k-1) * dt' to hold, with k = time 5 and k-1 = time 0, the
-  // reported velocity at 0 should be '8': (40 - 0) / 5 = 8 (i.e. the average velocity over 0 to 5),
+  // For '(pos k) = (pos k-1) + (vel k-1) * dt' to hold, with k = time 5
+  // and k-1 = time 0, the reported velocity at 0 should be '8':
+  //   (40 - 0) / 5 = 8  (i.e. the average velocity over time 0 to 5),
   // instead of the reported (instantaneous) velocity '10'.
   //
-  // Imo. this error is acceptable, as real life sensors (e.g. encoder and resolver) also report
-  // instantaneous values for position and velocity.
+  // Imo. this error is acceptable, as real life sensors (e.g. encoder and
+  // resolver) also report instantaneous values for position and velocity.
   //
   msgs::KinematicState1D msg;
 

--- a/src/systems/track_controller/TrackController.cc
+++ b/src/systems/track_controller/TrackController.cc
@@ -289,15 +289,15 @@ void TrackController::Configure(const Entity &_entity,
 
   double odometryFreq = _sdf->Get<double>(
     "odometry_publish_frequency", 50).first;
-  std::chrono::duration<double> odometryPer{0.0};
+  std::chrono::duration<double> odomPer{0.0};
   if (odometryFreq > 0)
   {
-    odometryPer = std::chrono::duration<double>(1 / odometryFreq);
+    odomPer = std::chrono::duration<double>(1 / odometryFreq);
     this->dataPtr->odometryPubPeriod =
-      std::chrono::duration_cast<std::chrono::steady_clock::duration>(odometryPer);
+      std::chrono::duration_cast<std::chrono::steady_clock::duration>(odomPer);
   }
   gzdbg << "Publishing odometry to " << odometryTopic
-    << " with period " << odometryPer.count() << " seconds." << std::endl;
+    << " with period " << odomPer.count() << " seconds." << std::endl;
 
 
   this->dataPtr->trackOrientation = _sdf->Get<math::Quaterniond>(

--- a/src/systems/track_controller/TrackController.cc
+++ b/src/systems/track_controller/TrackController.cc
@@ -17,6 +17,8 @@
 
 #include "TrackController.hh"
 
+#include <gz/msgs/kinematic_state_1D.pb.h>
+
 #include <limits>
 #include <mutex>
 #include <string>
@@ -29,6 +31,7 @@
 
 #include <gz/math/eigen3.hh>
 #include <gz/math/SpeedLimiter.hh>
+#include <gz/math/Helpers.hh>
 
 #include <gz/plugin/Register.hh>
 #include <gz/transport/Node.hh>
@@ -140,6 +143,8 @@ class gz::sim::systems::TrackControllerPrivate
   /// \brief World poses of all collision elements of the track's link.
   public: std::unordered_map<Entity, math::Pose3d> collisionsWorldPose;
 
+  /// \brief Track position
+  public: double position {0};
   /// \brief The last commanded velocity.
   public: double velocity {0};
   /// \brief Commanded velocity clipped to allowable range.
@@ -148,8 +153,9 @@ class gz::sim::systems::TrackControllerPrivate
   public: double prevVelocity {0};
   /// \brief Second previous clipped commanded velocity.
   public: double prevPrevVelocity {0};
+
   /// \brief The point around which the track circles (in world coords). Should
-  /// be set to +Inf if the track is going straight.
+  /// be set to Inf or NaN if the track is going straight.
   public: math::Vector3d centerOfRotation {math::Vector3d::Zero * math::INF_D};
   /// \brief protects velocity and centerOfRotation
   public: std::mutex cmdMutex;
@@ -169,6 +175,13 @@ class gz::sim::systems::TrackControllerPrivate
 
   /// \brief Limiter of the commanded velocity.
   public: math::SpeedLimiter limiter;
+
+  /// \brief Kinematic state message publisher.
+  public: transport::Node::Publisher kinematicStatePub;
+  /// \brief Update period calculated from <kinematic_state_publish_frequency>.
+  public: std::chrono::steady_clock::duration kinStatePubPeriod{0};
+  /// \brief Last sim time the kinematic state was published.
+  public: std::chrono::steady_clock::duration lastKinStatePubTime{0};
 };
 
 //////////////////////////////////////////////////
@@ -267,6 +280,25 @@ void TrackController::Configure(const Entity &_entity,
   }
   gzdbg << "Subscribed to " << corTopic << " for receiving track center "
          << "of rotation commands." << std::endl;
+
+  // Publish track kinematic state
+  const auto kDefaultKinTopic = topicPrefix + "/track_kinematic_state";
+  const auto kinTopic = validTopic({_sdf->Get<std::string>(
+    "kinematic_state_topic", kDefaultKinTopic).first, kDefaultKinTopic});
+  this->dataPtr->kinematicStatePub =
+    this->dataPtr->node.Advertise<msgs::KinematicState1D>(kinTopic);
+
+  double kinFreq = _sdf->Get<double>("kinematic_state_publish_frequency", 50).first;
+  std::chrono::duration<double> kinPer{0.0};
+  if (kinFreq > 0)
+  {
+    kinPer = std::chrono::duration<double>(1 / kinFreq);
+    this->dataPtr->kinStatePubPeriod =
+      std::chrono::duration_cast<std::chrono::steady_clock::duration>(kinPer);
+  }
+  gzdbg << "Publishing kinematic state to " << kinTopic << " with period " << kinPer.count()
+    << " seconds." << std::endl;
+
 
   this->dataPtr->trackOrientation = _sdf->Get<math::Quaterniond>(
     "track_orientation", math::Quaterniond::Identity).first;
@@ -423,6 +455,10 @@ void TrackController::PreUpdate(
     this->dataPtr->prevVelocity,
     this->dataPtr->prevPrevVelocity, _info.dt);
 
+  // Integrate track position
+  const double dtSec = std::chrono::duration<double>(_info.dt).count();
+  this->dataPtr->position += ( this->dataPtr->limitedVelocity * dtSec );
+
   this->dataPtr->prevPrevVelocity = this->dataPtr->prevVelocity;
   this->dataPtr->prevVelocity = this->dataPtr->limitedVelocity;
 
@@ -432,6 +468,67 @@ void TrackController::PreUpdate(
     this->dataPtr->markerId = 1;
   }
 }
+
+//////////////////////////////////////////////////
+void TrackController::PostUpdate(const UpdateInfo &_info,
+    const EntityComponentManager & /*_ecm*/)
+{
+  // Nothing left to do if paused.
+  if (_info.paused)
+    return;
+
+  // Throttle publishing
+  auto diff = _info.simTime - this->dataPtr->lastKinStatePubTime;
+  if (diff < this->dataPtr->kinStatePubPeriod)
+  {
+    return;
+  }
+  this->dataPtr->lastKinStatePubTime = _info.simTime;
+
+
+  // Construct the kinematic state message and publish it:
+  //
+  // Only the position and velocity fields of the message are populated, as
+  // these are the only known values. E.g. at timestep 'k':
+  // - Given an ideal system: (position k) = (position k-1) + (velocity k-1) * dt,
+  // - And (velocity k) is known from the velocity command (possibly limited by the SpeedLimiter).
+  // However, since this is a velocity-resolved controler, (acceleration k) and (jerk k)
+  // are unknown, e.g.:
+  //   (acceleration k) = ( (velocity k+1) - (velocity k) ) / dt
+  //   in which (velocity k+1) is unknown in timestep k.
+  //
+  // Note that, in case of a lower publish frequency than the simulation frequency, a similar issue
+  // exists for the velocity, since only the instantaneous velocity is known at each time step,
+  // and not the average velocity. E.g. consider:
+  //
+  //    Time        0    1    2    3    4    5
+  //    Velocity   10   10   10   10    0    0
+  //    Position    0   10   20   30   40   40
+  //
+  // with publish at:
+  // - time 0: position 10 and velocity 10
+  // - time 5: position 40 and velocity 0
+  //
+  // For '(pos k) = (pos k-1) + (vel k-1) * dt' to hold, with k = time 5 and k-1 = time 0, the
+  // reported velocity at 0 should be '8': (40 - 0) / 5 = 8 (i.e. the average velocity over 0 to 5),
+  // instead of the reported (instantaneous) velocity '10'.
+  //
+  // Imo. this error is acceptable, as real life sensors (e.g. encoder and resolver) also report
+  // instantaneous values for position and velocity.
+  //
+  msgs::KinematicState1D msg;
+
+  // Set the time stamp in the header
+  msg.mutable_header()->mutable_stamp()->CopyFrom(
+      convert<msgs::Time>(_info.simTime));
+
+  // Set position and velocity
+  msg.set_position(this->dataPtr->position);
+  msg.set_velocity(this->dataPtr->velocity);
+
+  this->dataPtr->kinematicStatePub.Publish(msg);
+}
+
 
 //////////////////////////////////////////////////
 void TrackControllerPrivate::ComputeSurfaceProperties(
@@ -616,7 +713,8 @@ void TrackControllerPrivate::OnCenterOfRotation(const msgs::Vector3d& _msg)
 GZ_ADD_PLUGIN(TrackController,
                     System,
                     TrackController::ISystemConfigure,
-                    TrackController::ISystemPreUpdate)
+                    TrackController::ISystemPreUpdate,
+                    TrackController::ISystemPostUpdate)
 
 GZ_ADD_PLUGIN_ALIAS(TrackController,
                           "gz::sim::systems::TrackController")

--- a/src/systems/track_controller/TrackController.hh
+++ b/src/systems/track_controller/TrackController.hh
@@ -82,6 +82,14 @@ namespace systems
   ///   rotation command will only act for the given number of seconds and the
   ///   track will be stopped if no command arrives before this timeout.
   ///
+  /// `<odometry_topic>` The topic on which the track odometry (i.e. position
+  ///   and instantaneous velocity) is published. This can be used e.g. to
+  ///   simulate a conveyor with encoder feedback.
+  ///   Defaults to `/model/${model_name}/link/${link_name}/odometry`.
+  /// 
+  /// `<odometry_publish_frequency>` the frequency (in Hz) at which the
+  ///   odometry messages are published. Defaults to 50 Hz.
+  ///
   /// `<min_velocity>`/`<max_velocity>` Min/max velocity of the track (m/s).
   ///   If not specified, the velocity is not limited (however the physics will,
   ///   in the end, have some implicit limit).

--- a/src/systems/track_controller/TrackController.hh
+++ b/src/systems/track_controller/TrackController.hh
@@ -86,7 +86,7 @@ namespace systems
   ///   and instantaneous velocity) is published. This can be used e.g. to
   ///   simulate a conveyor with encoder feedback.
   ///   Defaults to `/model/${model_name}/link/${link_name}/odometry`.
-  /// 
+  ///
   /// `<odometry_publish_frequency>` the frequency (in Hz) at which the
   ///   odometry messages are published. Defaults to 50 Hz.
   ///

--- a/src/systems/track_controller/TrackController.hh
+++ b/src/systems/track_controller/TrackController.hh
@@ -96,7 +96,8 @@ namespace systems
   class TrackController
       : public System,
         public ISystemConfigure,
-        public ISystemPreUpdate
+        public ISystemPreUpdate,
+        public ISystemPostUpdate
   {
     /// \brief Constructor
     public: TrackController();
@@ -112,8 +113,12 @@ namespace systems
 
     // Documentation inherited
     public: void PreUpdate(
-      const gz::sim::UpdateInfo &_info,
-      gz::sim::EntityComponentManager &_ecm) override;
+      const UpdateInfo &_info,
+      EntityComponentManager &_ecm) override;
+
+    // Documentation inherited
+    public: void PostUpdate(const UpdateInfo &_info,
+      const EntityComponentManager &_ecm) override;
 
     /// \brief Private data pointer
     private: std::unique_ptr<TrackControllerPrivate> dataPtr;

--- a/test/integration/tracked_vehicle_system.cc
+++ b/test/integration/tracked_vehicle_system.cc
@@ -550,19 +550,19 @@ class TrackedVehicleTest : public InternalFixture<::testing::Test>
     EXPECT_ANGLE_NEAR(poses.back().Rot().Yaw(), 0, 1e-3);
 
     // check reported odometry pose and twist
-    EXPECT_NEAR(0, odometryMsg.pose().position().x() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().position().y() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().position().z() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().orientation().x() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().orientation().x() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().orientation().z() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().orientation().w() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.twist().linear().x() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.twist().linear().y() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.twist().linear().z() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.twist().angular().x() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.twist().angular().x() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.twist().angular().z() ,1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().position().x(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().position().y(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().position().z(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().orientation().x(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().orientation().x(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().orientation().z(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().orientation().w(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.twist().linear().x(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.twist().linear().y(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.twist().linear().z(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.twist().angular().x(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.twist().angular().x(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.twist().angular().z(), 1e-6);
 
     poses.clear();
     odomMsgCounter = 0;
@@ -598,19 +598,19 @@ class TrackedVehicleTest : public InternalFixture<::testing::Test>
     EXPECT_ANGLE_NEAR(poses.back().Rot().Yaw(), 0, 1e-3);
 
     // check reported odometry pose and twist
-    EXPECT_NEAR(0.125, odometryMsg.pose().position().x() ,1e-1);
-    EXPECT_NEAR(0, odometryMsg.pose().position().y() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().position().z() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().orientation().x() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().orientation().x() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().orientation().z() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().orientation().w() ,1e-6);
-    EXPECT_NEAR(0.25, odometryMsg.twist().linear().x() ,1e-1);
-    EXPECT_NEAR(0, odometryMsg.twist().linear().y() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.twist().linear().z() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.twist().angular().x() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.twist().angular().x() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.twist().angular().z() ,1e-6);
+    EXPECT_NEAR(0.125, odometryMsg.pose().position().x(), 1e-1);
+    EXPECT_NEAR(0, odometryMsg.pose().position().y(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().position().z(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().orientation().x(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().orientation().x(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().orientation().z(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().orientation().w(), 1e-6);
+    EXPECT_NEAR(0.25, odometryMsg.twist().linear().x(), 1e-1);
+    EXPECT_NEAR(0, odometryMsg.twist().linear().y(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.twist().linear().z(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.twist().angular().x(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.twist().angular().x(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.twist().angular().z(), 1e-6);
 
     server.Run(true, 1000, false);
 
@@ -629,19 +629,19 @@ class TrackedVehicleTest : public InternalFixture<::testing::Test>
     EXPECT_ANGLE_NEAR(poses.back().Rot().Yaw(), 0, 1e-3);
 
     // check reported odometry pose and twist
-    EXPECT_NEAR(0.5, odometryMsg.pose().position().x() ,1e-1);
-    EXPECT_NEAR(0, odometryMsg.pose().position().y() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().position().z() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().orientation().x() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().orientation().x() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().orientation().z() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().orientation().w() ,1e-6);
-    EXPECT_NEAR(0.5, odometryMsg.twist().linear().x() ,1e-1);
-    EXPECT_NEAR(0, odometryMsg.twist().linear().y() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.twist().linear().z() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.twist().angular().x() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.twist().angular().x() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.twist().angular().z() ,1e-6);
+    EXPECT_NEAR(0.5, odometryMsg.pose().position().x(), 1e-1);
+    EXPECT_NEAR(0, odometryMsg.pose().position().y(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().position().z(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().orientation().x(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().orientation().x(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().orientation().z(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().orientation().w(), 1e-6);
+    EXPECT_NEAR(0.5, odometryMsg.twist().linear().x(), 1e-1);
+    EXPECT_NEAR(0, odometryMsg.twist().linear().y(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.twist().linear().z(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.twist().angular().x(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.twist().angular().x(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.twist().angular().z(), 1e-6);
 
     server.Run(true, 1000, false);
 
@@ -660,19 +660,19 @@ class TrackedVehicleTest : public InternalFixture<::testing::Test>
     EXPECT_ANGLE_NEAR(poses.back().Rot().Yaw(), 0, 1e-3);
 
     // check reported odometry pose and twist
-    EXPECT_NEAR(0.875, odometryMsg.pose().position().x() ,1e-1);
-    EXPECT_NEAR(0, odometryMsg.pose().position().y() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().position().z() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().orientation().x() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().orientation().x() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().orientation().z() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.pose().orientation().w() ,1e-6);
-    EXPECT_NEAR(0.25, odometryMsg.twist().linear().x() ,1e-1);
-    EXPECT_NEAR(0, odometryMsg.twist().linear().y() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.twist().linear().z() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.twist().angular().x() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.twist().angular().x() ,1e-6);
-    EXPECT_NEAR(0, odometryMsg.twist().angular().z() ,1e-6);
+    EXPECT_NEAR(0.875, odometryMsg.pose().position().x(), 1e-1);
+    EXPECT_NEAR(0, odometryMsg.pose().position().y(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().position().z(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().orientation().x(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().orientation().x(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().orientation().z(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.pose().orientation().w(), 1e-6);
+    EXPECT_NEAR(0.25, odometryMsg.twist().linear().x(), 1e-1);
+    EXPECT_NEAR(0, odometryMsg.twist().linear().y(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.twist().linear().z(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.twist().angular().x(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.twist().angular().x(), 1e-6);
+    EXPECT_NEAR(0, odometryMsg.twist().angular().z(), 1e-6);
 
     poses.clear();
   }


### PR DESCRIPTION
# 🎉 New feature

Closes #2016
~~Requires https://github.com/gazebosim/gz-msgs/pull/352~~

## Summary
This PR adds odometry output to the [track controller system](https://github.com/gazebosim/gz-sim/blob/gz-sim7/src/systems/track_controller/TrackController.cc), publishing position and instantaneous velocity. That way a conveyor with an encoder and/or resolver for respectively position and velocity feedback can be simulated.

The default topic is `/model/<model name>/link/<link name>/odometry`.
An alternative can be chosen by specifying the `odometry_topic` parameter of the plugin in the SDF.
The publication frequency is set through parameter `odometry_publish_frequency`.


## Test it
Run the conveyor demo: `gz sim conveyor.sdf`
Echo the odometry messages: `gz topic -e -t /model/conveyor/link/base_link/odometry`
