### PR TITLE
Add magnetometer plugin parameter to publish units as tesla

### DIFF
--- a/src/systems/magnetometer/Magnetometer.hh
+++ b/src/systems/magnetometer/Magnetometer.hh
@@ -37,6 +37,7 @@ namespace systems
   /// current location.
   class Magnetometer:
     public System,
+    public ISystemConfigure,
     public ISystemPreUpdate,
     public ISystemPostUpdate
   {
@@ -45,6 +46,12 @@ namespace systems
 
     /// \brief Destructor
     public: ~Magnetometer() override;
+
+    // Documentation inherited
+    public: void Configure(const Entity &_entity,
+                           const std::shared_ptr<const sdf::Element> &_sdf,
+                           EntityComponentManager &_ecm,
+                           EventManager &_eventMgr) override;
 
     /// Documentation inherited
     public: void PreUpdate(const UpdateInfo &_info,

--- a/test/worlds/magnetometer_with_tesla.sdf
+++ b/test/worlds/magnetometer_with_tesla.sdf
@@ -1,0 +1,94 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="magnetometer_sensor">
+    <magnetic_field>0.94 0.76 -0.12</magnetic_field>
+    <physics name="1ms" type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>0</real_time_factor>
+    </physics>
+    <plugin
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin
+      filename="gz-sim-magnetometer-system"
+      name="gz::sim::systems::Magnetometer">
+      <use_tesla_for_magnetic_field>false</use_tesla_for_magnetic_field>
+    </plugin>
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+
+    <!--We need spherical coordinates to update the magnetometer-->
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>37.3861</latitude_deg>
+      <longitude_deg>-122.0839</longitude_deg>
+      <elevation>0</elevation>
+      <heading_deg>0</heading_deg>
+    </spherical_coordinates>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="magnetometer_model">
+      <pose>4 0 3.0 0 0.0 3.14</pose>
+      <link name="link">
+        <pose>0.05 0.05 0.05 0 0 1.570796327</pose>
+        <inertial>
+          <mass>0.1</mass>
+          <inertia>
+            <ixx>0.000166667</ixx>
+            <iyy>0.000166667</iyy>
+            <izz>0.000166667</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name="magnetometer_sensor" type="magnetometer">
+          <always_on>1</always_on>
+          <update_rate>1</update_rate>
+        </sensor>
+      </link>
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2312

## Summary
As mentioned in #2312, the magnetic field message is incorrectly using Gauss as the units for the field strength, rather than the SI unit of teslas. 

This PR adds a flag, `use_tesla_for_magnetic_field`, to the `MagnetometerSystem` to enable this fix as to not break any existing functionality that assumes Gauss. It also adds the `Configure` step to the `MagnetometerSystem`.

While I was here, I noticed that the integration test doesn't actually update the `MagnetometerSystem` because the SphericalCoorindates are not set. I think this might be an oversight. I did not change that existing test in case it was like that on purpose.

## Checklist
- [ ] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
