### PR TITLE
Fix const-correctness of the `Model::JointByName` and `Model::LinkByName` APIs

### DIFF
--- a/include/gz/sim/Model.hh
+++ b/include/gz/sim/Model.hh
@@ -126,18 +126,16 @@ namespace gz
       /// \param[in] _ecm Entity-component manager.
       /// \param[in] _name Joint name.
       /// \return Joint entity.
-      /// \todo(anyone) Make const
       public: sim::Entity JointByName(const EntityComponentManager &_ecm,
-          const std::string &_name);
+          const std::string &_name) const;
 
       /// \brief Get the ID of a link entity which is an immediate child of
       /// this model.
       /// \param[in] _ecm Entity-component manager.
       /// \param[in] _name Link name.
       /// \return Link entity.
-      /// \todo(anyone) Make const
       public: sim::Entity LinkByName(const EntityComponentManager &_ecm,
-          const std::string &_name);
+          const std::string &_name) const;
 
       /// \brief Get all joints which are immediate children of this model.
       /// \param[in] _ecm Entity-component manager.

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -130,7 +130,7 @@ std::string Model::SourceFilePath(const EntityComponentManager &_ecm) const
 
 //////////////////////////////////////////////////
 Entity Model::JointByName(const EntityComponentManager &_ecm,
-    const std::string &_name)
+    const std::string &_name) const
 {
   return _ecm.EntityByComponents(
       components::ParentEntity(this->dataPtr->id),
@@ -140,7 +140,7 @@ Entity Model::JointByName(const EntityComponentManager &_ecm,
 
 //////////////////////////////////////////////////
 Entity Model::LinkByName(const EntityComponentManager &_ecm,
-    const std::string &_name)
+    const std::string &_name) const
 {
   return _ecm.EntityByComponents(
       components::ParentEntity(this->dataPtr->id),


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
This has been a longstanding pet-peeve of mine and a todo in the code base. Unfortunately, this change likely breaks ABI and hence can only be done in a major release. It does not however break API and hence old code should not have any issues compiling against this new change.

An alternative would be to introduce these const functions as duplicates in `citadel` and deprecate the non-const functions in garden, but this feels like more work.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
