### PR TITLE
Use dart13 packages from stable repository on ci (not focal)

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,10 +1,10 @@
 freeglut3-dev
 libbenchmark-dev
-libdart-collision-ode-dev
-libdart-dev
-libdart-external-ikfast-dev
-libdart-external-odelcpsolver-dev
-libdart-utils-urdf-dev
+libdart6.13-collision-ode-dev
+libdart6.13-dev
+libdart6.13-external-ikfast-dev
+libdart6.13-external-odelcpsolver-dev
+libdart6.13-utils-urdf-dev
 libfreeimage-dev
 libglew-dev
 libgz-cmake3-dev

--- a/examples/worlds/CMakeLists.txt
+++ b/examples/worlds/CMakeLists.txt
@@ -2,4 +2,8 @@ file(GLOB files "*.sdf")
 install(FILES ${files}
   DESTINATION ${GZ_DATA_INSTALL_DIR}/worlds)
 
+file(GLOB csv_files "*.csv")
+install(FILES ${csv_files}
+  DESTINATION ${GZ_DATA_INSTALL_DIR}/worlds)
+
 add_subdirectory(thumbnails)

--- a/examples/worlds/environmental_sensor.sdf
+++ b/examples/worlds/environmental_sensor.sdf
@@ -1,5 +1,12 @@
 <?xml version="1.0" ?>
-<!-- This example show cases how to load and unload environmental data. -->
+<!--
+  This example show cases how to load and unload environmental data.
+  Before opening this file in a seperate terminal run:
+    gz topic -e -t /sensors/humidity
+  Then open this file by running:
+    gz sim environmental_sensor.sdf
+  Play the simulation and you should see a data stream of increasing numbers eventually stop at 90.
+-->
 <sdf version="1.6">
   <world name="environmental_sensor_example">
     <plugin
@@ -20,6 +27,7 @@
       name="gz::sim::systems::EnvironmentalSystem">
     </plugin>
 
+    <!-- The system specifies where to preload -->
     <plugin
       filename="gz-sim-environment-preload-system"
       name="gz::sim::systems::EnvironmentPreload">
@@ -104,6 +112,7 @@
         <sensor name="custom_sensor" type="custom" gz:type="environmental_sensor/humidity">
           <always_on>1</always_on>
           <update_rate>30</update_rate>
+          <topic>sensors/humidity</topic>
         </sensor>
       </link>
     </model>

--- a/src/gui/plugins/environment_visualization/EnvironmentVisualization.hh
+++ b/src/gui/plugins/environment_visualization/EnvironmentVisualization.hh
@@ -30,7 +30,7 @@ namespace sim
 // Inline bracket to help doxygen filtering.
 inline namespace GZ_SIM_VERSION_NAMESPACE
 {
-  class EnvironmentVisualizationPrivate;
+  class EnvironmentVisualizationTool;
 
   /// \class EnvironmentVisualization EnvironmentVisualization.hh
   ///     gz/sim/systems/EnvironmentVisualization.hh
@@ -66,13 +66,15 @@ inline namespace GZ_SIM_VERSION_NAMESPACE
 
     /// \internal
     /// \brief Pointer to private data
-    private: std::unique_ptr<EnvironmentVisualizationPrivate> dataPtr;
+    private: std::unique_ptr<EnvironmentVisualizationTool> dataPtr;
 
     public: unsigned int xSamples{10};
 
     public: unsigned int ySamples{10};
 
     public: unsigned int zSamples{10};
+
+    private: QTimer* qtimer;
   };
 }
 }

