### PR TITLE
Don't merge: testing #2166 with ci_matching_branch

### DIFF
--- a/src/Server.cc
+++ b/src/Server.cc
@@ -121,6 +121,8 @@ Server::Server(const ServerConfig &_config)
       }
       gzmsg <<  msg;
       sdf::ParserConfig sdfParserConfig = sdf::ParserConfig::GlobalConfig();
+      sdfParserConfig.SetCalculateInertialConfiguration(
+        sdf::ConfigureResolveAutoInertials::SKIP_CALCULATION_IN_LOAD);
       errors = this->dataPtr->sdfRoot.LoadSdfString(
         _config.SdfString(), sdfParserConfig);
       this->dataPtr->sdfRoot.ResolveAutoInertials(errors, sdfParserConfig);
@@ -143,6 +145,8 @@ Server::Server(const ServerConfig &_config)
 
       sdf::Root sdfRoot;
       sdf::ParserConfig sdfParserConfig = sdf::ParserConfig::GlobalConfig();
+      sdfParserConfig.SetCalculateInertialConfiguration(
+        sdf::ConfigureResolveAutoInertials::SKIP_CALCULATION_IN_LOAD);
 
       MeshInertiaCalculator meshInertiaCalculator;
       sdfParserConfig.RegisterCustomInertiaCalc(meshInertiaCalculator);


### PR DESCRIPTION
Testing #2166 against https://github.com/gazebosim/sdformat/pull/1325 using `ci_matching_branch/*` names and https://github.com/osrf/homebrew-simulation/commit/4d2d61f8ed6ab09f314f3a39e62adc956c834bd2

Server: explicitly skip auto-inertial calculation

Automatic inertial calculation may not work in
Root::Load, so explicitly configure the loader
to skip auto-inertial calculation.

**Do not merge**