### PR TITLE
Server: explicitly skip auto-inertial calculation

### DIFF
--- a/src/Server.cc
+++ b/src/Server.cc
@@ -121,6 +121,8 @@ Server::Server(const ServerConfig &_config)
       }
       gzmsg <<  msg;
       sdf::ParserConfig sdfParserConfig = sdf::ParserConfig::GlobalConfig();
+      sdfParserConfig.SetCalculateInertialConfiguration(
+        sdf::ConfigureResolveAutoInertials::SKIP_CALCULATION_IN_LOAD);
       errors = this->dataPtr->sdfRoot.LoadSdfString(
         _config.SdfString(), sdfParserConfig);
       this->dataPtr->sdfRoot.ResolveAutoInertials(errors, sdfParserConfig);
@@ -143,6 +145,8 @@ Server::Server(const ServerConfig &_config)
 
       sdf::Root sdfRoot;
       sdf::ParserConfig sdfParserConfig = sdf::ParserConfig::GlobalConfig();
+      sdfParserConfig.SetCalculateInertialConfiguration(
+        sdf::ConfigureResolveAutoInertials::SKIP_CALCULATION_IN_LOAD);
 
       MeshInertiaCalculator meshInertiaCalculator;
       sdfParserConfig.RegisterCustomInertiaCalc(meshInertiaCalculator);


### PR DESCRIPTION
# 🦟 Bug fix

Needed when https://github.com/gazebosim/sdformat/pull/1325 is merged

## Summary

Automatic inertial calculation may not work in `Root::Load`, so explicitly configure the loader to skip auto-inertial calculation. Computation of auto-inertial values are currently skipped by default, but the default behavior is proposed to be changed in https://github.com/gazebosim/sdformat/pull/1325, after which, this pull request would be required.


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
