### PR TITLE
mecanum_drive: use mesh wheels in example world

### DIFF
--- a/examples/worlds/mecanum_drive.sdf
+++ b/examples/worlds/mecanum_drive.sdf
@@ -130,10 +130,7 @@
         <visual name='visual'>
           <pose>0 0 0 1.5707 0 0</pose>
           <geometry>
-            <!--sphere>
-              <radius>0.3</radius>
-            </sphere-->
-            <!--box><size>0.6 0.6 0.6</size></box-->
+            <!-- scale mesh to radius == 0.3 -->
             <mesh>
               <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Mecanum lift/tip/files/meshes/mecanum_wheel_left.STL</uri>
               <scale>0.006 0.006 0.006</scale>
@@ -179,10 +176,7 @@
         <visual name='visual'>
           <pose>0 0 0 1.5707 0 0</pose>
           <geometry>
-            <!--sphere>
-              <radius>0.3</radius>
-            </sphere-->
-            <!--box><size>0.6 0.6 0.6</size></box-->
+            <!-- scale mesh to radius == 0.3 -->
             <mesh>
               <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Mecanum lift/tip/files/meshes/mecanum_wheel_right.STL</uri>
               <scale>0.006 0.006 0.006</scale>
@@ -228,10 +222,7 @@
         <visual name='visual'>
           <pose>0 0 0 1.5707 0 0</pose>
           <geometry>
-            <!--sphere>
-              <radius>0.3</radius>
-            </sphere-->
-            <!--box><size>0.6 0.6 0.6</size></box-->
+            <!-- scale mesh to radius == 0.3 -->
             <mesh>
               <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Mecanum lift/tip/files/meshes/mecanum_wheel_right.STL</uri>
               <scale>0.006 0.006 0.006</scale>
@@ -277,10 +268,7 @@
         <visual name='visual'>
           <pose>0 0 0 1.5707 0 0</pose>
           <geometry>
-            <!--sphere>
-              <radius>0.3</radius>
-            </sphere-->
-            <!--box><size>0.6 0.6 0.6</size></box-->
+            <!-- scale mesh to radius == 0.3 -->
             <mesh>
               <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Mecanum lift/tip/files/meshes/mecanum_wheel_left.STL</uri>
               <scale>0.006 0.006 0.006</scale>

--- a/examples/worlds/mecanum_drive.sdf
+++ b/examples/worlds/mecanum_drive.sdf
@@ -128,15 +128,16 @@
           </inertia>
         </inertial>
         <visual name='visual'>
+          <pose>0 0 0 1.5707 0 0</pose>
           <geometry>
-            <sphere>
+            <!--sphere>
               <radius>0.3</radius>
-            </sphere>
+            </sphere-->
             <!--box><size>0.6 0.6 0.6</size></box-->
-            <!--mesh>
-              <uri>https://raw.githubusercontent.com/robomaster-oss/rmoss_ign_resources/main/models/rmua19_standard_robot/meshes/wheel_left.dae</uri>
-              <scale>2.4 2.4 2.4</scale>
-            </mesh-->
+            <mesh>
+              <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Mecanum lift/tip/files/meshes/mecanum_wheel_left.STL</uri>
+              <scale>0.006 0.006 0.006</scale>
+            </mesh>
           </geometry>
           <material>
             <ambient>0.2 0.2 0.2 1</ambient>
@@ -176,11 +177,16 @@
           </inertia>
         </inertial>
         <visual name='visual'>
+          <pose>0 0 0 1.5707 0 0</pose>
           <geometry>
-            <sphere>
+            <!--sphere>
               <radius>0.3</radius>
-            </sphere>
+            </sphere-->
             <!--box><size>0.6 0.6 0.6</size></box-->
+            <mesh>
+              <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Mecanum lift/tip/files/meshes/mecanum_wheel_right.STL</uri>
+              <scale>0.006 0.006 0.006</scale>
+            </mesh>
           </geometry>
           <material>
             <ambient>0.2 0.2 0.2 1</ambient>
@@ -220,11 +226,16 @@
           </inertia>
         </inertial>
         <visual name='visual'>
+          <pose>0 0 0 1.5707 0 0</pose>
           <geometry>
-            <sphere>
+            <!--sphere>
               <radius>0.3</radius>
-            </sphere>
+            </sphere-->
             <!--box><size>0.6 0.6 0.6</size></box-->
+            <mesh>
+              <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Mecanum lift/tip/files/meshes/mecanum_wheel_right.STL</uri>
+              <scale>0.006 0.006 0.006</scale>
+            </mesh>
           </geometry>
           <material>
             <ambient>0.2 0.2 0.2 1</ambient>
@@ -264,11 +275,16 @@
           </inertia>
         </inertial>
         <visual name='visual'>
+          <pose>0 0 0 1.5707 0 0</pose>
           <geometry>
-            <sphere>
+            <!--sphere>
               <radius>0.3</radius>
-            </sphere>
+            </sphere-->
             <!--box><size>0.6 0.6 0.6</size></box-->
+            <mesh>
+              <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Mecanum lift/tip/files/meshes/mecanum_wheel_left.STL</uri>
+              <scale>0.006 0.006 0.006</scale>
+            </mesh>
           </geometry>
           <material>
             <ambient>0.2 0.2 0.2 1</ambient>


### PR DESCRIPTION
# 🦟 Bug fix

Improves wheel visuals in the `mecanum_drive.sdf` example world.

## Summary

Use the Mecanum wheel meshes from the ["Mecanum lift" model on Gazebo Fuel](https://app.gazebosim.org/OpenRobotics/fuel/models/Mecanum%20lift) in the `mecanum_drive` example world.

<img width="556" alt="Screenshot 2023-11-18 at 4 10 51 PM" src="https://github.com/gazebosim/gz-sim/assets/3650755/f3abbaa6-b954-4a6e-905e-82eb10f1e317">


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
