### PR TITLE
Allow using plugin file names and environment variables compatible with Garden and later

### DIFF
--- a/include/gz/sim/Util.hh
+++ b/include/gz/sim/Util.hh
@@ -290,7 +290,7 @@ namespace ignition
     /// \brief Environment variable holding resource paths. Prefer using
     /// GZ_SIM_RESOURCE_PATH for compatibility with newer versions of Gazebo.
     const std::string kResourcePathEnv{"IGN_GAZEBO_RESOURCE_PATH"};
-    /// \brief Environment variable holding resource paths. 
+    /// \brief Environment variable holding resource paths.
     const std::string kResourcePathEnvGzSim{"GZ_SIM_RESOURCE_PATH"};
 
     /// \brief Environment variable used by SDFormat to find URIs inside

--- a/include/gz/sim/Util.hh
+++ b/include/gz/sim/Util.hh
@@ -287,19 +287,31 @@ namespace ignition
     std::optional<math::Vector3d> IGNITION_GAZEBO_VISIBLE sphericalCoordinates(
         Entity _entity, const EntityComponentManager &_ecm);
 
-    /// \brief Environment variable holding resource paths.
+    /// \brief Environment variable holding resource paths. Prefer using
+    /// GZ_SIM_RESOURCE_PATH for compatibility with newer versions of Gazebo.
     const std::string kResourcePathEnv{"IGN_GAZEBO_RESOURCE_PATH"};
+    /// \brief Environment variable holding resource paths. 
+    const std::string kResourcePathEnvGzSim{"GZ_SIM_RESOURCE_PATH"};
 
     /// \brief Environment variable used by SDFormat to find URIs inside
     /// `<include>`
     const std::string kSdfPathEnv{"SDF_PATH"};
 
-    /// \brief Environment variable holding server config paths.
+    /// \brief Environment variable holding server config paths. Prefer using
+    /// GZ_SIM_SERVER_CONFIG_PATH for compatibility with newer versions of
+    /// Gazebo.
     const std::string kServerConfigPathEnv{"IGN_GAZEBO_SERVER_CONFIG_PATH"};
+    /// \brief Environment variable holding server config paths.
+    const std::string kServerConfigPathEnvGzSim{"GZ_SIM_SERVER_CONFIG_PATH"};
 
     /// \brief Environment variable holding paths to custom rendering engine
-    /// plugins.
+    /// plugins. Prefer using GZ_SIM_RENDER_ENGINE_PATH for compatibility with
+    /// newer versions of Gazebo
     const std::string kRenderPluginPathEnv{"IGN_GAZEBO_RENDER_ENGINE_PATH"};
+    /// \brief Environment variable holding paths to custom rendering engine
+    /// plugins.
+    const std::string kRenderPluginPathEnvGzSim{"GZ_SIM_RENDER_ENGINE_PATH"};
+
     }
   }
 }

--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -1713,9 +1713,8 @@ msgs::ParticleEmitter ignition::gazebo::convert(const sdf::ParticleEmitter &_in)
   {
     std::string path = asFullPath(_in.ColorRangeImage(), _in.FilePath());
 
-    common::SystemPaths systemPaths;
-    systemPaths.SetFilePathEnv(kResourcePathEnv);
-    std::string absolutePath = systemPaths.FindFile(path);
+    const std::string absolutePath =
+        common::SystemPaths::LocateLocalFile(path, gazebo::resourcePaths());
 
     if (!absolutePath.empty())
       out.mutable_color_range_image()->set_data(absolutePath);

--- a/src/ServerConfig.cc
+++ b/src/ServerConfig.cc
@@ -966,7 +966,7 @@ ignition::gazebo::loadPluginInfo(bool _isPlayback)
     }
   }
 
-  // Process the gz-sim environment variable the same way. If the IGN variable 
+  // Process the gz-sim environment variable the same way. If the IGN variable
   // is set, it will have precedence.
   {
     std::string envConfig;

--- a/src/ServerConfig_TEST.cc
+++ b/src/ServerConfig_TEST.cc
@@ -198,14 +198,8 @@ TEST(LoadPluginInfo, FromEmptyEnv)
   EXPECT_TRUE(common::unsetenv(kServerConfigPathEnv));
 }
 
