### PR TITLE
Remove sdformat diff drive warning

### DIFF
--- a/examples/worlds/diff_drive.sdf
+++ b/examples/worlds/diff_drive.sdf
@@ -157,7 +157,6 @@
                 <friction>1</friction>
                 <friction2>1</friction2>
                 <rolling_friction>0.1</rolling_friction>
-                <spinning_friction>0.1</spinning_friction>
               </bullet>
             </friction>
           </surface>
@@ -208,7 +207,6 @@
                 <friction>1</friction>
                 <friction2>1</friction2>
                 <rolling_friction>0.1</rolling_friction>
-                <spinning_friction>0.1</spinning_friction>
               </bullet>
             </friction>
           </surface>
@@ -379,7 +377,6 @@
                 <friction>1</friction>
                 <friction2>1</friction2>
                 <rolling_friction>0.1</rolling_friction>
-                <spinning_friction>0.1</spinning_friction>
               </bullet>
             </friction>
           </surface>
@@ -430,7 +427,6 @@
                 <friction>1</friction>
                 <friction2>1</friction2>
                 <rolling_friction>0.1</rolling_friction>
-                <spinning_friction>0.1</spinning_friction>
               </bullet>
             </friction>
           </surface>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gazebo_test_cases/issues/240

## Summary
According with sdf definition https://github.com/gazebosim/sdformat/blob/sdf13/sdf/1.10/surface.sdf#L99-L131 there is no `spinning_friction`.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
