### PR TITLE
Default CMA in LiftDrag pluginto zero

### DIFF
--- a/src/systems/lift_drag/LiftDrag.cc
+++ b/src/systems/lift_drag/LiftDrag.cc
@@ -74,7 +74,7 @@ class gz::sim::systems::LiftDragPrivate
   /// \brief Coefficient of Moment / alpha slope.
   /// Moment = C_M * q * S
   /// where q (dynamic pressure) = 0.5 * rho * v^2
-  public: double cma = 0.01;
+  public: double cma = 0.0;
 
   /// \brief angle of attach when airfoil stalls
   public: double alphaStall = GZ_PI_2;
@@ -328,7 +328,7 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
       spanwiseI.Dot(velI), minRatio, maxRatio);
 
   // get cos from trig identity
-  double cosSweepAngle = sqrt(1.0 - sinSweepAngle * sinSweepAngle);
+  double cosSweepAngle = 1.0 - sinSweepAngle * sinSweepAngle;
   double sweep = std::asin(sinSweepAngle);
 
   // truncate sweep to within +/-90 deg

--- a/src/systems/lift_drag/LiftDrag.cc
+++ b/src/systems/lift_drag/LiftDrag.cc
@@ -328,7 +328,7 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
       spanwiseI.Dot(velI), minRatio, maxRatio);
 
   // get cos from trig identity
-  double cosSweepAngle = 1.0 - sinSweepAngle * sinSweepAngle;
+  double cosSweepAngle = sqrt(1.0 - sinSweepAngle * sinSweepAngle);
   double sweep = std::asin(sinSweepAngle);
 
   // truncate sweep to within +/-90 deg


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
The changes in https://github.com/gazebosim/gz-sim/pull/2189 have caused a regression for our upstream users.
This fix disables moment calculations by defaulting Cma to zero. It
should help mitigate some of the regression. There is also an [ongoing
discussion](https://github.com/gazebosim/gz-sim/pull/2189#issuecomment-1866589946) as to whether the cos term should be cos^2 or cos.

@srmainwaring do take a look at this fix.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

