### PR TITLE
Backport Component Inspector Vector3d layout width fix

### DIFF
--- a/src/gui/plugins/component_inspector/Vector3d.qml
+++ b/src/gui/plugins/component_inspector/Vector3d.qml
@@ -97,6 +97,7 @@ Rectangle {
         GzVector3 {
           id: gzVectorInstance
           Layout.fillWidth: true
+          Layout.preferredWidth: parent.width
           gzUnit: model && model.unit != undefined ? model.unit : 'm'
 
           xValue: model.data[0]


### PR DESCRIPTION


# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/2192

## Summary

Partial backport of https://github.com/gazebosim/gz-sim/pull/1680
* Only backported the Vector3d layout width fix.  
* Pose3d left untouched since it seems to be working fine in ign-gazebo6 (on ubuntu) and there are quite a bit of changes in gz-sim7 so the fix may not apply to ign-gazebo6

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

