### PR TITLE
Fix sensors system parallel updates 

### DIFF
--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -695,7 +695,8 @@ void Sensors::PostUpdate(const UpdateInfo &_info,
       this->dataPtr->updateTimeCv.wait(lock, [this]()
       {
         return !this->dataPtr->updateAvailable ||
-               this->dataPtr->updateTimeToApply == this->dataPtr->updateTimeApplied;
+               (this->dataPtr->updateTimeToApply ==
+               this->dataPtr->updateTimeApplied);
       });
 
       this->dataPtr->renderUtil.UpdateFromECM(_info, _ecm);

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -621,9 +621,9 @@ void Sensors::Reset(const UpdateInfo &_info, EntityComponentManager &)
       s->SetNextDataUpdateTime(_info.simTime);
     }
     this->dataPtr->nextUpdateTime =  _info.simTime;
-    this->dataPtr->updateTimeToApply =  _info.simTime;
-    std::unique_lock<std::mutex> lock(this->dataPtr->renderMutex);
+    std::unique_lock<std::mutex> lock2(this->dataPtr->renderUtilMutex);
     this->dataPtr->updateTime =  _info.simTime;
+    this->dataPtr->updateTimeToApply =  _info.simTime;
     this->dataPtr->updateTimeApplied =  _info.simTime;
   }
 }

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -125,12 +125,22 @@ class gz::sim::systems::SensorsPrivate
   /// \brief Mutex to protect rendering data
   public: std::mutex renderMutex;
 
+  /// \brief Mutex to protect renderUtil changes
+  public: std::mutex renderUtilMutex;
+
   /// \brief Condition variable to signal rendering thread
   ///
   /// This variable is used to block/unblock operations in the rendering
   /// thread.  For a more detailed explanation on the flow refer to the
   /// documentation on RenderThread.
   public: std::condition_variable renderCv;
+
+  /// \brief Condition variable to signal update time applied
+  ///
+  /// This variable is used to block/unblock operations in PostUpdate thread
+  /// to make sure renderUtil's ECM updates are applied to the scene first
+  /// before they are overriden by PostUpdate
+  public: std::condition_variable updateTimeCv;
 
   /// \brief Connection to events::Stop event, used to stop thread
   public: common::ConnectionPtr stopConn;
@@ -140,6 +150,12 @@ class gz::sim::systems::SensorsPrivate
 
   /// \brief Update time for the next rendering iteration
   public: std::chrono::steady_clock::duration updateTime;
+
+  /// \brief Update time applied in the rendering thread
+  public: std::chrono::steady_clock::duration updateTimeApplied;
+
+  /// \brief Update time to be appplied in the rendering thread
+  public: std::chrono::steady_clock::duration updateTimeToApply;
 
   /// \brief Next sensors update time
   public: std::chrono::steady_clock::duration nextUpdateTime;
@@ -297,13 +313,13 @@ void SensorsPrivate::RunOnce()
   if (!this->scene)
     return;
 
-  std::chrono::steady_clock::duration updateTimeApplied;
   GZ_PROFILE("SensorsPrivate::RunOnce");
   {
     GZ_PROFILE("Update");
-    std::unique_lock<std::mutex> timeLock(this->renderMutex);
+    std::unique_lock<std::mutex> timeLock(this->renderUtilMutex);
     this->renderUtil.Update();
-    updateTimeApplied = this->updateTime;
+    this->updateTimeApplied = this->updateTime;
+    this->updateTimeCv.notify_one();
   }
 
   bool activeSensorsEmpty = true;
@@ -334,7 +350,7 @@ void SensorsPrivate::RunOnce()
     {
       GZ_PROFILE("PreRender");
       this->eventManager->Emit<events::PreRender>();
-      this->scene->SetTime(updateTimeApplied);
+      this->scene->SetTime(this->updateTimeApplied);
       // Update the scene graph manually to improve performance
       // We only need to do this once per frame It is important to call
       // sensors::RenderingSensor::SetManualSceneUpdate and set it to true
@@ -361,11 +377,11 @@ void SensorsPrivate::RunOnce()
     // safety check to see if reset occurred while we're rendering
     // avoid publishing outdated data if reset occurred
     std::unique_lock<std::mutex> timeLock(this->renderMutex);
-    if (updateTimeApplied <= this->updateTime)
+    if (this->updateTimeApplied <= this->updateTime)
     {
       // publish data
       GZ_PROFILE("RunOnce");
-      this->sensorManager.RunOnce(updateTimeApplied);
+      this->sensorManager.RunOnce(this->updateTimeApplied);
       this->eventManager->Emit<events::Render>();
     }
 
@@ -605,8 +621,10 @@ void Sensors::Reset(const UpdateInfo &_info, EntityComponentManager &)
       s->SetNextDataUpdateTime(_info.simTime);
     }
     this->dataPtr->nextUpdateTime =  _info.simTime;
+    this->dataPtr->updateTimeToApply =  _info.simTime;
     std::unique_lock<std::mutex> lock(this->dataPtr->renderMutex);
     this->dataPtr->updateTime =  _info.simTime;
+    this->dataPtr->updateTimeApplied =  _info.simTime;
   }
 }
 
