### PR TITLE
Prevent printing misleading error msg in visualize lidar gui plugin

### DIFF
--- a/src/gui/plugins/visualize_lidar/VisualizeLidar.cc
+++ b/src/gui/plugins/visualize_lidar/VisualizeLidar.cc
@@ -180,7 +180,7 @@ void VisualizeLidar::LoadLidar()
     return;
   }
 
-  if (!scene->IsInitialized() || scene->VisualCount() == 0)
+  if (!scene->IsInitialized())
   {
     return;
   }


### PR DESCRIPTION

# 🦟 Bug fix

Prevents the following msg from being printed when the scene and plugin are loaded on startup:

```
[GUI] [Err] [VisualizeLidar.cc:252] Lidar pointer is not set
```

Related question:
https://robotics.stackexchange.com/questions/25151/gazebo-garden-gui-err-visualizelidar-cc251-lidar-pointer-is-not-set

## Summary

Currently we don't create the lidar visual if the scene does not have any visuals (happens on startup). As the result, in the first render event, the error msg is printed. This does not need to be the case. It is safe to create the lidar visual even if the scene is empty.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
