### PR TITLE
Update friction parameters for skid steer example

### DIFF
--- a/examples/worlds/diff_drive_skid.sdf
+++ b/examples/worlds/diff_drive_skid.sdf
@@ -150,8 +150,10 @@
           <surface>
             <friction>
               <ode>
-                <mu>0.5</mu>
-                <mu2>1.0</mu2>
+                <mu>1</mu>
+                <mu2>1</mu2>
+                <slip1>0.035</slip1>
+                <slip2>0</slip2>
                 <fdir1>0 0 1</fdir1>
               </ode>
             </friction>
@@ -193,8 +195,10 @@
           <surface>
             <friction>
               <ode>
-                <mu>0.5</mu>
-                <mu2>1.0</mu2>
+                <mu>1</mu>
+                <mu2>1</mu2>
+                <slip1>0.035</slip1>
+                <slip2>0</slip2>
                 <fdir1>0 0 1</fdir1>
               </ode>
             </friction>
@@ -236,8 +240,10 @@
           <surface>
             <friction>
               <ode>
-                <mu>0.5</mu>
-                <mu2>1.0</mu2>
+                <mu>1</mu>
+                <mu2>1</mu2>
+                <slip1>0.035</slip1>
+                <slip2>0</slip2>
                 <fdir1>0 0 1</fdir1>
               </ode>
             </friction>
@@ -279,8 +285,10 @@
           <surface>
             <friction>
               <ode>
-                <mu>0.5</mu>
-                <mu2>1.0</mu2>
+                <mu>1</mu>
+                <mu2>1</mu2>
+                <slip1>0.035</slip1>
+                <slip2>0</slip2>
                 <fdir1>0 0 1</fdir1>
               </ode>
             </friction>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2174

## Summary
As shown in #2174, the vehicle seems to rotate around the center of the rear axle instead of the center of the vehicle. The new friction parameters, which I copied from the `examples/worlds/diff_drive.sdf`, seem to fix the issue. 

@jasiex01  can you give this a try?

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)
