### PR TITLE
Fix multi_lrauv_race example

### DIFF
--- a/examples/standalone/multi_lrauv_race/multi_lrauv_race.cc
+++ b/examples/standalone/multi_lrauv_race/multi_lrauv_race.cc
@@ -74,7 +74,7 @@ int main(int argc, char** argv)
     rudderPubs[i] = node.Advertise<gz::msgs::Double>(rudderTopics[i]);
 
     propellerTopics[i] = gz::transport::TopicUtils::AsValidTopic(
-      "/model/" + ns[i] + "/joint/propeller_joint/cmd_pos");
+      "/model/" + ns[i] + "/joint/propeller_joint/cmd_thrust");
     propellerPubs[i] = node.Advertise<gz::msgs::Double>(
       propellerTopics[i]);
   }

--- a/examples/worlds/multi_lrauv_race.sdf
+++ b/examples/worlds/multi_lrauv_race.sdf
@@ -58,11 +58,6 @@
     </light>
 
     <include>
-      <pose>-5 0 0 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/mabelzhang/models/Turquoise turbidity generator</uri>
-    </include>
-
-    <include>
       <pose>0 0 1 0 0 1.57</pose>
       <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
 


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

Fix the `multi_lrauv_race` example. In particular I found two issues:

1. The topic to control the thruster of the vehicles needs to be updated.
2. I'm not 100% sure about this one but the turbidity generator looks very dark in my machine. Maybe @mabelzhang can confirm if that's the expected behavior. For now I just removed it to visualize a more clear race.

### With turbidity:

![lrauv_turbidity](https://github.com/gazebosim/gz-sim/assets/1440739/fdf2a05a-6f4a-4141-b2d9-e38c3601584c)

### No turbidity:

![lrauv_no_turbidity](https://github.com/gazebosim/gz-sim/assets/1440739/60721ba9-2e40-4ab8-b828-5c3b4566b55b)


## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.