### PR TITLE
TouchPlugin: Reset the plugin with the initial values

### DIFF
--- a/src/systems/touch_plugin/TouchPlugin.cc
+++ b/src/systems/touch_plugin/TouchPlugin.cc
@@ -118,8 +118,8 @@ class gz::sim::systems::TouchPluginPrivate
 };
 
 //////////////////////////////////////////////////
-void TouchPlugin::Reset(const gz::sim::UpdateInfo &_info,
-  gz::sim::EntityComponentManager &_ecm)
+void TouchPlugin::Reset(const gz::sim::UpdateInfo &/*_info*/,
+  gz::sim::EntityComponentManager &/*_ecm*/)
 {
   this->dataPtr->Enable(this->dataPtr->enableInitialValue);
 }

--- a/src/systems/touch_plugin/TouchPlugin.cc
+++ b/src/systems/touch_plugin/TouchPlugin.cc
@@ -109,10 +109,20 @@ class gz::sim::systems::TouchPluginPrivate
   /// \brief Whether the plugin is enabled.
   public: bool enabled{false};
 
+  /// Value used to reset the world with the initial value
+  public: bool enableInitialValue{false};
+
   /// \brief Mutex for variables mutated by the service callback.
   /// The variables are: touchPub, touchStart, enabled
   public: std::mutex serviceMutex;
 };
+
+//////////////////////////////////////////////////
+void TouchPlugin::Reset(const gz::sim::UpdateInfo &_info,
+  gz::sim::EntityComponentManager &_ecm)
+{
+  this->dataPtr->Enable(this->dataPtr->enableInitialValue);
+}
 
 //////////////////////////////////////////////////
 void TouchPluginPrivate::Load(const EntityComponentManager &_ecm,
@@ -195,6 +205,7 @@ void TouchPluginPrivate::Load(const EntityComponentManager &_ecm,
   // Start enabled or not
   if (_sdf->Get<bool>("enabled", false).first)
   {
+    this->enableInitialValue = true;
     this->Enable(true);
   }
 }
@@ -408,9 +419,10 @@ void TouchPlugin::PostUpdate(const UpdateInfo &_info,
 }
 
 GZ_ADD_PLUGIN(TouchPlugin,
-                    System,
-                    TouchPlugin::ISystemConfigure,
-                    TouchPlugin::ISystemPreUpdate,
-                    TouchPlugin::ISystemPostUpdate)
+              System,
+              TouchPlugin::ISystemConfigure,
+              TouchPlugin::ISystemPreUpdate,
+              TouchPlugin::ISystemPostUpdate,
+              TouchPlugin::ISystemReset)
 
 GZ_ADD_PLUGIN_ALIAS(TouchPlugin, "gz::sim::systems::TouchPlugin")

--- a/src/systems/touch_plugin/TouchPlugin.cc
+++ b/src/systems/touch_plugin/TouchPlugin.cc
@@ -217,9 +217,10 @@ void TouchPluginPrivate::Enable(const bool _value)
 
   if (_value)
   {
-    this->touchedPub.reset();
-    this->touchedPub = this->node.Advertise<msgs::Boolean>(
-        "/" + this->ns + "/touched");
+    if (!this->touchedPub.has_value()){
+      this->touchedPub = this->node.Advertise<msgs::Boolean>(
+          "/" + this->ns + "/touched");
+    }
 
     this->touchStart = DurationType::zero();
     this->enabled = true;
@@ -228,7 +229,6 @@ void TouchPluginPrivate::Enable(const bool _value)
   }
   else
   {
-    this->touchedPub.reset();
     this->enabled = false;
 
     gzdbg << "Stopped touch plugin [" << this->ns << "]" << std::endl;
@@ -330,7 +330,7 @@ void TouchPluginPrivate::Update(const UpdateInfo &_info,
 
     {
       std::lock_guard<std::mutex> lock(this->serviceMutex);
-      if (this->touchedPub.has_value())
+      if (this->enabled)
       {
         msgs::Boolean msg;
         msg.set_data(true);

--- a/src/systems/touch_plugin/TouchPlugin.hh
+++ b/src/systems/touch_plugin/TouchPlugin.hh
@@ -66,7 +66,8 @@ namespace systems
       : public System,
         public ISystemConfigure,
         public ISystemPreUpdate,
-        public ISystemPostUpdate
+        public ISystemPostUpdate,
+        public ISystemReset
   {
     /// \brief Constructor
     public: TouchPlugin();
@@ -83,6 +84,10 @@ namespace systems
     /// Documentation inherited
     public: void PreUpdate(const UpdateInfo &_info,
                            EntityComponentManager &_ecm) final;
+
+    // Documentation inherited
+    public: void Reset(const gz::sim::UpdateInfo &_info,
+                       gz::sim::EntityComponentManager &_ecm) final;
 
     // Documentation inherited
     public: void PostUpdate(


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gazebo_test_cases/issues/387

## Summary
When a TouchPlugin is resetted the initial state was not working properly, this PR should fix the issue

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