-//////////////////////////////////////////////////
-TEST(LoadPluginInfo, FromValidEnv)
+void testFromValidEnvPlugins()
 {
-  auto validPath = common::joinPaths(PROJECT_SOURCE_PATH,
-    "test", "worlds", "server_valid2.config");
-
-  ASSERT_TRUE(common::setenv(kServerConfigPathEnv, validPath));
-
   auto plugins = loadPluginInfo();
   ASSERT_EQ(2u, plugins.size());
 
@@ -226,7 +220,34 @@ TEST(LoadPluginInfo, FromValidEnv)
   EXPECT_EQ("gz::sim::TestModelSystem", plugin->Name());
   EXPECT_EQ("gz::sim::TestModelSystem", plugin->Plugin().Name());
 
+}
+//////////////////////////////////////////////////
+TEST(LoadPluginInfo, FromValidEnv)
+{
+  auto validPath = common::joinPaths(PROJECT_SOURCE_PATH,
+    "test", "worlds", "server_valid2.config");
+
+  ASSERT_TRUE(common::setenv(kServerConfigPathEnv, validPath));
+
+  SCOPED_TRACE("FromValidEnv");
+  testFromValidEnvPlugins();
+
   EXPECT_TRUE(common::unsetenv(kServerConfigPathEnv));
+}
+
+//////////////////////////////////////////////////
+TEST(LoadPluginInfo, FromValidEnvGzSimCompatibility)
+{
+  auto validPath = common::joinPaths(PROJECT_SOURCE_PATH,
+    "test", "worlds", "server_valid2.config");
+
+  ASSERT_TRUE(common::unsetenv(kServerConfigPathEnv));
+  ASSERT_TRUE(common::setenv(kServerConfigPathEnvGzSim, validPath));
+
+  SCOPED_TRACE("FromValidEnvGzSimCompatibility");
+  testFromValidEnvPlugins();
+
+  EXPECT_TRUE(common::unsetenv(kServerConfigPathEnvGzSim));
 }
 
 //////////////////////////////////////////////////

--- a/src/ServerPrivate.hh
+++ b/src/ServerPrivate.hh
@@ -122,7 +122,7 @@ namespace ignition
       /// string and return value of false will be used if the resource could
       /// not be found.
       ///
-      /// Fuel will be checked and then the GZ_GAZEBO_RESOURCE_PATH environment
+      /// Fuel will be checked and then the IGN_GAZEBO_RESOURCE_PATH environment
       /// variable paths. This service will not check for files relative to
       /// working directory of the Gazebo server.
       ///

--- a/src/ServerPrivate.hh
+++ b/src/ServerPrivate.hh
@@ -122,9 +122,9 @@ namespace ignition
       /// string and return value of false will be used if the resource could
       /// not be found.
       ///
-      /// Fuel will be checked and then the IGN_GAZEBO_RESOURCE_PATH environment
-      /// variable paths. This service will not check for files relative to
-      /// working directory of the Gazebo server.
+      /// Fuel will be checked and then paths from IGN_GAZEBO_RESOURCE_PATH and
+      /// GZ_SIM_RESOURCE_PATH environment variables. This service will not
+      /// check for files relative to working directory of the Gazebo server.
       ///
       /// \param[in] _req Request filled with a resource URI to resolve.
       /// Example values could be:

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -912,13 +912,12 @@ TEST_P(ServerFixture, Seed)
 }
 
 /////////////////////////////////////////////////
-TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ResourcePath))
+void testResourcePaths(const std::string &_envVariable)
 {
-  common::setenv("IGN_GAZEBO_RESOURCE_PATH",
+  common::setenv(_envVariable,
       (common::joinPaths(PROJECT_SOURCE_PATH, "test", "worlds:") +
        common::joinPaths(PROJECT_SOURCE_PATH,
            "test", "worlds", "models")).c_str());
-
   ServerConfig serverConfig;
   serverConfig.SetSdfFile("resource_paths.sdf");
   gz::sim::Server server(serverConfig);
@@ -998,8 +997,25 @@ TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ResourcePath))
   EXPECT_TRUE(server.HasEntity("scheme_resource_uri"));
   EXPECT_TRUE(server.HasEntity("the_link"));
   EXPECT_TRUE(server.HasEntity("the_visual"));
+  common::unsetenv(_envVariable);
 }
 
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, ResourcePath)
+{
+  SCOPED_TRACE("ResourcePaths");
+  testResourcePaths("IGN_GAZEBO_RESOURCE_PATH");
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, ResourcePathGzSimCompatibility)
+{
+  common::unsetenv("IGN_GAZEBO_RESOURCE_PATH");
+  SCOPED_TRACE("ResourcePathGzSimCompatibility");
+  testResourcePaths("GZ_SIM_RESOURCE_PATH");
+}
+
+/////////////////////////////////////////////////
 void testGetResourcePaths(const std::string &_envVariable)
 {
   common::setenv(_envVariable,

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -1000,14 +1000,12 @@ TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ResourcePath))
   EXPECT_TRUE(server.HasEntity("the_visual"));
 }
 
