### PR TITLE
Use ogre2 in wide angle camera and lens flares worlds

### DIFF
--- a/examples/worlds/wide_angle_camera.sdf
+++ b/examples/worlds/wide_angle_camera.sdf
@@ -15,7 +15,7 @@
     <plugin
       filename="gz-sim-sensors-system"
       name="gz::sim::systems::Sensors">
-      <render_engine>ogre</render_engine>
+      <render_engine>ogre2</render_engine>
     </plugin>
     <plugin
       filename="gz-sim-user-commands-system"

--- a/test/worlds/camera_lens_flare.sdf
+++ b/test/worlds/camera_lens_flare.sdf
@@ -16,7 +16,7 @@
     <plugin
       filename="gz-sim-sensors-system"
       name="gz::sim::systems::Sensors">
-      <render_engine>ogre</render_engine>
+      <render_engine>ogre2</render_engine>
       <background_color>0 0 0 1</background_color>
     </plugin>
 

--- a/test/worlds/wide_angle_camera_sensor.sdf
+++ b/test/worlds/wide_angle_camera_sensor.sdf
@@ -12,7 +12,7 @@
     <plugin
       filename="gz-sim-sensors-system"
       name="gz::sim::systems::Sensors">
-      <render_engine>ogre</render_engine>
+      <render_engine>ogre2</render_engine>
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix


## Summary
Switch to ogre2 engine in these worlds now that wide angle cameras and lens flares are supported in ogre2 in Harmonic.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

