### PR TITLE
Fix namespace and class links in documentation references that use namespace `gz`

### DIFF
--- a/api.md.in
+++ b/api.md.in
@@ -5,10 +5,10 @@ designed to rapidly develop robot and simulation applications.
 
 **Useful links**
 
-1. gz::sim::components : List of built-in Component types. Components represent data, such as position information, that can be added to an Entity.
-2. gz::sim::systems : List of available Systems. A System operates on Entities that have a specific set of Components.
-3. gz::sim::events : List of simulation events. See the
-   gz::sim::EventManager for details about events and how to use them.
+1. [gz::sim::components](\ref ignition::gazebo::components) : List of built-in Component types. Components represent data, such as position information, that can be added to an Entity.
+2. [gz::sim::systems](\ref ignition::gazebo::systems) : List of available Systems. A System operates on Entities that have a specific set of Components.
+3. [gz::sim::events](\ref ignition::gazebo::events) : List of simulation events. See the
+   [gz::sim::EventManager](\ref ignition::gazebo::EventManager) for details about events and how to use them.
 
 ## License
 


### PR DESCRIPTION
# 🦟 Bug fix


## Summary


The `gz` namespace is not recognized by doxygen enough for it to autogenerate links to inner namespaces and classes. For example, `\ref gz::sim::systems` or simply `gz::sim::systems` don't link to the namespace documentation. You'd have to use `ignition::gazebo::systems` instead. I was hoping there was a more clever solution that would allow all `gz::` refs to work automatically, but I was not able to find one, so this is a compromise to fix the landing page for ign-gazebo6 (https://gazebosim.org/api/sim/6)

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
