### PR TITLE
Fix plugin conversion error message

### DIFF
--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -453,13 +453,23 @@ void SimulationRunner::PublishStats()
     this->rootClockPub.Publish(clockMsg);
 }
 
+namespace {
+
+// Create an sdf::ElementPtr that corresponds to an empty `<plugin>` element.
+sdf::ElementPtr createEmptyPluginElement()
+{
+  auto plugin = std::make_shared<sdf::Element>();
+  sdf::initFile("plugin.sdf", plugin);
+  return plugin;
+}
+}
 //////////////////////////////////////////////////
 void SimulationRunner::AddSystem(const SystemPluginPtr &_system,
       std::optional<Entity> _entity,
       std::optional<std::shared_ptr<const sdf::Element>> _sdf)
 {
   auto entity = _entity.value_or(worldEntity(this->entityCompMgr));
-  auto sdf = _sdf.value_or(this->sdfWorld->Element());
+  auto sdf = _sdf.value_or(createEmptyPluginElement());
   this->systemMgr->AddSystem(_system, entity, sdf);
 }
 
@@ -470,7 +480,7 @@ void SimulationRunner::AddSystem(
       std::optional<std::shared_ptr<const sdf::Element>> _sdf)
 {
   auto entity = _entity.value_or(worldEntity(this->entityCompMgr));
-  auto sdf = _sdf.value_or(this->sdfWorld->Element());
+  auto sdf = _sdf.value_or(createEmptyPluginElement());
   this->systemMgr->AddSystem(_system, entity, sdf);
 }
 

--- a/src/TestFixture_TEST.cc
+++ b/src/TestFixture_TEST.cc
@@ -42,7 +42,7 @@ class TestFixtureTest : public InternalFixture<::testing::Test>
     EXPECT_EQ(worldEntity, _entity);
 
     ASSERT_NE(nullptr, _sdf);
-    EXPECT_EQ("world", _sdf->GetName());
+    EXPECT_EQ("plugin", _sdf->GetName());
 
     EXPECT_NE(kNullEntity, _ecm.EntityByComponents(components::Name("box")));
     EXPECT_NE(kNullEntity, _ecm.EntityByComponents(components::Name("sphere")));


### PR DESCRIPTION

# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/1555

## Summary
This fixes the error 

```
[Err] [Conversions.cc:1791] Tried to convert SDF [world] into [plugin]
```
The error comes from `AddSystem` passing an `sdf::ElementPtr` that corresponds to a `<world>` tag instead of a `<plugin>` tag when it's optional `_sdf` element is empty, which occurs mostly in tests when `AddSystem` is used to add `Relay` plugin which doesn't have an associated SDFormat file.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