-/////////////////////////////////////////////////
-TEST_P(ServerFixture, GetResourcePaths)
+void testGetResourcePaths(const std::string &_envVariable)
 {
-  common::setenv("IGN_GAZEBO_RESOURCE_PATH",
+  common::setenv(_envVariable,
       std::string("/tmp/some/path") +
       common::SystemPaths::Delimiter() +
       std::string("/home/user/another_path"));
-
   ServerConfig serverConfig;
   gz::sim::Server server(serverConfig);
 
@@ -1030,6 +1028,22 @@ TEST_P(ServerFixture, GetResourcePaths)
   EXPECT_EQ(2, res.data_size());
   EXPECT_EQ("/tmp/some/path", res.data(0));
   EXPECT_EQ("/home/user/another_path", res.data(1));
+  common::unsetenv(_envVariable);
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, GetResourcePaths)
+{
+  SCOPED_TRACE("GetResourcePaths");
+  testGetResourcePaths("IGN_GAZEBO_RESOURCE_PATH");
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, GetResourcePathsGzSimCompatibility)
+{
+  common::unsetenv("IGN_GAZEBO_RESOURCE_PATH");
+  SCOPED_TRACE("GetResourcePathsGzSimCompatibility");
+  testGetResourcePaths("GZ_SIM_RESOURCE_PATH");
 }
 
 /////////////////////////////////////////////////

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -40,6 +40,7 @@
 #include "plugins/MockSystem.hh"
 #include "../test/helpers/Relay.hh"
 #include "../test/helpers/EnvTestFixture.hh"
+#include "../test/helpers/Util.hh"
 
 using namespace gz;
 using namespace gz::sim;
@@ -263,14 +264,10 @@ TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ServerConfigRealPlugin))
   msgs::StringMsg rep;
   bool result{false};
   bool executed{false};
-  int sleep{0};
-  int maxSleep{30};
-  while (!executed && sleep < maxSleep)
-  {
-    igndbg << "Requesting /test/service" << std::endl;
-    executed = node.Request("/test/service", 100, rep, result);
-    sleep++;
-  }
+  const std::string service = "/test/service";
+  ASSERT_TRUE(test::waitForService(node, service));
+  igndbg << "Requesting " << service << std::endl;
+  executed = node.Request(service, 1000, rep, result);
   EXPECT_TRUE(executed);
   EXPECT_TRUE(result);
   EXPECT_EQ("TestModelSystem", rep.data());
@@ -315,14 +312,10 @@ TEST_P(ServerFixture,
   msgs::StringMsg rep;
   bool result{false};
   bool executed{false};
-  int sleep{0};
-  int maxSleep{30};
-  while (!executed && sleep < maxSleep)
-  {
-    igndbg << "Requesting /test/service/sensor" << std::endl;
-    executed = node.Request("/test/service/sensor", 100, rep, result);
-    sleep++;
-  }
+  const std::string service ="/test/service/sensor";
+  ASSERT_TRUE(test::waitForService(node, service));
+  igndbg << "Requesting " << service << std::endl;
+  executed = node.Request(service, 1000, rep, result);
   EXPECT_TRUE(executed);
   EXPECT_TRUE(result);
   EXPECT_EQ("TestSensorSystem", rep.data());
@@ -754,16 +747,12 @@ TEST_P(ServerFixture, ServerControlStop)
   msgs::Boolean res;
   bool result{false};
   bool executed{false};
-  int sleep{0};
-  int maxSleep{30};
 
+  const std::string service = "/server_control";
+  ASSERT_TRUE(test::waitForService(node, service));
   // first, call with stop = false; the server should keep running
-  while (!executed && sleep < maxSleep)
-  {
-    igndbg << "Requesting /server_control" << std::endl;
-    executed = node.Request("/server_control", req, 100, res, result);
-    sleep++;
-  }
+  igndbg << "Requesting " << service << std::endl;
+  executed = node.Request(service, req, 1000, res, result);
   EXPECT_TRUE(executed);
   EXPECT_TRUE(result);
   EXPECT_FALSE(res.data());
@@ -776,8 +765,8 @@ TEST_P(ServerFixture, ServerControlStop)
   // now call with stop = true; the server should stop
   req.set_stop(true);
 
-  igndbg << "Requesting /server_control" << std::endl;
-  executed = node.Request("/server_control", req, 100, res, result);
+  igndbg << "Requesting " << service << std::endl;
+  executed = node.Request(service, req, 1000, res, result);
 
   EXPECT_TRUE(executed);
   EXPECT_TRUE(result);
@@ -1001,14 +990,15 @@ void testResourcePaths(const std::string &_envVariable)
 }
 
 /////////////////////////////////////////////////
-TEST_P(ServerFixture, ResourcePath)
+TEST_P(ServerFixture, IGN_UTILS_TEST_DISABLED_ON_WIN32(ResourcePath))
 {
   SCOPED_TRACE("ResourcePaths");
   testResourcePaths("IGN_GAZEBO_RESOURCE_PATH");
 }
 
 /////////////////////////////////////////////////
