### PR TITLE
Fixed test worlds for underwater simulation of DopplerVelocityLogSystem plugin

### DIFF
--- a/test/worlds/bottomless_pit.sdf
+++ b/test/worlds/bottomless_pit.sdf
@@ -35,6 +35,10 @@
       name="gz::sim::systems::Buoyancy">
       <uniform_fluid_density>1000</uniform_fluid_density>
     </plugin>
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
 
     <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>

--- a/test/worlds/flat_seabed.sdf
+++ b/test/worlds/flat_seabed.sdf
@@ -35,6 +35,10 @@
       name="gz::sim::systems::Buoyancy">
       <uniform_fluid_density>1000</uniform_fluid_density>
     </plugin>
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
 
     <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>

--- a/test/worlds/underwater_currents.sdf
+++ b/test/worlds/underwater_currents.sdf
@@ -49,6 +49,10 @@
       filename="gz-sim-dvl-system"
       name="gz::sim::systems::DopplerVelocityLogSystem">
     </plugin>
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
 
     <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2344

## Summary
Running the tests for `DopplerVelocityLogSystem` plugin results in a blank screen.

**Command**
```bash
  gz sim underwater_currents.sdf --verbose 2
```
**Resulting blank screen**
![image](https://github.com/gazebosim/gz-sim/assets/75178156/811ddaf9-c3f9-4e17-8dcb-7842a343c3e5)

### Solution
After adding the `SceneBroadcaster` plugin to the world SDF through the following lines
```xml
    <plugin
      filename="gz-sim-scene-broadcaster-system"
      name="gz::sim::systems::SceneBroadcaster">
    </plugin>
```

**Running previous Command**
```bash
  gz sim underwater_currents.sdf --verbose 2
```
**Resulting simulation screen**
![image](https://github.com/gazebosim/gz-sim/assets/75178156/bc93d7fd-cff9-4412-a9ae-8ab344c99e17)

## Checklist
- [x] Signed all commits for DCO
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.