### PR TITLE
Allow removal of model that has joint_position_controller plugin.

### DIFF
--- a/src/systems/joint_position_controller/JointPositionController.cc
+++ b/src/systems/joint_position_controller/JointPositionController.cc
@@ -320,6 +320,8 @@ void JointPositionController::PreUpdate(
 {
   GZ_PROFILE("JointPositionController::PreUpdate");
 
+  // \TODO(anyone) This is a temporary fix for
+  // gazebosim/gz-sim#2165 until gazebosim/gz-sim#2217 is resolved.
   if (kNullEntity == this->dataPtr->model.Entity())
   {
     return;

--- a/src/systems/joint_position_controller/JointPositionController.cc
+++ b/src/systems/joint_position_controller/JointPositionController.cc
@@ -320,6 +320,19 @@ void JointPositionController::PreUpdate(
 {
   GZ_PROFILE("JointPositionController::PreUpdate");
 
+  if (kNullEntity == this->dataPtr->model.Entity())
+  {
+    return;
+  }
+
+  if (!this->dataPtr->model.Valid(_ecm))
+  {
+    gzwarn << "JointPositionController model no longer valid. "
+           << "Disabling plugin." << std::endl;
+    this->dataPtr->model = Model(kNullEntity);
+    return;
+  }
+
   // \TODO(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {


### PR DESCRIPTION
# 🦟 Bug fix

This is a temporary fix for gazebosim/gz-sim#2165 until gazebosim/gz-sim#2217 is resolved.