### PR TITLE
Bugfix: Updated Mesh Inertia Calculator to incorporate mesh scale in the calculations

### DIFF
--- a/src/MeshInertiaCalculator.cc
+++ b/src/MeshInertiaCalculator.cc
@@ -39,8 +39,8 @@ using namespace sim;
 
 //////////////////////////////////////////////////
 void MeshInertiaCalculator::GetMeshTriangles(
-  std::vector<Triangle>& _triangles,
-  gz::math::Vector3d _meshScale,
+  std::vector<Triangle> &_triangles,
+  const gz::math::Vector3d &_meshScale,
   const gz::common::Mesh* _mesh)
 {
   // Get the vertices & indices of the mesh

--- a/src/MeshInertiaCalculator.cc
+++ b/src/MeshInertiaCalculator.cc
@@ -40,6 +40,7 @@ using namespace sim;
 //////////////////////////////////////////////////
 void MeshInertiaCalculator::GetMeshTriangles(
   std::vector<Triangle>& _triangles,
+  gz::math::Vector3d _meshScale,
   const gz::common::Mesh* _mesh)
 {
   // Get the vertices & indices of the mesh
@@ -60,6 +61,12 @@ void MeshInertiaCalculator::GetMeshTriangles(
     triangle.v2.X() = vertArray[static_cast<ptrdiff_t>(3 * indArray[i+2])];
     triangle.v2.Y() = vertArray[static_cast<ptrdiff_t>(3 * indArray[i+2] + 1)];
     triangle.v2.Z() = vertArray[static_cast<ptrdiff_t>(3 * indArray[i+2] + 2)];
+
+    // Apply mesh scale to the triangle coordinates
+    triangle.v0 = triangle.v0 * _meshScale;
+    triangle.v1 = triangle.v1 * _meshScale;
+    triangle.v2 = triangle.v2 * _meshScale;
+
     triangle.centroid = (triangle.v0 + triangle.v1 + triangle.v2) / 3;
     _triangles.push_back(triangle);
   }
@@ -245,7 +252,7 @@ std::optional<gz::math::Inertiald> MeshInertiaCalculator::operator()
   gz::math::Pose3d inertiaOrigin;
 
   // Create a list of Triangle objects from the mesh vertices and indices
-  this->GetMeshTriangles(meshTriangles, mesh);
+  this->GetMeshTriangles(meshTriangles, sdfMesh->Scale(), mesh);
 
   // Calculate the mesh centroid and set is as centre of mass
   this->CalculateMeshCentroid(centreOfMass, meshTriangles);

--- a/src/MeshInertiaCalculator.hh
+++ b/src/MeshInertiaCalculator.hh
@@ -85,6 +85,7 @@ namespace gz
         /// \param[in] _mesh Mesh object
         public: void GetMeshTriangles(
           std::vector<Triangle>& _triangles,
+          gz::math::Vector3d _meshScale,
           const gz::common::Mesh* _mesh);
 
         /// \brief Function to calculate the centroid of the mesh. Since

--- a/src/MeshInertiaCalculator.hh
+++ b/src/MeshInertiaCalculator.hh
@@ -82,10 +82,12 @@ namespace gz
         /// \param[out] _triangles A vector to hold all the Triangle
         /// instances obtained
         /// from the vertices & indices of the mesh
+        /// \param[in] _meshScale A vector with the scaling factor
+        /// of all the 3 axes
         /// \param[in] _mesh Mesh object
         public: void GetMeshTriangles(
-          std::vector<Triangle>& _triangles,
-          gz::math::Vector3d _meshScale,
+          std::vector<Triangle> &_triangles,
+          const gz::math::Vector3d &_meshScale,
           const gz::common::Mesh* _mesh);
 
         /// \brief Function to calculate the centroid of the mesh. Since


### PR DESCRIPTION
# 🦟 Bug fix

The `MeshInertiaCalculator.cc` was not incorporating the scale value set through the SDF for the inertia calculations leading to incorrect values. This PR fixes this issue by scaling the mesh coordinates in `MeshInertiaCaclulator::GetMeshTriangles()` function before calculating the inertia. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.