### PR TITLE
Merge ign-gazebo3 ➡️  ign-gazebo6

### DIFF
--- a/src/SdfGenerator_TEST.cc
+++ b/src/SdfGenerator_TEST.cc
@@ -644,13 +644,13 @@ TEST_F(ElementUpdateFixture, WorldWithModelsIncludedNotExpanded)
 TEST_F(ElementUpdateFixture, WorldWithModelsIncludedWithInvalidUris)
 {
   const std::string goodUri =
-      "https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack/2";
+      "https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack/3";
 
   // These are URIs that are potentially problematic.
   const std::vector<std::string> fuelUris = {
       // Thes following two URIs are valid, but have a trailing '/'
       "https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack/",
-      "https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack/2/",
+      "https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack/3/",
       // Thes following two URIs are invalid, and will not be saved
       "https://fuel.gazebosim.org/1.0/OpenRobotics/models/Backpack/"
       "notInt",

--- a/test/integration/save_world.cc
+++ b/test/integration/save_world.cc
@@ -419,7 +419,7 @@ TEST_F(SdfGeneratorFixture, ModelWithNestedIncludes)
   ASSERT_NE(nullptr, uri);
   ASSERT_NE(nullptr, uri->GetText());
   EXPECT_EQ(
-    "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Coke Can/2",
+    "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Coke Can/3",
      std::string(uri->GetText()));
 
   name = include->FirstChildElement("name");


### PR DESCRIPTION
# ➡️  Forward port

Port `ign-gazebo3 ` ➡️  `ign-gazebo6`

Branch comparison: https://github.com/gazebosim/gz-sim/compare/ign-gazebo6...ign-gazebo3

This also cherry-picks 409d8c5f81995d52002f304976bcb18c9bf4a6a7 with a small change to fix a test failure.

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)