### PR TITLE
Fix ModelPhotoShootTest test failures

### DIFF
--- a/examples/worlds/model_photo_shoot.sdf
+++ b/examples/worlds/model_photo_shoot.sdf
@@ -17,7 +17,7 @@
       filename="gz-sim-sensors-system"
       name="gz::sim::systems::Sensors">
       <render_engine>ogre2</render_engine>
-      <background_color>1, 1, 1</background_color>
+      <background_color>1.0 1.0 1.0</background_color>
     </plugin>
     <include>
       <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Robonaut</uri>

--- a/test/integration/ModelPhotoShootTest.hh
+++ b/test/integration/ModelPhotoShootTest.hh
@@ -230,7 +230,6 @@ class ModelPhotoShootTest : public InternalFixture<::testing::Test>
     // First run of the server generating images through the plugin.
     TestFixture fixture(common::joinPaths(std::string(PROJECT_SOURCE_PATH),
         _sdfWorld));
-    fixture.Server()->SetUpdatePeriod(1ns);
 
     common::ConnectionPtr postRenderConn;
     fixture.OnConfigure([&](
@@ -243,7 +242,12 @@ class ModelPhotoShootTest : public InternalFixture<::testing::Test>
             std::bind(&ModelPhotoShootTest::OnPostRender, this));
     }).Finalize();
 
-    fixture.Server()->Run(true, 50, false);
+    fixture.Server()->SetUpdatePeriod(1ns);
+
+    for (int i = 0; i < 50; ++i)
+    {
+      fixture.Server()->RunOnce(true);
+    }
     this->LoadPoseValues();
 
     fixture.OnPreUpdate([&](const sim::UpdateInfo &,
@@ -285,7 +289,7 @@ class ModelPhotoShootTest : public InternalFixture<::testing::Test>
         }
         this->checkRandomJoints = false;
       }
-    }).Finalize();
+    });
 
     this->takeTestPics = true;
 
@@ -293,7 +297,7 @@ class ModelPhotoShootTest : public InternalFixture<::testing::Test>
         std::chrono::milliseconds(3000);
     while (takeTestPics && end_time > std::chrono::steady_clock::now())
     {
-      fixture.Server()->Run(true, 1, false);
+      fixture.Server()->RunOnce(true);
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
     testImages("1.png", "1_test.png");

--- a/test/worlds/model_photo_shoot_random_joints.sdf
+++ b/test/worlds/model_photo_shoot_random_joints.sdf
@@ -17,7 +17,7 @@
       filename="gz-sim-sensors-system"
       name="gz::sim::systems::Sensors">
       <render_engine>ogre2</render_engine>
-      <background_color>1, 1, 1</background_color>
+      <background_color>1.0 1.0 1.0</background_color>
     </plugin>
     <include>
       <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Robonaut</uri>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
ModelPhotoShoot tests have started failing recently (https://github.com/gazebosim/gz-sim/pull/2293#issuecomment-1900598909). The failures are caused by a change in the DART physics engine (https://github.com/dartsim/dart/pull/1774) which causes joints to recover after reaching or exceeding their position limits. The debs for this version of DART are in the prerelease repos for testing, so we've only started experiencing this since https://github.com/gazebo-tooling/gzdev/pull/77 which made gz-sim8 use prereleases.

It seems like the model used in the `ModelPhotoShoot` tests starts off with joint limits violated and recovers after a few iterations. This causes a small movement of the robot. Since the test works by comparing images taken of the robot at the start of simulation and after a few iterations, the small movement causes a discrepancy in the images. The solution here is to run the whole test while simulation is paused.

This also cleans up some TestFixture warnings.
## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
