### PR TITLE
 Standardize Doxygen parameter formatting for systems O-Z

### DIFF
--- a/examples/plugin/custom_sensor_system/CMakeLists.txt
+++ b/examples/plugin/custom_sensor_system/CMakeLists.txt
@@ -20,7 +20,7 @@ include(FetchContent)
 FetchContent_Declare(
   sensors_clone
   GIT_REPOSITORY https://github.com/gazebosim/gz-sensors
-  GIT_TAG main
+  GIT_TAG gz-sensors8
 )
 FetchContent_Populate(sensors_clone)
 add_subdirectory(${sensors_clone_SOURCE_DIR}/examples/custom_sensor ${sensors_clone_BINARY_DIR})

--- a/src/systems/buoyancy_engine/BuoyancyEngine.hh
+++ b/src/systems/buoyancy_engine/BuoyancyEngine.hh
@@ -74,16 +74,19 @@ namespace systems
   /// gz sim buoyancy_engine.sdf
   /// ```
   /// Enter the following in a separate terminal:
-  /// ```
-  /// gz topic -t /model/buoyant_box/buoyancy_engine/ -m gz.msgs.Double \
-  ///    -p "data: 0.003"
-  /// ```
+  /** ```
+      gz topic -t /model/buoyant_box/buoyancy_engine/ -m gz.msgs.Double \
+         -p "data: 0.003"
+      ```
+  **/
   /// to see the box float up.
-  /// ```
-  /// gz topic -t /model/buoyant_box/buoyancy_engine/ -m gz.msgs.Double \
-  ///    -p "data: 0.001"
-  /// ```
+  /** ```
+      gz topic -t /model/buoyant_box/buoyancy_engine/ -m gz.msgs.Double \
+         -p "data: 0.001"
+      ```
+  **/
   /// to see the box go down.
+  ///
   /// To see the current volume enter:
   /// ```
   /// gz topic -t /model/buoyant_box/buoyancy_engine/current_volume -e

--- a/src/systems/odometry_publisher/OdometryPublisher.hh
+++ b/src/systems/odometry_publisher/OdometryPublisher.hh
@@ -53,9 +53,9 @@ namespace systems
   /// messages. This element is optional, and the default value is
   /// `/model/{name_of_model}/odometry`.
   ///
-  /// - `<odom_covariance_topic>`: Custom topic on which this system will publish
-  /// odometry with covariance messages. This element is optional, and the
-  /// default value is `/model/{name_of_model}/odometry_with_covariance`.
+  /// - `<odom_covariance_topic>`: Custom topic on which this system will
+  /// publish odometry with covariance messages. This element is optional, and
+  /// the default value is `/model/{name_of_model}/odometry_with_covariance`.
   ///
   /// - `<tf_topic>`: Custom topic on which this system will publish the
   /// transform from `odom_frame` to `robot_base_frame`. This element is

--- a/src/systems/odometry_publisher/OdometryPublisher.hh
+++ b/src/systems/odometry_publisher/OdometryPublisher.hh
@@ -36,44 +36,44 @@ namespace systems
   /// order to periodically publish 2D or 3D odometry data in the form of
   /// gz::msgs::Odometry messages.
   ///
-  /// # System Parameters
+  /// ## System Parameters
   ///
-  /// `<odom_frame>`: Name of the world-fixed coordinate frame for the
+  /// - `<odom_frame>`: Name of the world-fixed coordinate frame for the
   //  odometry message. This element is optional, and the default value
   /// is `{name_of_model}/odom`.
   ///
-  /// `<robot_base_frame>`: Name of the coordinate frame rigidly attached
+  /// - `<robot_base_frame>`: Name of the coordinate frame rigidly attached
   /// to the mobile robot base. This element is optional, and the default
   /// value is `{name_of_model}/base_footprint`.
   ///
-  /// `<odom_publish_frequency>`: Odometry publication frequency. This
+  /// - `<odom_publish_frequency>`: Odometry publication frequency. This
   /// element is optional, and the default value is 50Hz.
   ///
-  /// `<odom_topic>`: Custom topic on which this system will publish odometry
+  /// - `<odom_topic>`: Custom topic on which this system will publish odometry
   /// messages. This element is optional, and the default value is
   /// `/model/{name_of_model}/odometry`.
   ///
-  /// `<odom_covariance_topic>`: Custom topic on which this system will publish
+  /// - `<odom_covariance_topic>`: Custom topic on which this system will publish
   /// odometry with covariance messages. This element is optional, and the
   /// default value is `/model/{name_of_model}/odometry_with_covariance`.
   ///
-  /// `<tf_topic>`: Custom topic on which this system will publish the
+  /// - `<tf_topic>`: Custom topic on which this system will publish the
   /// transform from `odom_frame` to `robot_base_frame`. This element is
   /// optional, and the default value is `/model/{name_of_model}/pose`.
   ///
-  /// `<dimensions>`: Number of dimensions to represent odometry. Only 2 and 3
+  /// - `<dimensions>`: Number of dimensions to represent odometry. Only 2 and 3
   /// dimensional spaces are supported. This element is optional, and the
   /// default value is 2.
   ///
-  /// `<xyz_offset>`: Position offset relative to the body fixed frame, the
+  /// - `<xyz_offset>`: Position offset relative to the body fixed frame, the
   /// default value is 0 0 0. This offset will be added to the odometry
   /// message.
   ///
-  /// `<rpy_offset>`: Rotation offset relative to the body fixed frame, the
+  /// - `<rpy_offset>`: Rotation offset relative to the body fixed frame, the
   /// default value is 0 0 0. This offset will be added to the odometry
-  ///  message.
+  /// message.
   ///
-  /// `<gaussian_noise>`: Standard deviation of the Gaussian noise to be added
+  /// - `<gaussian_noise>`: Standard deviation of the Gaussian noise to be added
   /// to pose and twist messages. This element is optional, and the default
   /// value is 0.
   class OdometryPublisher

--- a/src/systems/optical_tactile_plugin/OpticalTactilePlugin.hh
+++ b/src/systems/optical_tactile_plugin/OpticalTactilePlugin.hh
@@ -37,54 +37,52 @@ namespace systems
   ///
   /// It requires that contact sensor and depth camera be placed in at least
   /// one link on the model on which this plugin is attached.
-  /// TODO:
+  ///
+  /// \todo(anyone)
   /// Currently, the contacts returned from the physics engine (which tends to
   /// be sparse) and the normal forces separately computed from the depth
   /// camera (which is dense, resolution adjustable) are disjoint. It is
   /// left as future work to combine the two sets of data.
   ///
-  /// Parameters:
+  /// ## System Parameters
   ///
-  /// <enabled> Set this to true so the plugin works from the start and
-  ///           doesn't need to be enabled. This element is optional, and the
-  ///           default value is true.
+  /// - `<enabled>`: Set this to true so the plugin works from the start and
+  /// doesn't need to be enabled. This element is optional, and the
+  /// default value is true.
   ///
-  /// <namespace> Namespace for transport topics/services. If there are more
-  ///             than one optical tactile plugins, their namespaces should
-  ///             be different.
-  ///             This element is optional, and the default value is
-  ///             "optical_tactile_sensor".
-  ///             /<namespace>/enable : Service used to enable and disable the
-  ///                                   plugin.
-  ///             /<namespace>/normal_forces : Topic where a message is
-  ///                                          published each time the
-  ///                                          normal forces are computed
+  /// - `<namespace>`: Namespace for transport topics/services. If there are
+  /// more than one optical tactile plugins, their namespaces should
+  /// be different. This element is optional, and the default value is
+  /// "optical_tactile_sensor".
+  ///   - `/<namespace>/enable`: Service used to enable and disable the plugin.
+  ///   - `/<namespace>/normal_forces`: Topic where a message is
+  ///     published each time the normal forces are computed
   ///
-  /// <visualization_resolution> Number n of pixels to skip when visualizing
-  ///                            the forces. One vector representing a normal
-  ///                            force is computed for every nth pixel. This
-  ///                            element must be positive and it is optional.
-  ///                            The default value is 30.
+  /// - `<visualization_resolution>`: Number n of pixels to skip when
+  /// visualizing the forces. One vector representing a normal
+  /// force is computed for every nth pixel. This
+  /// element must be positive and it is optional.
+  /// The default value is 30.
   ///