-TEST_P(ServerFixture, ResourcePathGzSimCompatibility)
+TEST_P(ServerFixture,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ResourcePathGzSimCompatibility))
 {
   common::unsetenv("IGN_GAZEBO_RESOURCE_PATH");
   SCOPED_TRACE("ResourcePathGzSimCompatibility");
@@ -1031,14 +1021,10 @@ void testGetResourcePaths(const std::string &_envVariable)
   msgs::StringMsg_V res;
   bool result{false};
   bool executed{false};
-  int sleep{0};
-  int maxSleep{30};
-  while (!executed && sleep < maxSleep)
-  {
-    igndbg << "Requesting /gazebo/resource_paths/get" << std::endl;
-    executed = node.Request("/gazebo/resource_paths/get", 100, res, result);
-    sleep++;
-  }
+  const std::string service = "/gazebo/resource_paths/get";
+  ASSERT_TRUE(test::waitForService(node, service));
+  igndbg << "Requesting " << service << std::endl;
+  executed = node.Request(service, 1000, res, result);
   EXPECT_TRUE(executed);
   EXPECT_TRUE(result);
   EXPECT_EQ(2, res.data_size());
@@ -1101,7 +1087,9 @@ TEST_P(ServerFixture, AddResourcePaths)
                common::SystemPaths::Delimiter() +
                std::string("/tmp/even_more"));
   req.add_data("/tmp/some/path");
-  bool executed = node.Request("/gazebo/resource_paths/add", req);
+  const std::string service = "/gazebo/resource_paths/add";
+  ASSERT_TRUE(test::waitForService(node, service));
+  bool executed = node.Request(service, req);
   EXPECT_TRUE(executed);
 
   int sleep{0};
@@ -1155,17 +1143,12 @@ TEST_P(ServerFixture, ResolveResourcePaths)
           msgs::StringMsg req, res;
           bool result{false};
           bool executed{false};
-          int sleep{0};
-          int maxSleep{30};
 
           req.set_data(_uri);
-          while (!executed && sleep < maxSleep)
-          {
-            igndbg << "Requesting /gazebo/resource_paths/resolve" << std::endl;
-            executed = node.Request("/gazebo/resource_paths/resolve", req, 100,
-                res, result);
-            sleep++;
-          }
+          const std::string service ="/gazebo/resource_paths/resolve";
+          ASSERT_TRUE(test::waitForService(node, service));
+          igndbg << "Requesting " << service << std::endl;
+          executed = node.Request(service, req, 1000, res, result);
           EXPECT_TRUE(executed);
           EXPECT_EQ(_found, result);
           EXPECT_EQ(_expected, res.data()) << "Expected[" << _expected

--- a/src/SystemLoader.cc
+++ b/src/SystemLoader.cc
@@ -73,7 +73,7 @@ class ignition::gazebo::SystemLoaderPrivate
     const std::string gzSimPrefix{"gz-sim"};
     auto filename = _sdfPlugin.Filename();
     auto pos = filename.find(gzSimPrefix);
-    if (pos == 0u)
+    if (pos != std::string::npos)
     {
       filename.replace(pos, gzSimPrefix.size(), "ignition-gazebo");
     }

--- a/src/SystemLoader.cc
+++ b/src/SystemLoader.cc
@@ -46,6 +46,14 @@ class ignition::gazebo::SystemLoaderPrivate
     gz::common::SystemPaths systemPaths;
     systemPaths.SetPluginPathEnv(pluginPathEnv);
 
+    // Also add GZ_SYSTEM_SIM_PLUGIN_PATH for compatibility with Garden and
+    // later.
+    for (const auto &path :
+         common::SystemPaths::PathsFromEnv(this->pluginPathEnvGzSim))
+    {
+      systemPaths.AddPluginPaths(path);
+    }
+
     for (const auto &path : this->systemPluginPaths)
       systemPaths.AddPluginPaths(path);
 
@@ -62,6 +70,14 @@ class ignition::gazebo::SystemLoaderPrivate
   public: bool InstantiateSystemPlugin(const sdf::Plugin &_sdfPlugin,
               ignition::plugin::PluginPtr &_gzPlugin)
   {
+    const std::string gzSimPrefix{"gz-sim"};
+    auto filename = _sdfPlugin.Filename();
+    auto pos = filename.find(gzSimPrefix);
+    if (pos == 0u)
+    {
+      filename.replace(pos, gzSimPrefix.size(), "ignition-gazebo");
+    }
+
     std::list<std::string> paths = this->PluginPaths();
     common::SystemPaths systemPaths;
     for (const auto &p : paths)
@@ -69,7 +85,7 @@ class ignition::gazebo::SystemLoaderPrivate
       systemPaths.AddPluginPaths(p);
     }
 
-    auto pathToLib = systemPaths.FindSharedLibrary(_sdfPlugin.Filename());
+    auto pathToLib = systemPaths.FindSharedLibrary(filename);
     if (pathToLib.empty())
     {
       // We assume gz::sim corresponds to the levels feature
@@ -125,8 +141,11 @@ class ignition::gazebo::SystemLoaderPrivate
     return true;
   }
 
-  // Default plugin search path environment variable
+  // Default plugin search path environment variable. Prefer
+  // GZ_SYSTEM_SIM_PLUGIN_PATH for compatibility with future versions of Gazebo.
   public: std::string pluginPathEnv{"IGN_GAZEBO_SYSTEM_PLUGIN_PATH"};
+  // Default plugin search path environment variable
+  public: std::string pluginPathEnvGzSim{"GZ_SIM_SYSTEM_PLUGIN_PATH"};
 
   /// \brief Plugin loader instace
   public: gz::plugin::Loader loader;

