### PR TITLE
Fix duplicate entries in joint position controller GUI plugin

### DIFF
--- a/src/gui/plugins/joint_position_controller/JointPositionController.cc
+++ b/src/gui/plugins/joint_position_controller/JointPositionController.cc
@@ -45,8 +45,11 @@ namespace gz::sim::gui
     /// \brief Model holding all the joints.
     public: JointsModel jointsModel;
 
-    /// \brief Model entity being controller.
+    /// \brief Model entity being controlled.
     public: Entity modelEntity{kNullEntity};
+
+    /// \brief Previous model entity being controlled.
+    public: Entity prevModelEntity{kNullEntity};
 
     /// \brief Name of the model
     public: QString modelName{"No model selected"};
@@ -211,6 +214,12 @@ void JointPositionController::Update(const UpdateInfo &,
 
   auto jointEntities = _ecm.EntitiesByComponents(components::Joint(),
       components::ParentEntity(this->dataPtr->modelEntity));
+
+  if (this->dataPtr->prevModelEntity != this->dataPtr->modelEntity)
+  {
+    this->dataPtr->prevModelEntity = this->dataPtr->modelEntity;
+    this->dataPtr->jointsModel.Clear();
+  }
 
   // List all joints
   for (const auto &jointEntity : jointEntities)


### PR DESCRIPTION


# 🦟 Bug fix

Fixes #2099

## Summary
Prevents duplicate entries from being added to the Joint Position Controller GUI plugin.

Applies the patch from #2099. See #2099 for instructions and sdf file for reproducing the bug.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
