### PR TITLE
Fix name of gz-fuel_tools in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,7 @@
   <depend>glut</depend>
   <depend>gz-cmake3</depend>
   <depend>gz-common5</depend>
-  <depend>gz-fuel-tools9</depend>
+  <depend>gz-fuel_tools9</depend>
   <depend>gz-gui8</depend>
   <depend>gz-math7</depend>
   <depend>gz-msgs10</depend>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The package name has an underscore between `fuel` and `tools`.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
