### PR TITLE
Fix CMake warning in example

### DIFF
--- a/examples/plugin/hello_world/CMakeLists.txt
+++ b/examples/plugin/hello_world/CMakeLists.txt
@@ -10,7 +10,7 @@ set(GZ_PLUGIN_VER ${gz-plugin2_VERSION_MAJOR})
 gz_find_package(gz-sim8 REQUIRED)
 set(GZ_SIM_VER ${gz-sim8_VERSION_MAJOR})
 
-add_library(HelloWorld SHARED HelloWorld)
+add_library(HelloWorld SHARED HelloWorld.cc)
 set_property(TARGET HelloWorld PROPERTY CXX_STANDARD 17)
 target_link_libraries(HelloWorld
   PRIVATE gz-plugin${GZ_PLUGIN_VER}::gz-plugin${GZ_PLUGIN_VER}


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
The `add_library` call was missing the file extension which caused a CMake warning on CI:
```
133: CMake Warning (dev) at CMakeLists.txt:13 (add_library):
133:   Policy CMP0115 is not set: Source file extensions must be explicit.  Run
133:   "cmake --help-policy CMP0115" for policy details.  Use the cmake_policy
133:   command to set the policy and suppress this warning.
133: 
133:   File:
133: 
133:     /home/jenkins/workspace/gz_sim-ci-pr_any-jammy-amd64/gz-sim/examples/plugin/hello_world/HelloWorld.cc
133: This warning is for project developers.  Use -Wno-dev to suppress it.
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
