### PR TITLE
Add the dart6.13 packages to CI

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,5 +1,10 @@
 freeglut3-dev
 libbenchmark-dev
+libdart6.13-collision-ode-dev
+libdart6.13-dev
+libdart6.13-external-ikfast-dev
+libdart6.13-external-odelcpsolver-dev
+libdart6.13-utils-urdf-dev
 libfreeimage-dev
 libglew-dev
 libgz-cmake3-dev


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Somehow we were not using DART packages in our CI or I don't see them listed here. Add the ones in our stable repository.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.