### PR TITLE
Explicitly check SKIP_PYBIND11 for python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,7 +244,7 @@ add_subdirectory(examples)
 #============================================================================
 gz_create_packages()
 
-if (pybind11_FOUND)
+if (pybind11_FOUND AND NOT SKIP_PYBIND11)
 	add_subdirectory(python)
 endif()
 #============================================================================


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-sim/issues/2249, uses https://github.com/osrf/homebrew-simulation/pull/2543 via `ci_matching_branch/`

## Summary

This is a minor change to the cmake logic for enabling python bindings and is used as an opportunity to test whether the changes in https://github.com/osrf/homebrew-simulation/pull/2543 will help fix #2249.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
