### PR TITLE
Fix macOS test failures by registering components in the core library

### DIFF
--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -21,6 +21,14 @@
 #include "gz/sim/Events.hh"
 #include "gz/sim/SdfEntityCreator.hh"
 
+#ifdef __APPLE__
+// Include all known components to ensure that they are registered by the core
+// library instead of a plugin to fix
+// https://github.com/gazebosim/gz-sim/issues/2204.
+//
+// NOTE(azeey): This should not be forward ported to ign-gazebo6.
+#include "gz/sim/components/components.hh"
+#endif
 #include "gz/sim/components/Actor.hh"
 #include "gz/sim/components/AirPressureSensor.hh"
 #include "gz/sim/components/Altimeter.hh"


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2204
Needs https://github.com/gazebo-tooling/release-tools/pull/1051

## Summary
A better solution to the problem of components being registered by plugins is in https://github.com/gazebosim/gz-sim/pull/1836, but backporting that to citadel was not trivial. The solution in this PR is to force-register all built-in components in the core library by including the `components.hh` header (only for macOS). This fixes all of the gz-sim tests mentioned in #2204 locally.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
