### PR TITLE
Change type of `Component::typeName` and address outstanding todos

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -5,6 +5,16 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Gazebo Sim 7.x to 8.0
+* **Deprecated**
+    + `gz::sim::components::Factory::Register(const std::string &_type, ComponentDescriptorBase *_compDesc)` and
+      `gz::sim::components::Factory::Register(const std::string &_type, ComponentDescriptorBase *_compDesc, RegistrationObjectId _regObjId)`
+       have been deprecated. Instead, please use
+       `gz::sim::components::Factory::Register(const char *_type, ComponentDescriptorBase *_compDesc, RegistrationObjectId  _regObjId)`
+    + `gz::sim::components::Factory::Unregister()` has been deprecated. Instead, please use
+       `gz::sim::components::Factory::Unregister(RegistrationObjectId  _regObjId)`.
+* The type of the static data member `gz::sim::components::Component::typeName` has been changed from `std::string` to `const char*`.
+
 ## Gazebo Sim 6.x to 7.0
 
 * **Deprecated**

--- a/include/gz/sim/components/Component.hh
+++ b/include/gz/sim/components/Component.hh
@@ -387,9 +387,7 @@ namespace components
 
     /// \brief Unique name for this component type. This is set through the
     /// Factory registration.
-    // TODO(azeey) Change to const char* in Harmonic to prevent static
-    // initialization order fiasco.
-    public: inline static std::string typeName;
+    public: inline static const char *typeName{nullptr};
   };
 
   /// \brief Specialization for components that don't wrap any data.
@@ -435,9 +433,7 @@ namespace components
 
     /// \brief Unique name for this component type. This is set through the
     /// Factory registration.
-    // TODO(azeey) Change to const char* in Harmonic to prevent static
-    // initialization order fiasco.
-    public: inline static std::string typeName;
+    public: inline static const char *typeName{nullptr};
   };
 
   //////////////////////////////////////////////////

--- a/src/ComponentFactory.cc
+++ b/src/ComponentFactory.cc
@@ -21,5 +21,6 @@ using Factory = gz::sim::components::Factory;
 
 Factory *Factory::Instance()
 {
-  return common::SingletonT<Factory>::Instance();
+  static gz::utils::NeverDestroyed<Factory> instance;
+  return &instance.Access();
 }

--- a/src/ComponentFactory_TEST.cc
+++ b/src/ComponentFactory_TEST.cc
@@ -16,6 +16,7 @@
 */
 
 #include <gtest/gtest.h>
+#include <gz/utils/SuppressWarning.hh>
 #include "test_config.hh"
 #include "gz/sim/components/Component.hh"
 #include "gz/sim/components/Factory.hh"
@@ -48,14 +49,15 @@ TEST_F(ComponentFactoryTest, Register)
 
   // Check it has no type id yet
   EXPECT_EQ(0u, MyCustom::typeId);
-  EXPECT_EQ("", MyCustom::typeName);
+  EXPECT_EQ(nullptr, MyCustom::typeName);
   EXPECT_EQ("", factory->Name(MyCustom::typeId));
 
   // Store number of registered component types
   auto registeredCount = factory->TypeIds().size();
 
   factory->Register<MyCustom>("gz_sim_components.MyCustom",
-      new components::ComponentDescriptor<MyCustom>());
+                              new components::ComponentDescriptor<MyCustom>(),
+                              components::RegistrationObjectId(this));
 
   // Check now it has type id
   EXPECT_NE(0u, MyCustom::typeId);
@@ -70,20 +72,86 @@ TEST_F(ComponentFactoryTest, Register)
 
   // Registering the component twice doesn't change the number of type ids.
   factory->Register<MyCustom>("gz_sim_components.MyCustom",
-      new components::ComponentDescriptor<MyCustom>());
+                              new components::ComponentDescriptor<MyCustom>(),
+                              components::RegistrationObjectId(this));
 
   EXPECT_EQ(registeredCount + 1, factory->TypeIds().size());
 
   // Fail to register 2 components with same name
   using Duplicate = components::Component<components::NoData,
       class DuplicateTag>;
+
   factory->Register<Duplicate>("gz_sim_components.MyCustom",
-      new components::ComponentDescriptor<Duplicate>());
+                               new components::ComponentDescriptor<Duplicate>(),
+                               components::RegistrationObjectId(this));
 
   EXPECT_EQ(registeredCount + 1, factory->TypeIds().size());
 
   // Unregister
