### PR TITLE
thruster test: remove unnecessary sleep

### DIFF
--- a/test/integration/thruster.cc
+++ b/test/integration/thruster.cc
@@ -248,7 +248,6 @@ void ThrusterTest::TestWorld(const std::string &_world,
     for (sleep = 0; (modelPoses.empty() || modelPoses.back().Pos().X() < 5.0) &&
          sleep < maxSleep; ++sleep)
     {
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
       fixture.Server()->Run(true, 100, false);
     }
     EXPECT_LT(sleep, maxSleep);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
I'm not why this sleep was here in the first place. But it does not seem to be needed. The only thing it does is slow down our tests.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

