### PR TITLE
ComponentInspector: display PhysicsEnginePlugin

### DIFF
--- a/src/gui/plugins/component_inspector/ComponentInspector.cc
+++ b/src/gui/plugins/component_inspector/ComponentInspector.cc
@@ -764,6 +764,13 @@ void ComponentInspector::Update(const UpdateInfo &,
       if (comp)
         setData(item, comp->Data());
     }
+    else if (typeId == components::PhysicsEnginePlugin::typeId)
+    {
+      auto comp = _ecm.Component<components::PhysicsEnginePlugin>(
+          this->dataPtr->entity);
+      if (comp)
+        setData(item, comp->Data());
+    }
     else if (typeId == components::PhysicsSolver::typeId)
     {
       auto comp = _ecm.Component<components::PhysicsSolver>(


### PR DESCRIPTION
# 🎉 New feature

Display which physics plugin is in use

## Summary

This displays the name of the physics engine plugin in the GUI component inspector.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

<img width="410" alt="Screen Shot 2023-07-14 at 7 22 08 PM" src="https://github.com/gazebosim/gz-sim/assets/3650755/eac7eb28-44ee-4a4e-983a-54310519cc7d">


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