@@ -668,7 +686,18 @@ void Sensors::PostUpdate(const UpdateInfo &_info,
   if (this->dataPtr->running && this->dataPtr->initialized)
   {
     {
-      std::unique_lock<std::mutex> lock(this->dataPtr->renderMutex);
+      GZ_PROFILE("UpdateFromECM");
+      // Make sure we do not override the state in renderUtil if there are
+      // still ECM changes that still need to be propagated to the scene,
+      // i.e. wait until renderUtil.Update(), has taken place in the
+      // rendering thread
+      std::unique_lock<std::mutex> lock(this->dataPtr->renderUtilMutex);
+      this->dataPtr->updateTimeCv.wait(lock, [this]()
+      {
+        return !this->dataPtr->updateAvailable ||
+               this->dataPtr->updateTimeToApply == this->dataPtr->updateTimeApplied;
+      });
+
       this->dataPtr->renderUtil.UpdateFromECM(_info, _ecm);
       this->dataPtr->updateTime = _info.simTime;
     }
@@ -719,16 +748,21 @@ void Sensors::PostUpdate(const UpdateInfo &_info,
         std::unique_lock<std::mutex> lockSensors(this->dataPtr->sensorsMutex);
         this->dataPtr->activeSensors =
             std::move(this->dataPtr->sensorsToUpdate);
+      }
 
-        this->dataPtr->nextUpdateTime = this->dataPtr->NextUpdateTime(
-            this->dataPtr->sensorsToUpdate, _info.simTime);
+      this->dataPtr->nextUpdateTime = this->dataPtr->NextUpdateTime(
+          this->dataPtr->sensorsToUpdate, _info.simTime);
 
-        // Force scene tree update if there are sensors to be created or
-        // subscribes to the render events. This does not necessary force
-        // sensors to update. Only active sensors will be updated
-        this->dataPtr->forceUpdate =
-            (this->dataPtr->renderUtil.PendingSensors() > 0) ||
-            hasRenderConnections;
+      // Force scene tree update if there are sensors to be created or
+      // subscribes to the render events. This does not necessary force
+      // sensors to update. Only active sensors will be updated
+      this->dataPtr->forceUpdate =
+          (this->dataPtr->renderUtil.PendingSensors() > 0) ||
+          hasRenderConnections;
+
+      {
+        std::unique_lock<std::mutex> timeLock(this->dataPtr->renderUtilMutex);
+        this->dataPtr->updateTimeToApply = this->dataPtr->updateTime;
       }
       {
         std::unique_lock<std::mutex> cvLock(this->dataPtr->renderMutex);

--- a/test/integration/reset_sensors.cc
+++ b/test/integration/reset_sensors.cc
@@ -79,6 +79,7 @@ struct MsgReceiver
   transport::Node node;
 
   std::atomic<bool> msgReceived = {false};
+  std::atomic<unsigned int> msgCount = 0;
 
   void Start(const std::string &_topic) {
     this->msgReceived = false;
@@ -94,6 +95,7 @@ struct MsgReceiver
     std::lock_guard<std::mutex> lk(this->msgMutex);
     this->lastMsg = _msg;
     this->msgReceived = true;
+    this->msgCount++;
   }
 
   T Last() {
@@ -252,6 +254,10 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
     EXPECT_FLOAT_EQ(centerPix.G(), centerPix.B());
   }
 
+  // wait until expected no. of messages are received.
+  // sim runs for 2000 iterations with camera at 10 Hz + 1 msg at t=0
+  while (imageReceiver.msgCount < 21)
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
   // Send command to reset to initial state
   worldReset();


### PR DESCRIPTION
# 🦟 Bug fix

depends on #2200 

## Summary

While profiling the Sensors system, I noticed that the render updates are no longer happening in parallel but instead it's blocking the main thread. 

The remotery graph below illustrate the issue. The `SimulationRunner` is being blocked for the entire duration of the sensors system's update

![sensors_system_remotery_before](https://github.com/gazebosim/gz-sim/assets/4000684/7d624bae-4a36-4d2a-87b4-6fd7d1eb5d1f)



With changes in this PR, the  `SimulationRunner` will now continue to step while sensor updates take place:

![sensors_system_remotery_after](https://github.com/gazebosim/gz-sim/assets/4000684/06ef8139-7d02-473b-8338-9f4bef48e8e9)

More info:

It came down to this [lock](https://github.com/gazebosim/gz-sim/blob/8a808009f6672db964acd27e62b710f13535b063/src/systems/sensors/Sensors.cc#L668) that blocks the `PostUpdate` thread longer than it should. The fix is to use a new mutex (`renderUtilMutex`) that's specific `RenderUtil` updates. 

After reducing the scope of the lock, I noticed a race condition that sometimes the RenderUtil's states are [overriden](https://github.com/gazebosim/gz-sim/blob/8a808009f6672db964acd27e62b710f13535b063/src/systems/sensors/Sensors.cc#L669) (in the `PostUpdate` thread) before the changes are [applied](https://github.com/gazebosim/gz-sim/blob/8a808009f6672db964acd27e62b710f13535b063/src/systems/sensors/Sensors.cc#L305) to the scene (in the rendering thread). An `updateTimeCv` condition variable is added to make sure that does not happen. 

To test:

Run the `INTEGRATION_sensors_system_update_rate` test multiple times to verify the sensors' timestamps are correct.

On my desktop machine, the RTF values (displayed in the GUI)  for the `sensors_demo.sdf`  world are:

* Before: 77-78%
* After: 95-98%


Here is another [test world](https://gist.github.com/iche033/3af9b79fc45a28217df62cd93ab79fab) consisting of 2 1980x1280 cameras @ 10Hz.

The raw RTF values over 2000 iterations are plotted in the graphs below. 

Before:

RTF dips on every camera update

![sensors_demo_parallel_before](https://github.com/gazebosim/gz-sim/assets/4000684/e7420956-f37c-4579-8194-f8d4ee20d3dd)

After:

There is still jitter but less than before

![sensors_demo_parallel_after](https://github.com/gazebosim/gz-sim/assets/4000684/e56310c2-4e85-45c4-8346-281e67e65607)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

