### PR TITLE
Publish step size in world stats topic

### DIFF
--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -463,6 +463,15 @@ void SimulationRunner::PublishStats()
 
   msg.set_paused(this->currentInfo.paused);
 
+  msg.mutable_step_size();
+  if (!this->currentInfo.paused)
+  {
+    auto stepSizeSecNsec =
+      math::durationToSecNsec(this->stepSize);
+    msg.mutable_step_size()->set_sec(stepSizeSecNsec.first);
+    msg.mutable_step_size()->set_nsec(stepSizeSecNsec.second);
+  }
+
   if (this->Stepping())
   {
     // (deprecated) Remove this header in Gazebo H

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -463,14 +463,7 @@ void SimulationRunner::PublishStats()
 
   msg.set_paused(this->currentInfo.paused);
 
-  msg.mutable_step_size();
-  if (!this->currentInfo.paused)
-  {
-    auto stepSizeSecNsec =
-      math::durationToSecNsec(this->stepSize);
-    msg.mutable_step_size()->set_sec(stepSizeSecNsec.first);
-    msg.mutable_step_size()->set_nsec(stepSizeSecNsec.second);
-  }
+  msgs::Set(msg.mutable_step_size(), this->currentInfo.dt);
 
   if (this->Stepping())
   {


### PR DESCRIPTION


# 🎉 New feature



## Summary

The `step_size` field in `WorldStatistics` msg is currently not populated / published in the `/stats` topic. This PR populates the field in a way that conforms to the msg [documentation](https://github.com/gazebosim/gz-msgs/blob/5f9091093a9a0e8901dd0260b0ed87a31cecd328/proto/gz/msgs/world_stats.proto#L62-L63): `/// \brief Iteration step size. It's zero when paused.`

## Test it


```bash
# run gz sim
gz sim -v 4 -r shapes.sdf

...

# echo the stats topic
gz topic -e -t /world/shapes/stats

```
## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

