### PR TITLE
Remove direct dependency on libdart in CI 

### DIFF
--- a/.github/ci-focal/before_cmake.sh
+++ b/.github/ci-focal/before_cmake.sh
@@ -1,8 +1,0 @@
-#!/bin/sh -l
-
-set -x
-
-# Needed on Focal to get dart6-data for tests
-apt -y install software-properties-common
-apt-add-repository ppa:dartsim/ppa
-apt -y install dart6-data

--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,10 +1,5 @@
 freeglut3-dev
 libbenchmark-dev
-libdart-collision-ode-dev
-libdart-dev
-libdart-external-ikfast-dev
-libdart-external-odelcpsolver-dev
-libdart-utils-urdf-dev
 libfreeimage-dev
 libglew-dev
 libgz-cmake3-dev


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
Since libdart is a dependency of `libgz-physics`, we shouldn't have to depend on it directly. Currently, the direct dependence is causing build failures https://github.com/gazebosim/docs/actions/runs/6384535565/job/17327390515 (you'll have to read the logs to see the failure).
```
#24 7.289 The following information may help to resolve the situation:
#24 7.289 
#24 7.289 The following packages have unmet dependencies:
#24 7.377  libdart6.13-external-convhull-3d-dev : Breaks: libdart-external-convhull-3d-dev (< 6.14.0) but 6.12.1+dfsg4-11build2 is to be installed
#24 7.381 E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.
```
This also removed `ci-focal` since it's not needed anymore.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
