### PR TITLE
Backport test fix to garden

### DIFF
--- a/test/integration/save_world.cc
+++ b/test/integration/save_world.cc
@@ -422,7 +422,7 @@ TEST_F(SdfGeneratorFixture, ModelWithNestedIncludes)
   ASSERT_NE(nullptr, uri);
   ASSERT_NE(nullptr, uri->GetText());
   EXPECT_EQ(
-    "https://fuel.gazebosim.org/1.0/openrobotics/models/coke can/2",
+    "https://fuel.gazebosim.org/1.0/openrobotics/models/coke can/3",
      std::string(uri->GetText()));
 
   name = include->FirstChildElement("name");


### PR DESCRIPTION
# 🦟 Bug fix

Backports test fix in https://github.com/gazebosim/gz-sim/pull/2175/commits/409d8c5f81995d52002f304976bcb18c9bf4a6a7 from #2175 to garden

## Summary

fix INTEGRATION_save_world's SdfGeneratorFixture.ModelWithNestedIncludes test

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gazebo-ci-gz-sim7-homebrew-amd64&build=145)](https://build.osrfoundation.org/view/ign-garden/job/ignition_gazebo-ci-gz-sim7-homebrew-amd64/145/) https://build.osrfoundation.org/view/ign-garden/job/ignition_gazebo-ci-gz-sim7-homebrew-amd64/145/

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
