### PR TITLE
Add entity validation to OdometryPublisher

### DIFF
--- a/src/systems/odometry_publisher/OdometryPublisher.cc
+++ b/src/systems/odometry_publisher/OdometryPublisher.cc
@@ -316,7 +316,6 @@ void OdometryPublisher::PostUpdate(const UpdateInfo &_info,
     const EntityComponentManager &_ecm)
 {
   GZ_PROFILE("OdometryPublisher::PostUpdate");
-  gzwarn << "HElllo Anton" << std::endl;
 
   // \TODO(anyone) This is a temporary fix for
   // gazebosim/gz-sim#2165 until gazebosim/gz-sim#2217 is resolved.

--- a/src/systems/odometry_publisher/OdometryPublisher.cc
+++ b/src/systems/odometry_publisher/OdometryPublisher.cc
@@ -278,7 +278,18 @@ void OdometryPublisher::PreUpdate(const gz::sim::UpdateInfo &_info,
 {
   GZ_PROFILE("OdometryPublisher::PreUpdate");
 
-  if (!this->dataPtr->model.Valid(_ecm)) {
+  // \TODO(anyone) This is a temporary fix for
+  // gazebosim/gz-sim#2165 until gazebosim/gz-sim#2217 is resolved.
+  if (kNullEntity == this->dataPtr->model.Entity())
+  {
+    return;
+  }
+
+  if (!this->dataPtr->model.Valid(_ecm))
+  {
+    gzwarn << "OdometryPublisher model no longer valid. "
+           << "Disabling plugin." << std::endl;
+    this->dataPtr->model = Model(kNullEntity);
     return;
   }
 
@@ -305,13 +316,26 @@ void OdometryPublisher::PostUpdate(const UpdateInfo &_info,
     const EntityComponentManager &_ecm)
 {
   GZ_PROFILE("OdometryPublisher::PostUpdate");
+  gzwarn << "HElllo Anton" << std::endl;
+
+  // \TODO(anyone) This is a temporary fix for
+  // gazebosim/gz-sim#2165 until gazebosim/gz-sim#2217 is resolved.
+  if (kNullEntity == this->dataPtr->model.Entity())
+  {
+    return;
+  }
+
+  if (!this->dataPtr->model.Valid(_ecm))
+  {
+    gzwarn << "OdometryPublisher model no longer valid. "
+           << "Disabling plugin." << std::endl;
+    this->dataPtr->model = Model(kNullEntity);
+    return;
+  }
+
   // Nothing left to do if paused.
   if (_info.paused)
     return;
-
-  if (!this->dataPtr->model.Valid(_ecm)) {
-    return;
-  }
 
   this->dataPtr->UpdateOdometry(_info, _ecm);
 }

--- a/src/systems/odometry_publisher/OdometryPublisher.cc
+++ b/src/systems/odometry_publisher/OdometryPublisher.cc
@@ -324,13 +324,6 @@ void OdometryPublisher::PostUpdate(const UpdateInfo &_info,
     return;
   }
 
-  if (!this->dataPtr->model.Valid(_ecm))
-  {
-    gzwarn << "OdometryPublisher model no longer valid. "
-           << "Disabling plugin." << std::endl;
-    this->dataPtr->model = Model(kNullEntity);
-    return;
-  }
 
   // Nothing left to do if paused.
   if (_info.paused)

--- a/src/systems/odometry_publisher/OdometryPublisher.cc
+++ b/src/systems/odometry_publisher/OdometryPublisher.cc
@@ -278,6 +278,10 @@ void OdometryPublisher::PreUpdate(const gz::sim::UpdateInfo &_info,
 {
   GZ_PROFILE("OdometryPublisher::PreUpdate");
 
+  if (!this->dataPtr->model.Valid(_ecm)) {
+    return;
+  }
+
   // \TODO(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
@@ -304,6 +308,10 @@ void OdometryPublisher::PostUpdate(const UpdateInfo &_info,
   // Nothing left to do if paused.
   if (_info.paused)
     return;
+
+  if (!this->dataPtr->model.Valid(_ecm)) {
+    return;
+  }
 
   this->dataPtr->UpdateOdometry(_info, _ecm);
 }


### PR DESCRIPTION
# 🦟 Bug fix

Until SystemManager has the ability to unload system plugins, plugins require an explicit check of the validity of the entities used in the Update methods. Such a check was missing in OdometryPublisher, which led to non-critical but annoying errors in the console.

P.S. It's my first PR to open source project, sorry if i missing something