### PR TITLE
Standardize Doxygen parameter formatting for systems A-N

### DIFF
--- a/src/systems/ackermann_steering/AckermannSteering.hh
+++ b/src/systems/ackermann_steering/AckermannSteering.hh
@@ -36,106 +36,106 @@ namespace systems
   /// \brief Ackermann steering controller which can be attached to a model
   /// with any number of left and right wheels.
   ///
-  /// # System Parameters
+  /// ## System Parameters
   ///
-  /// `<steering_only>`: Boolean used to only control the steering angle
+  /// - `<steering_only>`: Boolean used to only control the steering angle
   /// only. Calculates the angles of wheels from steering_limit,  wheel_base,
   /// and wheel_separation. Uses gz::msg::Double on default topic name
   /// `/model/{name_of_model}/steer_angle`. Automatically set True when
   /// `<use_actuator_msg>` is True, uses defaults topic name "/actuators".
   ///
-  /// `<use_actuator_msg>` True to enable the use of actutor message
+  /// - `<use_actuator_msg>` True to enable the use of actutor message
   /// for steering angle command. Relies on `<actuator_number>` for the
   /// index of the position actuator and defaults to topic "/actuators".
   ///
-  /// `<actuator_number>` used with `<use_actuator_commands>` to set
+  /// - `<actuator_number>` used with `<use_actuator_commands>` to set
   /// the index of the steering angle position actuator.
   ///
-  /// `<steer_p_gain>`: Float used to control the steering angle P gain.
+  /// - `<steer_p_gain>`: Float used to control the steering angle P gain.
   /// Only used for when in steering_only mode.
   ///
-  /// `<left_joint>`: Name of a joint that controls a left wheel. This
+  /// - `<left_joint>`: Name of a joint that controls a left wheel. This
   /// element can appear multiple times, and must appear at least once.
   ///
-  /// `<right_joint>`: Name of a joint that controls a right wheel. This
+  /// - `<right_joint>`: Name of a joint that controls a right wheel. This
   /// element can appear multiple times, and must appear at least once.
   ///
-  /// `<left_steering_joint>`: Name of a joint that controls steering for
-  ///  left wheel. This element must appear once.  Vehicles that steer
-  ///  rear wheels are not currently correctly supported.
+  /// - `<left_steering_joint>`: Name of a joint that controls steering for
+  /// left wheel. This element must appear once.  Vehicles that steer
+  /// rear wheels are not currently correctly supported.
   ///
-  /// `<right_steering_joint>`: Name of a joint that controls steering for
-  ///  right wheel. This element must appear once.
+  /// - `<right_steering_joint>`: Name of a joint that controls steering for
+  /// right wheel. This element must appear once.
   ///
-  /// `<wheel_separation>`: Distance between wheels, in meters. This element
+  /// - `<wheel_separation>`: Distance between wheels, in meters. This element
   /// is optional, although it is recommended to be included with an
   /// appropriate value. The default value is 1.0m.
   ///
-  /// `<kingpin_width>`: Distance between wheel kingpins, in meters. This
+  /// - `<kingpin_width>`: Distance between wheel kingpins, in meters. This
   /// element is optional, although it is recommended to be included with an
   /// appropriate value. The default value is 0.8m.  Generally a bit smaller
   /// than the wheel_separation.
   ///
-  /// `<wheel_base>`: Distance between front and rear wheels, in meters. This
+  /// - `<wheel_base>`: Distance between front and rear wheels, in meters. This
   /// element is optional, although it is recommended to be included with an
   /// appropriate value. The default value is 1.0m.
   ///
-  /// `<steering_limit>`: Value to limit steering to.  Can be calculated by
+  /// - `<steering_limit>`: Value to limit steering to.  Can be calculated by
   /// measuring the turning radius and wheel_base of the real vehicle.
   /// steering_limit = asin(wheel_base / turning_radius)
   /// The default value is 0.5 radians.
   ///
-  /// `<wheel_radius>`: Wheel radius in meters. This element is optional,
+  /// - `<wheel_radius>`: Wheel radius in meters. This element is optional,
   /// although it is recommended to be included with an appropriate value. The
   /// default value is 0.2m.
   ///
-  /// `<odom_publish_frequency>`: Odometry publication frequency. This
+  /// - `<odom_publish_frequency>`: Odometry publication frequency. This
   /// element is optional, and the default value is 50Hz.
   ///
-  /// `<min_velocity>`: Minimum velocity [m/s], usually <= 0.
-  /// `<max_velocity>`: Maximum velocity [m/s], usually >= 0.
-  /// `<min_acceleration>`: Minimum acceleration [m/s^2], usually <= 0.
-  /// `<max_acceleration>`: Maximum acceleration [m/s^2], usually >= 0.
-  /// `<min_jerk Minimum>`: jerk [m/s^3], usually <= 0.
-  /// `<max_jerk Maximum>`: jerk [m/s^3], usually >= 0.
+  /// - `<min_velocity>`: Minimum velocity [m/s], usually <= 0.
+  /// - `<max_velocity>`: Maximum velocity [m/s], usually >= 0.
+  /// - `<min_acceleration>`: Minimum acceleration [m/s^2], usually <= 0.
+  /// - `<max_acceleration>`: Maximum acceleration [m/s^2], usually >= 0.
+  /// - `<min_jerk Minimum>`: jerk [m/s^3], usually <= 0.
+  /// - `<max_jerk Maximum>`: jerk [m/s^3], usually >= 0.
   ///
-  /// `<topic>`: Custom topic that this system will subscribe to in order to
+  /// - `<topic>`: Custom topic that this system will subscribe to in order to
   /// receive command messages. This element is optional, and the
   /// default value is `/model/{name_of_model}/cmd_vel` or when steering_only
   /// is true `/model/{name_of_model}/steer_angle`.
   ///
-  /// `<sub_topic>`: Custom sub_topic that this system will subscribe to in
+  /// - `<sub_topic>`: Custom sub_topic that this system will subscribe to in
   /// order to receive command messages. This element is optional, and
   /// creates a topic `/model/{name_of_model}/{sub_topic}`
   ///
-  /// `<odom_topic>`: Custom topic on which this system will publish odometry
+  /// - `<odom_topic>`: Custom topic on which this system will publish odometry
   /// messages. This element if optional, and the default value is
   /// `/model/{name_of_model}/odometry`.
   ///
-  /// `<tf_topic>`: Custom topic on which this system will publish the
+  /// - `<tf_topic>`: Custom topic on which this system will publish the
   /// transform from `frame_id` to `child_frame_id`. This element is optional,
   /// and the default value is `/model/{name_of_model}/tf`.
   ///
-  /// `<frame_id>`: Custom `frame_id` field that this system will use as the
+  /// - `<frame_id>`: Custom `frame_id` field that this system will use as the
   /// origin of the odometry transform in both the `<tf_topic>`
   /// `gz.msgs.Pose_V` message and the `<odom_topic>`
   /// `gz.msgs.Odometry` message. This element if optional, and the
   /// default value is `{name_of_model}/odom`.
   ///
-  /// `<child_frame_id>`: Custom `child_frame_id` that this system will use as
+  /// - `<child_frame_id>`: Custom `child_frame_id` that this system will use as
   /// the target of the odometry transform in both the `<tf_topic>`
-  /// `gz.msgs.Pose_V` message and the `<odom_topic>`
-  /// `gz.msgs.Odometry` message. This element if optional,
+  /// gz.msgs.Pose_V message and the `<odom_topic>`
+  /// gz.msgs.Odometry message. This element is optional,
   /// and the default value is `{name_of_model}/{name_of_link}`.
   ///
   /// A robot with rear drive and front steering would have one each
   /// of left_joint, right_joint, left_steering_joint and
-  /// right_steering_joint
+  /// right_steering_joint.
   ///
   /// References:
-  /// https://github.com/gazebosim/gz-sim/tree/main/src/systems/ackermann_steering
-  /// https://www.auto.tuwien.ac.at/bib/pdf_TR/TR0183.pdf
-  /// https://github.com/froohoo/ackermansteer/blob/master/ackermansteer/
+  /// - https://github.com/gazebosim/gz-sim/tree/main/src/systems/ackermann_steering
+  /// - https://www.auto.tuwien.ac.at/bib/pdf_TR/TR0183.pdf
+  /// - https://github.com/froohoo/ackermansteer/blob/master/ackermansteer/
 
 
   class AckermannSteering

--- a/src/systems/acoustic_comms/AcousticComms.hh
+++ b/src/systems/acoustic_comms/AcousticComms.hh
@@ -94,6 +94,7 @@ namespace systems
   ///    </propagation_model>
   ///
   ///  </plugin>
+  /// ```
 
   class AcousticComms:
     public gz::sim::comms::ICommsModel

--- a/src/systems/acoustic_comms/AcousticComms.hh
+++ b/src/systems/acoustic_comms/AcousticComms.hh
@@ -76,6 +76,7 @@ namespace systems
   ///       * <seed> : Seed value to be used for random sampling.
   ///
   /// Here's an example:
+  /// ```
   ///  <plugin
   ///    filename="gz-sim-acoustic-comms-system"
   ///    name="gz::sim::systems::AcousticComms">

--- a/src/systems/battery_plugin/LinearBatteryPlugin.hh
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.hh
@@ -39,12 +39,13 @@ namespace systems
 
   /// \brief A plugin for simulating battery usage
   ///
