### PR TITLE
Relax pose check in flaky ActorTrajectoryNoMesh test

### DIFF
--- a/test/integration/actor_trajectory.cc
+++ b/test/integration/actor_trajectory.cc
@@ -156,9 +156,12 @@ TEST_F(ActorFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(ActorTrajectoryNoMesh))
     std::lock_guard<std::mutex> lock(g_mutex);
     auto it = g_modelPoses.find(boxName);
     auto &poses = it->second;
-    for (unsigned int i = 0; i < poses.size()-1; ++i)
+    for (unsigned int i = 0; i < poses.size()-2; i+=2)
     {
-      EXPECT_NE(poses[i], poses[i+1]);
+      // There could be times when the rendering thread has not updated
+      // between PostUpdates so two consecutive poses may still be the same.
+      // So check for diff between every other pose
+      EXPECT_NE(poses[i], poses[i+2]);
     }
   }
 


### PR DESCRIPTION


# 🦟 Bug fix

Fixes #2186

## Summary

The test fails if the box does not move every iteration. This likely occurs when the rendering thread is not able to update as fast as the main update thread. This PR now checks pose difference between every other pose instead of consecutive poses.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

