### PR TITLE
Prevent reset button from being cropped in world control gui plugin

### DIFF
--- a/examples/plugin/rendering_plugins/rendering_plugins.sdf
+++ b/examples/plugin/rendering_plugins/rendering_plugins.sdf
@@ -79,7 +79,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/scripts/log_video_recorder/log_video_recorder.sdf
+++ b/examples/scripts/log_video_recorder/log_video_recorder.sdf
@@ -75,7 +75,6 @@
           <property type='bool' key='showTitleBar'>false</property>
           <property type='bool' key='resizable'>false</property>
           <property type='double' key='height'>72</property>
-          <property type='double' key='width'>121</property>
           <property type='double' key='z'>1</property>
           <property type='string' key='state'>floating</property>
           <anchors target='3D View'>

--- a/examples/worlds/boundingbox_camera.sdf
+++ b/examples/worlds/boundingbox_camera.sdf
@@ -82,7 +82,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/camera_sensor.sdf
+++ b/examples/worlds/camera_sensor.sdf
@@ -92,7 +92,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/dem_monterey_bay.sdf
+++ b/examples/worlds/dem_monterey_bay.sdf
@@ -71,7 +71,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/dem_moon.sdf
+++ b/examples/worlds/dem_moon.sdf
@@ -78,7 +78,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/dem_volcano.sdf
+++ b/examples/worlds/dem_volcano.sdf
@@ -70,7 +70,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/depth_camera_sensor.sdf
+++ b/examples/worlds/depth_camera_sensor.sdf
@@ -82,7 +82,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/fuel_textured_mesh.sdf
+++ b/examples/worlds/fuel_textured_mesh.sdf
@@ -95,7 +95,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/grid.sdf
+++ b/examples/worlds/grid.sdf
@@ -67,7 +67,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/lrauv_control_demo.sdf
+++ b/examples/worlds/lrauv_control_demo.sdf
@@ -111,7 +111,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/minimal_scene.sdf
+++ b/examples/worlds/minimal_scene.sdf
@@ -134,7 +134,6 @@ Features:
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/optical_tactile_sensor_plugin.sdf
+++ b/examples/worlds/optical_tactile_sensor_plugin.sdf
@@ -97,7 +97,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/plot_3d.sdf
+++ b/examples/worlds/plot_3d.sdf
@@ -71,7 +71,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/projector.sdf
+++ b/examples/worlds/projector.sdf
@@ -97,7 +97,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/resource_spawner.sdf
+++ b/examples/worlds/resource_spawner.sdf
@@ -81,7 +81,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
           <property type="string" key="state">floating</property>
           <anchors target="3D View">

--- a/examples/worlds/segmentation_camera.sdf
+++ b/examples/worlds/segmentation_camera.sdf
@@ -85,7 +85,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/sensors_demo.sdf
+++ b/examples/worlds/sensors_demo.sdf
@@ -87,7 +87,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/shader_param.sdf
+++ b/examples/worlds/shader_param.sdf
@@ -87,7 +87,6 @@ ShaderParam visual plugin over time.
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/sky.sdf
+++ b/examples/worlds/sky.sdf
@@ -70,7 +70,6 @@ Currently only supported using ogre2 rendering engine plugin.
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/spherical_coordinates.sdf
+++ b/examples/worlds/spherical_coordinates.sdf
@@ -163,7 +163,6 @@ gz service -s /world/spherical_coordinates/set_spherical_coordinates \
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/thermal_camera.sdf
+++ b/examples/worlds/thermal_camera.sdf
@@ -88,7 +88,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/tracked_vehicle_simple.sdf
+++ b/examples/worlds/tracked_vehicle_simple.sdf
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <sdf version='1.7'>
     <world name='default'>
         <!--
@@ -1780,7 +1781,6 @@
                     <property type='bool' key='showTitleBar'>0</property>
                     <property type='bool' key='resizable'>0</property>
                     <property type='double' key='height'>72</property>
-                    <property type='double' key='width'>121</property>
                     <property type='double' key='z'>1</property>
                     <property type='string' key='state'>floating</property>
                     <anchors target='3D View'>

--- a/examples/worlds/triggered_camera_sensor.sdf
+++ b/examples/worlds/triggered_camera_sensor.sdf
@@ -98,7 +98,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/tunnel.sdf
+++ b/examples/worlds/tunnel.sdf
@@ -108,7 +108,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/video_record_dbl_pendulum.sdf
+++ b/examples/worlds/video_record_dbl_pendulum.sdf
@@ -164,7 +164,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/visibility.sdf
+++ b/examples/worlds/visibility.sdf
@@ -99,7 +99,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/visualize_contacts.sdf
+++ b/examples/worlds/visualize_contacts.sdf
@@ -89,7 +89,6 @@ Contacts will be visualized as blue spheres and green cylinders.
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/visualize_lidar.sdf
+++ b/examples/worlds/visualize_lidar.sdf
@@ -83,7 +83,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/examples/worlds/wide_angle_camera.sdf
+++ b/examples/worlds/wide_angle_camera.sdf
@@ -133,7 +133,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/src/gui/playback_gui.config
+++ b/src/gui/playback_gui.config
@@ -111,7 +111,6 @@
     <property type="bool" key="showTitleBar">false</property>
     <property type="bool" key="resizable">false</property>
     <property type="double" key="height">72</property>
-    <property type="double" key="width">121</property>
     <property type="double" key="z">1</property>
 
     <property type="string" key="state">floating</property>


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix



## Summary

The reset button is cropped in many of the example worlds that have the world control gui plugin specified. 

![cropped_reset](https://github.com/gazebosim/gz-sim/assets/4000684/4ea6ff0e-9b7f-48a3-b2d7-884906c9e76a)

Removing the `width` property reveals the button, which matches what's done in the default [gui.config](https://github.com/gazebosim/gz-sim/blob/9d79b629c9e0fed1c8635e30f06b2c61462f32d8/src/gui/gui.config#L123-L143) file

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