-  /// <force_length> Length in meters of the forces visualized if
-  ///                <visualize_forces> is set to true. This parameter is
-  ///                optional, and the default value is 0.01.
+  /// - `<force_length>`: Length in meters of the forces visualized if
+  /// <visualize_forces> is set to true. This parameter is
+  /// optional, and the default value is 0.01.
   ///
-  /// <extended_sensing> Extended sensing distance in meters. The sensor will
-  ///                    output data coming from its collision geometry plus
-  ///                    this distance. This element is optional, and the
-  ///                    default value is 0.001.
+  /// - `<extended_sensing>`: Extended sensing distance in meters. The sensor
+  /// will output data coming from its collision geometry plus
+  /// this distance. This element is optional, and the
+  /// default value is 0.001.
   ///
-  /// <visualize_sensor> Whether to visualize the sensor or not. This element
-  ///                    is optional, and the default value is false.
+  /// - `<visualize_sensor>`: Whether to visualize the sensor or not. This
+  /// element is optional, and the default value is false.
   ///
-  /// <visualize_contacts> Whether to visualize the contacts from the contact
-  ///                      sensor based on physics. This element is optional,
-  ///                      and the default value is false.
+  /// - `<visualize_contacts>`: Whether to visualize the contacts from the
+  /// contact sensor based on physics. This element is optional,
+  /// and the default value is false.
   ///
-  /// <visualize_forces> Whether to visualize normal forces computed from the
-  ///                    depth camera. This element is optional, and the
-  ///                    default value is false.
+  /// - `<visualize_forces>`: Whether to visualize normal forces computed from
+  /// the depth camera. This element is optional, and the
+  /// default value is false.
 
   class OpticalTactilePlugin :
     public System,

--- a/src/systems/particle_emitter/ParticleEmitter.hh
+++ b/src/systems/particle_emitter/ParticleEmitter.hh
@@ -32,10 +32,10 @@ namespace systems
   class ParticleEmitterPrivate;
 
   /// \brief A system for running and managing particle emitters. A particle
-  /// emitter is defined using the <particle_emitter> SDF element.
+  /// emitter is defined using the `<particle_emitter>` SDF element.
   ///
   /// This system will create a transport subscriber for each
-  /// <particle_emitter> using the child <topic> name. If a <topic> is not
+  /// `<particle_emitter>` using the child `<topic>` name. If a `<topic>` is not
   /// specified, the following topic naming scheme will be used:
   /// `/model/{model_name}/link/{link_name}/particle_emitter/{emitter_name}/cmd`
   class ParticleEmitter

--- a/src/systems/performer_detector/PerformerDetector.hh
+++ b/src/systems/performer_detector/PerformerDetector.hh
@@ -45,8 +45,9 @@ namespace systems
   /// PerformerDetector's region, which is also represented by an
   /// gz::math::AxisAlignedBox. When a performer is detected, the system
   /// publishes a gz.msgs.Pose message with the pose of the detected
-  /// performer with respect to the model containing the PerformerDetector. The
-  /// name and id fields of the Pose message will be set to the name and the
+  /// performer with respect to the model containing the PerformerDetector.
+  ///
+  /// The name and id fields of the Pose message will be set to the name and the
   /// entity of the detected performer respectively. The header of the Pose
   /// message contains the time stamp of detection. The `data` field of the
   /// header will contain the key "frame_id" with a value set to the name of
@@ -62,19 +63,22 @@ namespace systems
   /// The system does not assume that levels are enabled, but it does require
   /// performers to be specified.
   ///
-  /// ## System parameters
+  /// ## System Parameters
   ///
-  /// `<topic>`: Custom topic to be used for publishing when a performer is
+  /// - `<topic>`: Custom topic to be used for publishing when a performer is
   /// detected. If not set, the default topic with the following pattern would
   /// be used "/model/<model_name>/performer_detector/status". The topic type
   /// is gz.msgs.Pose
-  /// `<geometry>`: Detection region. Currently, only the `<box>` geometry is
+  ///
+  /// - `<geometry>`: Detection region. Currently, only the `<box>` geometry is
   /// supported. The position of the geometry is derived from the pose of the
   /// containing model.
-  /// `<pose>`: Additional pose offset relative to the parent model's pose.
+  ///
+  /// - `<pose>`: Additional pose offset relative to the parent model's pose.
   /// This pose is added to the parent model pose when computing the
   /// detection region. Only the position component of the `<pose>` is used.
-  /// `<header_data>`: Zero or more key-value pairs that will be
+  ///
+  /// - `<header_data>`: Zero or more key-value pairs that will be
   /// included in the header of the detection messages. A `<header_data>`
   /// element should have child `<key>` and `<value>` elements whose
   /// contents are interpreted as strings. Keys value pairs are stored in a

--- a/src/systems/physics/Physics.hh
+++ b/src/systems/physics/Physics.hh
@@ -64,9 +64,15 @@ namespace systems
 
   /// \class Physics Physics.hh gz/sim/systems/Physics.hh
   /// \brief Base class for a System.
-  /// Includes optional parameter : <include_entity_names>. When set
+  ///
+  /// ## System Parameters
+  ///
+  /// - `<include_entity_names>`: Optional. When set
   /// to false, the name of colliding entities is not populated in
-  /// the contacts. Remains true by default. Usage :
+  /// the contacts. Remains true by default.
+  ///
+  /// ## Example
+  ///
   /// ```
   ///  <plugin
   ///    filename="gz-sim-physics-system"

--- a/src/systems/python_system_loader/PythonSystemLoader.hh
+++ b/src/systems/python_system_loader/PythonSystemLoader.hh
@@ -55,14 +55,14 @@ namespace systems
 /// check if the corresponding method is implemented in the Python system and
 /// skip it if it's not found.
 ///
-/// See examples/scripts/python_api/systems/test_system.py for an example
+/// See `examples/scripts/python_api/systems/test_system.py` for an example
 ///
-/// ## Parameters
-/// * <module_name> : Name of python module to be loaded. The search path
+/// ## System Parameters
+/// * `<module_name>` : Name of python module to be loaded. The search path
 ///                   includes `GZ_SIM_SYSTEM_PLUGIN_PATH` as well as
 ///                   `PYTHONPATH`.
 ///
-/// The contents of the <plugin> tag will be available in the configure method
+/// The contents of the `<plugin>` tag will be available in the configure method
 /// of the Python system
 // TODO(azeey) Add ParameterConfigure
 class GZ_SIM_PYTHON_SYSTEM_LOADER_SYSTEM_HIDDEN PythonSystemLoader final

--- a/src/systems/rf_comms/RFComms.hh
+++ b/src/systems/rf_comms/RFComms.hh
@@ -38,31 +38,37 @@ namespace systems
   /// This communication model has been ported from:
   /// https://github.com/osrf/subt .
   ///
+  /// ## System Parameters
+  ///
   /// This system can be configured with the following SDF parameters:
   ///
-  /// * Optional parameters:
-  /// <range_config> Element used to capture the range configuration based on a
-  ///                log-normal distribution. This block can contain any of the
-  ///                next parameters:
-  ///    * <max_range>: Hard limit on range (meters). No communication will
-  ///                   happen beyond this range. Default is 50.
-  ///    * <fading_exponent>: Fading exponent used in the normal distribution.
-  ///                         Default is 2.5.
-  ///    * <l0>: Path loss at the reference distance (1 meter) in dBm.
-  ///            Default is 40.
-  ///    * <sigma>: Standard deviation of the normal distribution.
-  ///               Default is 10.
+  /// Optional parameters:
   ///