-  /// This system processes the following sdf parameters:
+  /// ## System parameters
+  ///
   /// - `<battery_name>` name of the battery (required)
   /// - `<voltage>` Initial voltage of the battery (required)
   /// - `<open_circuit_voltage_constant_coef>` Voltage at full charge
   /// - `<open_circuit_voltage_linear_coef>` Amount of voltage decrease when no
-  ///                                    charge
+  ///   charge
   /// - `<initial_charge>` Initial charge of the battery (Ah)
   /// - `<capacity>` Total charge that the battery can hold (Ah)
   /// - `<resistance>` Internal resistance (Ohm)
@@ -52,22 +53,22 @@ namespace systems
   /// - `<power_load>` power load on battery (required) (Watts)
   /// - `<enable_recharge>` If true, the battery can be recharged
   /// - `<recharge_by_topic>` If true, the start/stop signals for recharging the
-  ///                     battery will also be available via topics. The
-  ///                     regular Gazebo services will still be available.
+  ///   battery will also be available via topics. The
+  ///   regular Gazebo services will still be available.
   /// - `<charging_time>` Hours taken to fully charge the battery.
-  ///                 (Required if `<enable_recharge>` is set to true)
+  ///   (Required if `<enable_recharge>` is set to true)
   /// - `<fix_issue_225>` True to change the battery behavior to fix some issues
-  /// described in https://github.com/gazebosim/gz-sim/issues/225.
+  ///   described in https://github.com/gazebosim/gz-sim/issues/225.
   /// - `<start_drainign>` Whether to start draining the battery right away.
-  /// False by default.
+  ///   False by default.
   /// - `<power_draining_topic>` A topic that is used to start battery
-  /// discharge. Any message on the specified topic will cause the battery to
-  /// start draining. This element can be specified multiple times if
-  /// multiple topics should be monitored. Note that this mechanism will
-  /// start the battery draining, and once started will keep drainig.
+  ///   discharge. Any message on the specified topic will cause the battery to
+  ///   start draining. This element can be specified multiple times if
+  ///   multiple topics should be monitored. Note that this mechanism will
+  ///   start the battery draining, and once started will keep drainig.
   /// - `<stop_power_draining_topic>` A topic that is used to stop battery
-  /// discharge. Any message on the specified topic will cause the battery to
-  /// stop draining.
+  ///   discharge. Any message on the specified topic will cause the battery to
+  ///   stop draining.
 
   class LinearBatteryPlugin
       : public System,

--- a/src/systems/breadcrumbs/Breadcrumbs.hh
+++ b/src/systems/breadcrumbs/Breadcrumbs.hh
@@ -56,7 +56,7 @@ namespace systems
   /// model using the `<include>` tag.
   /// See the example in examples/worlds/breadcrumbs.sdf.
   ///
-  /// System Paramters
+  /// ## System Parameters
   ///
   /// - `<topic>`: Custom topic to be used to deploy breadcrumbs. If topic is
   /// not set, the default topic with the following pattern would be used
@@ -82,7 +82,7 @@ namespace systems
   /// be deployed. Defaults to false.
   /// - `<breadcrumb>`: This is the model used as a template for deploying
   /// breadcrumbs.
-  /// `<topic_statistics>`: If true, then topic statistics are enabled on
+  /// - `<topic_statistics>`: If true, then topic statistics are enabled on
   /// `<topic>` and error messages will be generated when messages are
   /// dropped. Default to false.
   class Breadcrumbs

--- a/src/systems/buoyancy/Buoyancy.hh
+++ b/src/systems/buoyancy/Buoyancy.hh
@@ -67,7 +67,8 @@ namespace systems
   ///
   /// ## Examples
   ///
-  /// ### `uniform_fluid_density` world.
+  /// ### uniform_fluid_density world
+  ///
   /// The `buoyancy.sdf` SDF file contains three submarines. The first
   /// submarine is neutrally buoyant, the second sinks, and the third
   /// floats. To run:
@@ -76,7 +77,7 @@ namespace systems
   /// gz sim -v 4 buoyancy.sdf
   /// ```
   ///
-  /// ### `graded_buoyancy` world
+  /// ### graded_buoyancy world
   ///
   /// Often when simulating a maritime environment one may need to simulate both
   /// surface and underwater vessels. This means the buoyancy plugin needs to

--- a/src/systems/buoyancy_engine/BuoyancyEngine.hh
+++ b/src/systems/buoyancy_engine/BuoyancyEngine.hh
@@ -38,32 +38,35 @@ namespace systems
   /// `/model/{namespace}/buoyancy_engine` topic for the volume of the bladder
   /// in *cubicmeters*.
   ///
-  /// ## Parameters
-  /// <link_name> - The link which the plugin is attached to [required, string]
-  /// <namespace> - The namespace for the topic. If empty the plugin will listen
-  ///   on `buoyancy_engine` otherwise it listens on
+  /// ## System Parameters
+  /// - `<link_name>`: The link which the plugin is attached to [required,
+  ///   string]
+  /// - `<namespace>`: The namespace for the topic. If empty the plugin will
+  ///   listen on `buoyancy_engine` otherwise it listens on
   ///   `/model/{namespace}/buoyancy_engine` [optional, string]
-  /// <min_volume> - Minimum volume of the engine [optional, float,
+  /// - `<min_volume>`: Minimum volume of the engine [optional, float,
   ///   default=0.00003m^3]
-  /// <neutral_volume> - At this volume the engine has neutral buoyancy. Used to
-  ///   estimate the weight of the engine [optional, float, default=0.0003m^3]
-  /// <default_volume> - The volume which the engine starts at [optional, float,
+  /// - `<neutral_volume>`: At this volume the engine has neutral buoyancy. Used
+  ///   to estimate the weight of the engine [optional, float,
   ///   default=0.0003m^3]
-  /// <max_volume> - Maximum volume of the engine [optional, float,
+  /// - `<default_volume>`: The volume which the engine starts at [optional,
+  ///   float, default=0.0003m^3]
+  /// - `<max_volume>`: Maximum volume of the engine [optional, float,
   ///   default=0.00099m^3]
-  /// <max_inflation_rate> - Maximum inflation rate for bladder [optional,
+  /// - `<max_inflation_rate>`: Maximum inflation rate for bladder [optional,
   ///   float, default=0.000003m^3/s]
-  /// <fluid_density> - The fluid density of the liquid its suspended in kgm^-3.
-  ///   [optional, float, default=1000kgm^-3]
-  /// <surface> - The Z height in metres at which the surface of the water is.
-  /// If not defined then there is no surface [optional, float]
+  /// - `<fluid_density>`: The fluid density of the liquid its suspended in
+  ///   kgm^-3. [optional, float, default=1000kgm^-3]
+  /// - `<surface>`: The Z height in metres at which the surface of the water
+  ///   is. If not defined then there is no surface [optional, float]
   ///
   /// ## Topics
-  /// * Subscribes to a gz::msgs::Double on `buoyancy_engine` or
-  ///  `/model/{namespace}/buoyancy_engine`. This is the set point for the
-  ///  engine.
-  /// * Publishes a gz::msgs::Double on `buoyancy_engine` or
-  ///  `/model/{namespace}/buoyancy_engine/current_volume` on the current volume
+  /// - Subscribes to a gz::msgs::Double on `buoyancy_engine` or
+  ///   `/model/{namespace}/buoyancy_engine`. This is the set point for the
+  ///   engine.
+  /// - Publishes a gz::msgs::Double on `buoyancy_engine` or
+  ///   `/model/{namespace}/buoyancy_engine/current_volume` on the current
+  ///   volume
   ///
   /// ## Examples
   /// To get started run:
@@ -72,18 +75,18 @@ namespace systems
   /// ```
   /// Enter the following in a separate terminal:
   /// ```
-  /// gz topic -t  /model/buoyant_box/buoyancy_engine/ -m gz.msgs.Double
+  /// gz topic -t /model/buoyant_box/buoyancy_engine/ -m gz.msgs.Double \
   ///    -p "data: 0.003"
   /// ```
-  /// To see the box float up.
+  /// to see the box float up.
   /// ```
-  /// gz topic -t  /model/buoyant_box/buoyancy_engine/ -m gz.msgs.Double
+  /// gz topic -t /model/buoyant_box/buoyancy_engine/ -m gz.msgs.Double \
   ///    -p "data: 0.001"
   /// ```
-  /// To see the box go down.
+  /// to see the box go down.
   /// To see the current volume enter:
   /// ```
-  /// gz topic -t  /model/buoyant_box/buoyancy_engine/current_volume -e
+  /// gz topic -t /model/buoyant_box/buoyancy_engine/current_volume -e
   /// ```
   class BuoyancyEnginePlugin:
     public gz::sim::System,

--- a/src/systems/camera_video_recorder/CameraVideoRecorder.hh
+++ b/src/systems/camera_video_recorder/CameraVideoRecorder.hh
@@ -34,23 +34,25 @@ namespace systems
   /** \class CameraVideoRecorder CameraVideoRecorder.hh \
    * gz/sim/systems/CameraVideoRecorder.hh
   **/
+  ///
   /// \brief Record video from a camera sensor
-  /// The system takes in the following parameter:
-  ///   <service>  Name of topic for the video recorder service. If this is
-  ///              not specified, the topic defaults to:
-  ///              /world/<world_name/model/<model_name>/link/<link_name>/
-  ///              sensor/<sensor_name>/record_video
   ///
