### PR TITLE
Use sdf::Element::FindElement instead of GetElement in ApplyLinkWrench

### DIFF
--- a/src/systems/apply_link_wrench/ApplyLinkWrench.cc
+++ b/src/systems/apply_link_wrench/ApplyLinkWrench.cc
@@ -148,8 +148,7 @@ void ApplyLinkWrench::Configure(const Entity &_entity,
   this->dataPtr->verbose = _sdf->Get<bool>("verbose", true).first;
 
   // Initial wrenches
-  auto ptr = const_cast<sdf::Element *>(_sdf.get());
-  for (auto elem = ptr->GetElement("persistent");
+  for (auto elem = _sdf->FindElement("persistent");
        elem != nullptr;
        elem = elem->GetNextElement("persistent"))
   {
@@ -163,7 +162,7 @@ void ApplyLinkWrench::Configure(const Entity &_entity,
 
     msg.mutable_entity()->set_name(elem->Get<std::string>("entity_name"));
 
-    auto typeStr = elem->GetElement("entity_type")->Get<std::string>();
+    auto typeStr = elem->FindElement("entity_type")->Get<std::string>();
     if (typeStr == "link")
     {
       msg.mutable_entity()->set_type(msgs::Entity::LINK);
@@ -182,12 +181,12 @@ void ApplyLinkWrench::Configure(const Entity &_entity,
     if (elem->HasElement("force"))
     {
       msgs::Set(msg.mutable_wrench()->mutable_force(),
-          elem->GetElement("force")->Get<math::Vector3d>());
+          elem->FindElement("force")->Get<math::Vector3d>());
     }
     if (elem->HasElement("torque"))
     {
       msgs::Set(msg.mutable_wrench()->mutable_torque(),
-          elem->GetElement("torque")->Get<math::Vector3d>());
+          elem->FindElement("torque")->Get<math::Vector3d>());
     }
     this->dataPtr->OnWrenchPersistent(msg);
   }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
I noticed the error
```
Error [Utils.cc:174] Missing element description for [persistent]
```
when testing #2014.  /cc @Henrique-BO 


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.