### PR TITLE
DetachableJoint plugin: Reattached model when world is resetted

### DIFF
--- a/src/systems/detachable_joint/DetachableJoint.cc
+++ b/src/systems/detachable_joint/DetachableJoint.cc
@@ -212,6 +212,15 @@ void DetachableJoint::Configure(const Entity &_entity,
   this->validConfig = true;
 }
 
+void DetachableJoint::Reset(const gz::sim::UpdateInfo &/*_info*/,
+   gz::sim::EntityComponentManager &/*_ecm*/)
+{
+  // When the physics engine is resetted the detachable joint is removed
+  // We need to reattach it
+  this->attachRequested = true;
+  this->isAttached = false;
+}
+
 //////////////////////////////////////////////////
 void DetachableJoint::PreUpdate(
   const UpdateInfo &/*_info*/,
@@ -314,9 +323,10 @@ void DetachableJoint::OnDetachRequest(const msgs::Empty &)
 }
 
 GZ_ADD_PLUGIN(DetachableJoint,
-                    System,
-                    DetachableJoint::ISystemConfigure,
-                    DetachableJoint::ISystemPreUpdate)
+              System,
+              DetachableJoint::ISystemConfigure,
+              DetachableJoint::ISystemPreUpdate,
+              DetachableJoint::ISystemReset)
 
 GZ_ADD_PLUGIN_ALIAS(DetachableJoint,
   "gz::sim::systems::DetachableJoint")

--- a/src/systems/detachable_joint/DetachableJoint.hh
+++ b/src/systems/detachable_joint/DetachableJoint.hh
@@ -73,7 +73,8 @@ namespace systems
   class DetachableJoint
       : public System,
         public ISystemConfigure,
-        public ISystemPreUpdate
+        public ISystemPreUpdate,
+        public ISystemReset
   {
     /// Documentation inherited
     public: DetachableJoint() = default;
@@ -88,6 +89,10 @@ namespace systems
     public: void PreUpdate(
                 const gz::sim::UpdateInfo &_info,
                 gz::sim::EntityComponentManager &_ecm) final;
+
+    /// Documentation inherited
+    public: void Reset(const gz::sim::UpdateInfo &_info,
+                       gz::sim::EntityComponentManager &_ecm) final;
 
     /// \brief Gazebo communication node.
     private: transport::Node node;


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gazebo_test_cases/issues/238

## Summary
When a world with detachable joint is resetted the joint disappears, this should fix the issue

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
