### PR TITLE
Fix SDFormat xml output of sdf_exporter

### DIFF
--- a/examples/scripts/blender/sdf_exporter.py
+++ b/examples/scripts/blender/sdf_exporter.py
@@ -50,7 +50,7 @@ def export_sdf(prefix_path):
 
     # 1 model and 1 link
     model = ET.SubElement(sdf, "model", attrib={"name": "test"})
-    static = ET.SubElement(sdf, "static")
+    static = ET.SubElement(model, "static")
     static.text = "true"
     link = ET.SubElement(model, "link", attrib={"name": "testlink"})
     # for each geometry in geometry library add a <visual> tag
@@ -165,8 +165,8 @@ def export_sdf(prefix_path):
     uri.text = path.join(meshes_folder_prefix, dae_filename)
 
     surface = ET.SubElement(collision, "surface")
-    contact = ET.SubElement(collision, "contact")
-    collide_bitmask = ET.SubElement(collision, "collide_bitmask")
+    contact = ET.SubElement(surface, "contact")
+    collide_bitmask = ET.SubElement(contact, "collide_bitmask")
     collide_bitmask.text = "0x01"
 
     ## sdf write to file


### PR DESCRIPTION

# 🦟 Bug fix

Fixes https://github.com/gazebosim/gazebo_test_cases/issues/207

## Summary
The warnings were caused by improper xml hierarchy.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.