### PR TITLE
Add entity and sdf parameters to Server's AddSystem interface

### DIFF
--- a/include/gz/sim/Server.hh
+++ b/include/gz/sim/Server.hh
@@ -26,6 +26,8 @@
 #include <gz/sim/Export.hh>
 #include <gz/sim/ServerConfig.hh>
 #include <gz/sim/SystemPluginPtr.hh>
+#include <sdf/Element.hh>
+#include <sdf/Plugin.hh>
 
 namespace gz
 {
@@ -227,12 +229,58 @@ namespace gz
 
       /// \brief Add a System to the server. The server must not be running when
       /// calling this.
+      /// \param[in] _system system to be added
+      /// \param[in] _entity Entity of system to be added.
+      /// If _entity is std::nullopt, it will be added to the world entity.
+      /// \param[in] _sdf Pointer to the SDF element of a <plugin> tag with
+      /// configuration options for the system being added.
+      /// \param[in] _worldIndex Index of the world to query.
+      /// \return Whether the system was added successfully, or std::nullopt
+      /// if _worldIndex is invalid.
+      public: std::optional<bool> AddSystem(
+                  const SystemPluginPtr &_system,
+                  std::optional<Entity> _entity,
+                  std::optional<std::shared_ptr<const sdf::Element>> _sdf,
+                  const unsigned int _worldIndex = 0);
+
+      /// \brief Add a System to the server. The server must not be running when
+      /// calling this.
+      /// \param[in] _plugin system plugin to be added with any additional XML
+      /// contents.
+      /// \param[in] _entity Entity of system to be added.
+      /// If _entity is std::nullopt, it will be added to the world entity.
+      /// \param[in] _worldIndex Index of the world to query.
+      /// \return Whether the system was added successfully, or std::nullopt
+      /// if _worldIndex is invalid.
+      public: std::optional<bool> AddSystem(
+                  const sdf::Plugin &_plugin,
+                  std::optional<Entity> _entity,
+                  const unsigned int _worldIndex = 0);
+
+      /// \brief Add a System to the server. The server must not be running when
+      /// calling this.
       /// \param[in] _system System to be added
       /// \param[in] _worldIndex Index of the world to add to.
       /// \return Whether the system was added successfully, or std::nullopt
       /// if _worldIndex is invalid.
       public: std::optional<bool> AddSystem(
                   const std::shared_ptr<System> &_system,
+                  const unsigned int _worldIndex = 0);
+
+      /// \brief Add a System to the server. The server must not be running when
+      /// calling this.
+      /// \param[in] _system System to be added
+      /// \param[in] _entity Entity of system to be added.
+      /// If _entity is std::nullopt, it will be added to the world entity.
+      /// \param[in] _sdf Pointer to the SDF element of a <plugin> tag with
+      /// configuration options for the system being added
+      /// \param[in] _worldIndex Index of the world to add to.
+      /// \return Whether the system was added successfully, or std::nullopt
+      /// if _worldIndex is invalid.
+      public: std::optional<bool> AddSystem(
+                  const std::shared_ptr<System> &_system,
+                  std::optional<Entity> _entity,
+                  std::optional<std::shared_ptr<const sdf::Element>> _sdf,
                   const unsigned int _worldIndex = 0);
 
       /// \brief Get an Entity based on a name.

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -353,6 +353,29 @@ std::optional<size_t> Server::SystemCount(const unsigned int _worldIndex) const
 std::optional<bool> Server::AddSystem(const SystemPluginPtr &_system,
                                       const unsigned int _worldIndex)
 {
+  return this->AddSystem(_system, std::nullopt, std::nullopt, _worldIndex);
+}
+
+//////////////////////////////////////////////////
+std::optional<bool> Server::AddSystem(const sdf::Plugin &_plugin,
+                                      std::optional<Entity> _entity,
+                                      const unsigned int _worldIndex)
+{
+  auto system = this->dataPtr->systemLoader->LoadPlugin(_plugin);
+  if (system)
+  {
+    return this->AddSystem(*system, _entity, _plugin.ToElement(), _worldIndex);
+  }
+  return false;
+}
+
+//////////////////////////////////////////////////
+std::optional<bool> Server::AddSystem(
+    const SystemPluginPtr &_system,
+    std::optional<Entity> _entity,
+    std::optional<std::shared_ptr<const sdf::Element>> _sdf,
+    const unsigned int _worldIndex)
+{
   // Check the current state, and return early if preconditions are not met.
   std::lock_guard<std::mutex> lock(this->dataPtr->runMutex);
   // Do not allow running more than once.
@@ -364,7 +387,7 @@ std::optional<bool> Server::AddSystem(const SystemPluginPtr &_system,
 
   if (_worldIndex < this->dataPtr->simRunners.size())
   {
-    this->dataPtr->simRunners[_worldIndex]->AddSystem(_system);
+    this->dataPtr->simRunners[_worldIndex]->AddSystem(_system, _entity, _sdf);
     return true;
   }
 
@@ -375,6 +398,16 @@ std::optional<bool> Server::AddSystem(const SystemPluginPtr &_system,
 std::optional<bool> Server::AddSystem(const std::shared_ptr<System> &_system,
                                       const unsigned int _worldIndex)
 {
+  return this->AddSystem(_system, std::nullopt, std::nullopt, _worldIndex);
+}
+
+//////////////////////////////////////////////////
+std::optional<bool> Server::AddSystem(
+    const std::shared_ptr<System> &_system,
+    std::optional<Entity> _entity,
+    std::optional<std::shared_ptr<const sdf::Element>> _sdf,
+    const unsigned int _worldIndex)
+{
   std::lock_guard<std::mutex> lock(this->dataPtr->runMutex);
   if (this->dataPtr->running)
   {
@@ -384,7 +417,7 @@ std::optional<bool> Server::AddSystem(const std::shared_ptr<System> &_system,
 
   if (_worldIndex < this->dataPtr->simRunners.size())
   {
-    this->dataPtr->simRunners[_worldIndex]->AddSystem(_system);
+    this->dataPtr->simRunners[_worldIndex]->AddSystem(_system, _entity, _sdf);
     return true;
   }
 

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -625,16 +625,47 @@ TEST_P(ServerFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(RunOnceUnpaused))
   auto mockSystemPlugin = systemLoader.LoadPlugin(sdfPlugin);
   ASSERT_TRUE(mockSystemPlugin.has_value());
 
-  // Check that it was loaded
-  const size_t systemCount = *server.SystemCount();
-  EXPECT_TRUE(*server.AddSystem(mockSystemPlugin.value()));
-  EXPECT_EQ(systemCount + 1, *server.SystemCount());
-
   // Query the interface from the plugin
   auto system = mockSystemPlugin.value()->QueryInterface<sim::System>();
   EXPECT_NE(system, nullptr);
   auto mockSystem = dynamic_cast<sim::MockSystem*>(system);
   EXPECT_NE(mockSystem, nullptr);
+
+  Entity entity = server.EntityByName("default").value();
+  size_t configureCallCount = 0;
+  auto configureCallback = [&sdfPlugin, &entity, &configureCallCount](
+    const Entity &_entity,
+    const std::shared_ptr<const sdf::Element> &_sdf,
+    EntityComponentManager &,
+    EventManager &)
+  {
+    configureCallCount++;
+    EXPECT_EQ(entity, _entity);
+    EXPECT_EQ(sdfPlugin.ToElement()->ToString(""), _sdf->ToString(""));
+  };
+
+  mockSystem->configureCallback = configureCallback;
+  const size_t systemCount = *server.SystemCount();
+  EXPECT_TRUE(
+    *server.AddSystem(
+      mockSystemPlugin.value(), entity, sdfPlugin.ToElement()
+  ));
+
+  // Add pointer
+  auto mockSystemPtr = std::make_shared<MockSystem>();
+  mockSystemPtr->configureCallback = configureCallback;
+  EXPECT_TRUE(*server.AddSystem(mockSystemPtr, entity, sdfPlugin.ToElement()));
+
+  // Add an sdf::Plugin
+  EXPECT_TRUE(*server.AddSystem(sdfPlugin, entity));
+
+  // Fail if plugin is invalid
+  sdf::Plugin invalidPlugin("foo_plugin", "foo::systems::FooPlugin");
+  EXPECT_FALSE(*server.AddSystem(invalidPlugin, entity));
+
+  // Check that it was loaded
+  EXPECT_EQ(systemCount + 3, *server.SystemCount());
+  EXPECT_EQ(2u, configureCallCount);
 
   // No steps should have been executed
   EXPECT_EQ(0u, mockSystem->preUpdateCallCount);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2322 

## Summary

Entity and XML content information are lost when adding systems through the `Server::AddSystem(system)` API. To reproduce it:

1. Create a dummy system plugin:
```cpp
class DummyPlugin : public gz::sim::System,
  public gz::sim::ISystemConfigure,
{
public:
  void Configure(
    const gz::sim::Entity &_entity,
    const std::shared_ptr<const sdf::Element> &_sdf,
    gz::sim::EntityComponentManager &_ecm,
    gz::sim::EventManager &_eventMgr) override
  {
    std::cout << _sdf->ToString("") << std::endl;
  }
};
```
2. Load it with the `SystemLoader` (extracted from [here](https://github.com/gazebosim/gz-sim/blob/633ce72171e27e83bf2e0292c9998e036d5da3fc/src/Server_TEST.cc#L620-L626)):
```cpp
  sim::SystemLoader systemLoader;
  sdf::Plugin sdfPlugin("dummy_plugin", "gz::sim::systems::DummyPlugin", "<test>foo</test>");
  auto mockSystemPlugin = systemLoader.LoadPlugin(sdfPlugin);
  EXPECT_TRUE(*server.AddSystem(mockSystemPlugin.value()));
```

Without this patch, the code above will output:

```xml
<plugin filename='__default__'/>
```

After the patch, you will be able to use the extended `Server::AddSystem(plugin, entity, sdf)` API and get:

```xml
<plugin filename='dummy_plugin' name='gz::sim::DummyPlugin'>
  <test>foo</test>
</plugin>
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.