### PR TITLE
Fix URL in hydrodynamics tutorial

### DIFF
--- a/tutorials/theory_hydrodynamics.md
+++ b/tutorials/theory_hydrodynamics.md
@@ -150,7 +150,7 @@ Capytaine is typically used to model the interaction between floating bodies and
 waves, however it can be applied to ROVs by setting the wave frequency and free
 surface both to infinity (this assumes that the added mass is approximately
 constant since the ROV does not operate near the wave zone and that it operates
-in infinitely deep water respectively) [1](p.14), [2](p.18).
+in infinitely deep water respectively) [1] (p.14), [2] (p.18).
 
 Furthermore, it is recommended to use a simplified mesh when computing the added
 mass with Capytaine, since a complex mesh is computationally prohibitive.
@@ -159,9 +159,9 @@ mass with Capytaine, since a complex mesh is computationally prohibitive.
 
 Computing the linear and quadratic damping coefficients is generally not
 possible using computational analysis and is usually done experimentally
-[1](p.28). If determining the damping coefficients experimentally is not
+[1] (p.28). If determining the damping coefficients experimentally is not
 feasible, the same method described by Berg2012 can be used to estimate these
-values from a similar ROV [1](p.28-31).
+values from a similar ROV [1] (p.28-31).
 
 # References
 

--- a/tutorials/theory_hydrodynamics.md
+++ b/tutorials/theory_hydrodynamics.md
@@ -88,7 +88,7 @@ in the positive `X` direction.
 
 ```bash
 mkdir -p ~/gazebo_maritime/worlds
-wget https://raw.githubusercontent.com/gazebosim/gz-sim/main/tutorials/files/theory_hydrodynamics/buoyant_cylinder.sdf -o ~/gazebo_maritime/worlds/buoyant_cylinder.sdf
+wget https://raw.githubusercontent.com/gazebosim/gz-sim/gz-sim8/tutorials/files/theory_hydrodynamics/buoyant_cylinder.sdf -o ~/gazebo_maritime/worlds/buoyant_cylinder.sdf
 gz sim -r ~/gazebo_maritime/worlds/buoyant_cylinder.sdf
 ```
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

I think the automatic rebase from `main` to `gz-sim8` in the original PR broke the old URL.

Also fix citation bug - the `[]()` syntax is showing up as invalid links, so I added a space in between.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