--- a/src/SystemLoader_TEST.cc
+++ b/src/SystemLoader_TEST.cc
@@ -44,21 +44,21 @@ TEST(SystemLoader, Constructor)
   root.LoadSdfString(std::string("<?xml version='1.0'?><sdf version='1.6'>"
       "<world name='default'>"
       "<plugin filename='libignition-gazebo") +
-      IGNITION_GAZEBO_MAJOR_VERSION_STR + "-physics-system.so' "
-      "name='gz::sim::systems::Physics'></plugin>"
+      IGNITION_GAZEBO_MAJOR_VERSION_STR + "-user-commands-system.so' "
+      "name='gz::sim::systems::UserCommands'></plugin>"
       "<plugin filename='ignition-gazebo" +
-      IGNITION_GAZEBO_MAJOR_VERSION_STR + "-physics-system' "
-      "name='gz::sim::systems::Physics'></plugin>"
-      "<plugin filename='ignition-gazebo-physics-system' "
-      "name='gz::sim::systems::Physics'></plugin>"
+      IGNITION_GAZEBO_MAJOR_VERSION_STR + "-user-commands-system' "
+      "name='gz::sim::systems::UserCommands'></plugin>"
+      "<plugin filename='ignition-gazebo-user-commands-system' "
+      "name='gz::sim::systems::UserCommands'></plugin>"
       "<plugin filename='libgz-sim" +
-      IGNITION_GAZEBO_MAJOR_VERSION_STR + "-physics-system.so' "
-      "name='gz::sim::systems::Physics'></plugin>"
+      IGNITION_GAZEBO_MAJOR_VERSION_STR + "-user-commands-system.so' "
+      "name='gz::sim::systems::UserCommands'></plugin>"
       "<plugin filename='gz-sim" +
-      IGNITION_GAZEBO_MAJOR_VERSION_STR + "-physics-system' "
-      "name='gz::sim::systems::Physics'></plugin>"
-      "<plugin filename='gz-sim-physics-system' "
-      "name='gz::sim::systems::Physics'></plugin>"
+      IGNITION_GAZEBO_MAJOR_VERSION_STR + "-user-commands-system' "
+      "name='gz::sim::systems::UserCommands'></plugin>"
+      "<plugin filename='gz-sim-user-commands-system' "
+      "name='gz::sim::systems::UserCommands'></plugin>"
       "</world></sdf>");
 
   auto worldElem = root.WorldByIndex(0)->Element();

--- a/src/SystemLoader_TEST.cc
+++ b/src/SystemLoader_TEST.cc
@@ -77,7 +77,6 @@ TEST(SystemLoader, Constructor)
 /////////////////////////////////////////////////
 TEST(SystemLoader, FromPluginPathEnv)
 {
-
   sdf::Root root;
   root.LoadSdfString(R"(<?xml version='1.0'?>
     <sdf version='1.6'>

--- a/src/SystemLoader_TEST.cc
+++ b/src/SystemLoader_TEST.cc
@@ -46,6 +46,19 @@ TEST(SystemLoader, Constructor)
       "<plugin filename='libignition-gazebo") +
       IGNITION_GAZEBO_MAJOR_VERSION_STR + "-physics-system.so' "
       "name='gz::sim::systems::Physics'></plugin>"
+      "<plugin filename='ignition-gazebo" +
+      IGNITION_GAZEBO_MAJOR_VERSION_STR + "-physics-system' "
+      "name='gz::sim::systems::Physics'></plugin>"
+      "<plugin filename='ignition-gazebo-physics-system' "
+      "name='gz::sim::systems::Physics'></plugin>"
+      "<plugin filename='libgz-sim" +
+      IGNITION_GAZEBO_MAJOR_VERSION_STR + "-physics-system.so' "
+      "name='gz::sim::systems::Physics'></plugin>"
+      "<plugin filename='gz-sim" +
+      IGNITION_GAZEBO_MAJOR_VERSION_STR + "-physics-system' "
+      "name='gz::sim::systems::Physics'></plugin>"
+      "<plugin filename='gz-sim-physics-system' "
+      "name='gz::sim::systems::Physics'></plugin>"
       "</world></sdf>");
 
   auto worldElem = root.WorldByIndex(0)->Element();
@@ -59,6 +72,49 @@ TEST(SystemLoader, Constructor)
       ASSERT_TRUE(system.has_value());
       pluginElem = pluginElem->GetNextElement("plugin");
     }
