### PR TITLE
Enable StoreResolvedURIs when loading SDF

### DIFF
--- a/src/Server.cc
+++ b/src/Server.cc
@@ -119,7 +119,7 @@ Server::Server(const ServerConfig &_config)
       // resources are downloaded. Blocking here causes the GUI to block with
       // a black screen (search for "Async resource download" in
       // 'src/gui_main.cc'.
-      sdf::ParserConfig parserConfig;
+      auto &parserConfig = sdf::ParserConfig::GlobalConfig();
       parserConfig.SetStoreResolvedURIs(true);
       errors = sdfRoot.Load(filePath, parserConfig);
       if (errors.empty()) {

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -119,7 +119,9 @@ Server::Server(const ServerConfig &_config)
       // resources are downloaded. Blocking here causes the GUI to block with
       // a black screen (search for "Async resource download" in
       // 'src/gui_main.cc'.
-      errors = sdfRoot.Load(filePath);
+      sdf::ParserConfig parserConfig;
+      parserConfig.SetStoreResolvedURIs(true);
+      errors = sdfRoot.Load(filePath, parserConfig);
       if (errors.empty()) {
         if (sdfRoot.Model() == nullptr) {
           this->dataPtr->sdfRoot = std::move(sdfRoot);

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -711,9 +711,6 @@ rendering::GeometryPtr SceneManager::LoadGeometry(const sdf::Geometry &_geom,
          common::basename(_geom.MeshShape()->Uri()) :
          asFullPath(_geom.MeshShape()->Uri(),
                     _geom.MeshShape()->FilePath());
-    auto a =     asFullPath(_geom.MeshShape()->Uri(),
-                    _geom.MeshShape()->FilePath());
-
     descriptor.meshName = meshUri;
     descriptor.subMeshName = _geom.MeshShape()->Submesh();
     descriptor.centerSubMesh = _geom.MeshShape()->CenterSubmesh();


### PR DESCRIPTION

# 🎉 New feature

Depends on https://github.com/gazebosim/sdformat/pull/1373

## Summary

When ParserConfig's `SetStoreResolvedURIs` option is set to true, the URIs will be resolved / expanded and stored in the SDF parsed. Any consumer of the SDF will not have to resolve the URIs themselves.

One use case for this is that the bullet-featherstone implementation in gz-physics needs to load meshes from the URI element in SDF. Without resolved URIs, the bullet-featherstone engine will need to implement its own logic to resolve all mesh URIs which may result in duplicate code, e.g. https://github.com/gazebosim/gz-physics/pull/599.

For context, this ParserConfig option was added in https://github.com/gazebosim/sdformat/pull/1147 to help with bullet-featherstone work but for some reason it was not set at the time (https://github.com/gazebosim/gz-physics/pull/599#issuecomment-1958166114).  

While testing, I ran into some unused code for mesh URIs in `rendering/SceneManager.cc` so removed that as well.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

