### PR TITLE
Support specifying the name of light associated with lens flares

### DIFF
--- a/src/systems/lens_flare/LensFlare.cc
+++ b/src/systems/lens_flare/LensFlare.cc
@@ -122,6 +122,11 @@ void LensFlare::Configure(
     this->dataPtr->occlusionSteps = _sdf->Get<uint32_t>("occlusion_steps");
   }
 
+  if (_sdf->HasElement("light_name"))
+  {
+    this->dataPtr->lightName = _sdf->Get<std::string>("light_name");
+  }
+
   // Get Camera Name
   this->dataPtr->cameraName = scopedName(this->dataPtr->entity,
                       _ecm, "::", false);
@@ -187,7 +192,18 @@ void LensFlarePrivate::OnPostRender()
   }
 
   // get light
-  auto light = this->scene->LightByIndex(0);
+  rendering::LightPtr light;
+  if (!this->lightName.empty())
+  {
+    light = this->scene->LightByName(this->lightName);
+  }
+  else if (this->scene->LightCount() > 0)
+  {
+    light = this->scene->LightByIndex(0);
+  }
+  // Light not found. Keep trying in case it's not available in the world yet.
+  if (!light)
+    return;
 
   rendering::RenderEngine *engine = this->camera->Scene()->Engine();
   rendering::RenderPassSystemPtr rpSystem = engine->RenderPassSystem();

--- a/src/systems/lens_flare/LensFlare.hh
+++ b/src/systems/lens_flare/LensFlare.hh
@@ -46,9 +46,9 @@ namespace systems
   ///   <occlusion_steps> Sets the number of steps to take in
   ///                     each direction to check for occlusions.
   ///                     The default value is set to 10. Use 0 to disable
-  ///   <light_name > Sets the light associated with the lens flares.
-  ///                 If not specified. The first light in the scene will
-  ///                 be used.
+  ///   <light_name> Sets the light associated with the lens flares.
+  ///                If not specified. The first light in the scene will
+  ///                be used.
 
   class LensFlare:
     public System,

--- a/src/systems/lens_flare/LensFlare.hh
+++ b/src/systems/lens_flare/LensFlare.hh
@@ -46,6 +46,9 @@ namespace systems
   ///   <occlusion_steps> Sets the number of steps to take in
   ///                     each direction to check for occlusions.
   ///                     The default value is set to 10. Use 0 to disable
+  ///   <light_name > Sets the light associated with the lens flares.
+  ///                 If not specified. The first light in the scene will
+  ///                 be used.
 
   class LensFlare:
     public System,


### PR DESCRIPTION
# 🎉 New feature

## Summary

Currently by default, the lens flares system just picks the first light in the scene which may not always be what the user wants.  This PR adds a new plugin param named `<light_name>` for users to specify the name of the light for the lens flares.

Needed by https://github.com/gazebosim/harmonic_demo/pull/7 in order for lens flares to be visible in the camera view.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

