### PR TITLE
Fix for sensor pointer null when navsat plugin in included in sdf

### DIFF
--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -1424,6 +1424,37 @@ sdf::Sensor gazebo::convert(const msgs::Sensor &_in)
 
     out.SetCameraSensor(sensor);
   }
+
+  else if (out.Type() == sdf::SensorType::GPS ||
+           out.Type() == sdf::SensorType::NAVSAT)
+  {
+      sdf::NavSat sensor;
+      if (_in.has_gps())
+      {
+          if (_in.gps().position().has_horizontal_noise())
+          {
+              sensor.SetHorizontalPositionNoise(gazebo::convert<sdf::Noise>(_in.gps().position().horizontal_noise()));
+          }
+          if (_in.gps().position().has_vertical_noise())
+          {
+              sensor.SetVerticalPositionNoise(gazebo::convert<sdf::Noise>(_in.gps().position().vertical_noise()));
+          }
+          if (_in.gps().velocity().has_horizontal_noise())
+          {
+              sensor.SetHorizontalVelocityNoise(gazebo::convert<sdf::Noise>(_in.gps().velocity().horizontal_noise()));
+          }
+          if (_in.gps().velocity().has_vertical_noise())
+          {
+              sensor.SetVerticalVelocityNoise(gazebo::convert<sdf::Noise>(_in.gps().velocity().vertical_noise()));
+          }
+      }
+      else
+      {
+          ignerr << "Attempting to convert an navsat sensor message, but the "
+                 << "message does not have a navsat nested message.\n";
+      }
+  }
+
   else if (out.Type() == sdf::SensorType::ALTIMETER)
   {
     sdf::Altimeter sensor;

--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -1424,38 +1424,36 @@ sdf::Sensor gazebo::convert(const msgs::Sensor &_in)
 
     out.SetCameraSensor(sensor);
   }
-
   else if (out.Type() == sdf::SensorType::GPS ||
            out.Type() == sdf::SensorType::NAVSAT)
   {
-      sdf::NavSat sensor;
-      if (_in.has_gps())
+    sdf::NavSat sensor;
+    if (_in.has_gps())
+    {
+      if (_in.gps().position().has_horizontal_noise())
       {
-          if (_in.gps().position().has_horizontal_noise())
-          {
-              sensor.SetHorizontalPositionNoise(gazebo::convert<sdf::Noise>(_in.gps().position().horizontal_noise()));
-          }
-          if (_in.gps().position().has_vertical_noise())
-          {
-              sensor.SetVerticalPositionNoise(gazebo::convert<sdf::Noise>(_in.gps().position().vertical_noise()));
-          }
-          if (_in.gps().velocity().has_horizontal_noise())
-          {
-              sensor.SetHorizontalVelocityNoise(gazebo::convert<sdf::Noise>(_in.gps().velocity().horizontal_noise()));
-          }
-          if (_in.gps().velocity().has_vertical_noise())
-          {
-              sensor.SetVerticalVelocityNoise(gazebo::convert<sdf::Noise>(_in.gps().velocity().vertical_noise()));
-          }
+          sensor.SetHorizontalPositionNoise(gazebo::convert<sdf::Noise>(_in.gps().position().horizontal_noise()));
       }
-      else
+      if (_in.gps().position().has_vertical_noise())
       {
-          ignerr << "Attempting to convert an navsat sensor message, but the "
-                 << "message does not have a navsat nested message.\n";
+          sensor.SetVerticalPositionNoise(gazebo::convert<sdf::Noise>(_in.gps().position().vertical_noise()));
       }
-      out.SetNavSatSensor(sensor);
+      if (_in.gps().velocity().has_horizontal_noise())
+      {
+          sensor.SetHorizontalVelocityNoise(gazebo::convert<sdf::Noise>(_in.gps().velocity().horizontal_noise()));
+      }
+      if (_in.gps().velocity().has_vertical_noise())
+      {
+          sensor.SetVerticalVelocityNoise(gazebo::convert<sdf::Noise>(_in.gps().velocity().vertical_noise()));
+      }
+    }
+    else
+    {
+      ignerr << "Attempting to convert an navsat sensor message, but the "
+             << "message does not have a navsat nested message.\n";
+    }
+    out.SetNavSatSensor(sensor);
   }
-
   else if (out.Type() == sdf::SensorType::ALTIMETER)
   {
     sdf::Altimeter sensor;

--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -1453,6 +1453,7 @@ sdf::Sensor gazebo::convert(const msgs::Sensor &_in)
           ignerr << "Attempting to convert an navsat sensor message, but the "
                  << "message does not have a navsat nested message.\n";
       }
+      out.SetNavSatSensor(sensor);
   }
 
   else if (out.Type() == sdf::SensorType::ALTIMETER)

--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -1432,19 +1432,23 @@ sdf::Sensor gazebo::convert(const msgs::Sensor &_in)
     {
       if (_in.gps().position().has_horizontal_noise())
       {
-          sensor.SetHorizontalPositionNoise(gazebo::convert<sdf::Noise>(_in.gps().position().horizontal_noise()));
+        sensor.SetHorizontalPositionNoise(gazebo::convert<sdf::Noise>(
+              _in.gps().position().horizontal_noise()));
       }
       if (_in.gps().position().has_vertical_noise())
       {
-          sensor.SetVerticalPositionNoise(gazebo::convert<sdf::Noise>(_in.gps().position().vertical_noise()));
+        sensor.SetVerticalPositionNoise(gazebo::convert<sdf::Noise>(
+              _in.gps().position().vertical_noise()));
       }
       if (_in.gps().velocity().has_horizontal_noise())
       {
-          sensor.SetHorizontalVelocityNoise(gazebo::convert<sdf::Noise>(_in.gps().velocity().horizontal_noise()));
+        sensor.SetHorizontalVelocityNoise(gazebo::convert<sdf::Noise>(
+              _in.gps().velocity().horizontal_noise()));
       }
       if (_in.gps().velocity().has_vertical_noise())
       {
-          sensor.SetVerticalVelocityNoise(gazebo::convert<sdf::Noise>(_in.gps().velocity().vertical_noise()));
+        sensor.SetVerticalVelocityNoise(gazebo::convert<sdf::Noise>(
+              _in.gps().velocity().vertical_noise()));
       }
     }
     else
@@ -1452,6 +1456,7 @@ sdf::Sensor gazebo::convert(const msgs::Sensor &_in)
       ignerr << "Attempting to convert an navsat sensor message, but the "
              << "message does not have a navsat nested message.\n";
     }
+
     out.SetNavSatSensor(sensor);
   }
   else if (out.Type() == sdf::SensorType::ALTIMETER)

--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -1453,7 +1453,7 @@ sdf::Sensor gazebo::convert(const msgs::Sensor &_in)
     }
     else
     {
-      ignerr << "Attempting to convert an navsat sensor message, but the "
+      ignerr << "Attempting to convert a navsat sensor message, but the "
              << "message does not have a navsat nested message.\n";
     }
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2163

## Summary
When the play button is pressed in Gazebo, the terminal window shows an error as described in #2163. 

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸


## Test it
* create a `model.sdf ` with the following `navsat` plugin
```
<sensor name="navsat" type="navsat">
   <navsat>
        ....
   </navsat>
   <plugin  filename="libignition-gazebo-navsat-system"  
            name="ignition::gazebo::systems::NavSat">
   </plugin>
</sensor>
```
* `ign gazebo model.sdf`
* Press the play button
* There wont be any error on the terminal
