### PR TITLE
Avoid nullptr dereference if TouchPlugin is not attached to a model entity.

### DIFF
--- a/src/systems/touch_plugin/TouchPlugin.cc
+++ b/src/systems/touch_plugin/TouchPlugin.cc
@@ -103,7 +103,7 @@ class gz::sim::systems::TouchPluginPrivate
   public: bool initialized{false};
 
   /// \brief Set during Load to true if the configuration for the plugin is
-  /// valid and the post update can run
+  /// valid and the pre and post update can run
   public: bool validConfig{false};
 
   /// \brief Whether the plugin is enabled.
@@ -373,7 +373,7 @@ void TouchPlugin::Configure(const Entity &_entity,
 void TouchPlugin::PreUpdate(const UpdateInfo &, EntityComponentManager &_ecm)
 {
   GZ_PROFILE("TouchPlugin::PreUpdate");
-  if (!this->dataPtr->initialized)
+  if ((!this->dataPtr->initialized) && this->dataPtr->sdfConfig)
   {
     // We call Load here instead of Configure because we can't be guaranteed
     // that all entities have been created when Configure is called
@@ -381,9 +381,8 @@ void TouchPlugin::PreUpdate(const UpdateInfo &, EntityComponentManager &_ecm)
     this->dataPtr->initialized = true;
   }
 
-  // This is not an "else" because "initialized" can be set in the if block
-  // above
-  if (this->dataPtr->initialized)
+  // If Load() was successful, validConfig is set to true
+  if (this->dataPtr->validConfig)
   {
     // Update target entities when new collisions are added
     std::vector<Entity> potentialEntities;

--- a/src/systems/touch_plugin/TouchPlugin.hh
+++ b/src/systems/touch_plugin/TouchPlugin.hh
@@ -32,21 +32,24 @@ namespace systems
   // Forward declaration
   class TouchPluginPrivate;
 
-  /// \brief Plugin which checks if a model has touched some specific target
-  /// for a given time continuously and exclusively. After the touch is
-  /// completed, the plugin is disabled. It can be re-enabled through an
-  /// Gazebo Transport service.
+  /// \brief Plugin which publishes a message if the model it is attached
+  /// to has touched one or more specified targets continuously during a
+  /// given time.
   ///
-  /// It requires that contact sensors be placed in at least one link on the
-  /// model on which this plugin is attached.
+  /// After publishing, the plugin is disabled. It can be re-enabled through
+  /// a Gazebo Transport service call.
+  ///
+  /// The plugin requires that a contact sensors is placed in at least one
+  /// link on the model on which this plugin is attached.
   ///
   /// Parameters:
   ///
-  /// - `<target>` Scoped name of the desired collision entity that is checked
-  ///              to see if it's touching this model. This can be a substring
-  ///              of the desired collision name so we match more than one
-  ///              collision. For example, using the name of a model will match
-  ///              all its collisions.
+  /// - `<target>` Name, or substring of a name, that identifies the target
+  ///              collision entity/entities.
+  ///              This value is searched in the scoped name of all collision
+  ///              entities, so it can possibly match more than one collision.
+  ///              For example, using the name of a model will match all of its
+  ///              collisions (scoped name /model_name/link_name/collision_name).
   ///
   /// - `<time>` Target time in seconds to maintain contact.
   ///

--- a/src/systems/touch_plugin/TouchPlugin.hh
+++ b/src/systems/touch_plugin/TouchPlugin.hh
@@ -49,7 +49,8 @@ namespace systems
   ///              This value is searched in the scoped name of all collision
   ///              entities, so it can possibly match more than one collision.
   ///              For example, using the name of a model will match all of its
-  ///              collisions (scoped name /model_name/link_name/collision_name).
+  ///              collisions (scoped name
+  ///              /model_name/link_name/collision_name).
   ///
   /// - `<time>` Target time in seconds to maintain contact.
   ///


### PR DESCRIPTION
# 🦟 Bug fix


## Summary

Two small fixes:

- Avoid nullptr dereference in case the plugin is not attached to a model (as `sdfConfig` is initialized only if `TouchPlugin::Configure()` is successful, see code snippet below),
- Avoid execution of `preUpdate()` code if the system was not initialized correctly.


I also changed the documentation somewhat to better explain what the plugin actually does.

</br>

https://github.com/gazebosim/gz-sim/blob/f2ff574664574100989e3633e4debe16431fe00f/src/systems/touch_plugin/TouchPlugin.cc#L358-L370

