### PR TITLE
Bump Fuel model version in test

### DIFF
--- a/src/SdfGenerator_TEST.cc
+++ b/src/SdfGenerator_TEST.cc
@@ -544,13 +544,13 @@ TEST_F(ElementUpdateFixture, WorldWithModelsIncludedNotExpanded)
 TEST_F(ElementUpdateFixture, WorldWithModelsIncludedWithInvalidUris)
 {
   const std::string goodUri =
-      "https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack/2";
+      "https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack/3";
 
   // These are URIs that are potentially problematic.
   const std::vector<std::string> fuelUris = {
       // Thes following two URIs are valid, but have a trailing '/'
       "https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack/",
-      "https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack/2/",
+      "https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack/3/",
       // Thes following two URIs are invalid, and will not be saved
       "https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack/"
       "notInt",


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
The Fuel model being tested has been updated on the Fuel server, so tests fail without this fix.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
