### PR TITLE
Improve joint controller world visualization

### DIFF
--- a/examples/worlds/joint_controller.sdf
+++ b/examples/worlds/joint_controller.sdf
@@ -39,7 +39,7 @@
       <direction>-0.5 0.1 -0.9</direction>
     </light>
     <model name="joint_controller_demo">
-      <pose>0 0 0 0 1.57 0</pose>
+      <pose>0 0 0 0 -1.57 0</pose>
       <link name="base_link">
         <pose>0.0 0.0 0.0 0 0 0</pose>
         <inertial>
@@ -91,6 +91,8 @@
           </geometry>
           <material>
             <ambient>0.2 0.8 0.2 1</ambient>
+            <diffuse>0.2 0.8 0.2 1</diffuse>
+            <specular>0.2 0.8 0.2 1</specular>
           </material>
         </visual>
         <collision name="collision">
@@ -125,7 +127,7 @@
     </model>
 
     <model name="joint_controller_demo_2">
-      <pose>0 0.5 0 0 1.57 0</pose>
+      <pose>0 0.5 0 0 -1.57 0</pose>
       <link name="base_link">
         <pose>0.0 0.0 0.0 0 0 0</pose>
         <inertial>
@@ -177,6 +179,8 @@
           </geometry>
           <material>
             <ambient>0.2 0.8 0.2 1</ambient>
+            <diffuse>0.2 0.8 0.2 1</diffuse>
+            <specular>0.2 0.8 0.2 1</specular>
           </material>
         </visual>
         <collision name="collision">


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gazebo_test_cases/issues/273

## Summary
Visualization was very poor, you should move the camera around to check the joints, and it was really hard to see them because of the colors

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
