### PR TITLE
Fix default topic name of JointStatePublisher

### DIFF
--- a/src/systems/joint_state_publisher/JointStatePublisher.hh
+++ b/src/systems/joint_state_publisher/JointStatePublisher.hh
@@ -33,8 +33,8 @@ namespace sim
 inline namespace GZ_SIM_VERSION_NAMESPACE {
 namespace systems
 {
-  /// \brief The JointStatePublisher system publishes joint state information for
-  /// a model. The published message type is gz::msgs::Model, and the
+  /// \brief The JointStatePublisher system publishes joint state information
+  /// for a model. The published message type is gz::msgs::Model, and the
   /// publication topic is determined by the `<topic>` parameter.
   ///
   /// By default the JointStatePublisher will publish all joints for

--- a/src/systems/joint_state_publisher/JointStatePublisher.hh
+++ b/src/systems/joint_state_publisher/JointStatePublisher.hh
@@ -33,7 +33,7 @@ namespace sim
 inline namespace GZ_SIM_VERSION_NAMESPACE {
 namespace systems
 {
-  /// \brief The JointStatePub system publishes state information for
+  /// \brief The JointStatePublisher system publishes joint state information for
   /// a model. The published message type is gz::msgs::Model, and the
   /// publication topic is determined by the `<topic>` parameter.
   ///
@@ -45,7 +45,7 @@ namespace systems
   ///
   /// `<topic>`: Name of the topic to publish to. This parameter is optional,
   /// and if not provided, the joint state will be published to
-  /// "/world/<world_name>/model/<model_name>/state".
+  /// "/world/<world_name>/model/<model_name>/joint_state".
   /// `<joint_name>`: Name of a joint to publish. This parameter can be
   /// specified multiple times, and is optional. All joints in a model will
   /// be published if joint names are not specified.


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The default topic name is specified as `/joint_state` in [JointStatePublisher.cc](https://github.com/gazebosim/gz-sim/blob/2dbcc6c872a204e44f4dd3e3be8c44a98b04452f/src/systems/joint_state_publisher/JointStatePublisher.cc#L166)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.