### PR TITLE
Support visualizing mesh collisions with convex decomposition

### DIFF
--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -212,6 +212,13 @@ msgs::Geometry gz::sim::convert(const sdf::Geometry &_in)
     meshMsg->set_filename(asFullPath(meshSdf->Uri(), meshSdf->FilePath()));
     meshMsg->set_submesh(meshSdf->Submesh());
     meshMsg->set_center_submesh(meshSdf->CenterSubmesh());
+
+    if (!meshSdf->Simplification().empty())
+    {
+      auto header = out.mutable_header()->add_data();
+      header->set_key("simplification");
+      header->add_value(meshSdf->Simplification());
+    }
   }
   else if (_in.Type() == sdf::GeometryType::HEIGHTMAP && _in.HeightmapShape())
   {
@@ -341,6 +348,14 @@ sdf::Geometry gz::sim::convert(const msgs::Geometry &_in)
     meshShape.SetSubmesh(_in.mesh().submesh());
     meshShape.SetCenterSubmesh(_in.mesh().center_submesh());
 
+    for (int i = 0; i < _in.header().data_size(); ++i)
+    {
+      auto data = _in.header().data(i);
+      if (data.key() == "simplification" && data.value_size() > 0)
+      {
+        meshShape.SetSimplification(data.value(0));
+      }
+    }
     out.SetMeshShape(meshShape);
   }
   else if (_in.type() == msgs::Geometry::HEIGHTMAP && _in.has_heightmap())

--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -463,6 +463,7 @@ TEST(Conversions, GeometryMesh)
   meshShape.SetUri("file://watermelon");
   meshShape.SetSubmesh("grape");
   meshShape.SetCenterSubmesh(true);
+  meshShape.SetSimplification("convex_decomposition");
   geometry.SetMeshShape(meshShape);
 
   auto geometryMsg = convert<msgs::Geometry>(geometry);
@@ -473,6 +474,9 @@ TEST(Conversions, GeometryMesh)
   EXPECT_EQ("file://watermelon", geometryMsg.mesh().filename());
   EXPECT_EQ("grape", geometryMsg.mesh().submesh());
   EXPECT_TRUE(geometryMsg.mesh().center_submesh());
+  auto header = geometryMsg.header().data(0);
+  EXPECT_EQ("simplification", header.key());
+  EXPECT_EQ("convex_decomposition", header.value(0));
 
   auto newGeometry = convert<sdf::Geometry>(geometryMsg);
   EXPECT_EQ(sdf::GeometryType::MESH, newGeometry.Type());
@@ -481,6 +485,7 @@ TEST(Conversions, GeometryMesh)
   EXPECT_EQ("file://watermelon", newGeometry.MeshShape()->Uri());
   EXPECT_EQ("grape", newGeometry.MeshShape()->Submesh());
   EXPECT_TRUE(newGeometry.MeshShape()->CenterSubmesh());
+  EXPECT_EQ("convex_decomposition", newGeometry.MeshShape()->Simplification());
 }
 
 /////////////////////////////////////////////////

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -145,7 +145,6 @@ Server::Server(const ServerConfig &_config)
 
       sdf::Root sdfRoot;
       sdf::ParserConfig sdfParserConfig = sdf::ParserConfig::GlobalConfig();
-
       sdfParserConfig.SetCalculateInertialConfiguration(
         sdf::ConfigureResolveAutoInertials::SKIP_CALCULATION_IN_LOAD);
 

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -145,6 +145,8 @@ Server::Server(const ServerConfig &_config)
 
       sdf::Root sdfRoot;
       sdf::ParserConfig sdfParserConfig = sdf::ParserConfig::GlobalConfig();
+      sdfParserConfig.SetStoreResolvedURIs(true);
+
       sdfParserConfig.SetCalculateInertialConfiguration(
         sdf::ConfigureResolveAutoInertials::SKIP_CALCULATION_IN_LOAD);
 

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -145,7 +145,6 @@ Server::Server(const ServerConfig &_config)
 
       sdf::Root sdfRoot;
       sdf::ParserConfig sdfParserConfig = sdf::ParserConfig::GlobalConfig();
-      sdfParserConfig.SetStoreResolvedURIs(true);
 
       sdfParserConfig.SetCalculateInertialConfiguration(
         sdf::ConfigureResolveAutoInertials::SKIP_CALCULATION_IN_LOAD);


### PR DESCRIPTION


# 🎉 New feature

Depends on: 

* https://github.com/gazebosim/sdformat/pull/1380
* https://github.com/gazebosim/gz-common/pull/583
* https://github.com/gazebosim/gz-physics/pull/603

## Summary

Extends `VisualizationCapabilities` gui plugin to support visualizing mesh collisions with convex decomposition.

if a mesh collision has the new attribute `<mesh simplification="convex_decomposition">`, the plugin will decompose the meshes on the GUI side before visualizing them.


## Test it

I uploaded a [Cordless Drill Simplified](https://app.gazebosim.org/iche033/fuel/models/Cordless%20Drill%20Simplified) model on fuel for testing. This model uses convex decomposition on the collision mesh.

Here's the result:

<img width="401" alt="cordless_drill_simplified" src="https://github.com/gazebosim/gz-sim/assets/4000684/df01e180-9736-4f15-93e6-9c5ab1d1f4ac">

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
