### PR TITLE
Fixed turning error in ackermann steering

### DIFF
--- a/src/systems/ackermann_steering/AckermannSteering.cc
+++ b/src/systems/ackermann_steering/AckermannSteering.cc
@@ -968,11 +968,11 @@ void AckermannSteeringPrivate::UpdateAngle(
 
   double leftSteeringJointAngle =
       atan((2.0 * this->wheelBase * sin(ang)) / \
-      ((2.0 * this->wheelBase * cos(ang)) + \
+      ((2.0 * this->wheelBase * cos(ang)) - \
       (1.0 * this->wheelSeparation * sin(ang))));
   double rightSteeringJointAngle =
       atan((2.0 * this->wheelBase * sin(ang)) / \
-      ((2.0 * this->wheelBase * cos(ang)) - \
+      ((2.0 * this->wheelBase * cos(ang)) + \
       (1.0 * this->wheelSeparation * sin(ang))));
 
   auto leftSteeringPos = _ecm.Component<components::JointPosition>(


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2314 

## Summary
This is a fix to the error seen in Ackermann Steering's `<steering_only>` mode. The steps to reproduce this error are described in issue #2314. 

The solution to this was changing signs in [these equations](https://github.com/gazebosim/gz-sim/blob/5faaf5ea710f178ee15e0fb79d4a5f4b9990fe73/src/systems/ackermann_steering/AckermannSteering.cc#L969-L976).

### Steps to check the fix

1. Add the following tag in the [example SDF file](https://github.com/gazebosim/gz-sim/blob/gz-sim8/examples/worlds/ackermann_steering.sdf) of Ackermann Steering plugin.
```xml
  <steering_only>True</steering_only>
```
2. Build and source the workspace
3. Launch using the following command
```bash
  gz sim ackermann_steering.sdf
```
4. Publish the following
```bash
  gz topic -t "/model/vehicle_blue/steer_angle" -m gz.msgs.Double -p "data: 0.4"
```

Additionally comment out [chassis visual](https://github.com/gazebosim/gz-sim/blob/633ce72171e27e83bf2e0292c9998e036d5da3fc/examples/worlds/ackermann_steering.sdf#L102-L113) for better visibility.

The output after fix looks like this

![image](https://github.com/gazebosim/gz-sim/assets/75178156/9b8c3dfe-a124-4a58-9431-612a2befff47)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
