### PR TITLE
Fix DLL linkage/visibility issues

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -168,8 +168,8 @@ target_link_libraries(${gz_lib_target}
 )
 
 # Executable target that runs the GUI without ruby for debugging purposes.
-add_executable(runGui gz.cc)
-target_link_libraries(runGui PRIVATE ${gz_lib_target})
+add_executable(runGui cmd/runGui_main.cc)
+target_link_libraries(runGui PRIVATE gz ${gz_lib_target})
 
 # Create the library target
 gz_create_core_library(SOURCES ${sources} CXX_STANDARD 17)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -169,7 +169,7 @@ target_link_libraries(${gz_lib_target}
 
 # Executable target that runs the GUI without ruby for debugging purposes.
 add_executable(runGui cmd/runGui_main.cc)
-target_link_libraries(runGui PRIVATE gz ${gz_lib_target})
+target_link_libraries(runGui PRIVATE ${gz_lib_target})
 
 # Create the library target
 gz_create_core_library(SOURCES ${sources} CXX_STANDARD 17)

--- a/src/cmd/runGui_main.cc
+++ b/src/cmd/runGui_main.cc
@@ -1,0 +1,6 @@
+#include "gz/sim/gui/Gui.hh"
+
+int main(int argc, char* argv[])
+{
+  return gz::sim::gui::runGui(argc, argv, nullptr);
+}

--- a/src/cmd/runGui_main.cc
+++ b/src/cmd/runGui_main.cc
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
 #include "gz/sim/gui/Gui.hh"
 
 int main(int argc, char* argv[])

--- a/src/gz.cc
+++ b/src/gz.cc
@@ -452,8 +452,3 @@ extern "C" int runGui(const char *_guiConfig, const char *_file, int _waitGui,
   return gz::sim::gui::runGui(
     argc, argv, _guiConfig, _file, _waitGui, _renderEngine);
 }
-
-int main(int argc, char* argv[])
-{
-  return sim::gui::runGui(argc, argv, nullptr);
-}


### PR DESCRIPTION
This was caused by rebuilding the same file as a library and standalone executable.  This simply separates the two.

Closes #2251 