### PR TITLE
Disable distortion camera test on Linux

### DIFF
--- a/test/integration/distortion_camera.cc
+++ b/test/integration/distortion_camera.cc
@@ -67,7 +67,7 @@ void imageCb(const msgs::Image &_msg)
 /////////////////////////////////////////////////
 // The test checks the Distortion Camera readings
 TEST_F(DistortionCameraTest,
-    GZ_UTILS_TEST_DISABLED_ON_MAC(DistortionCameraBox))
+    DISABLED_DistortionCameraBox)
 {
   // Start server
   ServerConfig serverConfig;


### PR DESCRIPTION
# 🦟 Bug fix

Part of #2243.

## Summary

Disable the distortion camera test on Linux for `gz-sim8`, since it has been failing there. It [works on gz-sim7](https://build.osrfoundation.org/job/gz_sim-ci-gz-sim7-focal-amd64/7/testReport/(root)/DistortionCameraTest/) on Linux. It is already disabled on macOS and doesn't run on windows, so just disable it outright on gz-sim8.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