+  }
+}
+/////////////////////////////////////////////////
+TEST(SystemLoader, FromPluginPathEnv)
+{
+
+  sdf::Root root;
+  root.LoadSdfString(R"(<?xml version='1.0'?>
+    <sdf version='1.6'>
+      <world name='default'>
+        <plugin filename='libMockSystem.so' name='gz::sim::MockSystem'/>
+      </world>
+    </sdf>)");
+
+  ASSERT_NE(root.WorldCount(), 0u);
+  auto world = root.WorldByIndex(0);
+  ASSERT_TRUE(world != nullptr);
+  ASSERT_FALSE(world->Plugins().empty());
+  auto plugin = world->Plugins()[0];
+
+  {
+    gz::sim::SystemLoader sm;
+    auto system = sm.LoadPlugin(plugin);
+    EXPECT_FALSE(system.has_value());
+  }
+
+  const auto libPath = common::joinPaths(PROJECT_BINARY_PATH, "lib");
+
+  {
+    common::setenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH", libPath.c_str());
+
+    gz::sim::SystemLoader sm;
+    auto system = sm.LoadPlugin(plugin);
+    EXPECT_TRUE(system.has_value());
+    EXPECT_TRUE(common::unsetenv("IGN_GAZEBO_SYSTEM_PLUGIN_PATH"));
+  }
+  {
+    common::setenv("GZ_SIM_SYSTEM_PLUGIN_PATH", libPath.c_str());
+
+    gz::sim::SystemLoader sm;
+    auto system = sm.LoadPlugin(plugin);
+    EXPECT_TRUE(system.has_value());
+    EXPECT_TRUE(common::unsetenv("GZ_SIM_SYSTEM_PLUGIN_PATH"));
   }
 }
 

--- a/src/SystemLoader_TEST.cc
+++ b/src/SystemLoader_TEST.cc
@@ -31,9 +31,9 @@ using namespace gz;
 using namespace sim;
 
 #ifdef _WIN32
-  constexpr char *kPluginDir = "bin";
+  constexpr const char *kPluginDir = "bin";
 #else
-  constexpr char *kPluginDir = "lib";
+  constexpr const char *kPluginDir = "lib";
 #endif
 /////////////////////////////////////////////////
 TEST(SystemLoader, Constructor)

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -411,6 +411,11 @@ std::vector<std::string> resourcePaths()
     gzPaths = common::Split(gzPathCStr, common::SystemPaths::Delimiter());
   }
 
