### PR TITLE
Prevent crash when viewing heightmap collision

### DIFF
--- a/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc
+++ b/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc
@@ -1498,6 +1498,13 @@ rendering::VisualPtr VisualizationCapabilitiesPrivate::CreateCollisionVisual(
   if (!_visual.Geom())
     return rendering::VisualPtr();
 
+  if (_visual.Geom()->Type() == sdf::GeometryType::HEIGHTMAP)
+  {
+    gzwarn << "Collision visualization for heightmaps are not supported yet."
+           << std::endl;
+    return rendering::VisualPtr();
+  }
+
   std::string name = _visual.Name().empty() ? std::to_string(_id) :
       _visual.Name();
   if (_parent)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

If you try to view heightmap collisions (View > Collisions), the GUI crashes. This PR prints out a warning to say that it's not currently supported instead of just crashing.

The problem is that the heightmaps shaders currently expect texture maps exist (it does not work with just simple diffuse colors). If they are not available, the shaders fail to compile at runtime and cause the GUI to crash.


Note: I accidentally pushed to `gz-sim7` and created a reverse commit (https://github.com/gazebosim/gz-sim/commit/3f80b37695a4084ad64b37d0e376cb00e0ee315c) to undo the changes 🙇.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

