### PR TITLE
environment_preload: fix windows compiler warnings

### DIFF
--- a/src/systems/environment_preload/EnvironmentPreload.cc
+++ b/src/systems/environment_preload/EnvironmentPreload.cc
@@ -71,7 +71,7 @@ class gz::sim::systems::EnvironmentPreloadPrivate
   public: bool visualize{false};
 
   /// \brief Sample resolutions
-  public: math::Vector3d samples;
+  public: math::Vector3<unsigned int> samples;
 
   /// \brief Is the file loaded
   public: bool fileLoaded{false};
@@ -106,8 +106,13 @@ class gz::sim::systems::EnvironmentPreloadPrivate
       // Only visualize if a file exists
       return;
     }
-    auto converted = msgs::Convert(_resChanged);
-    if (this->samples == converted)
+    math::Vector3<unsigned int> converted{
+      static_cast<unsigned int>(ceil(_resChanged.x())),
+      static_cast<unsigned int>(ceil(_resChanged.y())),
+      static_cast<unsigned int>(ceil(_resChanged.z()))};
+    if (this->samples.X() == converted.X() &&
+        this->samples.Y() == converted.Y() &&
+        this->samples.Z() == converted.Z())
     {
       // If the sample has not changed return.
       // This is because resampling is expensive.

--- a/src/systems/environment_preload/VisualizationTool.cc
+++ b/src/systems/environment_preload/VisualizationTool.cc
@@ -61,7 +61,7 @@ void EnvironmentVisualizationTool::Step(
     const UpdateInfo &_info,
     const EntityComponentManager &_ecm,
     const std::shared_ptr<components::EnvironmentalData> &_data,
-    double _xSamples, double _ySamples, double _zSamples)
+    unsigned int _xSamples, unsigned int _ySamples, unsigned int _zSamples)
 {
   if (this->finishedTime)
   {
@@ -114,7 +114,7 @@ void EnvironmentVisualizationTool::Step(
 /////////////////////////////////////////////////
 void EnvironmentVisualizationTool::Visualize(
     const std::shared_ptr<components::EnvironmentalData> &_data,
-    double _xSamples, double _ySamples, double _zSamples)
+    unsigned int _xSamples, unsigned int _ySamples, unsigned int _zSamples)
 {
   for (auto key : _data->frame.Keys())
   {
@@ -126,13 +126,13 @@ void EnvironmentVisualizationTool::Visualize(
     auto dy = step.Y() / _ySamples;
     auto dz = step.Z() / _zSamples;
     std::size_t idx = 0;
-    for (std::size_t x_steps = 0; x_steps < ceil(_xSamples); x_steps++)
+    for (std::size_t x_steps = 0; x_steps < _xSamples; x_steps++)
     {
       auto x = lower_bound.X() + x_steps * dx;
-      for (std::size_t y_steps = 0; y_steps < ceil(_ySamples); y_steps++)
+      for (std::size_t y_steps = 0; y_steps < _ySamples; y_steps++)
       {
         auto y = lower_bound.Y() + y_steps * dy;
-        for (std::size_t z_steps = 0; z_steps < ceil(_zSamples); z_steps++)
+        for (std::size_t z_steps = 0; z_steps < _zSamples; z_steps++)
         {
           auto z = lower_bound.Z() + z_steps * dz;
           auto res = frame.LookUp(session, math::Vector3d(x, y, z));

--- a/src/systems/environment_preload/VisualizationTool.hh
+++ b/src/systems/environment_preload/VisualizationTool.hh
@@ -89,7 +89,7 @@ class EnvironmentVisualizationTool
     const UpdateInfo &_info,
     const EntityComponentManager &_ecm,
     const std::shared_ptr<components::EnvironmentalData> &_data,
-    double _xSamples, double _ySamples, double _zSamples);
+    unsigned int _xSamples, unsigned int _ySamples, unsigned int _zSamples);
 
   /// \brief Publishes a sample of the data
   /// \param[in] _data The data to be visualized
@@ -98,7 +98,7 @@ class EnvironmentVisualizationTool
   /// \param[in] _zSample Samples along z
   private: void Visualize(
     const std::shared_ptr<components::EnvironmentalData> &_data,
-    double _xSamples, double _ySamples, double _zSamples);
+    unsigned int _xSamples, unsigned int _ySamples, unsigned int _zSamples);
 
   /// \brief Get the point cloud data.
   private: void Publish();

--- a/src/systems/environment_preload/VisualizationTool.hh
+++ b/src/systems/environment_preload/VisualizationTool.hh
@@ -69,7 +69,7 @@ class EnvironmentVisualizationTool
 
   /// \brief Create publisher structures whenever a new environment is made
   /// available.
-  /// \param[in] _data Data to be visuallized
+  /// \param[in] _data Data to be visualized
   /// \param[in] _info simulation info for current time step
   private: void CreatePointCloudTopics(
     const std::shared_ptr<components::EnvironmentalData> &_data,
@@ -81,7 +81,7 @@ class EnvironmentVisualizationTool
   /// \brief Step the visualizations
   /// \param[in] _info The simulation info including timestep
   /// \param[in] _ecm The Entity-Component-Manager
-  /// \param[in] _data The data to be visuallized
+  /// \param[in] _data The data to be visualized
   /// \param[in] _xSample Samples along x
   /// \param[in] _ySample Samples along y
   /// \param[in] _zSample Samples along z
@@ -92,7 +92,7 @@ class EnvironmentVisualizationTool
     double _xSamples, double _ySamples, double _zSamples);
 
   /// \brief Publishes a sample of the data
-  /// \param[in] _data The data to be visuallized
+  /// \param[in] _data The data to be visualized
   /// \param[in] _xSample Samples along x
   /// \param[in] _ySample Samples along y
   /// \param[in] _zSample Samples along z
@@ -106,7 +106,7 @@ class EnvironmentVisualizationTool
   /// \brief Resize the point cloud structure (used to reallocate
   /// memory when resolution changes)
   /// \param[in] _ecm The Entity-Component-Manager
-  /// \param[in] _data The data to be visuallized
+  /// \param[in] _data The data to be visualized
   /// \param[in] _xSample Samples along x
   /// \param[in] _ySample Samples along y
   /// \param[in] _zSample Samples along z


### PR DESCRIPTION
# 🦟 Bug fix

Fixes some compiler warnings in windows CI from the `environment_preload` system

## Summary

The garden windows CI build has no test failures and just a few compiler warnings:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_gazebo-gz-7-win&build=143)](https://build.osrfoundation.org/view/ign-garden/job/ign_gazebo-gz-7-win/143/) https://build.osrfoundation.org/view/ign-garden/job/ign_gazebo-gz-7-win/143/msbuild/fileName.1593292455/

This is an attempt to fix the compiler warnings in the `environment_preload` system, specifically [VisualizationTool.cc:80](https://github.com/gazebosim/gz-sim/blob/c73c12bf759c4fd22b5290451cecc79670545130/src/systems/environment_preload/VisualizationTool.cc#L80).

~~~
'argument': conversion from 'double' to 'unsigned int', possible loss of data
~~~

From what I can see, the `/environment/visualize/res` topic uses a `gz::msgs::Vector3d` to store 3 integers because there is no `gz::msgs::Vector3i`. This PR casts the `double` values to `unsigned int` in the callback and changes the internal storage and APIs to use `unsigned int` instead of `double`.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
