### PR TITLE
Light entity match SDF boolean for UserCommands.

### DIFF
--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -1399,14 +1399,6 @@ bool LightCommand::Execute()
       {
         lightEntity = lightMsg->id();
       }
-      if (kNullEntity == lightEntity)
-      {
-        gzerr << "Failed to find light with name [" << lightMsg->name()
-               << "] and parent ID ["
-               << lightMsg->parent_id() << "]." << std::endl;
-        return false;
-      }
-
       if (!lightEntity)
       {
         gzmsg << "Failed to find light entity named [" << lightMsg->name()

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -548,7 +548,6 @@ class gz::sim::systems::UserCommandsPrivate
 
   /// \brief Mutex to protect pending queue.
   public: std::mutex pendingMutex;
-
 };
 
 /// \brief Pose3d equality comparison function.

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -119,6 +119,9 @@ class UserCommandsInterface
   /// \return True if a contact sensor is connected to the collision entity,
   /// false otherwise
   public: bool HasContactSensor(const Entity _collision);
+
+  /// \brief Bool to set all matching light entities.
+  public: bool setAllLightEntities = false;
 };
 
 /// \brief All user commands should inherit from this class so they can be
@@ -545,6 +548,7 @@ class gz::sim::systems::UserCommandsPrivate
 
   /// \brief Mutex to protect pending queue.
   public: std::mutex pendingMutex;
+
 };
 
 /// \brief Pose3d equality comparison function.
@@ -610,7 +614,7 @@ bool UserCommandsInterface::HasContactSensor(const Entity _collision)
 
 //////////////////////////////////////////////////
 void UserCommands::Configure(const Entity &_entity,
-    const std::shared_ptr<const sdf::Element> &,
+    const std::shared_ptr<const sdf::Element> &_sdf,
     EntityComponentManager &_ecm,
     EventManager &_eventManager)
 {
@@ -679,6 +683,15 @@ void UserCommands::Configure(const Entity &_entity,
   std::string lightTopic{"/world/" + validWorldName + "/light_config"};
   this->dataPtr->node.Subscribe(lightTopic, &UserCommandsPrivate::OnCmdLight,
                                 this->dataPtr.get());
+
+  if (_sdf->HasElement("set_all_light_entities"))
+  {
+    this->dataPtr->iface->setAllLightEntities =
+      _sdf->Get<bool>("set_all_light_entities");
+    gzmsg << "Set all light entities: "
+          << this->dataPtr->iface->setAllLightEntities
+          << std::endl;
+  }
 
   std::string materialColorTopic{
     "/world/" + validWorldName + "/material_color"};
@@ -858,7 +871,6 @@ void UserCommandsPrivate::OnCmdLight(const msgs::Light &_msg)
     this->pendingCmds.push_back(std::move(cmd));
   }
 }
