### PR TITLE
Modifies the definition of hydrodynamics plugin

### DIFF
--- a/examples/worlds/lrauv_control_demo.sdf
+++ b/examples/worlds/lrauv_control_demo.sdf
@@ -257,17 +257,17 @@
         <kDotP>0</kDotP>
         <mDotQ>-33.46</mDotQ>
         <nDotR>-33.46</nDotR>
-        <xUU>-6.2282</xUU>
+        <xUabsU>-6.2282</xUabsU>
         <xU>0</xU>
-        <yVV>-601.27</yVV>
+        <yVabsV>-601.27</yVabsV>
         <yV>0</yV>
-        <zWW>-601.27</zWW>
+        <zWabsW>-601.27</zWabsW>
         <zW>0</zW>
-        <kPP>-0.1916</kPP>
+        <kPabsP>-0.1916</kPabsP>
         <kP>0</kP>
-        <mQQ>-632.698957</mQQ>
+        <mQabsQ>-632.698957</mQabsQ>
         <mQ>0</mQ>
-        <nRR>-632.698957</nRR>
+        <nRabsR>-632.698957</nRabsR>
         <nR>0</nR>
       </plugin>
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gazebo_test_cases/issues/299

## Summary
modifies the names of the absolute variables in the plugin definition.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.