### PR TITLE
Fix TriggeredPublisher test

### DIFF
--- a/test/integration/triggered_publisher.cc
+++ b/test/integration/triggered_publisher.cc
@@ -728,7 +728,7 @@ TEST_F(TriggeredPublisherTest,
     // test are discarded properly.
     // TODO(azeey) Remove once
     // https://github.com/gazebosim/gz-transport/issues/491 is resolved.
-    GZ_SLEEP_MS(100);
+    GZ_SLEEP_MS(2000);
     recvCount = 0;
   }
 

--- a/test/integration/triggered_publisher.cc
+++ b/test/integration/triggered_publisher.cc
@@ -721,6 +721,16 @@ TEST_F(TriggeredPublisherTest,
 
   std::string service = "/srv-test";
   node.Advertise(service, srvEchoCb);
+  {
+    // This block of code is here because service requests from a previous test
+    // might interfere with this test. We sleep a small amount time and reset
+    // `recvCount` to 0. This ensures that the service requets from the previous
+    // test are discarded properly.
+    // TODO(azeey) Remove once
+    // https://github.com/gazebosim/gz-transport/issues/491 is resolved.
+    GZ_SLEEP_MS(100);
+    recvCount = 0;
+  }
 
   const std::size_t pubCount{10};
   for (std::size_t i = 0; i < pubCount; ++i)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fixes  `TriggeredPublisherTest.InputMessagesTriggerServices` test  which has been failing since https://github.com/gazebosim/gz-transport/pull/470. The issue is that service requests from the previous test, `TriggeredPublisherTest.InvalidServiceName`, are received in this test and cause a mismatch on the expected number of received requests. The (hopefully) temporary solution is to sleep a small amount of time right after advertising the service so that the extraneous service requests are received and discarded before we start the main body of the test. 

Also see https://github.com/gazebosim/gz-transport/issues/491

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.