-
 
 //////////////////////////////////////////////////
 bool UserCommandsPrivate::PoseService(const msgs::Pose &_req,
@@ -1362,79 +1374,150 @@ LightCommand::LightCommand(msgs::Light *_msg,
 //////////////////////////////////////////////////
 bool LightCommand::Execute()
 {
-  auto lightMsg = dynamic_cast<const msgs::Light *>(this->msg);
+  auto lightMsg = dynamic_cast<msgs::Light *>(this->msg);
   if (nullptr == lightMsg)
   {
     gzerr << "Internal error, null light message" << std::endl;
     return false;
   }
-
-  Entity lightEntity{kNullEntity};
-
-  if (lightMsg->id() != kNullEntity)
+  Entity lightEntity = kNullEntity;
+  if (this->iface->setAllLightEntities)
   {
-    lightEntity = lightMsg->id();
-  }
-  else if (!lightMsg->name().empty())
-  {
-    if (lightMsg->parent_id() != kNullEntity)
+    auto entities = entitiesFromScopedName(lightMsg->name(),
+        *this->iface->ecm);
+    if (entities.empty())
     {
-      lightEntity = this->iface->ecm->EntityByComponents(
-        components::Name(lightMsg->name()),
-        components::ParentEntity(lightMsg->parent_id()));
+      gzwarn << "Entity name: " << lightMsg->name() << ", is not found."
+             << std::endl;
+      return false;
     }
-    else
+    for (const Entity &id : entities)
     {
-      lightEntity = this->iface->ecm->EntityByComponents(
-        components::Name(lightMsg->name()));
+      lightEntity = kNullEntity;
+      lightMsg->set_id(id);
+      if (lightMsg->id() != kNullEntity)
+      {
+        lightEntity = lightMsg->id();
+      }
+      if (kNullEntity == lightEntity)
+      {
+        gzerr << "Failed to find light with name [" << lightMsg->name()
+               << "] and parent ID ["
+               << lightMsg->parent_id() << "]." << std::endl;
+        return false;
+      }
+
+      if (!lightEntity)
+      {
+        gzmsg << "Failed to find light entity named [" << lightMsg->name()
+          << "]." << std::endl;
+        return false;
+      }
+
+      auto lightPose =
+        this->iface->ecm->Component<components::Pose>(lightEntity);
+      if (nullptr == lightPose)
+      {
+        lightEntity = kNullEntity;
+      }
+
+      if (!lightEntity)
+      {
+        gzmsg << "Pose component not available" << std::endl;
+        return false;
+      }
+
+      if (lightMsg->has_pose())
+      {
+        lightPose->Data().Pos() = msgs::Convert(lightMsg->pose()).Pos();
+      }
+
+      auto lightCmdComp =
+        this->iface->ecm->Component<components::LightCmd>(lightEntity);
+      if (!lightCmdComp)
+      {
+        this->iface->ecm->CreateComponent(
+            lightEntity, components::LightCmd(*lightMsg));
+      }
+      else
+      {
+        auto state = lightCmdComp->SetData(*lightMsg, this->lightEql) ?
+            ComponentState::OneTimeChange :
+            ComponentState::NoChange;
+        this->iface->ecm->SetChanged(lightEntity, components::LightCmd::typeId,
+          state);
+      }
     }
-  }
-  if (kNullEntity == lightEntity)
-  {
-    gzerr << "Failed to find light with name [" << lightMsg->name()
-           << "], ID [" << lightMsg->id() << "] and parent ID ["
-           << lightMsg->parent_id() << "]." << std::endl;
-    return false;
-  }
-
-  if (!lightEntity)
-  {
-    gzmsg << "Failed to find light entity named [" << lightMsg->name()
-      << "]." << std::endl;
-    return false;
-  }
-
-  auto lightPose = this->iface->ecm->Component<components::Pose>(lightEntity);
-  if (nullptr == lightPose)
-    lightEntity = kNullEntity;
-
-  if (!lightEntity)
-  {
-    gzmsg << "Pose component not available" << std::endl;
-    return false;
-  }
-
-  if (lightMsg->has_pose())
-  {
-    lightPose->Data().Pos() = msgs::Convert(lightMsg->pose()).Pos();
-  }
-
-  auto lightCmdComp =
-    this->iface->ecm->Component<components::LightCmd>(lightEntity);
-  if (!lightCmdComp)
-  {
-    this->iface->ecm->CreateComponent(
-        lightEntity, components::LightCmd(*lightMsg));
   }
   else
   {
-    auto state = lightCmdComp->SetData(*lightMsg, this->lightEql) ?
-        ComponentState::OneTimeChange :
-        ComponentState::NoChange;
-    this->iface->ecm->SetChanged(lightEntity, components::LightCmd::typeId,
-      state);
-  }
+    lightEntity = kNullEntity;
+    if (lightMsg->id() != kNullEntity)
+    {
+      lightEntity = lightMsg->id();
+    }
+    else if (!lightMsg->name().empty())
+    {
+      if (lightMsg->parent_id() != kNullEntity)
+      {
+        lightEntity = this->iface->ecm->EntityByComponents(
+          components::Name(lightMsg->name()),
+          components::ParentEntity(lightMsg->parent_id()));
+      }
+      else
+      {
+        lightEntity = this->iface->ecm->EntityByComponents(
+          components::Name(lightMsg->name()));
+      }
+    }
+    if (kNullEntity == lightEntity)
+    {
+      gzerr << "Failed to find light with name [" << lightMsg->name()
+             << "], ID [" << lightMsg->id() << "] and parent ID ["
+             << lightMsg->parent_id() << "]." << std::endl;
+      return false;
+    }
 
+    if (!lightEntity)
+    {
+      gzmsg << "Failed to find light entity named [" << lightMsg->name()
+        << "]." << std::endl;
+      return false;
+    }
+
+    auto lightPose = this->iface->ecm->Component<components::Pose>(lightEntity);
+    if (nullptr == lightPose)
+    {
+      lightEntity = kNullEntity;
+    }
+
+    if (!lightEntity)
+    {
+      gzmsg << "Pose component not available" << std::endl;
+      return false;
+    }
+
+    if (lightMsg->has_pose())
+    {
+      lightPose->Data().Pos() = msgs::Convert(lightMsg->pose()).Pos();
+    }
+
+    auto lightCmdComp =
+      this->iface->ecm->Component<components::LightCmd>(lightEntity);
+    if (!lightCmdComp)
+    {
+      this->iface->ecm->CreateComponent(
+          lightEntity, components::LightCmd(*lightMsg));
+    }
+    else
+    {
+      auto state = lightCmdComp->SetData(*lightMsg, this->lightEql) ?
+          ComponentState::OneTimeChange :
+          ComponentState::NoChange;
+      this->iface->ecm->SetChanged(lightEntity, components::LightCmd::typeId,
+        state);
+    }
+  }
   return true;
 }
 

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -687,7 +687,7 @@ void UserCommands::Configure(const Entity &_entity,
   {
     this->dataPtr->iface->setAllLightEntities =
       _sdf->Get<bool>("set_all_light_entities");
-    gzmsg << "Set all light entities: "
+    gzdbg << "Set all light entities: "
           << this->dataPtr->iface->setAllLightEntities
           << std::endl;
   }

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -15,6 +15,8 @@
  *
  */
 
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include <gz/msgs/boolean.pb.h>

--- a/test/worlds/lights_render_all.sdf
+++ b/test/worlds/lights_render_all.sdf
@@ -19,6 +19,53 @@
       name="gz::sim::systems::Sensors">
       <render_engine>ogre2</render_engine>
     </plugin>
+
+    <light type="directional" name="directional">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>100</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>0.5 0.2 -0.9</direction>
+    </light>
+
+    <light type="point" name="point">
+      <pose>0 -1.5 3 0 0 0</pose>
+      <diffuse>1 0 0 1</diffuse>
+      <specular>.1 .1 .1 1</specular>
+      <attenuation>
+        <range>4</range>
+        <constant>0.2</constant>
+        <linear>0.5</linear>
+        <quadratic>0.01</quadratic>
+      </attenuation>
+      <cast_shadows>false</cast_shadows>
+    </light>
+
+    <light type="spot" name="spot">
+      <pose>0 1.5 3 0 0 0</pose>
+      <diffuse>0 1 0 1</diffuse>
+      <specular>.2 .2 .2 1</specular>
+      <attenuation>
+        <range>5</range>
+        <constant>0.3</constant>
+        <linear>0.4</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>0 0 -1</direction>
+      <spot>
+        <inner_angle>0.1</inner_angle>
+        <outer_angle>0.5</outer_angle>
+        <falloff>0.8</falloff>
+      </spot>
+      <cast_shadows>false</cast_shadows>
+    </light>
+
     <model name="sphere_0">
       <pose>0 0.0 0.0 0 0 0</pose>
       <link name="sphere_link_0">

--- a/test/worlds/lights_render_all.sdf
+++ b/test/worlds/lights_render_all.sdf
@@ -1,0 +1,102 @@
+<?xml version="1.0" ?>
+<sdf version="1.10">
+  <world name="lights_command">
+    <physics name="1ms" type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>0</real_time_factor>
+    </physics>
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+    <plugin
+      filename='gz-sim-user-commands-system'
+      name='gz::sim::systems::UserCommands'>
+      <set_all_light_entities>true</set_all_light_entities>
+    </plugin>
+    <plugin
+      filename="gz-sim-sensors-system"
+      name="gz::sim::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+    <model name="sphere_0">
+      <pose>0 0.0 0.0 0 0 0</pose>
+      <link name="sphere_link_0">
+        <!-- Added a render sensor to trigger RenderUtil:Update -->
+        <sensor name="camera" type="camera">
+          <pose>1 0 1.3 0 0 0</pose>
+          <camera>
+            <horizontal_fov>1.047</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>30</update_rate>
+          <visualize>false</visualize>
+          <topic>camera</topic>
+        </sensor>
+        <visual name="sphere_visual_0">
+          <geometry>
+            <sphere>
+              <radius>0.5</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0.3 0.3 0.3 1</ambient>
+            <diffuse>0.3 0.3 0.3 1</diffuse>
+            <specular>0.3 0.3 0.3 1</specular>
+          </material>
+        </visual>
+        <light type="spot" name="sphere_light">
+          <pose>0 0 1.0 0 0 0</pose>
+          <cast_shadows>false</cast_shadows>
+          <visualize>1</visualize>
+          <diffuse>1.0 1.0 1.0 1.0</diffuse>
+          <specular>1.0 1.0 1.0 1.0</specular>
+          <direction>0 0 -1</direction>
+          <intensity>1.0</intensity>
+          <spot>
+            <inner_angle>2.1</inner_angle>
+            <outer_angle>2.1</outer_angle>
+          </spot>
+        </light>
+      </link>
+    </model>
+    <model name="sphere_1">
+      <pose>0.5 1.0 0.0 0 0 0</pose>
+      <link name="sphere_link_1">
+        <visual name="sphere_visual_1">
+          <geometry>
+            <sphere>
+              <radius>0.5</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0.3 0.3 0.3 1</ambient>
+            <diffuse>0.3 0.3 0.3 1</diffuse>
+            <specular>0.3 0.3 0.3 1</specular>
+          </material>
+        </visual>
+        <light type="spot" name="sphere_light">
+          <pose>0 0 1.0 0 0 0</pose>
+          <cast_shadows>false</cast_shadows>
+          <visualize>1</visualize>
+          <diffuse>1.0 1.0 1.0 1.0</diffuse>
+          <specular>1.0 1.0 1.0 1.0</specular>
+          <direction>0 0 -1</direction>
+          <intensity>1.0</intensity>
+          <spot>
+            <inner_angle>2.1</inner_angle>
+            <outer_angle>2.1</outer_angle>
+          </spot>
+        </light>
+      </link>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Unable to set multiple matching light entities like what is done in MaterialColor.
Adding an SDF boolean element `<set_all_light_entities>` to usercommands plugin allows for controlling matching light entities.

Waiting first on merge of https://github.com/gazebosim/gz-sim/pull/2286 for MaterialColor change.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.