### PR TITLE
The error in the tunnel.sdf file has been corrected

### DIFF
--- a/examples/worlds/tunnel.sdf
+++ b/examples/worlds/tunnel.sdf
@@ -1165,7 +1165,7 @@
                     <outer_angle>1.1</outer_angle>
                     <falloff>1</falloff>
                 </spot>
-                <direction>0 0 0</direction>
+                <direction>0 0 -1</direction>
                 <cast_shadows>1</cast_shadows>
             </light>
         <sensor name="camera" type="camera">

--- a/examples/worlds/tunnel.sdf
+++ b/examples/worlds/tunnel.sdf
@@ -1165,7 +1165,7 @@
                     <outer_angle>1.1</outer_angle>
                     <falloff>1</falloff>
                 </spot>
-                <direction>0 -1 0</direction>
+                <direction>0 0 0</direction>
                 <cast_shadows>1</cast_shadows>
             </light>
         <sensor name="camera" type="camera">


### PR DESCRIPTION
The light on top of the vehicle was facing the wrong direction; this issue has been corrected

# 🦟 Bug fix
The light on top of the vehicle in the tunnel.sdf file was illuminating the left side of the vehicle. This has been corrected, and now the light illuminates the front of the vehicle.
## Summary
The light on top of the vehicle in the tunnel.sdf file was illuminating the left side of the vehicle. This has been corrected, and now the light illuminates the front of the vehicle.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
