### PR TITLE
Fix GCC/CMake warnings for Noble

### DIFF
--- a/examples/plugin/custom_sensor_system/CMakeLists.txt
+++ b/examples/plugin/custom_sensor_system/CMakeLists.txt
@@ -27,10 +27,11 @@ add_subdirectory(${sensors_clone_SOURCE_DIR}/examples/custom_sensor ${sensors_cl
 
 add_library(${PROJECT_NAME} SHARED ${PROJECT_NAME}.cc)
 target_link_libraries(${PROJECT_NAME}
-  PRIVATE gz-plugin${GZ_PLUGIN_VER}::gz-plugin${GZ_PLUGIN_VER}
-  PRIVATE gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
-  PRIVATE gz-sensors${GZ_SENSORS_VER}::gz-sensors${GZ_SENSORS_VER}
-  PRIVATE odometer
+  PRIVATE
+    gz-plugin${GZ_PLUGIN_VER}::gz-plugin${GZ_PLUGIN_VER}
+    gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
+    gz-sensors${GZ_SENSORS_VER}::gz-sensors${GZ_SENSORS_VER}
+    odometer
 )
 target_include_directories(${PROJECT_NAME}
     PUBLIC ${sensors_clone_SOURCE_DIR}/examples/custom_sensor)

--- a/examples/standalone/gtest_setup/CMakeLists.txt
+++ b/examples/standalone/gtest_setup/CMakeLists.txt
@@ -10,7 +10,8 @@ set(GZ_SIM_VER ${gz-sim8_VERSION_MAJOR})
 include(FetchContent)
 FetchContent_Declare(
   googletest
-  URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+  # Version 1.14. Use commit hash to prevent tag relocation
+  URL https://github.com/google/googletest/archive/f8d7d77c06936315286eb55f8de22cd23c188571.zip
 )
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)

--- a/src/systems/elevator/vender/afsm/include/afsm/detail/transitions.hpp
+++ b/src/systems/elevator/vender/afsm/include/afsm/detail/transitions.hpp
@@ -526,7 +526,7 @@ public:
     check_default_transition()
     {
         auto st = state_indexes{};
-        auto const& ttable = transition_table<none>( st );
+        auto const& ttable = transition_table<none>(st);
         ttable[current_state()](*this, none{});
     }
 

--- a/src/systems/elevator/vender/afsm/include/afsm/detail/transitions.hpp
+++ b/src/systems/elevator/vender/afsm/include/afsm/detail/transitions.hpp
@@ -555,7 +555,7 @@ public:
     process_transition_event(Event&& event)
     {
         auto st = state_indexes{};
-        auto const& inv_table = transition_table<Event>( st );
+        auto const& inv_table = transition_table<Event>(st);
         return inv_table[current_state()](*this, ::std::forward<Event>(event));
     }
 

--- a/src/systems/elevator/vender/afsm/include/afsm/detail/transitions.hpp
+++ b/src/systems/elevator/vender/afsm/include/afsm/detail/transitions.hpp
@@ -546,7 +546,7 @@ public:
     exit(Event&& event)
     {
         auto st = state_indexes{};
-        auto const& table = exit_table<Event>( st );
+        auto const& table = exit_table<Event>(st);
         table[current_state()](states_, ::std::forward<Event>(event), *fsm_);
     }
 

--- a/src/systems/elevator/vender/afsm/include/afsm/detail/transitions.hpp
+++ b/src/systems/elevator/vender/afsm/include/afsm/detail/transitions.hpp
@@ -525,7 +525,8 @@ public:
     void
     check_default_transition()
     {
-        auto const& ttable = transition_table<none>( state_indexes{} );
+        auto st = state_indexes{};
+        auto const& ttable = transition_table<none>( st );
         ttable[current_state()](*this, none{});
     }
 
@@ -544,7 +545,8 @@ public:
     void
     exit(Event&& event)
     {
-        auto const& table = exit_table<Event>( state_indexes{} );
+        auto st = state_indexes{};
+        auto const& table = exit_table<Event>( st );
         table[current_state()](states_, ::std::forward<Event>(event), *fsm_);
     }
 
@@ -552,7 +554,8 @@ public:
     actions::event_process_result
     process_transition_event(Event&& event)
     {
-        auto const& inv_table = transition_table<Event>( state_indexes{} );
+        auto st = state_indexes{};
+        auto const& inv_table = transition_table<Event>( st );
         return inv_table[current_state()](*this, ::std::forward<Event>(event));
     }
 
@@ -655,10 +658,11 @@ public:
     event_set
     current_handled_events() const
     {
-        auto const& table = get_current_events_table(state_indexes{});
+        auto st = state_indexes{};
+        auto const& table = get_current_events_table(st);
         auto res = table[current_state_](states_);
         auto const& available_transitions
-                            = get_available_transitions_table(state_indexes{});
+                            = get_available_transitions_table(st);
         auto const& trans = available_transitions[current_state_];
         res.insert( trans.begin(), trans.end());
         return res;
@@ -667,7 +671,8 @@ public:
     event_set
     current_deferrable_events() const
     {
-        auto const& table = get_current_deferred_events_table(state_indexes{});
+        auto st = state_indexes{};
+        auto const& table = get_current_deferred_events_table(st);
         return table[current_state_](states_);
     }
 


### PR DESCRIPTION
# 🎉 New feature

## Summary

Fix the CMake and GCC warnings that appeared when building on Noble. Each of the three commits is self-explanatory for review. The most tropical change is the 55498d807af68e18f5850f41adadbac3d7f5e9, quoting the commit description:

```  
    GCC is emitting a warning about a possible dangling pointer on table
    like definitions:
    
    warning: possibly dangling reference to a temporary [-Wdangling-reference]
      660 |         auto const& table = get_current_events_table(state_indexes{});
          |                     ^~~~~
    
    Which I think that really comes from the use of state_indexes{} as
    argument:
    
      note: the temporary was destroyed at the end of the full expression
      660 |         auto const& table = get_current_events_table(state_indexes{});
          |                             ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
    
    Clang is quiet about this and make me think that is a false positive
    since the metaprogramming code is using just the type of the state_indexes
    as much as I can see.
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.