### PR TITLE
Prevent deadlock in sensors system 

### DIFF
--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -280,11 +280,14 @@ void SensorsPrivate::RunOnce()
 {
   {
     std::unique_lock<std::mutex> cvLock(this->renderMutex);
-    this->renderCv.wait(cvLock, [this]()
+    this->renderCv.wait_for(cvLock, std::chrono::microseconds(1000), [this]()
     {
       return !this->running || this->updateAvailable;
     });
   }
+
+  if (!this->updateAvailable)
+    return;
 
   if (!this->running)
     return;


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary

The threading and lock mechanism in sensors system can potentially run into deadlock, especially after changes in https://github.com/gazebosim/gz-sim/pull/1938. 

This deadlock is found by users of gz-sim that use a custom sim update loop. I haven't been able to reproduce it in gz-sim yet but I was able to reproduce it with the custom update loop when the system in under high load.

More details on the deadlock:

There are 2 threads in the sensors system that use a condition variable to unblock each other in order to do a soft lockstep between physics and sensors. Deadlock occurs when both threads are waiting on each other:
* rendering thread's [wait](https://github.com/gazebosim/gz-sim/blob/001dd9b829eb8e8b4465d87c6c70ccf4ee2e6b6a/src/systems/sensors/Sensors.cc#L283)
* main thread's [wait](https://github.com/gazebosim/gz-sim/blob/001dd9b829eb8e8b4465d87c6c70ccf4ee2e6b6a/src/systems/sensors/Sensors.cc#L701)

In my testing, I noticed that the main thread's [notify_one](https://github.com/gazebosim/gz-sim/blob/001dd9b829eb8e8b4465d87c6c70ccf4ee2e6b6a/src/systems/sensors/Sensors.cc#L726) call does not always unblock the rendering thread's wait immediately. So if the main thread continues to the next iteration and [waits](https://github.com/gazebosim/gz-sim/blob/001dd9b829eb8e8b4465d87c6c70ccf4ee2e6b6a/src/systems/sensors/Sensors.cc#L247) again before the rendering thread wakes up, deadlock occurs. 

The workaround is to add a timeout to the wait call in the rendering thread so that it does not wait forever. The side effect of this change is that the rendering thread is now semi-polling for updates. If there are sensors that need update, there shouldn't be any noticeable change. However, if no sensors need to be updated, we'll see that the rendering thread would wake up every second but does nothing and goes back to waiting again.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

