### PR TITLE
Prepare for 6.16.0 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-gazebo6 VERSION 6.15.0)
+project(ignition-gazebo6 VERSION 6.16.0)
 set (GZ_DISTRIBUTION "Fortress")
 
 #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -23,9 +23,6 @@
 1. Backport component inspector Vector3d width fix
     * [Pull request #2195](https://github.com/gazebosim/gz-sim/pull/2195)
 
-1. Fix INTEGRATION_save_world's SdfGeneratorFixture.ModelWithNestedIncludes test
-    * [Pull request #fix INTEGRATION_save_world's SdfGeneratorFixture.ModelWithNestedIncludes test](https://github.com/gazebosim/gz-sim/pull/fix INTEGRATION_save_world's SdfGeneratorFixture.ModelWithNestedIncludes test)
-
 1. Bump Fuel model version in test
     * [Pull request #2190](https://github.com/gazebosim/gz-sim/pull/2190)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,37 @@
 ## Ignition Gazebo 6.x
 
+### Gazebo Sim 6.16.0 (2024-01-12)
+
+1. Allow using plugin file names and environment variables compatible with Garden and later
+    * [Pull request #2275](https://github.com/gazebosim/gz-sim/pull/2275)
+
+1. Update friction parameters for skid steer example
+    * [Pull request #2235](https://github.com/gazebosim/gz-sim/pull/2235)
+
+1. Relax pose check in actor no mesh test
+    * [Pull request #2196](https://github.com/gazebosim/gz-sim/pull/2196)
+
+1. Fix macOS test failures by registering components in the core library
+    * [Pull request #2220](https://github.com/gazebosim/gz-sim/pull/2220)
+
+1. Fix for sensor pointer null when navsat plugin in included in sdf
+    * [Pull request #2176](https://github.com/gazebosim/gz-sim/pull/2176)
+
+1. Fix another deadlock in sensors system
+    * [Pull request #2200](https://github.com/gazebosim/gz-sim/pull/2200)
+
+1. Backport component inspector Vector3d width fix
+    * [Pull request #2195](https://github.com/gazebosim/gz-sim/pull/2195)
+
+1. Fix INTEGRATION_save_world's SdfGeneratorFixture.ModelWithNestedIncludes test
+    * [Pull request #fix INTEGRATION_save_world's SdfGeneratorFixture.ModelWithNestedIncludes test](https://github.com/gazebosim/gz-sim/pull/fix INTEGRATION_save_world's SdfGeneratorFixture.ModelWithNestedIncludes test)
+
+1. Bump Fuel model version in test
+    * [Pull request #2190](https://github.com/gazebosim/gz-sim/pull/2190)
+
+1. Infrastructure
+    * [Pull request #2237](https://github.com/gazebosim/gz-sim/pull/2237)
+    * [Pull request #2222](https://github.com/gazebosim/gz-sim/pull/2222)
 
 ### Gazebo Sim 6.15.0 (2023-08-16)
 


### PR DESCRIPTION
# 🎈 Release

Preparation for 6.16.0 release.

Comparison to 6.15.0: https://github.com/gazebosim/gz-sim/compare/ignition-gazebo6_6.15.0...ign-gazebo6

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [x] Updated migration guide (as needed)
- [x] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.