+  const auto gzSimResourcePaths =
+      common::SystemPaths::PathsFromEnv(kResourcePathEnvGzSim);
+  gzPaths.insert(gzPaths.begin(), gzSimResourcePaths.begin(),
+                 gzSimResourcePaths.end());
+
   gzPaths.erase(std::remove_if(gzPaths.begin(), gzPaths.end(),
       [](const std::string &_path)
       {
@@ -447,6 +452,10 @@ void addResourcePaths(const std::vector<std::string> &_paths)
   {
     gzPaths = common::Split(gzPathCStr, common::SystemPaths::Delimiter());
   }
+  const auto gzSimResourcePaths =
+      common::SystemPaths::PathsFromEnv(kResourcePathEnvGzSim);
+  gzPaths.insert(gzPaths.begin(), gzSimResourcePaths.begin(),
+                 gzSimResourcePaths.end());
 
   // Add new paths to gzPaths
   for (const auto &path : _paths)

--- a/src/cmd/cmdgazebo.rb.in
+++ b/src/cmd/cmdgazebo.rb.in
@@ -160,9 +160,14 @@ COMMANDS = { 'gazebo' =>
   "Environment variables:                                                  \n"\
   "  IGN_GAZEBO_RESOURCE_PATH    Colon separated paths used to locate      \n"\
   " resources such as worlds and models.                                 \n\n"\
+  "  GZ_SIM_RESOURCE_PATH    Colon separated paths used to locate        \n"\
+  " resources such as worlds and models.                                 \n\n"\
   "  IGN_GAZEBO_SYSTEM_PLUGIN_PATH    Colon separated paths used to        \n"\
   " locate system plugins.                                               \n\n"\
+  "  GZ_SIM_SYSTEM_PLUGIN_PATH    Colon separated paths used to          \n"\
+  " locate system plugins.                                               \n\n"\
   "  IGN_GAZEBO_SERVER_CONFIG_PATH    Path to server configuration file. \n\n"\
+  "  GZ_SIM_SERVER_CONFIG_PATH    Path to server configuration file.     \n\n"\
   "  IGN_GUI_PLUGIN_PATH    Colon separated paths used to locate GUI       \n"\
   " plugins.                                                             \n\n"\
   "  GZ_GUI_RESOURCE_PATH    Colon separated paths used to locate GUI      \n"\
@@ -412,7 +417,7 @@ has properly set the DYLD_LIBRARY_PATH environment variables."
         # If not, then first check the IGN_GAZEBO_RESOURCE_PATH environment
         # variable, then the configuration path from the launch library.
         else
-          resourcePathEnv = ENV['IGN_GAZEBO_RESOURCE_PATH']
+          resourcePathEnv = "#{ENV['IGN_GAZEBO_RESOURCE_PATH']}:#{ENV['GZ_SIM_RESOURCE_PATH']}"
           if !resourcePathEnv.nil?
             resourcePaths = resourcePathEnv.split(':')
             for resourcePath in resourcePaths

--- a/src/gz_TEST.cc
+++ b/src/gz_TEST.cc
@@ -159,8 +159,14 @@ TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_WIN32(ResourcePath))
 
   // Correct path
   auto path = std::string("IGN_GAZEBO_RESOURCE_PATH=") +
-    PROJECT_SOURCE_PATH + "/test/worlds ";
+              gz::common::joinPaths(PROJECT_SOURCE_PATH, "test", "worlds ");
 
+  output = customExecStr(path + cmd);
+  EXPECT_EQ(output.find("Unable to find file plugins.sdf"), std::string::npos)
+      << output;
+
+  path = std::string("GZ_SIM_RESOURCE_PATH=") +
+         gz::common::joinPaths(PROJECT_SOURCE_PATH, "test", "worlds ");
   output = customExecStr(path + cmd);
   EXPECT_EQ(output.find("Unable to find file plugins.sdf"), std::string::npos)
       << output;
@@ -172,6 +178,25 @@ TEST(CmdLine, IGN_UTILS_TEST_DISABLED_ON_WIN32(ResourcePath))
   output = customExecStr(path + cmd);
   EXPECT_EQ(output.find("Unable to find file plugins.sdf"), std::string::npos)
       << output;
+
+  // Test nested models
+  // Use a direct path to the input file. Using a file name that has to be
+  // resolved interacts with how resource environment variables are processed
+  // and so will have different behavior than when a direct path is provided.
+  cmd = kIgnCommand + " -s -r -v 4 --iterations 1 " +
+        gz::common::joinPaths(PROJECT_SOURCE_PATH, "test", "worlds",
+                              "include_nested_models.sdf");
+  output = customExecStr(cmd);
+  EXPECT_NE(output.find("Unable to find"), std::string::npos) << output;
+
+  std::string pathValue =
+      gz::common::joinPaths(PROJECT_SOURCE_PATH, "test", "worlds", "models");
+
+  output = customExecStr("IGN_GAZEBO_RESOURCE_PATH=" + pathValue + " " + cmd);
+  EXPECT_EQ(output.find("Unable to find"), std::string::npos) << output;
+
+  output = customExecStr("GZ_SIM_RESOURCE_PATH=" + pathValue + " " + cmd);
+  EXPECT_EQ(output.find("Unable to find"), std::string::npos) << output;
 }
 
 //////////////////////////////////////////////////

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -2555,6 +2555,9 @@ void RenderUtil::InitRenderEnginePluginPaths()
   common::SystemPaths pluginPath;
   pluginPath.SetPluginPathEnv(kRenderPluginPathEnv);
   rendering::setPluginPaths(pluginPath.PluginPaths());
+
+  rendering::setPluginPaths(
+      common::SystemPaths::PathsFromEnv(kRenderPluginPathEnvGzSim));
 }
 
 /////////////////////////////////////////////////

--- a/src/systems/particle_emitter/ParticleEmitter.cc
+++ b/src/systems/particle_emitter/ParticleEmitter.cc
@@ -250,9 +250,8 @@ void ParticleEmitter::Configure(const Entity &_entity,
     auto colorRangeImagePath = _sdf->Get<std::string>("color_range_image");
     auto path = asFullPath(colorRangeImagePath, modelPath.value());
 
-    common::SystemPaths systemPaths;
-    systemPaths.SetFilePathEnv(kResourcePathEnv);
-    auto absolutePath = systemPaths.FindFile(path);
+    const std::string absolutePath =
+        common::SystemPaths::LocateLocalFile(path, gazebo::resourcePaths());
 
     this->dataPtr->emitter.mutable_color_range_image()->set_data(
         absolutePath);

--- a/test/helpers/Util.hh
+++ b/test/helpers/Util.hh
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <chrono>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gz/transport/Node.hh>
+
+namespace ignition::gazebo::test
+{
+/// \brief Wait until a service becomes available.
+/// See https://github.com/gazebosim/gz-transport/issues/468 for why this might
+/// be necessary before make a service request.
+/// \param[in] _node Transport Node to use
+/// \param[in] _service Name of service to wait for
+/// \param[in] _timeoutS Time out in seconds
+bool waitForService(const transport::Node &_node, const std::string &_service,
+                    int _timeoutS = 5)
+{
+  int curSleep = 0;
+  while (curSleep < _timeoutS)
+  {
+    std::vector<transport::ServicePublisher> publishers;
+    if (_node.ServiceInfo(_service, publishers))
+    {
+      return true;
+    }
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    ++curSleep;
+  }
+  return false;
+}
+}  // namespace gz::sim::test

--- a/tutorials/migration_sdf.md
+++ b/tutorials/migration_sdf.md
@@ -146,7 +146,7 @@ Each simulator uses a different environment variable:
     * `GAZEBO_MODEL_PATH` for models
     * `GAZEBO_RESOURCE_PATH` for worlds and some rendering resources
 * Ignition Gazebo:
-    * `IGN_GAZEBO_RESOURCE_PATH` for worlds, models and other resources
+    * `IGN_GAZEBO_RESOURCE_PATH` or `GZ_SIM_RESOURCE_PATH` for worlds, models and other resources
 
 For example, if you have the file structure above, you can set the environment
 variable to `/home/username/models`:
@@ -236,7 +236,7 @@ where that plugin is located. The variables are different for each simulator:
 * Gazebo classic:
     * `GAZEBO_PLUGIN_PATH` for all plugin types.
 * Ignition Gazebo:
-    * `IGN_GAZEBO_SYSTEM_PLUGIN_PATH` for Ignition Gazebo systems (world, model,
+    * `IGN_GAZEBO_SYSTEM_PLUGIN_PATH` or `GZ_SIM_SYSTEM_PLUGIN_PATH` for Ignition Gazebo systems (world, model,
       sensor and visual plugins).
     * `IGN_GUI_PLUGIN_PATH` for GUI plugins.
 

--- a/tutorials/resources.md
+++ b/tutorials/resources.md
@@ -38,7 +38,7 @@ System plugins may be loaded through:
 
 Ignition will look for system plugins on the following paths, in order:
 
-1. All paths on the `IGN_GAZEBO_SYSTEM_PLUGIN_PATH` environment variable
+1. All paths on the `IGN_GAZEBO_SYSTEM_PLUGIN_PATH` or `GZ_SIM_SYSTEM_PLUGIN_PATH` environment variables
 2. `$HOME/.ignition/gazebo/plugins`
 3. [Systems that are installed with Ignition Gazebo](https://gazebosim.org/api/gazebo/6/namespace gz_1_1gazebo_1_1systems.html)
 
@@ -116,7 +116,7 @@ Top-level entities such as models, lights and actors may be loaded through:
 
 Ignition will look for URIs (path / URL) in the following, in order:
 
-1. All paths on the `IGN_GAZEBO_RESOURCE_PATH`\* environment variable (if
+1. All paths on the `IGN_GAZEBO_RESOURCE_PATH` and `GZ_SIM_RESOURCE_PATH`\* environment variables (if
    path is URI, scheme is stripped)
 2. Current running path / absolute path
 3. [Ignition Fuel](https://app.gazebosim.org/fuel/models)
@@ -138,7 +138,7 @@ Mesh files may be loaded through:
 Ignition will look for URIs (path / URL) in the following, in order:
 
 1. Current running path / absolute path
-2. All paths on the `IGN_GAZEBO_RESOURCE_PATH`\* environment variable (if path
+2. All paths on the `IGN_GAZEBO_RESOURCE_PATH` and `GZ_SIM_RESOURCE_PATH`\* environment variables (if path
    is URI, scheme is stripped)
 
 \* The `IGN_FILE_PATH` environment variable also works in some scenarios, but

--- a/tutorials/server_config.md
+++ b/tutorials/server_config.md
@@ -13,13 +13,13 @@ a simulation.
 There are a few places where the plugins can be defined:
 
 1. `<plugin>` elements inside an SDF file.
-2. File path defined by the `IGN_GAZEBO_SERVER_CONFIG_PATH` environment variable.
+2. File path defined by the `IGN_GAZEBO_SERVER_CONFIG_PATH` or `GZ_SIM_SERVER_CONFIG_PATH` environment variables.
 3. The default configuration file at `$HOME/.ignition/gazebo/<#>/server.config` \*,
    where `<#>` is Gazebo's major version.
 
 Each of the items above takes precedence over the ones below it. For example,
 if a the SDF file has any `<plugin>` elements, then the
-`IGN_GAZEBO_SERVER_CONFIG_PATH` variable is ignored. And the default configuration
+`IGN_GAZEBO_SERVER_CONFIG_PATH` and `GZ_SIM_SERVER_CONFIG_PATH` variables are ignored. And the default configuration
 file is only loaded if no plugins are passed through the SDF file or the
 environment variable.
 


### PR DESCRIPTION
# 🎉 New feature

## Summary
Allows using gz-* in plugin filenames (eg.  `<plugin filename="gz-sim-physics-system" name="gz::sim::systems::Physics"/>`) and using `GZ_*` environment variables in Fortress. This is meant to help users (especially ROS users) maintain SDF files and launch files that work in both Fortress and Garden/Harmonic.


## Test it
I've added tests that exercise:
* Using `gz-sim-*` filenames in `<plugin>` tags (`src/SystemLoader_TEST.cc`)
* Using `GZ_SIM_SYSTEM_PLUGIN_PATH` (`src/SystemLoader_TEST.cc`)
* Using `GZ_SIM_RESOURCE_PATH` (`src/Server.cc`)
* Using `GZ_SIM_SERVER_CONFIG_PATH` (`src/ServerConfig_TEST.cc`)

I have not added a test for `GZ_SIM_RENDER_ENGINE_PATH` since I couldn't find a test for `IGN_GAZEBO_RENDER_ENGINE_PATH` and I don't think it's a commonly used environment variable.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