-  ///   <use_sim_time> True/false value that specifies if the video should
-  ///                   be recorded using simulation time or real time. The
-  ///                   default is false, which indicates the use of real
-  ///                   time.
+  /// ## System Parameters
   ///
-  ///   <fps> Video recorder frames per second. The default value is 25, and
-  ///         the support type is unsigned int.
+  /// - `<service>`:  Name of topic for the video recorder service. If this is
+  ///   not specified, the topic defaults to:
+  ///   /world/<world_name/model/<model_name>/link/<link_name>/
+  ///   sensor/<sensor_name>/record_video
   ///
-  ///   <bitrate> Video recorder bitrate (bps). The default value is
-  ///             2070000 bps, and the supported type is unsigned int.
+  /// - `<use_sim_time>`: True/false value that specifies if the video should
+  ///   be recorded using simulation time or real time. The default is false,
+  ///   which indicates the use of real time.
+  ///
+  /// - `<fps>`: Video recorder frames per second. The default value is 25, and
+  ///   the support type is unsigned int.
+  ///
+  /// - `<bitrate>`: Video recorder bitrate (bps). The default value is
+  ///   2070000 bps, and the supported type is unsigned int.
   class CameraVideoRecorder final:
     public System,
     public ISystemConfigure,

--- a/src/systems/comms_endpoint/CommsEndpoint.hh
+++ b/src/systems/comms_endpoint/CommsEndpoint.hh
@@ -36,22 +36,23 @@ namespace systems
   /// running. The system will bind this address in the broker automatically
   /// for you and unbind it when the model is destroyed.
   ///
-  /// The endpoint can be configured with the following SDF parameters:
+  /// ## System Parameters
   ///
-  /// * Required parameters:
-  /// <address> An identifier used to receive messages (string).
-  /// <topic> The topic name where you want to receive the messages targeted to
-  /// this address.
+  /// Required parameters:
+  /// - `<address>`: An identifier used to receive messages (string).
+  /// - `<topic>`: The topic name where you want to receive the messages
+  ///   targeted to this address.
   ///
-  /// * Optional parameters:
-  /// <broker> Element used to capture where are the broker services.
-  ///          This block can contain any of the next optional parameters:
-  ///    <bind_service>: Service name used to bind an address.
-  ///                    The default value is "/broker/bind"
-  ///    <unbind_service>: Service name used to unbind from an address.
-  ///                      The default value is "/broker/unbind"
+  /// Optional parameters:
+  /// - `<broker>`: Element used to capture where are the broker services.
+  ///   This block can contain any of the next optional parameters:
+  ///   - `<bind_service>`: Service name used to bind an address.
+  ///     The default value is "/broker/bind"
+  ///   - `<unbind_service>`: Service name used to unbind from an address.
+  ///     The default value is "/broker/unbind"
   ///
-  /// Here's an example:
+  /// ## Example
+  /// ```
   /// <plugin
   ///   filename="gz-sim-comms-endpoint-system"
   ///   name="gz::sim::systems::CommsEndpoint">
@@ -62,6 +63,7 @@ namespace systems
   ///     <unbind_service>/broker/unbind</unbind_service>
   ///   </broker>
   /// </plugin>
+  /// ```
   class CommsEndpoint
       : public System,
         public ISystemConfigure,

--- a/src/systems/detachable_joint/DetachableJoint.hh
+++ b/src/systems/detachable_joint/DetachableJoint.hh
@@ -40,7 +40,7 @@ namespace systems
   /// model can be re-attached during simulation via a topic. The status of the
   /// detached state can be monitored via a topic as well.
   ///
-  /// Parameters:
+  /// ## System Parameters
   ///
   /// - `<parent_link>`: Name of the link in the parent model to be used in
   /// creating a fixed joint with a link in the child model.

--- a/src/systems/diff_drive/DiffDrive.hh
+++ b/src/systems/diff_drive/DiffDrive.hh
@@ -35,99 +35,99 @@ namespace systems
   /// \brief Differential drive controller which can be attached to a model
   /// with any number of left and right wheels.
   ///
-  /// # System Parameters
+  /// ## System Parameters
   ///
-  /// `<left_joint>`: Name of a joint that controls a left wheel. This
+  /// - `<left_joint>`: Name of a joint that controls a left wheel. This
   /// element can appear multiple times, and must appear at least once.
   ///
-  /// `<right_joint>`: Name of a joint that controls a right wheel. This
+  /// - `<right_joint>`: Name of a joint that controls a right wheel. This
   /// element can appear multiple times, and must appear at least once.
   ///
-  /// `<wheel_separation>`: Distance between wheels, in meters. This element
+  /// - `<wheel_separation>`: Distance between wheels, in meters. This element
   /// is optional, although it is recommended to be included with an
   /// appropriate value. The default value is 1.0m.
   ///
-  /// `<wheel_radius>`: Wheel radius in meters. This element is optional,
+  /// - `<wheel_radius>`: Wheel radius in meters. This element is optional,
   /// although it is recommended to be included with an appropriate value. The
   /// default value is 0.2m.
   ///
-  /// `<odom_publish_frequency>`: Odometry publication frequency. This
+  /// - `<odom_publish_frequency>`: Odometry publication frequency. This
   /// element is optional, and the default value is 50Hz.
   ///
-  /// `<topic>`: Custom topic that this system will subscribe to in order to
+  /// - `<topic>`: Custom topic that this system will subscribe to in order to
   /// receive command velocity messages. This element if optional, and the
   /// default value is `/model/{name_of_model}/cmd_vel`.
   ///
-  /// `<odom_topic>`: Custom topic on which this system will publish odometry
+  /// - `<odom_topic>`: Custom topic on which this system will publish odometry
   /// messages. This element if optional, and the default value is
   /// `/model/{name_of_model}/odometry`.
   ///
-  /// `<tf_topic>`: Custom topic on which this system will publish the
+  /// - `<tf_topic>`: Custom topic on which this system will publish the
   /// transform from `frame_id` to `child_frame_id`. This element is optional,
   ///  and the default value is `/model/{name_of_model}/tf`.
   ///
-  /// `<frame_id>`: Custom `frame_id` field that this system will use as the
+  /// - `<frame_id>`: Custom `frame_id` field that this system will use as the
   /// origin of the odometry transform in both the `<tf_topic>`
-  /// `gz.msgs.Pose_V` message and the `<odom_topic>`
-  /// `gz.msgs.Odometry` message. This element if optional, and the
+  /// gz.msgs.Pose_V message and the `<odom_topic>`
+  /// gz.msgs.Odometry message. This element if optional, and the
   /// default value is `{name_of_model}/odom`.
   ///
-  /// `<child_frame_id>`: Custom `child_frame_id` that this system will use as
+  /// - `<child_frame_id>`: Custom `child_frame_id` that this system will use as
   /// the target of the odometry trasnform in both the `<tf_topic>`
-  /// `gz.msgs.Pose_V` message and the `<odom_topic>`
-  /// `gz.msgs.Odometry` message. This element if optional,
+  /// gz.msgs.Pose_V message and the `<odom_topic>`
+  /// gz.msgs.Odometry message. This element if optional,
   ///  and the default value is `{name_of_model}/{name_of_link}`.
   ///
-  /// `<min_velocity>`: Sets both the minimum linear and minimum angular
+  /// - `<min_velocity>`: Sets both the minimum linear and minimum angular
   ///  velocity.
   ///
-  /// `<max_velocity>`: Sets both the maximum linear and maximum angular
+  /// - `<max_velocity>`: Sets both the maximum linear and maximum angular
   /// velocity.
   ///
-  /// `<min_acceleration>`: Sets both the minimum linear and minimum angular
+  /// - `<min_acceleration>`: Sets both the minimum linear and minimum angular
   /// acceleration.
   ///
-  /// `<max_acceleration>`: Sets both the maximum linear and maximum angular
+  /// - `<max_acceleration>`: Sets both the maximum linear and maximum angular
   /// acceleration.
   ///
-  /// `<min_jerk>`: Sets both the minimum linear and minimum angular jerk.
+  /// - `<min_jerk>`: Sets both the minimum linear and minimum angular jerk.
   ///
-  /// `<max_jerk>`: Sets both the maximum linear and maximum angular jerk.
+  /// - `<max_jerk>`: Sets both the maximum linear and maximum angular jerk.
   ///
-  /// `<min_linear_velocity>`: Sets the minimum linear velocity. Overrides
+  /// - `<min_linear_velocity>`: Sets the minimum linear velocity. Overrides
   /// `<min_velocity>` if set.
   ///
-  /// `<max_linear_velocity>`: Sets the maximum linear velocity. Overrides
+  /// - `<max_linear_velocity>`: Sets the maximum linear velocity. Overrides
   /// `<max_velocity>` if set.
   ///
-  /// `<min_angular_velocity>`: Sets the minimum angular velocity. Overrides
+  /// - `<min_angular_velocity>`: Sets the minimum angular velocity. Overrides
   /// `<min_velocity>` if set.
   ///
-  /// `<max_angular_velocity>`: Sets the maximum angular velocity. Overrides
+  /// - `<max_angular_velocity>`: Sets the maximum angular velocity. Overrides
   /// `<max_velocity>` if set.
   ///
-  /// `<min_linear_acceleration>`: Sets the minimum linear acceleration.
+  /// - `<min_linear_acceleration>`: Sets the minimum linear acceleration.
   /// Overrides `<min_acceleration>` if set.
   ///
