### PR TITLE
Fixes the link for the Hardware Acceleration Tutorial

### DIFF
--- a/tutorials/video_recorder.md
+++ b/tutorials/video_recorder.md
@@ -106,5 +106,5 @@ generated video. The default bitrate is 2Mbps.
 
 Since Gazebo Common 3.10.2, there is support for utilizing the power of GPUs
 to speed up the video encoding process. See the
-[Hardware-accelerated Video Encoding tutorial](https://gazebosim.org/api/common/3.10/hw-encoding.html)
+[Hardware-accelerated Video Encoding tutorial](https://gazebosim.org/api/common/5/hw-encoding.html)
 for more details.


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gazebo_test_cases/issues/397

## Summary
Fixes the link for the current Hardware Acceleration Video Recording Tutorial

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
