### PR TITLE
Use default physics engine in example worlds

### DIFF
--- a/examples/worlds/nested_model.sdf
+++ b/examples/worlds/nested_model.sdf
@@ -8,7 +8,6 @@
     <plugin
       filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
-      <engine><filename>gz-physics-tpe-plugin</filename></engine>
     </plugin>
     <plugin
       filename="gz-sim-user-commands-system"

--- a/examples/worlds/particle_emitter.sdf
+++ b/examples/worlds/particle_emitter.sdf
@@ -30,8 +30,6 @@
     <plugin
       filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
-      <!-- Use TPE in order to use nested models -->
-      <engine><filename>gz-physics-tpe-plugin</filename></engine>
     </plugin>
     <plugin
       filename="gz-sim-user-commands-system"


### PR DESCRIPTION


# 🦟 Bug fix

Related issue: https://github.com/gazebosim/gazebo_test_cases/issues/339

## Summary

When launching a world with TPE and the world that has nested models, the following errors flood the console:

```
[Err] [Physics.cc:2889] Internal error: a physics entity ptr with an ID of [9] does not exist.
[Err] [Physics.cc:2889] Internal error: a physics entity ptr with an ID of [7] does not exist.
```

I think nested models are be supported in dart now so updated the examples worlds to use the default physics engine

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

