### PR TITLE
Adds a warning if the `Server` method of a `TestFixture` is called before `Finalize`

### DIFF
--- a/src/TestFixture.cc
+++ b/src/TestFixture.cc
@@ -210,6 +210,13 @@ TestFixture &TestFixture::OnPostUpdate(std::function<void(
 //////////////////////////////////////////////////
 std::shared_ptr<Server> TestFixture::Server() const
 {
+  if (!this->dataPtr->finalized)
+  {
+    ignwarn << "Fixture has not been finalized, any functions you attempted"
+      << "to hook into will not be run. It is recommended to call Finalize()"
+      << "before accessing the server."
+      << std::endl;
+  }
   return this->dataPtr->server;
 }
 

--- a/src/TestFixture.cc
+++ b/src/TestFixture.cc
@@ -212,7 +212,7 @@ std::shared_ptr<Server> TestFixture::Server() const
 {
   if (!this->dataPtr->finalized)
   {
-    gzwarn << "Fixture has not been finalized, any functions you attempted"
+    ignwarn << "Fixture has not been finalized, any functions you attempted"
       << "to hook into will not be run. It is recommended to call Finalize()"
       << "before accessing the server."
       << std::endl;

--- a/src/TestFixture.cc
+++ b/src/TestFixture.cc
@@ -212,7 +212,7 @@ std::shared_ptr<Server> TestFixture::Server() const
 {
   if (!this->dataPtr->finalized)
   {
-    ignwarn << "Fixture has not been finalized, any functions you attempted"
+    gzwarn << "Fixture has not been finalized, any functions you attempted"
       << "to hook into will not be run. It is recommended to call Finalize()"
       << "before accessing the server."
       << std::endl;


### PR DESCRIPTION

## Summary
This PR adds a warning if someone were to call `Server()` before `Finalize`. The rationale for this is because I made the mistake of not calling `Finalize` ina program I was writing. It took me some time to track down the root cause of the problem. I figure if we warn users it should be immediately obvious.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