-  factory->Unregister<MyCustom>();
+  factory->Unregister<MyCustom>(components::RegistrationObjectId(this));
+
+  ids = factory->TypeIds();
+  EXPECT_EQ(registeredCount + 1, ids.size());
+}
+
+/////////////////////////////////////////////////
+TEST_F(ComponentFactoryTest, DeprecatedRegister)
+{
+  auto factory = components::Factory::Instance();
+
+  // Create a custom component.
+  using MyDeprecatedCustom =
+      components::Component<components::NoData, class MyDeprecatedCustomTag>;
+
+  // Check it has no type id yet
+  EXPECT_EQ(0u, MyDeprecatedCustom::typeId);
+  EXPECT_EQ(nullptr, MyDeprecatedCustom::typeName);
+  EXPECT_EQ("", factory->Name(MyDeprecatedCustom::typeId));
+
+  // Store number of registered component types
+  auto registeredCount = factory->TypeIds().size();
+
+GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
+  factory->Register<MyDeprecatedCustom>("gz_sim_components.MyDeprecatedCustom",
+      new components::ComponentDescriptor<MyDeprecatedCustom>());
+GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
+
+  // Check now it has type id
+  EXPECT_NE(0u, MyDeprecatedCustom::typeId);
+  EXPECT_STREQ("gz_sim_components.MyDeprecatedCustom",
+               MyDeprecatedCustom::typeName);
+  EXPECT_EQ("gz_sim_components.MyDeprecatedCustom",
+            factory->Name(MyDeprecatedCustom::typeId));
+
+  // Check factory knows id
+  auto ids = factory->TypeIds();
+  EXPECT_EQ(registeredCount + 1, ids.size());
+  EXPECT_NE(ids.end(),
+            std::find(ids.begin(), ids.end(), MyDeprecatedCustom::typeId));
+
+  // Registering the component twice doesn't change the number of type ids.
+GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
+  factory->Register<MyDeprecatedCustom>("gz_sim_components.MyDeprecatedCustom",
+      new components::ComponentDescriptor<MyDeprecatedCustom>());
+GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
+
+  EXPECT_EQ(registeredCount + 1, factory->TypeIds().size());
+
+  // Fail to register 2 components with same name
+  using Duplicate = components::Component<components::NoData,
+      class DuplicateTag>;
+
+GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
+  factory->Register<Duplicate>("gz_sim_components.MyDeprecatedCustom",
+      new components::ComponentDescriptor<Duplicate>());
+GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
+
+  EXPECT_EQ(registeredCount + 1, factory->TypeIds().size());
+
+  // Unregister
+GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
+  factory->Unregister<MyDeprecatedCustom>();
+GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
 
   ids = factory->TypeIds();
   EXPECT_EQ(registeredCount + 1, ids.size());

--- a/src/Component_TEST.cc
+++ b/src/Component_TEST.cc
@@ -70,8 +70,11 @@ TEST_F(ComponentTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(DataByMove))
   // Create a custom component with shared_ptr data
   using CustomComponent =
       components::Component<std::shared_ptr<int>, class CustomComponentTag>;
-  factory->Register<CustomComponent>("gz_sim_components.MyCustom",
-     new components::ComponentDescriptor<CustomComponent>());
+
+  factory->Register<CustomComponent>(
+      "gz_sim_components.MyCustom",
+      new components::ComponentDescriptor<CustomComponent>(),
+      components::RegistrationObjectId(this));
 
   EntityComponentManager ecm;
   Entity entity = ecm.CreateEntity();

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -1277,19 +1277,6 @@ TEST_P(SimulationRunnerTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(LoadPlugins) )
   EXPECT_TRUE(runner.EntityCompMgr().HasComponentType(visualComponentId));
   EXPECT_TRUE(runner.EntityCompMgr().EntityHasComponentType(visualId,
       visualComponentId));
-
-  // Clang re-registers components between tests. If we don't unregister them
-  // beforehand, the new plugin tries to create a storage type from a previous
-  // plugin, causing a crash.
-  // Is this only a problem with GTest, or also during simulation? How to
-  // reproduce? Maybe we need to test unloading plugins, but we have no API for
-  // it yet.
-  #if defined (__clang__)
-    Factory::Instance()->Unregister(worldComponentId);
-    Factory::Instance()->Unregister(modelComponentId);
-    Factory::Instance()->Unregister(sensorComponentId);
-    Factory::Instance()->Unregister(visualComponentId);
-  #endif
 }
 
 /////////////////////////////////////////////////
@@ -1402,18 +1389,6 @@ TEST_P(SimulationRunnerTest,
   EXPECT_TRUE(runner.EntityCompMgr().HasComponentType(sensorComponentId));
   EXPECT_TRUE(runner.EntityCompMgr().EntityHasComponentType(sensorId,
       sensorComponentId));
-
-  // Clang re-registers components between tests. If we don't unregister them
-  // beforehand, the new plugin tries to create a storage type from a previous
-  // plugin, causing a crash.
-  // Is this only a problem with GTest, or also during simulation? How to
-  // reproduce? Maybe we need to test unloading plugins, but we have no API for
-  // it yet.
-  #if defined (__clang__)
-    Factory::Instance()->Unregister(worldComponentId);
-    Factory::Instance()->Unregister(modelComponentId);
-    Factory::Instance()->Unregister(sensorComponentId);
-  #endif
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
## Summary
The type is changed from `std::string` to `const char *` to prevent the static initialization order fiasco. This PR also deprecates `Factory::Register` functions that don't include the ID of the entity that wants to register the component.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