-  /// `<max_linear_acceleration>`: Sets the maximum linear acceleration.
+  /// - `<max_linear_acceleration>`: Sets the maximum linear acceleration.
   /// Overrides `<max_acceleration>` if set.
   ///
-  /// `<min_angular_acceleration>`: Sets the minimum angular acceleration.
+  /// - `<min_angular_acceleration>`: Sets the minimum angular acceleration.
   /// Overrides `<min_acceleration>` if set.
   ///
-  /// `<max_angular_acceleration>`: Sets the maximum angular acceleration.
+  /// - `<max_angular_acceleration>`: Sets the maximum angular acceleration.
   /// Overrides `<max_acceleration>` if set.
   ///
-  /// `<min_linear_jerk>`: Sets the minimum linear jerk. Overrides `<min_jerk>`
-  /// if set.
-  ///
-  /// `<max_linear_jerk>`: Sets the maximum linear jerk. Overrides `<max_jerk>`
-  /// if set.
-  ///
-  /// `<min_angular_jerk>`: Sets the minimum angular jerk. Overrides
+  /// - `<min_linear_jerk>`: Sets the minimum linear jerk. Overrides
   /// `<min_jerk>` if set.
   ///
-  /// `<max_angular_jerk>`: Sets the maximum angular jerk. Overrides
+  /// - `<max_linear_jerk>`: Sets the maximum linear jerk. Overrides
+  /// `<max_jerk>` if set.
+  ///
+  /// - `<min_angular_jerk>`: Sets the minimum angular jerk. Overrides
+  /// `<min_jerk>` if set.
+  ///
+  /// - `<max_angular_jerk>`: Sets the maximum angular jerk. Overrides
   /// `<max_jerk>` if set.
   class DiffDrive
       : public System,

--- a/src/systems/elevator/Elevator.hh
+++ b/src/systems/elevator/Elevator.hh
@@ -69,37 +69,37 @@ class ElevatorPrivate;
 ///
 /// ## System Parameters
 ///
-/// `<update_rate>`: System update rate. This element is optional and the
+/// - `<update_rate>`: System update rate. This element is optional and the
 /// default value is 10Hz. A value of zero gets translated to the simulation
 /// rate (no throttling for the system).
 ///
-/// `<floor_link_prefix>`: Prefix in the names of the links that function as
+/// - `<floor_link_prefix>`: Prefix in the names of the links that function as
 /// a reference for each floor level. When the elevator is requested to move
 /// to a given floor level, the cabin is commanded to move to the height of
 /// the corresponding floor link. The names of the links will be expected to
 /// be `{prerix}i`, where \f$i=[0,N)\f$ and N is the number of floors. This
 /// element is optional and the default value is `floor_`.
 ///
-/// `<door_joint_prefix>`: Prefix in the names of the joints that control the
+/// - `<door_joint_prefix>`: Prefix in the names of the joints that control the
 /// doors of the elevator. The names of the joints will be expected to be
 /// `{prerix}i`, where \f$i=[0,N)\f$ and N is the number of floors. This
 /// element is optional and the default value is `door_`.
 ///
-/// `<cabin_joint>`: Name of the joint that controls the position of the
+/// - `<cabin_joint>`: Name of the joint that controls the position of the
 /// cabin. This element is optional and the default value is `lift`.
 ///
-/// `<cmd_topic>`: Topic to which this system will subscribe in order to
+/// - `<cmd_topic>`: Topic to which this system will subscribe in order to
 /// receive command messages. This element is optional and the default value
 /// is `/model/{model_name}/cmd`.
 ///
-/// `<state_topic>`: Topic on which this system will publish state (current
+/// - `<state_topic>`: Topic on which this system will publish state (current
 /// floor) messages. This element is optional and the default value is
 /// `/model/{model_name}/state`.
 ///
-/// `<state_publish_rate>`: State publication rate. This rate is bounded by
+/// - `<state_publish_rate>`: State publication rate. This rate is bounded by
 /// `<update_rate>`. This element is optional and the default value is 5Hz.
 ///
-/// `<open_door_wait_duration>`: Time to wait with a door open before the door
+/// - `<open_door_wait_duration>`: Time to wait with a door open before the door
 /// closes. This element is optional and the default value is 5 sec.
 class GZ_SIM_VISIBLE Elevator : public System,
                                          public ISystemConfigure,

