### PR TITLE
Revert to use of cos^2 in LiftDrag plugin

### DIFF
--- a/src/systems/lift_drag/LiftDrag.cc
+++ b/src/systems/lift_drag/LiftDrag.cc
@@ -74,7 +74,7 @@ class gz::sim::systems::LiftDragPrivate
   /// \brief Coefficient of Moment / alpha slope.
   /// Moment = C_M * q * S
   /// where q (dynamic pressure) = 0.5 * rho * v^2
-  public: double cma = 0.01;
+  public: double cma = 0.0;
 
   /// \brief angle of attach when airfoil stalls
   public: double alphaStall = GZ_PI_2;
@@ -328,7 +328,7 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
       spanwiseI.Dot(velI), minRatio, maxRatio);
 
   // get cos from trig identity
-  double cosSweepAngle = sqrt(1.0 - sinSweepAngle * sinSweepAngle);
+  double cosSweepAngle = 1.0 - sinSweepAngle * sinSweepAngle;
   double sweep = std::asin(sinSweepAngle);
 
   // truncate sweep to within +/-90 deg

--- a/src/systems/lift_drag/LiftDrag.cc
+++ b/src/systems/lift_drag/LiftDrag.cc
@@ -328,7 +328,7 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
       spanwiseI.Dot(velI), minRatio, maxRatio);
 
   // get cos from trig identity
-  double cosSweepAngle = sqrt(1.0 - sinSweepAngle * sinSweepAngle);
+  double cos2SweepAngle = 1.0 - sinSweepAngle * sinSweepAngle;
   double sweep = std::asin(sinSweepAngle);
 
   // truncate sweep to within +/-90 deg
@@ -390,7 +390,7 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
   {
     cl = (this->cla * this->alphaStall +
           this->claStall * (alpha - this->alphaStall)) *
-         cosSweepAngle;
+         cos2SweepAngle;
     // make sure cl is still great than 0
     cl = std::max(0.0, cl);
   }
@@ -398,12 +398,12 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
   {
     cl = (-this->cla * this->alphaStall +
           this->claStall * (alpha + this->alphaStall))
-         * cosSweepAngle;
+         * cos2SweepAngle;
     // make sure cl is still less than 0
     cl = std::min(0.0, cl);
   }
   else
-    cl = this->cla * alpha * cosSweepAngle;
+    cl = this->cla * alpha * cos2SweepAngle;
 
   // modify cl per control joint value
   if (controlJointPosition && !controlJointPosition->Data().empty())
@@ -421,16 +421,16 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
   {
     cd = (this->cda * this->alphaStall +
           this->cdaStall * (alpha - this->alphaStall))
-         * cosSweepAngle;
+         * cos2SweepAngle;
   }
   else if (alpha < -this->alphaStall)
   {
     cd = (-this->cda * this->alphaStall +
           this->cdaStall * (alpha + this->alphaStall))
-         * cosSweepAngle;
+         * cos2SweepAngle;
   }
   else
-    cd = (this->cda * alpha) * cosSweepAngle;
+    cd = (this->cda * alpha) * cos2SweepAngle;
 
   // make sure drag is positive
   cd = std::fabs(cd);
@@ -444,7 +444,7 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
   {
     cm = (this->cma * this->alphaStall +
           this->cmaStall * (alpha - this->alphaStall))
-         * cosSweepAngle;
+         * cos2SweepAngle;
     // make sure cm is still great than 0
     cm = std::max(0.0, cm);
   }
@@ -452,12 +452,12 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
   {
     cm = (-this->cma * this->alphaStall +
           this->cmaStall * (alpha + this->alphaStall))
-         * cosSweepAngle;
+         * cos2SweepAngle;
     // make sure cm is still less than 0
     cm = std::min(0.0, cm);
   }
   else
-    cm = this->cma * alpha * cosSweepAngle;
+    cm = this->cma * alpha * cos2SweepAngle;
 
   // Take into account the effect of control surface deflection angle to cm
   if (controlJointPosition && !controlJointPosition->Data().empty())

--- a/src/systems/lift_drag/LiftDrag.cc
+++ b/src/systems/lift_drag/LiftDrag.cc
@@ -327,7 +327,8 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
   double sinSweepAngle = math::clamp(
       spanwiseI.Dot(velI), minRatio, maxRatio);
 
-  // get cos from trig identity
+  // The sweep adjustment depends on the velocity component normal to the wing leading
+  // edge which appears quadratically in the dynamic pressure, so scale by cos^2 .
   double cos2SweepAngle = 1.0 - sinSweepAngle * sinSweepAngle;
   double sweep = std::asin(sinSweepAngle);
 

--- a/src/systems/lift_drag/LiftDrag.cc
+++ b/src/systems/lift_drag/LiftDrag.cc
@@ -327,8 +327,9 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
   double sinSweepAngle = math::clamp(
       spanwiseI.Dot(velI), minRatio, maxRatio);
 
-  // The sweep adjustment depends on the velocity component normal to the wing leading
-  // edge which appears quadratically in the dynamic pressure, so scale by cos^2 .
+  // The sweep adjustment depends on the velocity component normal to
+  // the wing leading edge which appears quadratically in the
+  // dynamic pressure, so scale by cos^2 .
   double cos2SweepAngle = 1.0 - sinSweepAngle * sinSweepAngle;
   double sweep = std::asin(sinSweepAngle);
 

--- a/src/systems/lift_drag/LiftDrag.cc
+++ b/src/systems/lift_drag/LiftDrag.cc
@@ -328,7 +328,7 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
       spanwiseI.Dot(velI), minRatio, maxRatio);
 
   // get cos from trig identity
-  double cosSweepAngle = 1.0 - sinSweepAngle * sinSweepAngle;
+  double cosSweepAngle = sqrt(1.0 - sinSweepAngle * sinSweepAngle);
   double sweep = std::asin(sinSweepAngle);
 
   // truncate sweep to within +/-90 deg


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
In response to https://github.com/gazebosim/gz-sim/pull/2189#issuecomment-1869798904

As suggested by @srmainwaring I also renamed cosSweepAngle ->
cos2SweepAngle to prevent further confusion.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