--- a/src/systems/environment_preload/CMakeLists.txt
+++ b/src/systems/environment_preload/CMakeLists.txt
@@ -1,6 +1,7 @@
 gz_add_system(environment-preload
   SOURCES
     EnvironmentPreload.cc
+    VisualizationTool.cc
   PUBLIC_LINK_LIBS
     gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
     gz-common${GZ_COMMON_VER}::io

--- a/src/systems/environment_preload/EnvironmentPreload.cc
+++ b/src/systems/environment_preload/EnvironmentPreload.cc
@@ -15,8 +15,10 @@
  *
  */
 #include "EnvironmentPreload.hh"
+#include "VisualizationTool.hh"
 
 #include <array>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -27,6 +29,11 @@
 
 #include <gz/plugin/Register.hh>
 
+#include <gz/transport/Node.hh>
+
+#include <gz/msgs/data_load_options.pb.h>
+#include <gz/msgs/Utility.hh>
+
 #include "gz/sim/components/Environment.hh"
 #include "gz/sim/components/World.hh"
 #include "gz/sim/Util.hh"
@@ -35,12 +42,256 @@ using namespace gz;
 using namespace sim;
 using namespace systems;
 
+using Units = msgs::DataLoadPathOptions_DataAngularUnits;
 //////////////////////////////////////////////////
 class gz::sim::systems::EnvironmentPreloadPrivate
 {
+  /// \brief Is the file loaded
   public: bool loaded{false};
 
+  /// \brief SDF Description
   public: std::shared_ptr<const sdf::Element> sdf;
+
+  /// \brief GzTransport node
+  public: transport::Node node;
+
+  /// \brief Data descriptions
+  public: msgs::DataLoadPathOptions dataDescription;
+
+  /// \brief mutex to protect the samples and data description
+  public: std::mutex mtx;
+
+  /// \brief Do we need to reload the system.
+  public: std::atomic<bool> needsReload{false};
+
+  /// \brief Visualization Helper
+  public: std::unique_ptr<EnvironmentVisualizationTool> visualizationPtr;
+
+  /// \brief Are visualizations enabled
+  public: bool visualize{false};
+
+  /// \brief Sample resolutions
+  public: math::Vector3d samples;
+
+  /// \brief Is the file loaded
+  public: bool fileLoaded{false};
+
+  /// \brief File loading error logger
+  public: bool logFileLoadError{true};
+
+  /// \brief Reference to data
+  public: std::shared_ptr<components::EnvironmentalData> envData;
+
+  //////////////////////////////////////////////////
+  public: EnvironmentPreloadPrivate() :
+    visualizationPtr(new EnvironmentVisualizationTool) {}
+
+  //////////////////////////////////////////////////
+  public: void OnLoadCommand(const msgs::DataLoadPathOptions &_msg)
+  {
+    std::lock_guard<std::mutex> lock(this->mtx);
+    this->dataDescription = _msg;
+    this->needsReload = true;
+    this->logFileLoadError = true;
+    this->visualizationPtr->FileReloaded();
+    gzdbg << "Loading file " << _msg.path() << "\n";
+  }
+
+  //////////////////////////////////////////////////
+  public: void OnVisualResChanged(const msgs::Vector3d &_resChanged)
+  {
+    std::lock_guard<std::mutex> lock(this->mtx);
+    if (!this->fileLoaded)
+    {
+      // Only visualize if a file exists
+      return;
+    }
+    auto converted = msgs::Convert(_resChanged);
+    if (this->samples == converted)
+    {
+      // If the sample has not changed return.
+      // This is because resampling is expensive.
+      return;
+    }
+    this->samples = converted;
+    this->visualize = true;
+    this->visualizationPtr->resample = true;
+  }
+
+  //////////////////////////////////////////////////
+  public: void ReadSdf(EntityComponentManager &_ecm)
+  {
+    if (!this->sdf->HasElement("data"))
+    {
+      gzerr << "No environmental data file was specified" << std::endl;
+      return;
+    }
+
+    std::lock_guard<std::mutex> lock(mtx);
+    std::string dataPath =
+        this->sdf->Get<std::string>("data");
+
+    if (common::isRelativePath(dataPath))
+    {
+      auto *component =
+          _ecm.Component<components::WorldSdf>(worldEntity(_ecm));
+      const std::string rootPath =
+          common::parentPath(component->Data().Element()->FilePath());
+      dataPath = common::joinPaths(rootPath, dataPath);
+    }
+    this->dataDescription.set_path(dataPath);
+
+    this->dataDescription.set_units(
+      Units::DataLoadPathOptions_DataAngularUnits_RADIANS);
+    std::string timeColumnName{"t"};
+    bool ignoreTime = false;
+    std::array<std::string, 3> spatialColumnNames{"x", "y", "z"};
+    sdf::ElementConstPtr elem =
+        this->sdf->FindElement("dimensions");
+    msgs::SphericalCoordinatesType spatialReference =
+      msgs::SphericalCoordinatesType::GLOBAL;
+    if (elem)
+    {
+      if (elem->HasElement("ignore_time"))
+      {
+        ignoreTime = elem->Get<bool>("ignore_time");
+      }
+      if (elem->HasElement("time"))
+      {
+        timeColumnName = elem->Get<std::string>("time");
+      }
+      elem = elem->FindElement("space");
+      if (elem)
+      {
+        if (elem->HasAttribute("reference"))
+        {
+          const std::string referenceName =
+              elem->Get<std::string>("reference");
+          if (referenceName == "global")
+          {
+            spatialReference = msgs::SphericalCoordinatesType::GLOBAL;
+          }
+          else if (referenceName == "spherical")
+          {
+            spatialReference = msgs::SphericalCoordinatesType::SPHERICAL;
+            if (elem->HasAttribute("units"))
+            {
+              std::string unitName = elem->Get<std::string>("units");
+              if (unitName == "degrees")
+              {
+                this->dataDescription.set_units(
+                  Units::DataLoadPathOptions_DataAngularUnits_DEGREES);
+              }
+              else if (unitName != "radians")
+              {
+                ignerr << "Unrecognized unit " << unitName << "\n";
+              }
+            }
+          }
+          else if (referenceName == "ecef")
+          {
+            spatialReference = msgs::SphericalCoordinatesType::ECEF;
+          }
+          else
+          {
+            gzerr << "Unknown reference '" << referenceName << "'"
+                  << std::endl;
+            return;
+          }
+        }
+        for (size_t i = 0; i < spatialColumnNames.size(); ++i)
+        {
+          if (elem->HasElement(spatialColumnNames[i]))
+          {
+            spatialColumnNames[i] =
+                elem->Get<std::string>(spatialColumnNames[i]);
+          }
+        }
+      }
+    }
+
+    this->dataDescription.set_static_time(ignoreTime);
+    this->dataDescription.set_coordinate_type(spatialReference);
+    this->dataDescription.set_time(timeColumnName);
+    this->dataDescription.set_x(spatialColumnNames[0]);
+    this->dataDescription.set_y(spatialColumnNames[1]);
+    this->dataDescription.set_z(spatialColumnNames[2]);
+
+    this->needsReload = true;
+  }
+
+  //////////////////////////////////////////////////
+  public: components::EnvironmentalData::ReferenceUnits ConvertUnits(
+    const Units &_unit)
+  {
+    switch (_unit)
+    {
+      case Units::DataLoadPathOptions_DataAngularUnits_DEGREES:
+        return components::EnvironmentalData::ReferenceUnits::DEGREES;
+      case Units::DataLoadPathOptions_DataAngularUnits_RADIANS:
+        return components::EnvironmentalData::ReferenceUnits::RADIANS;
+      default:
+        gzerr << "Invalid unit conversion. Defaulting to radians." << std::endl;
+        return components::EnvironmentalData::ReferenceUnits::RADIANS;
+    }
+  }
+
+  //////////////////////////////////////////////////
+  public: void LoadEnvironment(EntityComponentManager &_ecm)
+  {
+    try
+    {
+      std::lock_guard<std::mutex> lock(this->mtx);
+      std::array<std::string, 3> spatialColumnNames{
+        this->dataDescription.x(),
+        this->dataDescription.y(),
+        this->dataDescription.z()};
+
+      math::SphericalCoordinates::CoordinateType spatialReference =
+        msgs::Convert(this->dataDescription.coordinate_type());
+      auto units = this->ConvertUnits(this->dataDescription.units());
+
+      std::ifstream dataFile(this->dataDescription.path());
+      if (!dataFile.is_open())
+      {
+        if (this->logFileLoadError)
+        {
+          gzerr << "No environmental data file was found at " <<
+            this->dataDescription.path() << std::endl;
+          logFileLoadError = false;
+        }
+        return;
+      }
+
+      gzmsg << "Loading Environment Data " << this->dataDescription.path() <<
+        std::endl;
+
+      using ComponentDataT = components::EnvironmentalData;
+      auto data = ComponentDataT::MakeShared(
+          common::IO<ComponentDataT::FrameT>::ReadFrom(
+              common::CSVIStreamIterator(dataFile),
+              common::CSVIStreamIterator(),
+              this->dataDescription.time(), spatialColumnNames),
+          spatialReference, units, this->dataDescription.static_time());
+      this->envData = data;
+      using ComponentT = components::Environment;
+      auto component = ComponentT{std::move(data)};
+      _ecm.CreateComponent(worldEntity(_ecm), std::move(component));
+      this->visualizationPtr->resample = true;
+      this->fileLoaded = true;
+    }
+    catch (const std::invalid_argument &exc)
+    {
+      if (this->logFileLoadError)
+      {
+        gzerr << "Failed to load environment data" << std::endl
+              << exc.what() << std::endl;
+        this->logFileLoadError = false;
+      }
+    }
+
+    this->needsReload = false;
+  }
 };
 
 //////////////////////////////////////////////////
@@ -64,122 +315,38 @@ void EnvironmentPreload::Configure(
 
 //////////////////////////////////////////////////
 void EnvironmentPreload::PreUpdate(
-  const gz::sim::UpdateInfo &,
+  const gz::sim::UpdateInfo &_info,
   gz::sim::EntityComponentManager &_ecm)
 {
   if (!std::exchange(this->dataPtr->loaded, true))
   {
-    if (!this->dataPtr->sdf->HasElement("data"))
-    {
-      gzerr << "No environmental data file was specified";
-      return;
-    }
+    auto world = worldEntity(_ecm);
 
-    std::string dataPath =
-        this->dataPtr->sdf->Get<std::string>("data");
-    if (common::isRelativePath(dataPath))
-    {
-      auto * component =
-          _ecm.Component<components::WorldSdf>(worldEntity(_ecm));
-      const std::string rootPath =
-          common::parentPath(component->Data().Element()->FilePath());
-      dataPath = common::joinPaths(rootPath, dataPath);
-    }
+    // See https://github.com/gazebosim/gz-sim/issues/1786
+    this->dataPtr->node.Subscribe(
+      transport::TopicUtils::AsValidTopic(
+        scopedName(world, _ecm) + "/environment"),
+      &EnvironmentPreloadPrivate::OnLoadCommand, this->dataPtr.get());
+    this->dataPtr->node.Subscribe(
+      transport::TopicUtils::AsValidTopic(
+        scopedName(world, _ecm) + "/environment/visualize/res"),
+      &EnvironmentPreloadPrivate::OnVisualResChanged, this->dataPtr.get());
 
-    std::ifstream dataFile(dataPath);
-    if (!dataFile.is_open())
-    {
-      gzerr << "No environmental data file was found at " << dataPath;
-      return;
-    }
+    this->dataPtr->visualizationPtr->resample = true;
+    this->dataPtr->ReadSdf(_ecm);
+  }
 
-    components::EnvironmentalData::ReferenceUnits unit{
-      components::EnvironmentalData::ReferenceUnits::RADIANS};
-    std::string timeColumnName{"t"};
-    bool ignoreTime = false;
-    std::array<std::string, 3> spatialColumnNames{"x", "y", "z"};
-    auto spatialReference = math::SphericalCoordinates::GLOBAL;
-    sdf::ElementConstPtr elem =
-        this->dataPtr->sdf->FindElement("dimensions");
-    if (elem)
-    {
-      if (elem->HasElement("ignore_time"))
-      {
-        ignoreTime = elem->Get<bool>("ignore_time");
-      }
-      if (elem->HasElement("time"))
-      {
-        timeColumnName = elem->Get<std::string>("time");
-      }
-      elem = elem->FindElement("space");
-      if (elem)
-      {
-        if (elem->HasAttribute("reference"))
-        {
-          const std::string referenceName =
-              elem->Get<std::string>("reference");
-          if (referenceName == "global")
-          {
-            spatialReference = math::SphericalCoordinates::GLOBAL;
-          }
-          else if (referenceName == "spherical")
-          {
-            spatialReference = math::SphericalCoordinates::SPHERICAL;
-            if (elem->HasAttribute("units"))
-            {
-              std::string unitName = elem->Get<std::string>("units");
-              if (unitName == "degrees")
-              {
-                unit = components::EnvironmentalData::ReferenceUnits::DEGREES;
-              }
-              else if (unitName != "radians")
-              {
-                gzerr << "Unrecognized unit " << unitName << "\n";
-              }
-            }
-          }
-          else if (referenceName == "ecef")
-          {
-            spatialReference = math::SphericalCoordinates::ECEF;
-          }
-          else
-          {
-            gzerr << "Unknown reference '" << referenceName << "'"
-                  << std::endl;
-            return;
-          }
-        }
-        for (size_t i = 0; i < spatialColumnNames.size(); ++i)
-        {
-          if (elem->HasElement(spatialColumnNames[i]))
-          {
-            spatialColumnNames[i] =
-                elem->Get<std::string>(spatialColumnNames[i]);
-          }
-        }
-      }
-    }
+  if (this->dataPtr->needsReload)
+  {
+    this->dataPtr->LoadEnvironment(_ecm);
+  }
 
-    try
-    {
-      gzmsg << "Loading Environment Data\n";
-      using ComponentDataT = components::EnvironmentalData;
-      auto data = ComponentDataT::MakeShared(
-          common::IO<ComponentDataT::FrameT>::ReadFrom(
-              common::CSVIStreamIterator(dataFile),
-              common::CSVIStreamIterator(),
-              timeColumnName, spatialColumnNames),
-          spatialReference, unit, ignoreTime);
-
-      using ComponentT = components::Environment;
-      auto component = ComponentT{std::move(data)};
-      _ecm.CreateComponent(worldEntity(_ecm), std::move(component));
-    }
-    catch (const std::invalid_argument &exc)
-    {
-      gzerr << "Failed to load environment data" << std::endl
-            << exc.what() << std::endl;
-    }
+  if (this->dataPtr->visualize)
+  {
+    std::lock_guard<std::mutex> lock(this->dataPtr->mtx);
+    auto samples = this->dataPtr->samples;
+    this->dataPtr->visualizationPtr->Step(_info, _ecm, this->dataPtr->envData,
+      samples.X(), samples.Y(), samples.Z());
   }
 }
 

--- a/src/systems/environment_preload/VisualizationTool.cc
+++ b/src/systems/environment_preload/VisualizationTool.cc
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "VisualizationTool.hh"
+
+/////////////////////////////////////////////////
+EnvironmentVisualizationTool::EnvironmentVisualizationTool()
+{
+  this->pcPub =
+    this->node.Advertise<gz::msgs::PointCloudPacked>("/point_cloud");
+}
+
+/////////////////////////////////////////////////
+void EnvironmentVisualizationTool::CreatePointCloudTopics(
+    const std::shared_ptr<components::EnvironmentalData> &_data,
+    const UpdateInfo &_info)
+{
+  this->pubs.clear();
+  this->sessions.clear();
+
+  for (auto key : _data->frame.Keys())
+  {
+    this->pubs.emplace(key, node.Advertise<gz::msgs::Float_V>(key));
+    gz::msgs::Float_V msg;
+    this->floatFields.emplace(key, msg);
+    const double time = std::chrono::duration<double>(_info.simTime).count();
+    auto sess = _data->frame[key].CreateSession(time);
+    if (!_data->frame[key].IsValid(sess))
+    {
+      gzerr << key << "data is out of time bounds. Nothing will be published"
+        <<std::endl;
+      this->finishedTime = true;
+      continue;
+    }
+    this->sessions.emplace(key, sess);
+  }
+}
+
+/////////////////////////////////////////////////
+void EnvironmentVisualizationTool::FileReloaded()
+{
+  this->finishedTime = false;
+}
+
+/////////////////////////////////////////////////
+void EnvironmentVisualizationTool::Step(
+    const UpdateInfo &_info,
+    const EntityComponentManager &_ecm,
+    const std::shared_ptr<components::EnvironmentalData> &_data,
+    double _xSamples, double _ySamples, double _zSamples)
+{
+  if (this->finishedTime)
+  {
+    return;
+  }
+  auto now = std::chrono::steady_clock::now();
+  std::chrono::duration<double> dt(now - this->lastTick);
+
+  if (this->resample)
+  {
+    this->CreatePointCloudTopics(_data, _info);
+    if (this->finishedTime) {
+      this->resample = false;
+      return;
+    }
+    this->ResizeCloud(_data, _ecm, _xSamples, _ySamples, _zSamples);
+    this->resample = false;
+    this->lastTick = now;
+  }
+
+  // Progress session pointers to next time stamp
+  for (auto &it : this->sessions)
+  {
+    auto res =
+      _data->frame[it.first].StepTo(it.second,
+        std::chrono::duration<double>(_info.simTime).count());
+    if (res.has_value())
+    {
+      it.second = res.value();
+    }
+    else
+    {
+      gzerr << "Data does not exist beyond this time."
+        << " Not publishing new environment visuallization data."
+        << std::endl;
+      this->finishedTime = true;
+      return;
+    }
+  }
+
+  // Publish at 2 hz for now. In future make reconfigureable.
+  if (dt.count() > 0.5 && !this->finishedTime)
+  {
+    this->Visualize(_data, _xSamples, _ySamples, _zSamples);
+    this->Publish();
+    lastTick = now;
+  }
+}
+
+/////////////////////////////////////////////////
+void EnvironmentVisualizationTool::Visualize(
+    const std::shared_ptr<components::EnvironmentalData> &_data,
+    double _xSamples, double _ySamples, double _zSamples)
+{
+  for (auto key : _data->frame.Keys())
+  {
+    const auto session = this->sessions[key];
+    auto frame = _data->frame[key];
+    auto [lower_bound, upper_bound] = frame.Bounds(session);
+    auto step = upper_bound - lower_bound;
+    auto dx = step.X() / _xSamples;
+    auto dy = step.Y() / _ySamples;
+    auto dz = step.Z() / _zSamples;
+    std::size_t idx = 0;
+    for (std::size_t x_steps = 0; x_steps < ceil(_xSamples); x_steps++)
+    {
+      auto x = lower_bound.X() + x_steps * dx;
+      for (std::size_t y_steps = 0; y_steps < ceil(_ySamples); y_steps++)
+      {
+        auto y = lower_bound.Y() + y_steps * dy;
+        for (std::size_t z_steps = 0; z_steps < ceil(_zSamples); z_steps++)
+        {
+          auto z = lower_bound.Z() + z_steps * dz;
+          auto res = frame.LookUp(session, math::Vector3d(x, y, z));
+
+          if (res.has_value())
+          {
+            this->floatFields[key].mutable_data()->Set(idx,
+              static_cast<float>(res.value()));
+          }
+          else
+          {
+            this->floatFields[key].mutable_data()->Set(idx, std::nanf(""));
+          }
+          idx++;
+        }
+      }
+    }
+  }
+}
+
+/////////////////////////////////////////////////
+void EnvironmentVisualizationTool::Publish()
+{
+  pcPub.Publish(this->pcMsg);
+  for (auto &[key, pub] : this->pubs)
+  {
+    pub.Publish(this->floatFields[key]);
+  }
+}
+
+/////////////////////////////////////////////////
+void EnvironmentVisualizationTool::ResizeCloud(
+  const std::shared_ptr<components::EnvironmentalData> &_data,
+  const EntityComponentManager &_ecm,
+  unsigned int _numXSamples,
+  unsigned int _numYSamples,
+  unsigned int _numZSamples)
+{
+  assert(pubs.size() > 0);
+
+  // Assume all data have same point cloud.
+  gz::msgs::InitPointCloudPacked(pcMsg, "some_frame", true,
+      {{"xyz", gz::msgs::PointCloudPacked::Field::FLOAT32}});
+  auto numberOfPoints = _numXSamples * _numYSamples * _numZSamples;
+  std::size_t dataSize{
+    static_cast<std::size_t>(numberOfPoints * pcMsg.point_step())};
+  pcMsg.mutable_data()->resize(dataSize);
+  pcMsg.set_height(1);
+  pcMsg.set_width(numberOfPoints);
+
+  auto session = this->sessions[this->pubs.begin()->first];
+  auto frame = _data->frame[this->pubs.begin()->first];
+  auto [lower_bound, upper_bound] = frame.Bounds(session);
+
+  auto step = upper_bound - lower_bound;
+  auto dx = step.X() / _numXSamples;
+  auto dy = step.Y() / _numYSamples;
+  auto dz = step.Z() / _numZSamples;
+
+  // Populate point cloud
+  gz::msgs::PointCloudPackedIterator<float> xIter(pcMsg, "x");
+  gz::msgs::PointCloudPackedIterator<float> yIter(pcMsg, "y");
+  gz::msgs::PointCloudPackedIterator<float> zIter(pcMsg, "z");
+
+  for (std::size_t x_steps = 0; x_steps < _numXSamples; x_steps++)
+  {
+    auto x = lower_bound.X() + x_steps * dx;
+    for (std::size_t y_steps = 0; y_steps < _numYSamples; y_steps++)
+    {
+      auto y = lower_bound.Y() + y_steps * dy;
+      for (std::size_t z_steps = 0; z_steps < _numZSamples; z_steps++)
+      {
+        auto z = lower_bound.Z() + z_steps * dz;
+        auto coords = getGridFieldCoordinates(_ecm, math::Vector3d{x, y, z},
+          _data);
+
+        if (!coords.has_value())
+        {
+          continue;
+        }
+
+        auto pos = coords.value();
+        *xIter = pos.X();
+        *yIter = pos.Y();
+        *zIter = pos.Z();
+        ++xIter;
+        ++yIter;
+        ++zIter;
+      }
+    }
+  }
+  for (auto key : _data->frame.Keys())
+  {
+    this->floatFields[key].mutable_data()->Resize(
+      numberOfPoints, std::nanf(""));
+  }
+}

--- a/src/systems/environment_preload/VisualizationTool.hh
+++ b/src/systems/environment_preload/VisualizationTool.hh
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef GZ_SIM_SYSTEMS_ENVIRONMENTPRELOAD_VIZTOOL_HH_
+#define GZ_SIM_SYSTEMS_ENVIRONMENTPRELOAD_VIZTOOL_HH_
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <gz/common/CSVStreams.hh>
+#include <gz/common/DataFrame.hh>
+
+#include <gz/transport/Node.hh>
+
+#include <gz/msgs/float_v.pb.h>
+#include <gz/msgs/pointcloud_packed.pb.h>
+#include <gz/msgs/PointCloudPackedUtils.hh>
+#include <gz/msgs/Utility.hh>
+
+#include "gz/sim/components/Environment.hh"
+#include "gz/sim/Util.hh"
+
+using namespace gz;
+using namespace sim;
+
+namespace gz
+{
+namespace sim
+{
+inline namespace GZ_SIM_VERSION_NAMESPACE
+{
+
+/// \brief This class helps handle point cloud visuallizations
+/// of environment data.
+class EnvironmentVisualizationTool
+{
+  /// \brief Environment constructor
+  public: EnvironmentVisualizationTool();
+
+  /// \brief To synchronize member access.
+  private: std::mutex mutex;
+
+  /// \brief First load we need to scan for existing data sensor
+  private: bool first{true};
+
+  /// \brief Enable resampling
+  public: std::atomic<bool> resample{true};
+
+  /// \brief Time has come to an end.
+  private: bool finishedTime{false};
+
+  /// \brief Create publisher structures whenever a new environment is made
+  /// available.
+  /// \param[in] _data Data to be visuallized
+  /// \param[in] _info simulation info for current time step
+  private: void CreatePointCloudTopics(
+    const std::shared_ptr<components::EnvironmentalData> &_data,
+    const UpdateInfo &_info);
+
+  /// \brief Invoke when new file is made available.
+  public: void FileReloaded();
+
+  /// \brief Step the visualizations
+  /// \param[in] _info The simulation info including timestep
+  /// \param[in] _ecm The Entity-Component-Manager
+  /// \param[in] _data The data to be visuallized
+  /// \param[in] _xSample Samples along x
+  /// \param[in] _ySample Samples along y
+  /// \param[in] _zSample Samples along z
+  public: void Step(
+    const UpdateInfo &_info,
+    const EntityComponentManager &_ecm,
+    const std::shared_ptr<components::EnvironmentalData> &_data,
+    double _xSamples, double _ySamples, double _zSamples);
+
+  /// \brief Publishes a sample of the data
+  /// \param[in] _data The data to be visuallized
+  /// \param[in] _xSample Samples along x
+  /// \param[in] _ySample Samples along y
+  /// \param[in] _zSample Samples along z
+  private: void Visualize(
+    const std::shared_ptr<components::EnvironmentalData> &_data,
+    double _xSamples, double _ySamples, double _zSamples);
+
+  /// \brief Get the point cloud data.
+  private: void Publish();
+
+  /// \brief Resize the point cloud structure (used to reallocate
+  /// memory when resolution changes)
+  /// \param[in] _ecm The Entity-Component-Manager
+  /// \param[in] _data The data to be visuallized
+  /// \param[in] _xSample Samples along x
+  /// \param[in] _ySample Samples along y
+  /// \param[in] _zSample Samples along z
+  private: void ResizeCloud(
+    const std::shared_ptr<components::EnvironmentalData> &_data,
+    const EntityComponentManager &_ecm,
+    unsigned int _xSamples, unsigned int _ySamples, unsigned int _zSamples);
+
+  /// \brief Publisher for point clouds
+  private: transport::Node::Publisher pcPub;
+
+  /// \brief Publishers for data
+  private: std::unordered_map<std::string, transport::Node::Publisher> pubs;
+
+  /// \brief Floating point message buffers
+  private: std::unordered_map<std::string, gz::msgs::Float_V> floatFields;
+
+  /// \brief GZ buffers
+  private: transport::Node node;
+
+  /// \brief Point cloud buffer
+  private: gz::msgs::PointCloudPacked pcMsg;
+
+  /// \brief Session cursors
+  private: std::unordered_map<std::string,
+    gz::math::InMemorySession<double, double>> sessions;
+
+  /// \brief Duration from last update
+  private:  std::chrono::time_point<std::chrono::steady_clock> lastTick;
+};
+}
+}
+}
+#endif

--- a/src/systems/lift_drag/LiftDrag.cc
+++ b/src/systems/lift_drag/LiftDrag.cc
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <string>
 #include <vector>
+#include <cmath>
 
 #include <gz/common/Profiler.hh>
 #include <gz/plugin/Register.hh>
@@ -40,6 +41,7 @@
 #include "gz/sim/components/Name.hh"
 #include "gz/sim/components/ExternalWorldWrenchCmd.hh"
 #include "gz/sim/components/Pose.hh"
+#include "gz/sim/components/Wind.hh"
 
 using namespace gz;
 using namespace sim;
@@ -86,6 +88,10 @@ class gz::sim::systems::LiftDragPrivate
 
   /// \brief Cm-alpha rate after stall
   public: double cmaStall = 0.0;
+
+  /// \brief How much Cm changes with a change in control
+  /// surface deflection angle
+  public: double cm_delta = 0.0;
 
   /// \brief air density
   /// at 25 deg C it's about 1.1839 kg/m^3
@@ -155,6 +161,7 @@ void LiftDragPrivate::Load(const EntityComponentManager &_ecm,
   this->area = _sdf->Get<double>("area", this->area).first;
   this->alpha0 = _sdf->Get<double>("a0", this->alpha0).first;
   this->cp = _sdf->Get<math::Vector3d>("cp", this->cp).first;
+  this->cm_delta = _sdf->Get<double>("cm_delta", this->cm_delta).first;
 
   // blade forward (-drag) direction in link frame
   this->forward =
@@ -205,7 +212,6 @@ void LiftDragPrivate::Load(const EntityComponentManager &_ecm,
     this->validConfig = false;
     return;
   }
-
 
   if (_sdf->HasElement("control_joint_name"))
   {
@@ -259,6 +265,13 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
   const auto worldPose =
       _ecm.Component<components::WorldPose>(this->linkEntity);
 
+  // get wind as a component from the _ecm
+  components::WorldLinearVelocity *windLinearVel = nullptr;
+  if(_ecm.EntityByComponents(components::Wind()) != kNullEntity){
+    Entity windEntity = _ecm.EntityByComponents(components::Wind());
+    windLinearVel =
+        _ecm.Component<components::WorldLinearVelocity>(windEntity);
+  }
   components::JointPosition *controlJointPosition = nullptr;
   if (this->controlJointEntity != kNullEntity)
   {
@@ -271,7 +284,12 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
 
   const auto &pose = worldPose->Data();
   const auto cpWorld = pose.Rot().RotateVector(this->cp);
-  const auto vel = worldLinVel->Data() + worldAngVel->Data().Cross(cpWorld);
+  auto vel = worldLinVel->Data() + worldAngVel->Data().Cross(
+  cpWorld);
+  if (windLinearVel != nullptr){
+    vel = worldLinVel->Data() + worldAngVel->Data().Cross(
+    cpWorld) - windLinearVel->Data();
+  }
 
   if (vel.Length() <= 0.01)
     return;
@@ -280,6 +298,12 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
 
   // rotate forward and upward vectors into world frame
   const auto forwardI = pose.Rot().RotateVector(this->forward);
+
+  if (forwardI.Dot(vel) <= 0.0){
+    // Only calculate lift or drag if the wind relative velocity
+    // is in the same direction
+    return;
+  }
 
   math::Vector3d upwardI;
   if (this->radialSymmetry)
@@ -304,7 +328,7 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
       spanwiseI.Dot(velI), minRatio, maxRatio);
 
   // get cos from trig identity
-  const double cosSweepAngle = 1.0 - sinSweepAngle * sinSweepAngle;
+  double cosSweepAngle = sqrt(1.0 - sinSweepAngle * sinSweepAngle);
   double sweep = std::asin(sinSweepAngle);
 
   // truncate sweep to within +/-90 deg
@@ -336,7 +360,7 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
 
   // compute angle between upwardI and liftI
   // in general, given vectors a and b:
-  //   cos(theta) = a.Dot(b)/(a.Length()*b.Lenghth())
+  //   cos(theta) = a.Dot(b)/(a.Length()*b.Length())
   // given upwardI and liftI are both unit vectors, we can drop the denominator
   //   cos(theta) = a.Dot(b)
   const double cosAlpha =
@@ -435,14 +459,15 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
   else
     cm = this->cma * alpha * cosSweepAngle;
 
-  /// \todo(anyone): implement cm
-  /// for now, reset cm to zero, as cm needs testing
-  cm = 0.0;
+  // Take into account the effect of control surface deflection angle to cm
+  if (controlJointPosition && !controlJointPosition->Data().empty())
+  {
+    cm += this->cm_delta * controlJointPosition->Data()[0];
+  }
 
   // compute moment (torque) at cp
   // spanwiseI used to be momentDirection
   math::Vector3d moment = cm * q * this->area * spanwiseI;
-
 
   // force and torque about cg in world frame
   math::Vector3d force = lift + drag;
@@ -529,7 +554,6 @@ void LiftDrag::PreUpdate(const UpdateInfo &_info, EntityComponentManager &_ecm)
     // that all entities have been created when Configure is called
     this->dataPtr->Load(_ecm, this->dataPtr->sdfConfig);
     this->dataPtr->initialized = true;
-
 
     if (this->dataPtr->validConfig)
     {

--- a/src/systems/lift_drag/LiftDrag.hh
+++ b/src/systems/lift_drag/LiftDrag.hh
@@ -35,34 +35,37 @@ namespace systems
   /// \brief The LiftDrag system computes lift and drag forces enabling
   /// simulation of aerodynamic robots.
   ///
-  /// The following parameters are used by the system:
+  /// ## System Parameters
   ///
-  /// link_name   : Name of the link affected by the group of lift/drag
-  ///               properties. This can be a scoped name to reference links in
-  ///               nested models. \sa entitiesFromScopedName to learn more
-  ///               about scoped names.
-  /// air_density : Density of the fluid this model is suspended in.
-  /// area        : Surface area of the link.
-  /// a0          : The initial "alpha" or initial angle of attack. a0 is also
-  ///               the y-intercept of the alpha-lift coefficient curve.
-  /// cla         : The ratio of the coefficient of lift and alpha slope before
-  ///               stall. Slope of the first portion of the alpha-lift
-  ///               coefficient curve.
-  /// cda         : The ratio of the coefficient of drag and alpha slope before
-  ///               stall.
-  /// cp          : Center of pressure. The forces due to lift and drag will be
-  ///               applied here.
-  /// forward     : 3-vector representing the forward direction of motion in the
-  ///               link frame.
-  /// upward      : 3-vector representing the direction of lift or drag.
-  /// alpha_stall : Angle of attack at stall point; the peak angle of attack.
-  /// cla_stall   : The ratio of coefficient of lift and alpha slope after
-  ///               stall.  Slope of the second portion of the alpha-lift
-  ///               coefficient curve.
-  /// cda_stall   : The ratio of coefficient of drag and alpha slope after
-  ///               stall.
-  /// control_joint_name: Name of joint that actuates a control surface for this
-  ///                     lifting body (Optional)
+  /// - `<link_name>`: Name of the link affected by the group of lift/drag
+  /// properties. This can be a scoped name to reference links in
+  /// nested models. \sa entitiesFromScopedName to learn more
+  /// about scoped names.
+  /// - `<air_density>`: Density of the fluid this model is suspended in.
+  /// - `<area>`: Surface area of the link.
+  /// - `<a0>`: The initial "alpha" or initial angle of attack. a0 is also
+  /// the y-intercept of the alpha-lift coefficient curve.
+  /// - `<cla>`: The ratio of the coefficient of lift and alpha slope before
+  /// stall. Slope of the first portion of the alpha-lift
+  /// coefficient curve.
+  /// - `<cda>`: The ratio of the coefficient of drag and alpha slope before
+  /// stall.
+  /// - `<cp>`: Center of pressure. The forces due to lift and drag will be
+  /// applied here.
+  /// - `<forward>`: 3-vector representing the forward direction of motion
+  /// in the link frame.
+  /// - `<upward>`: 3-vector representing the direction of lift or drag.
+  /// - `<alpha_stall>`: Angle of attack at stall point; the peak angle
+  /// of attack.
+  /// - `<cla_stall>`: The ratio of coefficient of lift and alpha slope after
+  /// stall.  Slope of the second portion of the alpha-lift
+  /// coefficient curve.
+  /// - `<cda_stall>`: The ratio of coefficient of drag and alpha slope after
+  /// stall.
+  /// - `<control_joint_name>`: Name of joint that actuates a control surface
+  /// for this lifting body (Optional)
+  /// - `<cm_delta>`: How much Cm changes with a change in control
+  /// surface deflection angle
   class LiftDrag
       : public System,
         public ISystemConfigure,

--- a/test/integration/actor_trajectory.cc
+++ b/test/integration/actor_trajectory.cc
@@ -156,9 +156,12 @@ TEST_F(ActorFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(ActorTrajectoryNoMesh))
     std::lock_guard<std::mutex> lock(g_mutex);
     auto it = g_modelPoses.find(boxName);
     auto &poses = it->second;
-    for (unsigned int i = 0; i < poses.size()-1; ++i)
+    for (unsigned int i = 0; i < poses.size()-2; i+=2)
     {
-      EXPECT_NE(poses[i], poses[i+1]);
+      // There could be times when the rendering thread has not updated
+      // between PostUpdates so two consecutive poses may still be the same.
+      // So check for diff between every other pose
+      EXPECT_NE(poses[i], poses[i+2]);
     }
   }
 

--- a/test/integration/save_world.cc
+++ b/test/integration/save_world.cc
@@ -422,7 +422,7 @@ TEST_F(SdfGeneratorFixture, ModelWithNestedIncludes)
   ASSERT_NE(nullptr, uri);
   ASSERT_NE(nullptr, uri->GetText());
   EXPECT_EQ(
-    "https://fuel.gazebosim.org/1.0/openrobotics/models/coke can/2",
+    "https://fuel.gazebosim.org/1.0/openrobotics/models/coke can/3",
      std::string(uri->GetText()));
 
   name = include->FirstChildElement("name");


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
Our stable repository has now dart6.13 packages released for Harmonic. We should be using them instead of system ones.

For focal, we are using the dartsim PPA and we do not have them in our repository so I leave it untouched by now.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.