### PR TITLE
Fix `INTEGRATION_save_world` on windows

### DIFF
--- a/test/worlds/non_rendering_sensors.sdf
+++ b/test/worlds/non_rendering_sensors.sdf
@@ -5,11 +5,6 @@
       <real_time_factor>0</real_time_factor>
     </physics>
     <plugin
-      filename="gz-sim-sensors-system"
-      name="gz::sim::systems::Sensors">
-      <render_engine>ogre2</render_engine>
-    </plugin>
-    <plugin
       filename="gz-sim-scene-broadcaster-system"
       name="gz::sim::systems::SceneBroadcaster">
     </plugin>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2177

## Summary

Loading the rendering pipeline multiple times in a test doesn't seem to work well. This removes the Sensors system from the `non_rendering_sensors.sdf` file so that Ogre2 and the whole rendering pipeline is only loaded once.

## CI Builds:
- [![Build Status](https://build.osrfoundation.org/job/gz_sim-pr-win/203/badge/icon)](https://build.osrfoundation.org/job/gz_sim-pr-win/203/)
- [![Build Status](https://build.osrfoundation.org/job/gz_sim-pr-win/204/badge/icon)](https://build.osrfoundation.org/job/gz_sim-pr-win/204/)
- [![Build Status](https://build.osrfoundation.org/job/gz_sim-pr-win/205/badge/icon)](https://build.osrfoundation.org/job/gz_sim-pr-win/205/)
- [![Build Status](https://build.osrfoundation.org/job/gz_sim-pr-win/206/badge/icon)](https://build.osrfoundation.org/job/gz_sim-pr-win/206/)

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