-  /// <radio_config> Element used to capture the radio configuration.
-  ///                This block can contain any of the
-  ///                next parameters:
-  ///    * <capacity>: Capacity of radio in bits-per-second.
-  ///                  Default is 54000000 (54 Mbps).
-  ///    * <tx_power>: Transmitter power in dBm. Default is 27dBm (500mW).
-  ///    * <noise_floor>: Noise floor in dBm.  Default is -90dBm.
-  ///    * <modulation>: Supported modulations: ["QPSK"]. Default is "QPSK".
+  /// - `<range_config>`: Element used to capture the range configuration based
+  ///   on a log-normal distribution. This block can contain any of the
+  ///   next parameters:
+  ///   - `<max_range>`: Hard limit on range (meters). No communication will
+  ///                    happen beyond this range. Default is 50.
+  ///   - `<fading_exponent>`: Fading exponent used in the normal distribution.
+  ///                          Default is 2.5.
+  ///   - `<l0>`: Path loss at the reference distance (1 meter) in dBm.
+  ///             Default is 40.
+  ///   - `<sigma>`: Standard deviation of the normal distribution.
+  ///                Default is 10.
+  ///
+  /// - `<radio_config>`: Element used to capture the radio configuration.
+  ///                     This block can contain any of the
+  ///                     next parameters:
+  ///   - `<capacity>`: Capacity of radio in bits-per-second.
+  ///                   Default is 54000000 (54 Mbps).
+  ///   - `<tx_power>`: Transmitter power in dBm. Default is 27dBm (500mW).
+  ///   - `<noise_floor>`: Noise floor in dBm.  Default is -90dBm.
+  ///   - `<modulation>`: Supported modulations: ["QPSK"]. Default is "QPSK".
+  ///
+  /// ## Example
   ///
   /// Here's an example:
+  /// ```
   /// <plugin
   ///   filename="gz-sim-rf-comms-system"
   ///   name="gz::sim::systems::RFComms">
@@ -79,6 +85,7 @@ namespace systems
   ///     <modulation>QPSK</modulation>
   ///   </radio_config>
   /// </plugin>
