### PR TITLE
Fix another deadlock in sensors system

### DIFF
--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -361,13 +361,16 @@ void SensorsPrivate::RunOnce()
 
     // safety check to see if reset occurred while we're rendering
     // avoid publishing outdated data if reset occurred
-    std::unique_lock<std::mutex> timeLock(this->renderMutex);
-    if (updateTimeApplied <= this->updateTime)
     {
-      // publish data
-      GZ_PROFILE("RunOnce");
-      this->sensorManager.RunOnce(updateTimeApplied);
-      this->eventManager->Emit<events::Render>();
+      std::unique_lock<std::mutex> timeLock(this->renderMutex);
+      if (updateTimeApplied <= this->updateTime)
+      {
+        timeLock.unlock();
+        // publish data
+        GZ_PROFILE("RunOnce");
+        this->sensorManager.RunOnce(updateTimeApplied);
+        this->eventManager->Emit<events::Render>();
+      }
     }
 
     // re-enble sensors
@@ -390,9 +393,12 @@ void SensorsPrivate::RunOnce()
     this->activeSensors.clear();
   }
 
-  this->updateAvailable = false;
   this->forceUpdate = false;
-  this->renderCv.notify_one();
+  {
+    std::unique_lock<std::mutex> cvLock(this->renderMutex);
+    this->updateAvailable = false;
+    this->renderCv.notify_one();
+  }
 }
 
 //////////////////////////////////////////////////
@@ -736,19 +742,22 @@ void Sensors::PostUpdate(const UpdateInfo &_info,
         std::unique_lock<std::mutex> lockSensors(this->dataPtr->sensorsMutex);
         this->dataPtr->activeSensors =
             std::move(this->dataPtr->sensorsToUpdate);
-
-        this->dataPtr->nextUpdateTime = this->dataPtr->NextUpdateTime(
-            this->dataPtr->sensorsToUpdate, _info.simTime);
-
-        // Force scene tree update if there are sensors to be created or
-        // subscribes to the render events. This does not necessary force
-        // sensors to update. Only active sensors will be updated
-        this->dataPtr->forceUpdate =
-            (this->dataPtr->renderUtil.PendingSensors() > 0) ||
-            hasRenderConnections;
-        this->dataPtr->updateAvailable = true;
       }
-      this->dataPtr->renderCv.notify_one();
+
+      this->dataPtr->nextUpdateTime = this->dataPtr->NextUpdateTime(
+          this->dataPtr->sensorsToUpdate, _info.simTime);
+
+      // Force scene tree update if there are sensors to be created or
+      // subscribes to the render events. This does not necessary force
+      // sensors to update. Only active sensors will be updated
+      this->dataPtr->forceUpdate =
+          (this->dataPtr->renderUtil.PendingSensors() > 0) ||
+          hasRenderConnections;
+      {
+        std::unique_lock<std::mutex> cvLock(this->dataPtr->renderMutex);
+        this->dataPtr->updateAvailable = true;
+        this->dataPtr->renderCv.notify_one();
+      }
     }
   }
 }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This PR:

* Fixed a situation deadlock that occurs when waiting on the `updateAvailable` variable with a condition variable while that variable is also being written.  
* ~~Reduced scope of a lock (`timeLock`). Not needed for fixing deadlock - can be done in a separate PR if needed.~~ 
    * Update: Reverted these changes.

More info on the deadlock:

These two operations can happen concurrently (from 2 threads):

```cpp
        std::unique_lock<std::mutex> cvLock(this->dataPtr->renderMutex);
        // updateAvailable is true here
        this->dataPtr->renderCv.wait(cvLock, [this] {
          return !this->dataPtr->running || !this->dataPtr->updateAvailable; });
```

```cpp
        // updateAvailable is set to false
        this->dataPtr->updateAvailable = true;
        this->dataPtr->renderCv.notify_one();
```

The `wait` condition may miss the `notify_one()` call causing it to sleep forever. To solve this, we need to make sure these two groups of operations are performed one after another. This fix is to group and lock the `updateAvailable = [true|false]` and `notify_one` calls using the same lock that's used by the `wait` condition variable.


## Test it

Ran into this deadlock when adding the DvL sensor system to the Harmonic demo world. The DVL sensor is implemented as a custom rendering sensor. It changes the timing of the sensors system which revealed this deadlock issue. 

Test with this pull request that adds a DVL sensor to the harmonic demo world:
https://github.com/gazebosim/harmonic_demo/pull/9

Without the changes in this PR, the deadlock happens within 1 minute of running the simulation for me.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

