### PR TITLE
  Enable HIDE_SYMBOLS_BY_DEFAULT + linux patches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,8 @@ set(GZ_SIM_GUI_PLUGIN_INSTALL_DIR
 #============================================================================
 # Configure the build
 #============================================================================
-gz_configure_build(QUIT_IF_BUILD_ERRORS)
+gz_configure_build(QUIT_IF_BUILD_ERRORS
+  HIDE_SYMBOLS_BY_DEFAULT)
 
 add_subdirectory(examples)
 

--- a/src/gui/plugins/joint_position_controller/JointPositionController.hh
+++ b/src/gui/plugins/joint_position_controller/JointPositionController.hh
@@ -22,9 +22,18 @@
 #include <memory>
 #include <string>
 
-#include <gz/sim/gui/Export.hh>
 #include <gz/sim/gui/GuiSystem.hh>
 #include <gz/sim/Types.hh>
+
+#ifndef _WIN32
+#  define JointPositionController_EXPORTS_API __attribute__ ((visibility ("default")))
+#else
+#  if (defined(JointPositionController_EXPORTS))
+#    define JointPositionController_EXPORTS_API __declspec(dllexport)
+#  else
+#    define JointPositionController_EXPORTS_API __declspec(dllimport)
+#  endif
+#endif
 
 Q_DECLARE_METATYPE(gz::sim::Entity)
 
@@ -37,7 +46,7 @@ namespace gui
   class JointPositionControllerPrivate;
 
   /// \brief Model holding information about joints
-  class GZ_SIM_GUI_VISIBLE JointsModel : public QStandardItemModel
+  class JointPositionController_EXPORTS_API JointsModel : public QStandardItemModel
   {
     Q_OBJECT
 
@@ -89,7 +98,7 @@ namespace gui
   /// `<model_name>`: Load the widget pointed at the given model, so it's not
   /// necessary to select it. If a model is given at startup, the plugin starts
   /// in locked mode.
-  class GZ_SIM_GUI_VISIBLE JointPositionController : public sim::GuiSystem
+  class JointPositionController_EXPORTS_API JointPositionController : public sim::GuiSystem
   {
     Q_OBJECT
 

--- a/src/gui/plugins/joint_position_controller/JointPositionController.hh
+++ b/src/gui/plugins/joint_position_controller/JointPositionController.hh
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 
+#include <gz/sim/gui/Export.hh>
 #include <gz/sim/gui/GuiSystem.hh>
 #include <gz/sim/Types.hh>
 
@@ -36,7 +37,7 @@ namespace gui
   class JointPositionControllerPrivate;
 
   /// \brief Model holding information about joints
-  class JointsModel : public QStandardItemModel
+  class GZ_SIM_GUI_VISIBLE JointsModel : public QStandardItemModel
   {
     Q_OBJECT
 
@@ -88,7 +89,7 @@ namespace gui
   /// `<model_name>`: Load the widget pointed at the given model, so it's not
   /// necessary to select it. If a model is given at startup, the plugin starts
   /// in locked mode.
-  class JointPositionController : public sim::GuiSystem
+  class GZ_SIM_GUI_VISIBLE JointPositionController : public sim::GuiSystem
   {
     Q_OBJECT
 

--- a/src/gui/plugins/joint_position_controller/JointPositionController.hh
+++ b/src/gui/plugins/joint_position_controller/JointPositionController.hh
@@ -26,7 +26,8 @@
 #include <gz/sim/Types.hh>
 
 #ifndef _WIN32
-#  define JointPositionController_EXPORTS_API __attribute__ ((visibility ("default")))
+#  define JointPositionController_EXPORTS_API \
+      __attribute__ ((visibility ("default")))
 #else
 #  if (defined(JointPositionController_EXPORTS))
 #    define JointPositionController_EXPORTS_API __declspec(dllexport)
@@ -46,7 +47,8 @@ namespace gui
   class JointPositionControllerPrivate;
 
   /// \brief Model holding information about joints
-  class JointPositionController_EXPORTS_API JointsModel : public QStandardItemModel
+  class JointPositionController_EXPORTS_API JointsModel :
+    public QStandardItemModel
   {
     Q_OBJECT
 
@@ -98,7 +100,8 @@ namespace gui
   /// `<model_name>`: Load the widget pointed at the given model, so it's not
   /// necessary to select it. If a model is given at startup, the plugin starts
   /// in locked mode.
-  class JointPositionController_EXPORTS_API JointPositionController : public sim::GuiSystem
+  class JointPositionController_EXPORTS_API JointPositionController :
+    public sim::GuiSystem
   {
     Q_OBJECT
 

--- a/src/gui/plugins/plot_3d/Plot3D.hh
+++ b/src/gui/plugins/plot_3d/Plot3D.hh
@@ -20,6 +20,7 @@
 
 #include <memory>
 
+#include <gz/sim/gui/Export.hh>
 #include <gz/sim/gui/GuiSystem.hh>
 
 #include "gz/gui/qt.h"
@@ -59,7 +60,7 @@ namespace gui
   /// After this number is reached, the older points start being deleted.
   /// Defaults to 1000.
   ///
-  class Plot3D : public gz::sim::GuiSystem
+  class GZ_SIM_GUI_VISIBLE Plot3D : public gz::sim::GuiSystem
   {
     Q_OBJECT
 

--- a/src/gui/plugins/plot_3d/Plot3D.hh
+++ b/src/gui/plugins/plot_3d/Plot3D.hh
@@ -20,10 +20,19 @@
 
 #include <memory>
 
-#include <gz/sim/gui/Export.hh>
 #include <gz/sim/gui/GuiSystem.hh>
 
 #include "gz/gui/qt.h"
+
+#ifndef _WIN32
+#  define Plot3D_EXPORTS_API __attribute__ ((visibility ("default")))
+#else
+#  if (defined(Plot3D_EXPORTS))
+#    define Plot3D_EXPORTS_API __declspec(dllexport)
+#  else
+#    define Plot3D_EXPORTS_API __declspec(dllimport)
+#  endif
+#endif
 
 namespace gz
 {
@@ -60,7 +69,7 @@ namespace gui
   /// After this number is reached, the older points start being deleted.
   /// Defaults to 1000.
   ///
-  class GZ_SIM_GUI_VISIBLE Plot3D : public gz::sim::GuiSystem
+  class Plot3D_EXPORTS_API Plot3D : public gz::sim::GuiSystem
   {
     Q_OBJECT
 


### PR DESCRIPTION
# 🎉 New feature

## Summary
Part of https://github.com/gazebosim/gz-cmake/pull/392 and https://github.com/gazebosim/gz-cmake/issues/166.

## Test it
The PR enables the HIDE_SYMBOLS_BY_DEFAULT option and patch the failures found during the build on Linux.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.