--- a/src/systems/environment_preload/EnvironmentPreload.hh
+++ b/src/systems/environment_preload/EnvironmentPreload.hh
@@ -32,8 +32,9 @@ namespace systems
 {
   class EnvironmentPreloadPrivate;
 
-  /// \class EnvironmentPreload EnvironmentPreload.hh
-  ///     gz/sim/systems/EnvironmentPreload.hh
+  /** \class EnvironmentPreload EnvironmentPreload.hh \
+   * gz/sim/systems/EnvironmentPreload.hh
+  **/
   /// \brief A plugin to preload an Environment component
   /// into the ECM upon simulation start-up.
   class EnvironmentPreload :

--- a/src/systems/follow_actor/FollowActor.hh
+++ b/src/systems/follow_actor/FollowActor.hh
@@ -35,24 +35,23 @@ namespace systems
   /// \class FollowActor FollowActor.hh gz/sim/systems/FollowActor.hh
   /// \brief Make an actor follow a target entity in the world.
   ///
-  /// ## SDF parameters
+  /// ## System Parameters
   ///
-  /// <target>: Name of entity to follow.
+  /// - `<target>`: Name of entity to follow.
   ///
-  /// <min_distance>: Distance in meters to keep from target's origin.
+  /// - `<min_distance>`: Distance in meters to keep from target's origin.
   ///
-  /// <max_distance>: Distance in meters from target's origin when to stop
-  ///                 following. When the actor is back within range it starts
-  ///                 following again.
+  /// - `<max_distance>`: Distance in meters from target's origin when to stop
+  ///   following. When the actor is back within range it starts following
+  ///   again.
   ///
-  /// <velocity>: Actor's velocity in m/s
+  /// - `<velocity>`: Actor's velocity in m/s
   ///
-  /// <animation>: Actor's animation to play. If empty, the first animation in
-  ///              the model will be used.
+  /// - `<animation>`: Actor's animation to play. If empty, the first animation
+  ///   in the model will be used.
   ///
-  /// <animation_x_vel>: Velocity of the animation on the X axis. Used to
-  ///                    coordinate translational motion with the actor's
-  ///                    animation.
+  /// - `<animation_x_vel>`: Velocity of the animation on the X axis. Used to
+  ///   coordinate translational motion with the actor's animation.
   class FollowActor:
     public System,
     public ISystemConfigure,

--- a/src/systems/hydrodynamics/Hydrodynamics.hh
+++ b/src/systems/hydrodynamics/Hydrodynamics.hh
@@ -40,7 +40,7 @@ namespace systems
   /// forces like linear and quadratic drag, buoyancy (not provided by this
   /// plugin), etc.
   ///
-  /// # System Parameters
+  /// ## System Parameters
   /// The exact description of these parameters can be found on p. 37 and
   /// p. 43 of Fossen's book. They are used to calculate added mass, linear and
   /// quadratic drag and coriolis force.

--- a/src/systems/joint_controller/JointController.hh
+++ b/src/systems/joint_controller/JointController.hh
@@ -37,56 +37,60 @@ namespace systems
   ///
   /// ## System Parameters
   ///
-  /// `<joint_name>` The name of the joint to control. Required parameter.
+  /// - `<joint_name>` The name of the joint to control. Required parameter.
   ///  Can also include multiple `<joint_name>` for identical joints.
   ///
-  /// `<use_force_commands>` True to enable the controller implementation
+  /// - `<use_force_commands>` True to enable the controller implementation
   /// using force commands. If this parameter is not set or is false, the
   /// controller will use velocity commands internally.
   ///
-  /// `<use_actuator_msg>` True to enable the use of actuator message
+  /// - `<use_actuator_msg>` True to enable the use of actuator message
   /// for velocity command. The actuator msg is an array of floats for
   /// position, velocity and normalized commands. Relies on
   /// `<actuator_number>` for the index of the velocity actuator and
   /// defaults to topic "/actuators" when `topic` or `subtopic not set.
   ///
-  /// `<actuator_number>` used with `<use_actuator_msg>` to set
+  /// - `<actuator_number>` used with `<use_actuator_msg>` to set
   /// the index of the velocity actuator.
   ///
-  /// `<topic>` Topic to receive commands in. Defaults to
+  /// - `<topic>` Topic to receive commands in. Defaults to
   ///     `/model/<model_name>/joint/<joint_name>/cmd_vel`.
   ///
-  /// `<sub_topic>` Sub topic to receive commands in.
-  ///  Defaults to "/model/<model_name>/<sub_topic>".
+  /// - `<sub_topic>` Sub topic to receive commands in.
+  /// Defaults to "/model/<model_name>/<sub_topic>".
   ///
-  /// `<initial_velocity>` Velocity to start with.
+  /// - `<initial_velocity>` Velocity to start with.
   ///
-  /// ### Velocity mode: No additional parameters are required.
+  /// ### Velocity mode
   ///
-  /// ### Force mode: The controller accepts the next optional parameters:
+  /// No additional parameters are required.
   ///
-  /// `<p_gain>` The proportional gain of the PID.
-  ///  The default value is 1.
+  /// ### Force mode
   ///
-  /// `<i_gain>` The integral gain of the PID.
-  ///  The default value is 0.
+  /// The controller accepts the next optional parameters:
   ///
-  /// `<d_gain>` The derivative gain of the PID.
-  ///  The default value is 0.
+  /// - `<p_gain>` The proportional gain of the PID.
+  /// The default value is 1.
   ///
-  /// `<i_max>` The integral upper limit of the PID.
-  ///  The default value is 1.
+  /// - `<i_gain>` The integral gain of the PID.
+  /// The default value is 0.
   ///
-  /// `<i_min>` The integral lower limit of the PID.
-  ///  The default value is -1.
+  /// - `<d_gain>` The derivative gain of the PID.
+  /// The default value is 0.
   ///
-  /// `<cmd_max>` Output max value of the PID.
-  ///  The default value is 1000.
+  /// - `<i_max>` The integral upper limit of the PID.
+  /// The default value is 1.
   ///
-  /// `<cmd_min>` Output min value of the PID.
-  ///  The default value is -1000.
+  /// - `<i_min>` The integral lower limit of the PID.
+  /// The default value is -1.
   ///
-  /// `<cmd_offset>` Command offset (feed-forward) of the PID.
+  /// - `<cmd_max>` Output max value of the PID.
+  /// The default value is 1000.
+  ///
+  /// - `<cmd_min>` Output min value of the PID.
+  /// The default value is -1000.
+  ///
+  /// - `<cmd_offset>` Command offset (feed-forward) of the PID.
   /// The default value is 0.
   class JointController
       : public System,

--- a/src/systems/joint_position_controller/JointPositionController.hh
+++ b/src/systems/joint_position_controller/JointPositionController.hh
@@ -46,56 +46,56 @@ namespace systems
   ///
   /// ## System Parameters
   ///
-  /// `<joint_name>` The name of the joint to control. Required parameter.
-  ///  Can also include multiple `<joint_name>` for identical joints.
+  /// - `<joint_name>` The name of the joint to control. Required parameter.
+  /// Can also include multiple `<joint_name>` for identical joints.
   ///
-  /// `<joint_index>` Axis of the joint to control. Optional parameter.
-  ///  The default value is 0.
+  /// - `<joint_index>` Axis of the joint to control. Optional parameter.
+  /// The default value is 0.
   ///
-  /// `<use_actuator_msg>` True to enable the use of actutor message
+  /// - `<use_actuator_msg>` True to enable the use of actutor message
   /// for position command. Relies on `<actuator_number>` for the
   /// index of the position actuator and defaults to topic "/actuators".
   ///
-  /// `<actuator_number>` used with `<use_actuator_commands>` to set
+  /// - `<actuator_number>` used with `<use_actuator_commands>` to set
   /// the index of the position actuator.
   ///
-  /// `<p_gain>` The proportional gain of the PID. Optional parameter.
-  ///  The default value is 1.
+  /// - `<p_gain>` The proportional gain of the PID. Optional parameter.
+  /// The default value is 1.
   ///
-  /// `<i_gain>` The integral gain of the PID. Optional parameter.
-  ///  The default value is 0.1.
+  /// - `<i_gain>` The integral gain of the PID. Optional parameter.
+  /// The default value is 0.1.
   ///
-  /// `<d_gain>` The derivative gain of the PID. Optional parameter.
-  ///  The default value is 0.01
+  /// - `<d_gain>` The derivative gain of the PID. Optional parameter.
+  /// The default value is 0.01
   ///
-  /// `<i_max>` The integral upper limit of the PID. Optional parameter.
-  ///  The default value is 1.
+  /// - `<i_max>` The integral upper limit of the PID. Optional parameter.
+  /// The default value is 1.
   ///
-  /// `<i_min>` The integral lower limit of the PID. Optional parameter.
-  ///  The default value is -1.
+  /// - `<i_min>` The integral lower limit of the PID. Optional parameter.
+  /// The default value is -1.
   ///
-  /// `<cmd_max>` Output max value of the PID. Optional parameter.
-  ///  The default value is 1000.
+  /// - `<cmd_max>` Output max value of the PID. Optional parameter.
+  /// The default value is 1000.
   ///
-  /// `<cmd_min>` Output min value of the PID. Optional parameter.
-  ///  The default value is -1000.
+  /// - `<cmd_min>` Output min value of the PID. Optional parameter.
+  /// The default value is -1000.
   ///
-  /// `<cmd_offset>` Command offset (feed-forward) of the PID. Optional
+  /// - `<cmd_offset>` Command offset (feed-forward) of the PID. Optional
   /// parameter. The default value is 0.
   ///
-  /// `<use_velocity_commands>` Bypasses the PID and creates a perfect
+  /// - `<use_velocity_commands>` Bypasses the PID and creates a perfect
   /// position. The maximum speed on the joint can be set using the `<cmd_max>`
   /// tag.
   ///
-  /// `<topic>` If you wish to listen on a non-default topic you may specify it
-  /// here, otherwise the controller defaults to listening on
+  /// - `<topic>` If you wish to listen on a non-default topic you may specify
+  /// it here, otherwise the controller defaults to listening on
   /// "/model/<model_name>/joint/<joint_name>/<joint_index>/cmd_pos".
   ///
-  /// `<sub_topic>` If you wish to listen on a sub_topic you may specify it
+  /// - `<sub_topic>` If you wish to listen on a sub_topic you may specify it
   /// here "/model/<model_name>/<sub_topic>".
   ///
-  /// `<initial_position>` Initial position of a joint. Optional parameter.
-  ///  The default value is 0.
+  /// - `<initial_position>` Initial position of a joint. Optional parameter.
+  /// The default value is 0.
   class JointPositionController
       : public System,
         public ISystemConfigure,

--- a/src/systems/joint_state_publisher/JointStatePublisher.hh
+++ b/src/systems/joint_state_publisher/JointStatePublisher.hh
@@ -41,12 +41,13 @@ namespace systems
   /// a model. Use the `<joint_name>` system parameter, described below, to
   /// control which joints are published.
   ///
-  /// # System Parameters
+  /// ## System Parameters
   ///
-  /// `<topic>`: Name of the topic to publish to. This parameter is optional,
+  /// - `<topic>`: Name of the topic to publish to. This parameter is optional,
   /// and if not provided, the joint state will be published to
   /// "/world/<world_name>/model/<model_name>/joint_state".
-  /// `<joint_name>`: Name of a joint to publish. This parameter can be
+  ///
+  /// - `<joint_name>`: Name of a joint to publish. This parameter can be
   /// specified multiple times, and is optional. All joints in a model will
   /// be published if joint names are not specified.
   class JointStatePublisher

--- a/src/systems/joint_traj_control/JointTrajectoryController.hh
+++ b/src/systems/joint_traj_control/JointTrajectoryController.hh
@@ -65,68 +65,68 @@ namespace systems
   ///
   /// ## System Parameters
   ///
-  /// `<topic>` The name of the topic that this plugin subscribes to.
+  /// - `<topic>` The name of the topic that this plugin subscribes to.
   ///  Optional parameter.
   ///  Defaults to "/model/${MODEL_NAME}/joint_trajectory".
   ///
-  /// `<use_header_start_time>` If enabled, trajectory execution begins at the
+  /// - `<use_header_start_time>` If enabled, trajectory execution begins at the
   ///  timestamp contained in the header of received trajectory messages.
   ///  Optional parameter.
   ///  Defaults to false.
   ///
-  /// `<joint_name>` Name of a joint to control.
+  /// - `<joint_name>` Name of a joint to control.
   ///  This parameter can be specified multiple times, i.e. once for each joint.
   ///  Optional parameter.
   ///  Defaults to all 1-axis joints contained in the model SDF (order is kept).
   ///
-  /// `<initial_position>` Initial position of a joint (for position control).
+  /// - `<initial_position>` Initial position of a joint (for position control).
   ///  This parameter can be specified multiple times. Follows joint_name order.
   ///  Optional parameter.
   ///  Defaults to 0 for all joints.
   ///
-  /// `<%s_p_gain>` The proportional gain of the PID.
+  /// - `<%s_p_gain>` The proportional gain of the PID.
   ///  Substitute '%s' for "position" or "velocity" (e.g. "position_p_gain").
   ///  This parameter can be specified multiple times. Follows joint_name order.
   ///  Optional parameter.
   ///  The default value is 0 (disabled).
   ///
-  /// `<%s_i_gain>` The integral gain of the PID. Optional parameter.
+  /// - `<%s_i_gain>` The integral gain of the PID. Optional parameter.
   ///  Substitute '%s' for "position" or "velocity" (e.g. "position_p_gain").
   ///  This parameter can be specified multiple times. Follows joint_name order.
   ///  Optional parameter.
   ///  The default value is 0 (disabled).
   ///
-  /// `<%s_d_gain>` The derivative gain of the PID.
+  /// - `<%s_d_gain>` The derivative gain of the PID.
   ///  Substitute '%s' for "position" or "velocity" (e.g. "position_p_gain").
   ///  This parameter can be specified multiple times. Follows joint_name order.
   ///  Optional parameter.
   ///  The default value is 0 (disabled).
   ///
-  /// `<%s_i_min>` The integral lower limit of the PID.
+  /// - `<%s_i_min>` The integral lower limit of the PID.
   ///  Substitute '%s' for "position" or "velocity" (e.g. "position_p_gain").
   ///  This parameter can be specified multiple times. Follows joint_name order.
   ///  Optional parameter.
   ///  The default value is 0 (no limit if higher than `%s_i_max`).
   ///
-  /// `<%s_i_max>` The integral upper limit of the PID.
+  /// - `<%s_i_max>` The integral upper limit of the PID.
   ///  Substitute '%s' for "position" or "velocity" (e.g. "position_p_gain").
   ///  This parameter can be specified multiple times. Follows joint_name order.
   ///  Optional parameter.
   ///  The default value is -1 (no limit if lower than `%s_i_min`).
   ///
-  /// `<%s_cmd_min>` Output min value of the PID.
+  /// - `<%s_cmd_min>` Output min value of the PID.
   ///  Substitute '%s' for "position" or "velocity" (e.g. "position_p_gain").
   ///  This parameter can be specified multiple times. Follows joint_name order.
   ///  Optional parameter.
   ///  The default value is 0 (no limit if higher than `%s_i_max`).
   ///
-  /// `<%s_cmd_max>` Output max value of the PID.
+  /// - `<%s_cmd_max>` Output max value of the PID.
   ///  Substitute '%s' for "position" or "velocity" (e.g. "position_p_gain").
   ///  This parameter can be specified multiple times. Follows joint_name order.
   ///  Optional parameter.
   ///  The default value is -1 (no limit if lower than `%s_i_min`).
   ///
-  /// `<%s_cmd_offset>` Command offset (feed-forward) of the PID.
+  /// - `<%s_cmd_offset>` Command offset (feed-forward) of the PID.
   ///  Substitute '%s' for "position" or "velocity" (e.g. "position_p_gain").
   ///  This parameter can be specified multiple times. Follows joint_name order.
   ///  Optional parameter.

--- a/src/systems/kinetic_energy_monitor/KineticEnergyMonitor.hh
+++ b/src/systems/kinetic_energy_monitor/KineticEnergyMonitor.hh
@@ -39,20 +39,20 @@ namespace systems
   /// that surpasses a specific threshold.
   /// This system can be used to detect when a model could be damaged.
   ///
-  /// # System Parameters
+  /// ## System Parameters
   ///
-  /// `<link_name>`: Name of the link to monitor. This name must match
+  /// - `<link_name>`: Name of the link to monitor. This name must match
   /// a name of link within the model.
   ///
-  /// `<kinetic_energy_threshold>`: Threshold, in Joule (J), after which
+  /// - `<kinetic_energy_threshold>`: Threshold, in Joule (J), after which
   /// a message is generated on `<topic>` with the kinetic energy value that
   /// surpassed the threshold.
   ///
-  /// `<topic>`: Custom topic that this system will publish to when kinetic
+  /// - `<topic>`: Custom topic that this system will publish to when kinetic
   /// energy surpasses the threshold. This element if optional, and the
   /// default value is `/model/{name_of_model}/kinetic_energy`.
   ///
-  /// # Example Usage
+  /// ## Example Usage
   ///
   /** \verbatim
    <model name="sphere">

--- a/src/systems/lens_flare/LensFlare.hh
+++ b/src/systems/lens_flare/LensFlare.hh
@@ -32,20 +32,22 @@ namespace systems
   /// \brief Private data class for LensFlare Plugin
   class LensFlarePrivate;
 
-    /** \class LensFlare LensFlare.hh \
+  /** \class LensFlare LensFlare.hh \
    * gz/sim/systems/LensFlare.hh
   **/
   /// \brief Add lens flare effects to the camera output as a render pass
-  /// The system takes in the following parameter:
-  ///   <scale> Sets the scale of the lens flare. If this is
-  ///           not specified, the value defaults to 1.0
   ///
-  ///   <color> Sets the color of the lens flare. The default
-  ///           is {1.4, 1.2, 1.0}
+  /// ## System Parameters
   ///
-  ///   <occlusion_steps> Sets the number of steps to take in
-  ///                     each direction to check for occlusions.
-  ///                     The default value is set to 10. Use 0 to disable
+  /// - `<scale>`: Sets the scale of the lens flare. If this is
+  ///   not specified, the value defaults to 1.0
+  ///
+  /// - `<color>`: Sets the color of the lens flare. The default
+  ///   is {1.4, 1.2, 1.0}
+  ///
+  /// - `<occlusion_steps>`: Sets the number of steps to take in
+  ///   each direction to check for occlusions.
+  ///   The default value is set to 10. Use 0 to disable
 
   class LensFlare:
     public System,

--- a/src/systems/lift_drag/LiftDrag.hh
+++ b/src/systems/lift_drag/LiftDrag.hh
@@ -35,34 +35,35 @@ namespace systems
   /// \brief The LiftDrag system computes lift and drag forces enabling
   /// simulation of aerodynamic robots.
   ///
-  /// The following parameters are used by the system:
+  /// ## System Parameters
   ///
-  /// link_name   : Name of the link affected by the group of lift/drag
-  ///               properties. This can be a scoped name to reference links in
-  ///               nested models. \sa entitiesFromScopedName to learn more
-  ///               about scoped names.
-  /// air_density : Density of the fluid this model is suspended in.
-  /// area        : Surface area of the link.
-  /// a0          : The initial "alpha" or initial angle of attack. a0 is also
-  ///               the y-intercept of the alpha-lift coefficient curve.
-  /// cla         : The ratio of the coefficient of lift and alpha slope before
-  ///               stall. Slope of the first portion of the alpha-lift
-  ///               coefficient curve.
-  /// cda         : The ratio of the coefficient of drag and alpha slope before
-  ///               stall.
-  /// cp          : Center of pressure. The forces due to lift and drag will be
-  ///               applied here.
-  /// forward     : 3-vector representing the forward direction of motion in the
-  ///               link frame.
-  /// upward      : 3-vector representing the direction of lift or drag.
-  /// alpha_stall : Angle of attack at stall point; the peak angle of attack.
-  /// cla_stall   : The ratio of coefficient of lift and alpha slope after
-  ///               stall.  Slope of the second portion of the alpha-lift
-  ///               coefficient curve.
-  /// cda_stall   : The ratio of coefficient of drag and alpha slope after
-  ///               stall.
-  /// control_joint_name: Name of joint that actuates a control surface for this
-  ///                     lifting body (Optional)
+  /// - `<link_name>`: Name of the link affected by the group of lift/drag
+  ///   properties. This can be a scoped name to reference links in
+  ///   nested models. \sa entitiesFromScopedName to learn more
+  ///   about scoped names.
+  /// - `<air_density>`: Density of the fluid this model is suspended in.
+  /// - `<area>`: Surface area of the link.
+  /// - `<a0>`: The initial "alpha" or initial angle of attack. a0 is also
+  ///   the y-intercept of the alpha-lift coefficient curve.
+  /// - `<cla>`: The ratio of the coefficient of lift and alpha slope before
+  ///   stall. Slope of the first portion of the alpha-lift
+  ///   coefficient curve.
+  /// - `<cda>`: The ratio of the coefficient of drag and alpha slope before
+  ///   stall.
+  /// - `<cp>`: Center of pressure. The forces due to lift and drag will be
+  ///   applied here.
+  /// - `<forward>`: 3-vector representing the forward direction of motion in
+  ///   the link frame.
+  /// - `<upward>`: 3-vector representing the direction of lift or drag.
+  /// - `<alpha_stall>`: Angle of attack at stall point; the peak angle of
+  ///   attack.
+  /// - `<cla_stall>`: The ratio of coefficient of lift and alpha slope after
+  ///   stall.  Slope of the second portion of the alpha-lift
+  ///   coefficient curve.
+  /// - `<cda_stall>`: The ratio of coefficient of drag and alpha slope after
+  ///   stall.
+  /// - `<control_joint_name>`: Name of joint that actuates a control surface
+  ///   for this lifting body (Optional)
   class LiftDrag
       : public System,
         public ISystemConfigure,

--- a/src/systems/log/LogPlayback.hh
+++ b/src/systems/log/LogPlayback.hh
@@ -33,8 +33,9 @@ namespace systems
   // Forward declarations.
   class LogPlaybackPrivate;
 
-  /// \class LogPlayback LogPlayback.hh
-  ///   gz/sim/systems/log/LogPlayback.hh
+  /** \class LogPlayback LogPlayback.hh \
+   *    gz/sim/systems/log/LogPlayback.hh
+  **/
   /// \brief Log state playback
   class LogPlayback:
     public System,

--- a/src/systems/log_video_recorder/LogVideoRecorder.hh
+++ b/src/systems/log_video_recorder/LogVideoRecorder.hh
@@ -38,18 +38,21 @@ namespace systems
   /// \brief System which recordings videos from log playback
   /// There are two ways to specify what entities in the log playback to follow
   /// and record videos for: 1) by entity name and 2) by region. See the
-  /// following parameters:
-  ///   - `<entity>`         Name of entity to record.
-  ///   - `<region>`         Axis-aligned box where entities are at start of log
-  ///     + `<min>` Min corner position of box region.
-  ///     + `<max>`  Max corner position of box region.
-  ///   - `<start_time>`     Sim time when recording should start
-  ///   - `<end_time>`       Sim time when recording should end
-  ///   - `<exit_on_finish>` Exit gz-sim when log playback recording ends
+  /// system parameters.
   ///
   /// When recording is finished. An `end` string will be published to the
   /// `/log_video_recorder/status` topic and the videos are saved to a
   /// timestamped directory
+  ///
+  /// ## System Parameters
+  ///
+  /// - `<entity>`         Name of entity to record.
+  /// - `<region>`         Axis-aligned box where entities are at start of log
+  ///   + `<min>` Min corner position of box region.
+  ///   + `<max>`  Max corner position of box region.
+  /// - `<start_time>`     Sim time when recording should start
+  /// - `<end_time>`       Sim time when recording should end
+  /// - `<exit_on_finish>` Exit gz-sim when log playback recording ends
   class LogVideoRecorder final:
     public System,
     public ISystemConfigure,

--- a/src/systems/logical_audio_sensor_plugin/LogicalAudioSensorPlugin.hh
+++ b/src/systems/logical_audio_sensor_plugin/LogicalAudioSensorPlugin.hh
@@ -42,6 +42,8 @@ namespace systems
   /// such as speakers. This plugin is meant to check if audio
   /// could theoretically be heard at a certain location or not.
   ///
+  /// ## System Parameters
+  ///
   /// Secifying an audio source via SDF is done as follows:
   ///
   /// - `<source>` A new audio source in the environment, which has the

--- a/src/systems/mecanum_drive/MecanumDrive.hh
+++ b/src/systems/mecanum_drive/MecanumDrive.hh
@@ -35,58 +35,59 @@ namespace systems
   /// \brief Mecanum drive controller which can be attached to a model
   /// with any number of front/back left/right wheels.
   ///
-  /// # System Parameters
+  /// ## System Parameters
   ///
-  /// `<front_left_joint>`: Name of a joint that controls a front left wheel.
+  /// - `<front_left_joint>`: Name of a joint that controls a front left wheel.
   /// This element can appear multiple times, and must appear at least once.
   ///
-  /// `<front_right_joint>`: Name of a joint that controls a front right wheel.
+  /// - `<front_right_joint>`: Name of a joint that controls a front right
+  /// wheel. This element can appear multiple times, and must appear at least
+  /// once.
+  ///
+  /// - `<back_left_joint>`: Name of a joint that controls a back left wheel.
   /// This element can appear multiple times, and must appear at least once.
   ///
-  /// `<back_left_joint>`: Name of a joint that controls a back left wheel.
+  /// - `<back_right_joint>`: Name of a joint that controls a back right wheel.
   /// This element can appear multiple times, and must appear at least once.
   ///
-  /// `<back_right_joint>`: Name of a joint that controls a back right wheel.
-  /// This element can appear multiple times, and must appear at least once.
-  ///
-  /// `<wheelbase>`: Longitudinal distance between front and back wheels,
+  /// - `<wheelbase>`: Longitudinal distance between front and back wheels,
   /// in meters. This element is optional, although it is recommended to be
   /// included with an appropriate value. The default value is 1.0m.
   ///
-  /// `<wheel_separation>`: Lateral distance between left and right wheels,
+  /// - `<wheel_separation>`: Lateral distance between left and right wheels,
   /// in meters. This element is optional, although it is recommended to be
   /// included with an appropriate value. The default value is 1.0m.
   ///
-  /// `<wheel_radius>`: Wheel radius in meters. This element is optional,
+  /// - `<wheel_radius>`: Wheel radius in meters. This element is optional,
   /// although it is recommended to be included with an appropriate value. The
   /// default value is 0.2m.
   ///
-  /// `<odom_publish_frequency>`: Odometry publication frequency. This
+  /// - `<odom_publish_frequency>`: Odometry publication frequency. This
   /// element is optional, and the default value is 50Hz.
   ///
-  /// `<topic>`: Custom topic that this system will subscribe to in order to
+  /// - `<topic>`: Custom topic that this system will subscribe to in order to
   /// receive command velocity messages. This element if optional, and the
   /// default value is `/model/{name_of_model}/cmd_vel`.
   ///
-  /// `<odom_topic>`: Custom topic on which this system will publish odometry
+  /// - `<odom_topic>`: Custom topic on which this system will publish odometry
   /// messages. This element if optional, and the default value is
   /// `/model/{name_of_model}/odometry`.
   ///
-  /// `<tf_topic>`: Custom topic on which this system will publish the
+  /// - `<tf_topic>`: Custom topic on which this system will publish the
   /// transform from `frame_id` to `child_frame_id`. This element if optional,
   ///  and the default value is `/model/{name_of_model}/tf`.
   ///
-  /// `<frame_id>`: Custom `frame_id` field that this system will use as the
+  /// - `<frame_id>`: Custom `frame_id` field that this system will use as the
   /// origin of the odometry transform in both the `<tf_topic>`
   /// `gz.msgs.Pose_V` message and the `<odom_topic>`
   /// `gz.msgs.Odometry` message. This element if optional, and the
   /// default value is `{name_of_model}/odom`.
   ///
-  /// `<child_frame_id>`: Custom `child_frame_id` that this system will use as
+  /// - `<child_frame_id>`: Custom `child_frame_id` that this system will use as
   /// the target of the odometry trasnform in both the `<tf_topic>`
   /// `gz.msgs.Pose_V` message and the `<odom_topic>`
   /// `gz.msgs.Odometry` message. This element if optional,
-  ///  and the default value is `{name_of_model}/{name_of_link}`.
+  /// and the default value is `{name_of_model}/{name_of_link}`.
   class MecanumDrive
       : public System,
         public ISystemConfigure,

--- a/src/systems/multicopter_control/MulticopterVelocityControl.hh
+++ b/src/systems/multicopter_control/MulticopterVelocityControl.hh
@@ -69,84 +69,85 @@ namespace systems
   ///  * Maximum acceleration limit
   ///  * Can be enabled/disabled at runtime.
   ///
-  /// # Parameters
-  /// The following parameters are used by the system
+  /// ## System Parameters
   ///
-  /// robotNamespace: All gz-transport topics subscribed to and published by
-  ///  the system will be prefixed by this string. This is a required parameter.
+  /// - `robotNamespace`: All gz-transport topics subscribed to and published by
+  /// the system will be prefixed by this string. This is a required parameter.
   ///
-  /// commandSubTopic: The system subscribes to this topic to receive twist
+  /// - `commandSubTopic`: The system subscribes to this topic to receive twist
   /// commands. The default value is "cmd_vel".
   ///
-  /// enableSubTopic: Topic to enable or disable the system. If false, the
+  /// - `enableSubTopic`: Topic to enable or disable the system. If false, the
   /// controller sends a zero rotor velocity command once and gets disabled. If
   /// the vehicle is in the air, disabling the controller will cause it to fall.
   /// If true, the controller becomes enabled and waits for a twist message. The
   /// default value is "enable".
   ///
-  /// comLinkName: The link associated with the center of mass of the vehicle.
-  /// That is, the origin of the center of mass may not be on this link, but
-  /// this link and the center of mass frame have a fixed transform. Almost
-  /// always this should be the base_link of the vehicle. This is a required
-  /// parameter.
+  /// - `comLinkName`: The link associated with the center of mass of the
+  /// vehicle. That is, the origin of the center of mass may not be on this
+  /// link, but this link and the center of mass frame have a fixed transform.
+  /// Almost always this should be the base_link of the vehicle. This is a
+  /// required parameter.
   ///
-  /// velocityGain (x, y, z): Proportional gain on linear velocity.
+  /// - `velocityGain` (x, y, z): Proportional gain on linear velocity.
   /// attitudeGain (roll, pitch, yaw): Proportional gain on attitude. This
   /// parameter is scaled by the inverse of the inertia matrix so two vehicles
   /// with different inertial characteristics may have the same gain if other
   /// parameters, such as the forceConstant, are kept the same. This is a
   /// required parameter.
   ///
-  /// angularRateGain (roll, pitch, yaw): Proportional gain on angular velocity.
-  /// Even though only the yaw angle velocity is controlled, proper gain values
-  /// for roll and pitch velocities must be specified. This parameter is scaled
-  /// by the inverse of the inertia matrix so two vehicles with different
-  /// inertial characteristics may have the same gain if other parameters, such
-  /// as the forceConstant, are kept the same. This is a required parameter.
+  /// - `angularRateGain` (roll, pitch, yaw): Proportional gain on angular
+  /// velocity. Even though only the yaw angle velocity is controlled, proper
+  /// gain values for roll and pitch velocities must be specified. This
+  /// parameter is scaled by the inverse of the inertia matrix so two vehicles
+  /// with different inertial characteristics may have the same gain if other
+  /// parameters, such as the forceConstant, are kept the same. This is a
+  /// required parameter.
   ///
-  /// maxLinearAcceleration (x, y, z): Maximum limit on linear acceleration.
+  /// - `maxLinearAcceleration` (x, y, z): Maximum limit on linear acceleration.
   /// The default value is DBL_MAX.
   ///
-  /// maximumLinearVelocity (x, y, z): Maximum commanded linear velocity. The
-  /// default value is DBL_MAX.
-
-  /// maximumAngularVelocity (roll, pitch, yaw): Maximum commanded angular
+  /// - `maximumLinearVelocity` (x, y, z): Maximum commanded linear velocity.
+  /// The default value is DBL_MAX.
+  ///
+  /// - `maximumAngularVelocity` (roll, pitch, yaw): Maximum commanded angular
   /// velocity. The default value is DBL_MAX.
   ///
-  /// linearVelocityNoiseMean (x, y, z): Mean of Gaussian noise on linear
+  /// - `linearVelocityNoiseMean` (x, y, z): Mean of Gaussian noise on linear
   /// velocity values obtained from simulation. The default value is (0, 0, 0).
   ///
-  /// linearVelocityNoiseStdDev (x, y, z): Standard deviation of Gaussian noise
-  /// on linear values obtained from simulation. A value of 0 implies noise is
-  /// NOT applied to the component. The default value is (0, 0, 0).
+  /// - `linearVelocityNoiseStdDev` (x, y, z): Standard deviation of Gaussian
+  /// noise on linear values obtained from simulation. A value of 0 implies
+  /// noise is NOT applied to the component. The default value is (0, 0, 0).
   ///
-  /// angularVelocityNoiseMean (roll, pitch, yaw): Mean of Gaussian noise on
+  /// - `angularVelocityNoiseMean` (roll, pitch, yaw): Mean of Gaussian noise on
   /// angular velocity values obtained from simulation. The default value is (0,
   /// 0, 0).
   ///
-  /// angularVelocityNoiseStdDev (roll, pitch, yaw): Standard deviation of
+  /// - `angularVelocityNoiseStdDev` (roll, pitch, yaw): Standard deviation of
   /// gaussian noise on angular velocity values obtained from simulation. A
   /// value of 0 implies noise is NOT applied to the component. The default
   /// value is (0, 0, 0).
   ///
-  /// rotorConfiguration: This contains a list of `<rotor>` elements for each
-  /// rotor in the vehicle. This is a required parameter.
+  /// - `rotorConfiguration`: This contains a list of `<rotor>` elements for
+  /// each rotor in the vehicle. This is a required parameter.
   ///
-  ///    rotor: Contains information about a rotor in the vehicle. All the
+  ///    - `rotor`: Contains information about a rotor in the vehicle. All the
   ///    elements of `<rotor>` are required parameters.
   ///
-  ///      jointName: The name of the joint associated with this rotor.
+  ///      - `jointName`: The name of the joint associated with this rotor.
   ///
-  ///      forceConstant: A constant that multiplies with the square of the
+  ///      - `forceConstant`: A constant that multiplies with the square of the
   ///      rotor's velocity to compute its thrust.
   ///
-  ///      momentConstant: A constant the multiplies with the rotor's thrust to
-  ///      compute its moment.
+  ///      - `momentConstant`: A constant the multiplies with the rotor's
+  ///      thrust to compute its moment.
   ///
-  ///      direction: Direction of rotation of the rotor. +1 is counterclockwise
-  ///      and -1 is clockwise.
+  ///      - `direction`: Direction of rotation of the rotor. +1 is
+  ///      counterclockwise and -1 is clockwise.
   ///
-  /// # Examples
+  /// ## Examples
+  ///
   /// See examples/worlds/quadcopter.sdf for a demonstration.
   ///
   class MulticopterVelocityControl

--- a/src/systems/pose_publisher/PosePublisher.hh
+++ b/src/systems/pose_publisher/PosePublisher.hh
@@ -37,33 +37,27 @@ namespace systems
   /// messages, or a single gz::msgs::Pose_V message if
   /// "use_pose_vector_msg" is true.
   ///
-  /// The following parameters are used by the system:
+  /// ## System Parameters
   ///
-  /// publish_link_pose         : Set to true to publish link pose
-  /// publish_visual_pose       : Set to true to publish visual pose
-  /// publish_collision_pose    : Set to true to publish collision pose
-  /// publish_sensor_pose       : Set to true to publish sensor pose
-  /// publish_model_pose        : Set to true to publish model pose.
-  /// publish_nested_model_pose : Set to true to publish nested model pose. The
-  ///                             pose of the model that contains this system is
-  ///                             also published unless publish_model_pose is
-  ///                             set to false
-  /// use_pose_vector_msg       : Set to true to publish an
-  ///                             gz::msgs::Pose_V message instead of
-  ///                             mulitple gz::msgs::Pose messages.
-  /// update_frequency          : Frequency of pose publications in Hz. A
-  ///                             negative frequency publishes as fast as
-  ///                             possible (i.e, at the rate of the simulation
-  ///                             step)
-  /// static_publisher          : Set to true to publish static poses on
-  ///                             a "<scoped_entity_name>/pose_static" topic.
-  ///                             This will cause only dynamic poses to be
-  ///                             published on the "<scoped_entity_name>/pose"
-  ///                             topic.
-  /// static_update_frequency   : Frequency of static pose publications in Hz. A
-  ///                             negative frequency publishes as fast as
-  ///                             possible (i.e, at the rate of the simulation
-  ///                             step).
+  /// - `<publish_link_pose>`: Set to true to publish link pose
+  /// - `<publish_visual_pose>`: Set to true to publish visual pose
+  /// - `<publish_collision_pose>`: Set to true to publish collision pose
+  /// - `<publish_sensor_pose>`: Set to true to publish sensor pose
+  /// - `<publish_model_pose>`: Set to true to publish model pose.
+  /// - `<publish_nested_model_pose>`: Set to true to publish nested model
+  ///   pose. The pose of the model that contains this system is also published
+  ///   unless publish_model_pose is set to false
+  /// - `<use_pose_vector_msg>`: Set to true to publish a gz::msgs::Pose_V
+  ///   message instead of mulitple gz::msgs::Pose messages.
+  /// - `<update_frequency>`: Frequency of pose publications in Hz. A negative
+  ///   frequency publishes as fast as possible (i.e, at the rate of the
+  ///   simulation step)
+  /// - `<static_publisher>`: Set to true to publish static poses on a
+  ///   "<scoped_entity_name>/pose_static" topic. This will cause only dynamic
+  ///   poses to be published on the "<scoped_entity_name>/pose" topic.
+  /// - `<static_update_frequency>`: Frequency of static pose publications in
+  ///   Hz. A negative frequency publishes as fast as possible (i.e, at the
+  ///   rate of the simulation step).
   class PosePublisher
       : public System,
         public ISystemConfigure,

--- a/src/systems/user_commands/UserCommands.hh
+++ b/src/systems/user_commands/UserCommands.hh
@@ -38,38 +38,38 @@ namespace systems
   /// \todo(louise) In the future, an interface undo/redo commands will also
   /// be provided.
   ///
-  /// # Spawn entity
+  /// ### Spawn entity
   ///
   /// * **Service**: `/world/<world name>/create`
-  /// * **Request type*: gz.msgs.EntityFactory
-  /// * **Response type*: gz.msgs.Boolean
+  /// * **Request type**: gz.msgs.EntityFactory
+  /// * **Response type**: gz.msgs.Boolean
   ///
-  /// # Spawn multiple entities
+  /// ### Spawn multiple entities
   ///
   /// This service can spawn multiple entities in the same iteration,
   /// thereby eliminating simulation steps between entity spawn times.
   ///
   /// * **Service**: `/world/<world name>/create_multiple`
-  /// * **Request type*: gz.msgs.EntityFactory_V
-  /// * **Response type*: gz.msgs.Boolean
+  /// * **Request type**: gz.msgs.EntityFactory_V
+  /// * **Response type**: gz.msgs.Boolean
   ///
-  /// # Set entity pose
+  /// ### Set entity pose
   ///
   /// This service set the pose of entities
   ///
   /// * **Service**: `/world/<world name>/set_pose`
-  /// * **Request type*: gz.msgs.Pose
-  /// * **Response type*: gz.msgs.Boolean
+  /// * **Request type**: gz.msgs.Pose
+  /// * **Response type**: gz.msgs.Boolean
   ///
-  /// # Set multiple entity poses
+  /// ### Set multiple entity poses
   ///
   /// This service set the pose of multiple entities
   ///
   /// * **Service**: `/world/<world name>/set_pose_vector`
-  /// * **Request type*: gz.msgs.Pose_V
-  /// * **Response type*: gz.msgs.Boolean
+  /// * **Request type**: gz.msgs.Pose_V
+  /// * **Response type**: gz.msgs.Boolean
   ///
-  /// Try some examples described on examples/worlds/empty.sdf
+  /// Try some examples described in examples/worlds/empty.sdf
   class UserCommands final:
     public System,
     public ISystemConfigure,


### PR DESCRIPTION
# 🦟 Bug fix

We were looking to improve the Doxygen pages for system plugins and noticed some huge paragraphs that meant to be bullet lists, and inconsistencies in headings.

This PR standardizes the formatting for SDF parameters for systems starting with letter A to N (which is not to say I will do the same for O to Z, as this isn't really the task I'm tackling... just fixing on the way as I familiarize myself with how systems are documented).
A-N is 46 systems. There are only 24 remaining that others can fight over.

## Summary

This is the standard being adopted (comes from `AckermannSteering`, not because it's the first in the alphabetical list, but because its rendered page looks the best):
- Heading size should be `## System Parameters`, to appear the same size as the preset "Detailed Description" heading
- Parameters should be in bullets, otherwise there's a variety of rendered results, especially when you have sub-bullets too, or if you do a `\sa`, or they are all in one huge paragraph.
- Parameter font should be in code face, ideally surrounded by angle brackets, e.g. `- <param>`
- Most parameters are followed by a colon, as in `- <param>:`, but I let some pass with hyphen, because it wasn't worth the effort.
- I wasn't too picky about indentation after the first line, because it wasn't worth the effort

## To test
```
colcon build --packages-select gz-sim8
```
In a browser, navigate to `build/gz-sim8/doxygen/html/index.html`
Click on the “gz::sim::systems” link.
Look at the corresponding system pages.

Compare to the live render here before the fix: https://gazebosim.org/api/sim/8/

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.