### PR TITLE
Blast545/fix unused gcc warnings

### DIFF
--- a/src/network/NetworkConfig_TEST.cc
+++ b/src/network/NetworkConfig_TEST.cc
@@ -33,6 +33,7 @@ TEST(NetworkManager, ValueConstructor)
     assert(config.role == NetworkRole::None);
     assert(config.numSecondariesExpected == 0);
     // Expect console warning as well
+    (void) config;
   }
 
   {
@@ -40,23 +41,27 @@ TEST(NetworkManager, ValueConstructor)
     auto config = NetworkConfig::FromValues("PRIMARY", 3);
     assert(config.role == NetworkRole::SimulationPrimary);
     assert(config.numSecondariesExpected == 3);
+    (void) config;
   }
 
   {
     // Secondary is always valid
     auto config = NetworkConfig::FromValues("SECONDARY", 0);
     assert(config.role == NetworkRole::SimulationSecondary);
+    (void) config;
   }
 
   {
     // Readonly is always valid
     auto config = NetworkConfig::FromValues("READONLY");
     assert(config.role == NetworkRole::ReadOnly);
+    (void) config;
   }
 
   {
     // Anything else is invalid
     auto config = NetworkConfig::FromValues("READ_WRITE");
     assert(config.role == NetworkRole::None);
+    (void) config;
   }
 }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes gcc warnings appearing in CI:
https://build.osrfoundation.org/job/gz_sim-ci-main-jammy-amd64/66/gcc/

## Summary
Does not change at all the tests, just voids the variables so the compiler takes them as read and won't emit the warning

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.