+  /// ```
   class RFComms
     : public comms::ICommsModel
   {

--- a/src/systems/sensors/Sensors.hh
+++ b/src/systems/sensors/Sensors.hh
@@ -40,14 +40,14 @@ namespace systems
   ///
   /// ## System Parameters
   ///
-  /// - `<render_engine>` Name of the render engine, such as 'ogre' or 'ogre2'.
-  /// - `<background_color>` Color used for the scene's background. This
+  /// - `<render_engine>`: Name of the render engine, such as "ogre" or "ogre2".
+  /// - `<background_color>`: Color used for the scene's background. This
   /// will override the background color specified in a world's SDF <scene>
   /// element. This background color is used by sensors, not the GUI.
-  /// - `<ambient_light>` Color used for the scene's ambient light. This
+  /// - `<ambient_light>`: Color used for the scene's ambient light. This
   /// will override the ambient value specified in a world's SDF <scene>
   /// element. This ambient light is used by sensors, not the GUI.
-  /// - `<disable_on_drained_battery>` Disable sensors if the model's
+  /// - `<disable_on_drained_battery>`: Disable sensors if the model's
   /// battery plugin charge reaches zero. Sensors that are in nested
   /// models are also affected.
   ///

--- a/src/systems/shader_param/ShaderParam.hh
+++ b/src/systems/shader_param/ShaderParam.hh
@@ -35,42 +35,42 @@ namespace systems
 
   /// \brief A plugin for setting shaders to a visual and its params
   ///
-  /// Plugin parameters:
+  /// ## System Parameters
   ///
-  /// <shader>     Shader to use - can be repeated to specify shader programs
-  ///              written in different languages.
-  ///              Attributes:
-  ///                language - Shader language. Possible values: glsl, metal
-  ///                           Default to glsl if not specified
-  ///   <vertex>   Path to vertex program
-  ///   <fragment> Path to fragment program
-  /// <param>      Shader parameter - can be repeated within plugin SDF element
-  ///   <name>     Name of uniform variable bound to the shader
-  ///   <shader>   Type of shader, i.e. vertex, fragment
-  ///   <type>     Variable type: float, int, float_array, int_array
-  ///   <value>    Value to set the shader parameter to. The vallue string can
-  ///              be an int, float, or a space delimited array of ints or
-  ///              floats. It can also be 'TIME', in which case the value will
-  ///              be bound to sim time.
+  /// - `<shader>`: Shader to use - can be repeated to specify shader programs
+  ///               written in different languages.
+  ///   - Attributes:
+  ///     - `language`: Shader language. Possible values: glsl, metal
+  ///                   Default to glsl if not specified
+  ///   - `<vertex>`: Path to vertex program
+  ///   - `<fragment>`: Path to fragment program
+  /// - `<param>`: Shader parameter - can be repeated within plugin SDF element
+  ///   - `<name>`: Name of uniform variable bound to the shader
+  ///   - `<shader>`: Type of shader, i.e. vertex, fragment
+  ///   - `<type>`: Variable type: float, int, float_array, int_array
+  ///   - `<value>`: Value to set the shader parameter to. The vallue string can
+  ///                be an int, float, or a space delimited array of ints or
+  ///                floats. It can also be "TIME", in which case the value will
+  ///                be bound to sim time.
   ///
-  /// Example usage:
+  /// ## Example
   ///
-  /// \verbatim
-  ///     <plugin filename="gz-sim-shader-param-system"
-  ///             name="gz::sim::systems::ShaderParam">
-  ///        <shader language='glsl'>
-  ///          <vertex>materials/my_vs.glsl</vertex>
-  ///          <fragment>materials/my_fs.glsl</fragment>
-  ///        </shader>
-  ///        <!-- Sets a fragment shader variable named "ambient" to red -->
-  ///        <param>
-  ///          <name>ambient</name>
-  ///          <shader>fragment</shader>
-  ///          <type>float_array</type>
-  ///          <value>1.0 0.0 0.0 1.0</value>
-  ///        </param>
-  ///    </plugin>
-  /// \endverbatim
+  /// ```
+  /// <plugin filename="gz-sim-shader-param-system"
+  ///         name="gz::sim::systems::ShaderParam">
+  ///   <shader language='glsl'>
+  ///     <vertex>materials/my_vs.glsl</vertex>
+  ///     <fragment>materials/my_fs.glsl</fragment>
+  ///   </shader>
+  ///   <!-- Sets a fragment shader variable named "ambient" to red -->
+  ///   <param>
+  ///     <name>ambient</name>
+  ///     <shader>fragment</shader>
+  ///     <type>float_array</type>
+  ///     <value>1.0 0.0 0.0 1.0</value>
+  ///   </param>
+  /// </plugin>
+  /// ```
   class ShaderParam
       : public System,
         public ISystemConfigure,

--- a/src/systems/thruster/Thruster.hh
+++ b/src/systems/thruster/Thruster.hh
@@ -123,15 +123,17 @@ namespace systems
   /// gz sim auv_controls.sdf
   /// ```
   /// To control the rudder of the craft run the following:
-  /// ```
-  /// gz topic -t /model/tethys/joint/vertical_fins_joint/0/cmd_pos \
-  ///    -m gz.msgs.Double -p 'data: -0.17'
-  /// ```
+  /** ```
+      gz topic -t /model/tethys/joint/vertical_fins_joint/0/cmd_pos \
+         -m gz.msgs.Double -p 'data: -0.17'
+      ```
+  **/
   /// To apply a thrust you may run the following command:
-  /// ```
-  /// gz topic -t /model/tethys/joint/propeller_joint/cmd_thrust \
-  ///    -m gz.msgs.Double -p 'data: -31'
-  /// ```
+  /** ```
+      gz topic -t /model/tethys/joint/propeller_joint/cmd_thrust \
+         -m gz.msgs.Double -p 'data: -31'
+      ```
+  **/
   /// The vehicle should move in a circle.
   class Thruster:
     public gz::sim::System,

--- a/src/systems/thruster/Thruster.hh
+++ b/src/systems/thruster/Thruster.hh
@@ -46,64 +46,75 @@ namespace systems
   /// `/model/{ns}/joint/{joint_name}/force`.
   ///
   /// ## System Parameters
-  /// - <namespace> - The namespace in which the robot exists. The plugin will
+  ///
+  /// - `<namespace>`: The namespace in which the robot exists. The plugin will
   ///   listen on the topic `/model/{namespace}/joint/{joint_name}/cmd_thrust`or
   ///   `/model/{namespace}/joint/{joint_name}/cmd_vel` depending on the mode of
   ///   operation. If {topic} is set then the plugin will listen on
   ///   {namespace}/{topic}
   ///   [Optional]
-  /// - <topic> - The topic for receiving thrust commands. [Optional]
-  /// - <joint_name> - This is the joint in the model which corresponds to the
+  /// - `<topic>`: The topic for receiving thrust commands. [Optional]
+  /// - `<joint_name>`: This is the joint in the model which corresponds to the
   ///   propeller. [Required]
-  /// - <use_angvel_cmd> - If set to true will make the thruster
+  /// - `<use_angvel_cmd>`: If set to true will make the thruster
   ///   plugin accept commands in angular velocity in radians per seconds in
   ///   terms of newtons. [Optional, Boolean, defaults to false]
-  /// - <fluid_density> - The fluid density of the liquid in which the thruster
+  /// - `<fluid_density>`: The fluid density of the liquid in which the thruster
   ///   is operating in. [Optional, kg/m^3, defaults to 1000 kg/m^3]
-  /// - <propeller_diameter> - The diameter of the propeller in meters.
+  /// - `<propeller_diameter>`: The diameter of the propeller in meters.
   ///   [Optional, m, defaults to 0.02m]
-  /// - <thrust_coefficient> - This is the coefficient which relates the angular
-  ///   velocity to thrust. A positive coefficient corresponds to a clockwise
-  ///   propeller, which is a propeller that spins clockwise under positive
-  ///   thrust when viewed along the parent link from stern (-x) to bow (+x).
-  ///   [Optional, no units, defaults to 1.0]
-  ///
-  ///      omega = sqrt(thrust /
-  ///          (fluid_density * thrust_coefficient * propeller_diameter ^ 4))
-  ///
-  ///   Where omega is the propeller's angular velocity in rad/s.
-  /// - <velocity_control> - If true, use joint velocity commands to rotate the
+  /// - `<thrust_coefficient>`: This is the coefficient which relates the
+  ///   angular velocity to thrust. A positive coefficient corresponds to a
+  ///   clockwise propeller, which is a propeller that spins clockwise under
+  ///   positive thrust when viewed along the parent link from stern (-x) to
+  ///   bow (+x). [Optional, no units, defaults to 1.0]
+  ///   ```
+  ///   omega = sqrt(thrust /
+  ///       (fluid_density * thrust_coefficient * propeller_diameter ^ 4))
+  ///   ```
+  ///   where omega is the propeller's angular velocity in rad/s.
+  /// - `<velocity_control>`: If true, use joint velocity commands to rotate the
   ///   propeller. If false, use a PID controller to apply wrenches directly to
   ///   the propeller link instead. [Optional, defaults to false].
-  /// - <p_gain> - Proportional gain for joint PID controller. [Optional,
-  ///              no units, defaults to 0.1]
-  /// - <i_gain> - Integral gain for joint PID controller. [Optional,
-  ///              no units, defaults to 0.0]
-  /// - <d_gain> - Derivative gain for joint PID controller. [Optional,
-  ///              no units, defaults to 0.0]
-  /// - <max_thrust_cmd> - Maximum input thrust or angular velocity command.
-  ///                      [Optional, defaults to 1000N or 1000rad/s]
-  /// - <min_thrust_cmd> - Minimum input thrust or angular velocity command.
-  ///                      [Optional, defaults to -1000N or -1000rad/s]
-  /// - <deadband> - Deadband of the thruster. Absolute value below which the
-  ///                thruster won't spin nor generate thrust. This value can
-  ///                be changed at runtime using a topic. The topic is either
-  ///                `/model/{ns}/joint/{jointName}/enable_deadband` or
-  ///                `{ns}/{topic}/enable_deadband` depending on other params
-  /// - <wake_fraction>  - Relative speed reduction between the water
+  /// - `<p_gain>`: Proportional gain for joint PID controller. [Optional,
+  ///               no units, defaults to 0.1]
+  /// - `<i_gain>`: Integral gain for joint PID controller. [Optional,
+  ///               no units, defaults to 0.0]
+  /// - `<d_gain>`: Derivative gain for joint PID controller. [Optional,
+  ///               no units, defaults to 0.0]
+  /// - `<max_thrust_cmd>`: Maximum input thrust or angular velocity command.
+  ///                       [Optional, defaults to 1000N or 1000rad/s]
+  /// - `<min_thrust_cmd>`: Minimum input thrust or angular velocity command.
+  ///                       [Optional, defaults to -1000N or -1000rad/s]
+  /// - `<deadband>`: Deadband of the thruster. Absolute value below which the
+  ///                 thruster won't spin nor generate thrust. This value can
+  ///                 be changed at runtime using a topic. The topic is either
+  ///                 `/model/{ns}/joint/{jointName}/enable_deadband` or
+  ///                 `{ns}/{topic}/enable_deadband` depending on other params
+  /// - `<wake_fraction>`: Relative speed reduction between the water
   ///                      at the propeller (Va) vs behind the vessel.
   ///                      [Optional, defults to 0.2]
-  /// See Thor I Fossen's  "Guidance and Control of ocean vehicles" p. 95:
-  ///                Va = (1 - wake_fraction) * advance_speed
-  /// - <alpha_1> - Constant given by the open water propeller diagram. Used
-  ///               in the calculation of the thrust coefficient (Kt).
-  ///               [Optional, defults to 1]
-  /// - <alpha_2> - Constant given by the open water propeller diagram. Used
-  ///               in the calculation of the thrust coefficient (Kt).
-  ///               [Optional, defults to 0]
-  /// See Thor I Fossen's  "Guidance and Control of ocean vehicles" p. 95:
-  /// Kt = alpha_1 * alpha_2 * (Va/(propeller_revolution * propeller_diameter))
+  ///
+  ///   See Thor I Fossen's  "Guidance and Control of ocean vehicles" p. 95:
+  ///   ```
+  ///   Va = (1 - wake_fraction) * advance_speed
+  ///   ```
+  ///
+  /// - `<alpha_1>`: Constant given by the open water propeller diagram. Used
+  ///                in the calculation of the thrust coefficient (Kt).
+  ///                [Optional, defults to 1]
+  /// - `<alpha_2>`: Constant given by the open water propeller diagram. Used
+  ///                in the calculation of the thrust coefficient (Kt).
+  ///                [Optional, defults to 0]
+  ///
+  ///   See Thor I Fossen's  "Guidance and Control of ocean vehicles" p. 95:
+  ///   ```
+  ///   Kt = alpha_1 * alpha_2 *
+  ///       (Va / (propeller_revolution * propeller_diameter))
+  ///   ```
+  ///
   /// ## Example
+  ///
   /// An example configuration is installed with Gazebo. The example
   /// uses the LiftDrag plugin to apply steering controls. It also uses the
   /// thruster plugin to propell the craft and the buoyancy plugin for buoyant
@@ -113,13 +124,13 @@ namespace systems
   /// ```
   /// To control the rudder of the craft run the following:
   /// ```
-  /// gz topic -t /model/tethys/joint/vertical_fins_joint/0/cmd_pos
+  /// gz topic -t /model/tethys/joint/vertical_fins_joint/0/cmd_pos \
   ///    -m gz.msgs.Double -p 'data: -0.17'
   /// ```
   /// To apply a thrust you may run the following command:
   /// ```
-  /// gz topic -t /model/tethys/joint/propeller_joint/cmd_thrust
-  /// -m gz.msgs.Double -p 'data: -31'
+  /// gz topic -t /model/tethys/joint/propeller_joint/cmd_thrust \
+  ///    -m gz.msgs.Double -p 'data: -31'
   /// ```
   /// The vehicle should move in a circle.
   class Thruster:

--- a/src/systems/touch_plugin/TouchPlugin.hh
+++ b/src/systems/touch_plugin/TouchPlugin.hh
@@ -42,7 +42,7 @@ namespace systems
   /// The plugin requires that a contact sensors is placed in at least one
   /// link on the model on which this plugin is attached.
   ///
-  /// Parameters:
+  /// ## System Parameters
   ///
   /// - `<target>` Name, or substring of a name, that identifies the target
   ///              collision entity/entities.
@@ -50,15 +50,15 @@ namespace systems
   ///              entities, so it can possibly match more than one collision.
   ///              For example, using the name of a model will match all of its
   ///              collisions (scoped name
-  ///              /model_name/link_name/collision_name).
+  ///              `/model_name/link_name/collision_name`).
   ///
   /// - `<time>` Target time in seconds to maintain contact.
   ///
   /// - `<namespace>` Namespace for transport topics/services:
-  ///             + `/<namespace>/enable` : Service used to enable and disable
-  ///                                       the plugin.
-  ///             + `/<namespace>/touched` : Topic where a message is published
-  ///                                        once the touch event occurs.
+  ///   - `/<namespace>/enable` : Service used to enable and disable
+  ///                             the plugin.
+  ///   - `/<namespace>/touched` : Topic where a message is published
+  ///                              once the touch event occurs.
   ///
   /// - `<enabled>` Set this to true so the plugin works from the start and
   ///               doesn't need to be enabled.

--- a/src/systems/track_controller/TrackController.hh
+++ b/src/systems/track_controller/TrackController.hh
@@ -39,68 +39,75 @@ namespace systems
   /// The system is implemented along the lines of M. Pecka, K. Zimmermann and
   /// T. Svoboda, "Fast simulation of vehicles with non-deformable tracks,"
   /// 2017 IEEE/RSJ International Conference on Intelligent Robots and
-  /// Systems (IROS), 2017, pp. 6414-6419, doi: 10.1109/IROS.2017.8206546. It
-  /// does not provide 100% plausible track drivetrain simulation, but provides
-  /// one that is provably better than a set of wheels instead of the track.
+  /// Systems (IROS), 2017, pp. 6414-6419, doi: 10.1109/IROS.2017.8206546.
+  ///
+  /// It does not provide 100% plausible track drivetrain simulation, but
+  /// provides one that is provably better than a set of wheels instead of the
+  /// track.
+  ///
   /// Only velocity control is supported - no effort controller is available.
+  ///
   /// The basic idea of the implementation is utilizing the so called "contact
   /// surface motion" parameter of each contact point between the track and the
   /// environment. Instead of telling the physics engine to push velocity
   /// towards zero in contact points (up to friction), it tells it to maintain
-  /// the desired track velocity in the contact point (up to friction). For
-  /// better behavior when turning with tracked vehicles, it also accepts the
-  /// position of the center of rotation of the whole vehicle so that it can
-  /// adjust the direction of friction along the desired circle. This system
-  /// does not simulate the effect of grousers. The best way to achieve a
-  /// similar effect is to set a very high `<mu1>` for the track links.
+  /// the desired track velocity in the contact point (up to friction).
   ///
-  /// # Examples
+  /// For better behavior when turning with tracked vehicles, it also accepts
+  /// the position of the center of rotation of the whole vehicle so that it can
+  /// adjust the direction of friction along the desired circle.
   ///
-  /// See example usage in worlds example/conveyor.sdf and
-  /// example/tracked_vehicle_simple.sdf .
+  /// This system does not simulate the effect of grousers. The best way to
+  /// achieve a similar effect is to set a very high `<mu1>` for the track
+  /// links.
   ///
-  /// # System Parameters
+  /// ## System Parameters
   ///
-  /// `<link>` Name of the link the controller controls. Required parameter.
+  /// - `<link>`: Name of the link the controller controls. Required parameter.
   ///
-  /// `<debug>` If 1, the system will output debugging info and visualizations.
-  ///   The default value is 0.
+  /// - `<debug>`: If 1, the system will output debugging info and
+  ///   visualizations. The default value is 0.
   ///
-  /// `<track_orientation>` Orientation of the track relative to the link.
+  /// - `<track_orientation>`: Orientation of the track relative to the link.
   ///   It is assumed that the track moves along the +x direction of the
   ///   transformed coordinate system. Defaults to no rotation (`0 0 0`).
   ///
-  /// `<velocity_topic>` Name of the topic on which the system accepts velocity
-  ///   commands.
+  /// - `<velocity_topic>`: Name of the topic on which the system accepts
+  ///   velocity commands.
   ///   Defaults to `/model/${model_name}/link/${link_name}/track_cmd_vel`.
   ///
-  /// `<center_of_rotation_topic>` The topic on which the track accepts center
-  ///   of rotation commands. Defaults to
+  /// - `<center_of_rotation_topic>`: The topic on which the track accepts
+  ///   center of rotation commands. Defaults to
   ///   `/model/${model_name}/link/${link_name}/track_cmd_center_of_rotation`.
   ///
-  /// `<max_command_age>` If this parameter is set, each velocity or center of
-  ///   rotation command will only act for the given number of seconds and the
-  ///   track will be stopped if no command arrives before this timeout.
+  /// - `<max_command_age>`: If this parameter is set, each velocity or center
+  ///   of rotation command will only act for the given number of seconds and
+  ///   the track will be stopped if no command arrives before this timeout.
   ///
-  /// `<odometry_topic>` The topic on which the track odometry (i.e. position
+  /// - `<odometry_topic>`: The topic on which the track odometry (i.e. position
   ///   and instantaneous velocity) is published. This can be used e.g. to
   ///   simulate a conveyor with encoder feedback.
   ///   Defaults to `/model/${model_name}/link/${link_name}/odometry`.
   ///
-  /// `<odometry_publish_frequency>` the frequency (in Hz) at which the
+  /// - `<odometry_publish_frequency>`: the frequency (in Hz) at which the
   ///   odometry messages are published. Defaults to 50 Hz.
   ///
-  /// `<min_velocity>`/`<max_velocity>` Min/max velocity of the track (m/s).
+  /// - `<min_velocity>`/`<max_velocity>`: Min/max velocity of the track (m/s).
   ///   If not specified, the velocity is not limited (however the physics will,
   ///   in the end, have some implicit limit).
   ///
-  /// `<min_acceleration>`/`<max_acceleration>` Min/max acceleration of the
+  /// - `<min_acceleration>`/`<max_acceleration>`: Min/max acceleration of the
   ///   track (m/s^2). If not specified, the acceleration is not limited
   ///   (however the physics will, in the end, have some implicit limit).
   ///
-  /// `<min_jerk>`/`<max_jerk>` Min/max jerk of the track (m/s^3). If not
+  /// - `<min_jerk>`/`<max_jerk>`: Min/max jerk of the track (m/s^3). If not
   ///   specified, the acceleration is not limited (however the physics will,
   ///   in the end, have some implicit limit).
+  ///
+  /// ## Examples
+  ///
+  /// See example usage in worlds `example/conveyor.sdf` and
+  /// `example/tracked_vehicle_simple.sdf`.
   class TrackController
       : public System,
         public ISystemConfigure,

--- a/src/systems/tracked_vehicle/TrackedVehicle.hh
+++ b/src/systems/tracked_vehicle/TrackedVehicle.hh
@@ -40,95 +40,96 @@ namespace systems
   /// So far, this system only supports tracks that are parallel along a common
   /// axis (other designs are possible, but not implemented).
   ///
-  /// # Examples
+  /// ## System Parameters
   ///
-  /// See example usage in world example/tracked_vehicle_simple.sdf .
+  /// - `<left_track>`: Configuration of a left track link. This element can
+  ///   appear multiple times, and must appear at least once.
   ///
-  /// # System Parameters
+  /// - `<right_track>`: Configuration of a right track link. This element can
+  ///   appear multiple times, and must appear at least once.
   ///
-  /// `<left_track>`: Configuration of a left track link. This element can
-  /// appear multiple times, and must appear at least once.
+  /// - `<left_track>`, `<right_track>` subelements:
+  ///   - `<link>`: The link representing the track. Required parameter.
+  ///   - `<velocity_topic>`: The topic on which the track accepts velocity
+  ///       commands (defaults to
+  ///       `/model/${model_name}/link/${link_name}/track_cmd_vel`).
+  ///   - `<center_of_rotation_topic>`: The topic on which the track accepts
+  ///       center of rotation commands (defaults to
+  ///       `/model/${model_name}/link/${link_name}/track_cmd_center_of_rotation`)
   ///
-  /// `<right_track>`: Configuration of a right track link. This element can
-  /// appear multiple times, and must appear at least once.
-  ///
-  /// `<left_track>`, `<right_track>` subelements:
-  /// - `<link>`: The link representing the track. Required parameter.
-  /// - `<velocity_topic>`: The topic on which the track accepts velocity
-  ///     commands (defaults to
-  ///     `/model/${model_name}/link/${link_name}/track_cmd_vel`).
-  /// - `<center_of_rotation_topic>`: The topic on which the track accepts
-  ///     center of rotation commands (defaults to
-  ///     `/model/${model_name}/link/${link_name}/track_cmd_center_of_rotation`)
-  ///
-  /// `<tracks_separation>`: Distance between tracks, in meters. Required
+  /// - `<tracks_separation>`: Distance between tracks, in meters. Required
   ///   parameter.
   ///
-  /// `<track_height>`: Height of the tracks, in meters (used for computing
-  /// odometry). Required parameter.
+  /// - `<track_height>`: Height of the tracks, in meters (used for computing
+  ///   odometry). Required parameter.
   ///
-  /// `<steering_efficiency>`: Initial steering efficiency. Defaults to 0.5.
+  /// - `<steering_efficiency>`: Initial steering efficiency. Defaults to 0.5.
   ///
-  /// `<debug>` If 1, the system will output debugging info and visualizations.
-  ///   Defaults to 0.
+  /// - `<debug>`: If 1, the system will output debugging info and
+  ///   visualizations. Defaults to 0.
   ///
-  /// `<linear_velocity>`: Limiter of linear velocity of the vehicle. Please
+  /// - `<linear_velocity>`: Limiter of linear velocity of the vehicle. Please
   /// note that the tracks can each have their own speed limitations. If the
   /// element is not specified, the velocities etc. have no implicit limits.
-  /// - `<min_velocity>`/`<max_velocity>` Min/max velocity of the vehicle (m/s).
+  ///   - `<min_velocity>`/`<max_velocity>` Min/max velocity of the vehicle
+  ///     (m/s).
   ///     If not specified, the velocity is not limited (however the physics
   ///     will, in the end, have some implicit limit).
-  /// - `<min_acceleration>`/`<max_acceleration>` Min/max acceleration of the
+  ///   - `<min_acceleration>`/`<max_acceleration>` Min/max acceleration of the
   ///     vehicle (m/s^2). If not specified, the acceleration is not limited
   ///     (however the physics will, in the end, have some implicit limit).
-  /// - `<min_jerk>`/`<max_jerk>` Min/max jerk of the vehicle (m/s^3). If not
+  ///   - `<min_jerk>`/`<max_jerk>` Min/max jerk of the vehicle (m/s^3). If not
   ///     specified, the acceleration is not limited (however the physics will,
   ///     in the end, have some implicit limit).
   ///
-  /// `<angular_velocity>`: Limiter of angular velocity of the vehicle. Please
-  /// note that the tracks can each have their own speed limitations. If the
-  /// element is not specified, the velocities etc. have no implicit limits.
-  /// - `<min_velocity>`/`<max_velocity>` Min/max velocity of the vehicle
+  /// - `<angular_velocity>`: Limiter of angular velocity of the vehicle. Please
+  ///   note that the tracks can each have their own speed limitations. If the
+  ///   element is not specified, the velocities etc. have no implicit limits.
+  ///   - `<min_velocity>`/`<max_velocity>` Min/max velocity of the vehicle
   ///     (rad/s). If not specified, the velocity is not limited (however the
-  ///      physics will, in the end, have some implicit limit).
-  /// - `<min_acceleration>`/`<max_acceleration>` Min/max acceleration of the
+  ///     physics will, in the end, have some implicit limit).
+  ///   - `<min_acceleration>`/`<max_acceleration>` Min/max acceleration of the
   ///     vehicle (rad/s^2). If not specified, the velocity is not limited
   ///     (however the physics will, in the end, have some implicit limit).
-  /// - `<min_jerk>`/`<max_jerk>` Min/max jerk of the vehicle (rad/s^3). If not
-  ///     specified, the velocity is not limited (however the physics
+  ///   - `<min_jerk>`/`<max_jerk>` Min/max jerk of the vehicle (rad/s^3). If
+  ///     not specified, the velocity is not limited (however the physics
   ///     will, in the end, have some implicit limit).
   ///
-  /// `<odom_publish_frequency>`: Odometry publication frequency. This
-  /// element is optional, and the default value is 50Hz.
+  /// - `<odom_publish_frequency>`: Odometry publication frequency. This
+  ///   element is optional, and the default value is 50Hz.
   ///
-  /// `<topic>`: Custom topic that this system will subscribe to in order to
-  /// receive command velocity messages. This element is optional, and the
-  /// default value is `/model/{model_name}/cmd_vel`.
+  /// - `<topic>`: Custom topic that this system will subscribe to in order to
+  ///   receive command velocity messages. This element is optional, and the
+  ///   default value is `/model/{model_name}/cmd_vel`.
   ///
-  /// `<steering_efficiency_topic>`: Custom topic that this system will
-  /// subscribe to in order to receive steering efficiency messages.
-  /// This element is optional, and the default value is
-  /// `/model/{model_name}/steering_efficiency`.
+  /// - `<steering_efficiency_topic>`: Custom topic that this system will
+  ///   subscribe to in order to receive steering efficiency messages.
+  ///   This element is optional, and the default value is
+  ///   `/model/{model_name}/steering_efficiency`.
   ///
-  /// `<odom_topic>`: Custom topic on which this system will publish odometry
-  /// messages. This element is optional, and the default value is
-  /// `/model/{model_name}/odometry`.
+  /// - `<odom_topic>`: Custom topic on which this system will publish odometry
+  ///   messages. This element is optional, and the default value is
+  ///   `/model/{model_name}/odometry`.
   ///
-  /// `<tf_topic>`: Custom topic on which this system will publish the
-  /// transform from `frame_id` to `child_frame_id`. This element is optional,
-  ///  and the default value is `/model/{model_name}/tf`.
+  /// - `<tf_topic>`: Custom topic on which this system will publish the
+  ///   transform from `frame_id` to `child_frame_id`. This element is optional,
+  ///   and the default value is `/model/{model_name}/tf`.
   ///
-  /// `<frame_id>`: Custom `frame_id` field that this system will use as the
-  /// origin of the odometry transform in both the `<tf_topic>`
-  /// `gz.msgs.Pose_V` message and the `<odom_topic>`
-  /// `gz.msgs.Odometry` message. This element if optional, and the
-  /// default value is `{model_name}/odom`.
+  /// - `<frame_id>`: Custom `frame_id` field that this system will use as the
+  ///   origin of the odometry transform in both the `<tf_topic>`
+  ///   `gz.msgs.Pose_V` message and the `<odom_topic>`
+  ///   `gz.msgs.Odometry` message. This element if optional, and the
+  ///   default value is `{model_name}/odom`.
   ///
-  /// `<child_frame_id>`: Custom `child_frame_id` that this system will use as
-  /// the target of the odometry trasnform in both the `<tf_topic>`
-  /// `gz.msgs.Pose_V` message and the `<odom_topic>`
-  /// `gz.msgs.Odometry` message. This element if optional,
-  ///  and the default value is `{model_name}/{link_name}`.
+  /// - `<child_frame_id>`: Custom `child_frame_id` that this system will use as
+  ///   the target of the odometry trasnform in both the `<tf_topic>`
+  ///   `gz.msgs.Pose_V` message and the `<odom_topic>`
+  ///   `gz.msgs.Odometry` message. This element if optional,
+  ///   and the default value is `{model_name}/{link_name}`.
+  ///
+  /// ## Examples
+  ///
+  /// See example usage in world `example/tracked_vehicle_simple.sdf`.
   class TrackedVehicle
       : public System,
         public ISystemConfigure,

--- a/src/systems/trajectory_follower/TrajectoryFollower.hh
+++ b/src/systems/trajectory_follower/TrajectoryFollower.hh
@@ -45,78 +45,92 @@ namespace systems
   /// generated relative to the model's initial position via the <line> or
   /// <circle> elements.  Only one of these options should be used.
   ///
-  /// This plugin requires the following SDF parameters:
-  /// * Required parameters:
-  /// <link_name>: The name of the link within the model where the force/torque
-  ///              will be applied when moving the vehicle.
+  /// ## System Parameters
   ///
-  /// * Optional parameters:
-  /// <loop>: When true, all waypoints will be visited continously in a
-  ///         circular pattern. If false, the model will stop when the
-  ///         last waypoint is reached. Note, that if the vehicle moves,
-  ///         it will still try to reach the very last waypoint.
-  /// <waypoints>: Element specifying the set of waypoints that the
-  ///              the model should navigate through. This block should contain
-  ///              at least one of these blocks:
-  ///                <waypoint>: This block should contain the X, Y of a
-  ///                            waypoint.
-  /// <range_tolerance>: The current waypoint is considered reached if the
-  ///                    distance to it is within +- this tolerance (m).
-  ///                    The default value is 0.5m.
-  /// <bearing_tolerance>: If the bearing to the current waypoint is within
-  ///                      +- this tolerance, a torque won't be applied (degree)
-  ///                      The default value is 2 deg.
-  /// <zero_vel_on_bearing_reached>: Force angular velocity to be zero when
-  ///                                target bearing is reached.
-  ///                                Default is false.
-  ///                                Note: this is an experimental parameter
-  ///                                and may be removed in the future.
-  /// <force>: The force to apply at every plugin iteration in the X direction
-  ///          of the link (N). The default value is 60.
-  /// <torque>: The torque to apply at every plugin iteration in the Yaw
-  ///           direction of the link (Nm). The default value is 50.
-  /// <line>: Element that indicates the model should travel in "line" mode.
-  ///         The block should contain the relative direction and distance from
-  ///         the initial position in which the vehicle should move, specified
-  ///         in the world frame.
-  ///           <direction>: Relative direction (radians) in the world frame for
-  ///                        the vehicle to travel.
-  ///           <length>: Distance (meters) for the vehicle to travel.
-  /// <circle>: Element that indicates the model should travel in "circle" mode.
-  ///           The block should contain the desired radius of the circle about
-  ///           the vehicle's initial position
-  ///             <radius>: Radius (meters) of circular path to travel.
+  /// This plugin requires the following SDF parameters:
+  ///
+  /// Required parameters:
+  ///
+  /// - `<link_name>`: The name of the link within the model where the
+  ///   force/torque will be applied when moving the vehicle.
+  ///
+  /// Optional parameters:
+  ///
+  /// - `<loop>`: When true, all waypoints will be visited continously in a
+  ///   circular pattern. If false, the model will stop when the
+  ///   last waypoint is reached. Note, that if the vehicle moves,
+  ///   it will still try to reach the very last waypoint.
+  ///
+  /// - `<waypoints>`: Element specifying the set of waypoints that the
+  ///   the model should navigate through. This block should contain
+  ///   at least one of these blocks:
+  ///   - `<waypoint>`: This block should contain the X, Y of a waypoint.
+  ///
+  /// - `<range_tolerance>`: The current waypoint is considered reached if the
+  ///   distance to it is within +- this tolerance (m).
+  ///   The default value is 0.5m.
+  ///
+  /// - `<bearing_tolerance>`: If the bearing to the current waypoint is within
+  ///   +- this tolerance, a torque won't be applied (degree).
+  ///   The default value is 2 deg.
+  ///
+  /// - `<zero_vel_on_bearing_reached>`: Force angular velocity to be zero when
+  ///   target bearing is reached.
+  ///   Default is false.
+  ///   Note: this is an experimental parameter and may be removed in the
+  ///   future.
+  ///
+  /// - `<force>`: The force to apply at every plugin iteration in the X
+  ///   direction of the link (N). The default value is 60.
+  ///
+  /// - `<torque>`: The torque to apply at every plugin iteration in the Yaw
+  ///   direction of the link (Nm). The default value is 50.
+  ///
+  /// - `<line>`: Element that indicates the model should travel in "line" mode.
+  ///   The block should contain the relative direction and distance from
+  ///   the initial position in which the vehicle should move, specified
+  ///   in the world frame.
+  ///   - `<direction>`: Relative direction (radians) in the world frame for
+  ///     the vehicle to travel.
+  ///   - `<length>`: Distance (meters) for the vehicle to travel.
+  ///
+  /// - `<circle>`: Element that indicates the model should travel in "circle"
+  ///   mode. The block should contain the desired radius of the circle about
+  ///   the vehicle's initial position
+  ///   - `<radius>`: Radius (meters) of circular path to travel.
   ///
   /// Here are three examples:
-  // <plugin
-  //   filename="gz-sim-trajectory-follower-system"
-  //   name="gz::sim::systems::TrajectoryFollower">
-  //   <link_name>base_link</link_name>
-  //   <loop>true</loop>
-  //   <waypoints>
-  //     <waypoint>25 0</waypoint>
-  //     <waypoint>15 0</waypoint>
-  //   </waypoints>
-  // </plugin>
-  // <plugin
-  //   filename="gz-sim-trajectory-follower-system"
-  //   name="gz::sim::systems::TrajectoryFollower">
-  //   <link_name>base_link</link_name>
-  //   <loop>true</loop>
-  //   <line>
-  //     <direction>0</direction>
-  //     <length>5</length>
-  //   </line>
-  // </plugin>
-  // <plugin
-  //   filename="gz-sim-trajectory-follower-system"
-  //   name="gz::sim::systems::TrajectoryFollower">
-  //   <link_name>base_link</link_name>
-  //   <loop>true</loop>
-  //   <circle>
-  //     <radius>2</radius>
-  //   </circle>
-  // </plugin>
+  /// ```
+  /// <plugin
+  ///   filename="gz-sim-trajectory-follower-system"
+  ///   name="gz::sim::systems::TrajectoryFollower">
+  ///   <link_name>base_link</link_name>
+  ///   <loop>true</loop>
+  ///   <waypoints>
+  ///     <waypoint>25 0</waypoint>
+  ///     <waypoint>15 0</waypoint>
+  ///   </waypoints>
+  /// </plugin>
+  /// <plugin
+  ///   filename="gz-sim-trajectory-follower-system"
+  ///   name="gz::sim::systems::TrajectoryFollower">
+  ///   <link_name>base_link</link_name>
+  ///   <loop>true</loop>
+  ///   <line>
+  ///     <direction>0</direction>
+  ///     <length>5</length>
+  ///   </line>
+  /// </plugin>
+  /// <plugin
+  ///   filename="gz-sim-trajectory-follower-system"
+  ///   name="gz::sim::systems::TrajectoryFollower">
+  ///   <link_name>base_link</link_name>
+  ///   <loop>true</loop>
+  ///   <circle>
+  ///     <radius>2</radius>
+  ///   </circle>
+  /// </plugin>
+  /// ```
   class TrajectoryFollower
       : public System,
         public ISystemConfigure,

--- a/src/systems/triggered_publisher/TriggeredPublisher.hh
+++ b/src/systems/triggered_publisher/TriggeredPublisher.hh
@@ -44,10 +44,10 @@ namespace systems
   ///
   /// ## System Parameters
   ///
-  /// - `<input>` The tag contains the input message type, topic and matcher
+  /// - `<input>`: The tag contains the input message type, topic and matcher
   /// information.
   ///   * Attributes:
-  ///     * `type`: Input message type (eg. `gz.msgs.Boolean`)
+  ///     * `type`: Input message type (e.g. `gz.msgs.Boolean`)
   ///     * `topic`: Input message topic name
   ///
   /// - `<input><match>`: Contains configuration for matchers. Multiple
@@ -71,7 +71,7 @@ namespace systems
   /// `<output>` tags are possible. A message will be published on each output
   /// topic for each input that matches.
   ///   * Attributes:
-  ///     * `type`: Output message type (eg. `gz.msgs.Boolean`)
+  ///     * `type`: Output message type (e.g. `gz.msgs.Boolean`)
   ///     * `topic`: Output message topic name
   ///   * Value: String used to construct the output protobuf message . This is
   ///     the human-readable representation of a protobuf message as used by
@@ -84,13 +84,14 @@ namespace systems
   /// `<service>` tags are possible. A service will be called for each input
   /// that matches.
   ///   * Attributes:
-  ///     * `name`: Service name (eg. `/world/triggered_publisher/set_pose`)
+  ///     * `name`: Service name (e.g. `/world/triggered_publisher/set_pose`)
   ///     * `timeout`: Service timeout
-  ///     * `reqType`: Service request message type (eg. gz.msgs.Pose)
-  ///     * `repType`: Service response message type (eg. gz.msgs.Empty)
+  ///     * `reqType`: Service request message type (e.g. gz.msgs.Pose)
+  ///     * `repType`: Service response message type (e.g. gz.msgs.Empty)
   ///     * `reqMsg`: String used to construct the service protobuf message.
   ///
-  /// Examples:
+  /// ## Examples
+  ///
   /// 1. Any receipt of a Boolean messages on the input topic triggers an output
   /// \code{.xml}
   ///    <plugin>
@@ -166,7 +167,7 @@ namespace systems
   /// </plugin>
   /// \endcode
   ///
-  /// ### Limitations
+  /// ## Limitations
   /// The current implementation of this system does not support specifying a
   /// subfield of a repeated field in the "field" attribute. i.e, if
   /// `field="f1.f2"`, `f1` cannot be a repeated field.

--- a/src/systems/velocity_control/VelocityControl.hh
+++ b/src/systems/velocity_control/VelocityControl.hh
@@ -38,12 +38,12 @@ namespace systems
   ///
   /// ## System Parameters
   ///
-  /// `<topic>` Topic to receive commands in. Defaults to
-  ///     `/model/<model_name>/cmd_vel`.
+  /// - `<topic>`: Topic to receive commands in. Defaults to
+  ///   `/model/<model_name>/cmd_vel`.
   ///
-  /// `<initial_linear>` Linear velocity to start with.
+  /// - `<initial_linear>`: Linear velocity to start with.
   ///
-  /// `<initial_angular>` Linear velocity to start with.
+  /// - `<initial_angular>`: Linear velocity to start with.
   class VelocityControl
       : public System,
         public ISystemConfigure,

--- a/src/systems/wheel_slip/WheelSlip.hh
+++ b/src/systems/wheel_slip/WheelSlip.hh
@@ -34,19 +34,25 @@ namespace systems
 
   /// \brief A system that updates wheel slip parameters based
   /// on linear wheel spin velocity (radius * spin rate).
-  /// It currently assumes that the fdir1 friction parameter is set
+  ///
+  /// ## System parameters
+  ///
+  /// It currently assumes that the `fdir1` friction parameter is set
   /// parallel to the joint axis (often [0 0 1]) and that the link
   /// origin is on the joint axis.
-  /// The slip parameter is a Force-Dependent Slip (slip1, slip2)
+  ///
+  /// The `slip` parameter is a Force-Dependent Slip (slip1, slip2)
   /// and it has units of velocity / force (m / s / N),
   /// similar to the inverse of a viscous damping coefficient.
-  /// The slip_compliance parameters specified in this plugin
+  ///
+  /// The `slip_compliance` parameters specified in this plugin
   /// are unitless, representing the lateral or longitudinal slip ratio
   /// (see https://en.wikipedia.org/wiki/Slip_(vehicle_dynamics) )
   /// to tangential force ratio (tangential / normal force).
+  ///
   /// Note that the maximum force ratio is the friction coefficient.
   /// At each time step, these compliances are multiplied by
-  /// the linear wheel spin velocity and divided by the wheel_normal_force
+  /// the linear wheel spin velocity and divided by the `wheel_normal_force`
   /// parameter specified below in order to match the units of the
   /// slip parameters.
   ///
@@ -55,6 +61,7 @@ namespace systems
   /// The horizontal axis corresponds to the slip ratio at the wheel,
   /// and the vertical axis corresponds to the tangential force ratio
   /// (tangential / normal force).
+  ///
   /// As wheel slip increases, the tangential force increases until
   /// it reaches the maximum set by the friction coefficient.
   /// The slip compliance corresponds to the inverse of the slope
@@ -63,7 +70,7 @@ namespace systems
   /// portion of the plot below.
   /// As slip compliance increases, the slope decreases.
   ///
-  /** \verbatim
+  /** \code{.xml}
         |                                            .
         |      _________ friction coefficient        .
         |     /                                      .
@@ -74,7 +81,11 @@ namespace systems
         |/                                           .
       --+-------------------------- slipRatio
         |
-
+  \endcode */
+  ///
+  /// ## Examples
+  ///
+  /** \code{.xml}
     <plugin filename="gz-sim-wheel-slip-system"
      name="gz::sim::systems::WheelSlip">
       <wheel link_name="wheel_front_left">
@@ -102,7 +113,7 @@ namespace systems
         <wheel_radius>0.1651</wheel_radius>
       </wheel>
     </plugin>
-   \endverbatim */
+  \endcode */
 
   class WheelSlip
       : public System,

--- a/src/systems/wind_effects/WindEffects.hh
+++ b/src/systems/wind_effects/WindEffects.hh
@@ -56,46 +56,48 @@ namespace systems
   /// attenuated on a per location basis by specifying a piecewise scalar
   /// field for a scaling factor.
   ///
+  /// ## System Parameters
+  ///
   /// The following parameters are used by the system:
   ///
-  /// - `<horizontal><magnitude><time_for_rise>`
+  /// - `<horizontal><magnitude><time_for_rise>`:
   /// Analogous to the time constant of the low pass filter.
   ///
-  /// - `<horizontal><magnitude><sin><amplitude_percent>`
+  /// - `<horizontal><magnitude><sin><amplitude_percent>`:
   /// Fraction of the filtered wind velocity magnitude that is set to be the
   /// amplitude of the sinusoid.
   ///
-  /// - `<horizontal><magnitude><sin><period>`
+  /// - `<horizontal><magnitude><sin><period>`:
   /// Period of the sinusoid that is added to the wind velocity magnitude.
   ///
-  /// - `<horizontal><magnitude><noise>`
+  /// - `<horizontal><magnitude><noise>`:
   /// Parameters for the noise that is added to the wind velocity magnitude.
   ///
-  /// - `<horizontal><direction><time_for_rise>`
+  /// - `<horizontal><direction><time_for_rise>`:
   /// Analogous to the time constant of the low pass filter.
   ///
-  /// - `<horizontal><direction><sin><amplitude>`
+  /// - `<horizontal><direction><sin><amplitude>`:
   /// Amplitude of the sinusoidal that is added on the direction of the wind
   /// velocity.
   ///
-  /// - `<horizontal><direction><sin><period>`
+  /// - `<horizontal><direction><sin><period>`:
   /// Period of the sinusoid that is added to the wind velocity direction.
   ///
-  /// - `<horizontal><direction><noise>`
+  /// - `<horizontal><direction><noise>`:
   /// Parameters for the noise that is added to the wind velocity direction.
   ///
-  /// - `<vertical><time_for_rise>`
+  /// - `<vertical><time_for_rise>`:
   /// Analogous to the time constant of the low pass filter for the vertical
   /// wind velocity magnitude.
   ///
-  /// - `<vertical><noise>`
+  /// - `<vertical><noise>`:
   /// Parameters for the noise that is added to the vertical wind velocity
   /// magnitude.
   ///
-  /// - `<force_approximation_scaling_factor>`
+  /// - `<force_approximation_scaling_factor>`:
   /// Proportionality constant used for wind force approximations as a
   /// piecewise, separable scalar field:
-  /// \verbatim
+  /// ```
   ///   <force_approximation_scaling_factor>
   ///     <when xlt="0"> <!-- Half space where x < 0 -->
   ///       <k>1</k>
@@ -104,25 +106,25 @@ namespace systems
   ///       <rz>0 1 0 1</rz>  <!-- r(z) = z^2 -->
   ///     </when>
   ///   </force_approximation_scaling_factor>
-  /// \endverbatim
+  /// ```
   /// When the scaling factor is to be constant in a region, a numerical
   /// constant may be used in place for the scalar field definition:
-  /// \verbatim
+  /// ```
   ///   <force_approximation_scaling_factor>
   ///     <!-- First octant -->
   ///     <when xge="0" yge="0" zge="0">1</when>
   ///   </force_approximation_scaling_factor>
-  /// \endverbatim
+  /// ```
   /// To use the same constant or scalar field in all space, region
   /// definition may be dropped:
-  /// \verbatim
+  /// ```
   ///   <force_approximation_scaling_factor>
   ///     <k>2</k>
   ///     <px>1 0 1 0</px>  <!-- p(x) = x^3 + x -->
   ///     <qy>0 1 0 1</qy>  <!-- q(y) = x^2 + 1 -->
   ///     <rz>1 0 1 0</rz>  <!-- r(z) = z^3 + z -->
   ///   </force_approximation_scaling_factor>
-  /// \endverbatim
+  /// ```
   /// Regions may not overlap.
   ///
   class WindEffects final:


### PR DESCRIPTION
# 🦟 Bug fix

Follow up to https://github.com/gazebosim/gz-sim/pull/2183
Fixes the rest of the alphabet.

## Summary
See #2183

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.