### PR TITLE
Add libpython3-dev CI dependency

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -23,6 +23,7 @@ libsdformat14-dev
 libtinyxml2-dev
 libxi-dev
 libxmu-dev
+libpython3-dev
 python3-distutils
 python3-gz-math7
 python3-gz-msgs10

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -80,6 +80,9 @@ struct MaybeGilScopedRelease
 #else
   struct MaybeGilScopedRelease
   {
+    // The empty constructor is needed to avoid an "unused variable" warning
+    // when an instance of this class is used.
+    MaybeGilScopedRelease(){}
   };
 #endif
 }


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
https://github.com/gazebosim/gz-sim/pull/2187 introduced cmake and compiler warnings as a result of removing libdart dependencies:

```
# cmake
-- Searching for Python - not found.
CMake Warning at /usr/share/cmake/gz-cmake3/cmake3/GzConfigureBuild.cmake:68 (message):
   CONFIGURATION WARNINGS:
   -- Python is missing: Python interfaces are disabled.
Call Stack (most recent call first):
  CMakeLists.txt:238 (gz_configure_build)

```
and
```
# gcc
/home/jenkins/workspace/gz_sim-ci-gz-sim8-jammy-amd64/gz-sim/src/SimulationRunner.cc:615:29: warning: unused variable ‘release’ [-Wunused-variable]
  615 |       MaybeGilScopedRelease release;
```

This adds a direct dependency on `libpython3-dev` as opposed to the indirect dependency we had through `libdart-dev`. This PR also fixes the compiler warning in case python bindings are disabled.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

