### PR TITLE
Use steer_p_gain for UpdateVelocity steer joint speed

### DIFF
--- a/src/systems/ackermann_steering/AckermannSteering.cc
+++ b/src/systems/ackermann_steering/AckermannSteering.cc
@@ -926,11 +926,10 @@ void AckermannSteeringPrivate::UpdateVelocity(
   double leftDelta = leftSteeringJointAngle - leftSteeringPos->Data()[0];
   double rightDelta = rightSteeringJointAngle - rightSteeringPos->Data()[0];
 
-  // Simple proportional control with a gain of 1
+  // Simple proportional control with settable gain.
   // Adding programmable PID values might be a future feature.
-  // Works as is for tested cases
-  this->leftSteeringJointSpeed = leftDelta;
-  this->rightSteeringJointSpeed = rightDelta;
+  this->leftSteeringJointSpeed = this->gainPAng * leftDelta;
+  this->rightSteeringJointSpeed = this->gainPAng * rightDelta;
 }
 
 //////////////////////////////////////////////////

--- a/src/systems/ackermann_steering/AckermannSteering.hh
+++ b/src/systems/ackermann_steering/AckermannSteering.hh
@@ -52,7 +52,6 @@ namespace systems
   /// the index of the steering angle position actuator.
   ///
   /// - `<steer_p_gain>`: Float used to control the steering angle P gain.
-  /// Only used for when in steering_only mode.
   ///
   /// - `<left_joint>`: Name of a joint that controls a left wheel. This
   /// element can appear multiple times, and must appear at least once.


### PR DESCRIPTION
## Summary
This PR uses the steer_p_gain to control steering joint speed for ackermann based vehicles using Twist to drive. Replicates logic from the UpdateAngle, which is steering only.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
