### PR TITLE
Handle null mesh pointers

### DIFF
--- a/src/MeshInertiaCalculator.cc
+++ b/src/MeshInertiaCalculator.cc
@@ -218,6 +218,11 @@ std::optional<gz::math::Inertiald> MeshInertiaCalculator::operator()
   // Load the Mesh
   gz::common::MeshManager *meshManager = gz::common::MeshManager::Instance();
   mesh = meshManager->Load(fullPath);
+  if (!mesh)
+  {
+    gzerr << "Failed to load mesh: " << fullPath << std::endl;
+    return std::nullopt;
+  }
   std::vector<Triangle> meshTriangles;
   gz::math::MassMatrix3d meshMassMatrix;
   gz::math::Pose3d centreOfMass;

--- a/src/gui/plugins/apply_force_torque/ApplyForceTorque.cc
+++ b/src/gui/plugins/apply_force_torque/ApplyForceTorque.cc
@@ -19,7 +19,6 @@
 #include <mutex>
 #include <string>
 
-#include <gz/common/MeshManager.hh>
 #include <gz/common/MouseEvent.hh>
 #include <gz/gui/Application.hh>
 #include <gz/gui/GuiEvents.hh>

--- a/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc
+++ b/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc
@@ -1245,7 +1245,14 @@ rendering::GeometryPtr VisualizationCapabilitiesPrivate::CreateGeometry(
     gz::common::MeshManager *meshManager =
         gz::common::MeshManager::Instance();
     descriptor.mesh = meshManager->Load(descriptor.meshName);
-    geom = this->scene->CreateMesh(descriptor);
+    if (descriptor.mesh)
+    {
+      geom = this->scene->CreateMesh(descriptor);
+    }
+    else
+    {
+      gzerr << "Failed to load mesh: " << descriptor.meshName << std::endl;
+    }
     scale = _geom.MeshShape()->Scale();
   }
   else if (_geom.Type() == sdf::GeometryType::HEIGHTMAP)

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -813,8 +813,14 @@ rendering::GeometryPtr SceneManager::LoadGeometry(const sdf::Geometry &_geom,
     rendering::MeshDescriptor descriptor;
     descriptor.meshName = name;
     descriptor.mesh = meshManager->MeshByName(name);
-
-    geom = this->dataPtr->scene->CreateMesh(descriptor);
+    if (descriptor.mesh)
+    {
+      geom = this->dataPtr->scene->CreateMesh(descriptor);
+    }
+    else
+    {
+      gzerr << "Unable to find the polyline mesh: " << name << std::endl;
+    }
   }
   else
   {


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

In the same spirit as https://github.com/gazebosim/gz-rendering/pull/982, this PR adds sanity checks for null pointers returned by `common::MeshManager`.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
