### PR TITLE
Fix a minor issue in the documentation of the server API

### DIFF
--- a/include/gz/sim/Server.hh
+++ b/include/gz/sim/Server.hh
@@ -80,13 +80,15 @@ namespace ignition
     ///
     /// List syntax: *service_name(request_msg_type) : response_msg_type*
     ///
-    ///   1. `/world/<world_name>/scene/info(none)` : gz::msgs::Scene
+    ///   1. `/world/<world_name>/scene/info`(none) : gz::msgs::Scene
     ///     + Returns the current scene information.
     ///
-    ///   2. `/gazebo/resource_paths/get` : gz::msgs::StringMsg_V
+    ///   2. `/gazebo/resource_paths/get`(gz::msgs::Empty) :
+    ///         gz::msgs::StringMsg_V
     ///     + Get list of resource paths.
     ///
-    ///   3. `/gazebo/resource_paths/add` : gz::msgs::Empty
+    ///   3. `/gazebo/resource_paths/add`(gz::msgs::StringMsg_V) :
+    ///         gz::msgs::Empty
     ///     + Add new resource paths.
     ///
     ///   4. `/server_control`(gz::msgs::ServerControl) :


### PR DESCRIPTION
# 🦟 Bug fix

Fixes an inconsistency in the server API documentation where types of services aren't correctly named.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.