### PR TITLE
Add support for no gravity link

### DIFF
--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -594,10 +594,6 @@ Entity SdfEntityCreator::CreateEntities(const sdf::Link *_link)
     // This gravity will have value 0,0,0
     this->dataPtr->ecm->CreateComponent(
         linkEntity, components::Gravity());
-    // Debug code
-    // ignmsg << "gravity disabled" << std::endl;
-    // const components::Gravity *gravity = this->dataPtr->ecm->Component<components::Gravity>(linkEntity);
-    // ignmsg << _link->EnableGravity() << std::endl;
   }
 
   // Visuals

--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -588,6 +588,18 @@ Entity SdfEntityCreator::CreateEntities(const sdf::Link *_link)
         linkEntity, components::WindMode(_link->EnableWind()));
   }
 
+  if (!_link->EnableGravity())
+  {
+    // If disable gravity, create a gravity component to the entity
+    // This gravity will have value 0,0,0
+    this->dataPtr->ecm->CreateComponent(
+        linkEntity, components::Gravity());
+    // Debug code
+    // ignmsg << "gravity disabled" << std::endl;
+    // const components::Gravity *gravity = this->dataPtr->ecm->Component<components::Gravity>(linkEntity);
+    // ignmsg << _link->EnableGravity() << std::endl;
+  }
+
   // Visuals
   for (uint64_t visualIndex = 0; visualIndex < _link->VisualCount();
       ++visualIndex)

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -1143,11 +1143,9 @@ void PhysicsPrivate::CreateLinkEntities(const EntityComponentManager &_ecm)
         auto modelPtrPhys =
             this->entityModelMap.Get(_parent->Data());
 
-
         sdf::Link link;
         link.SetName(_name->Data());
         link.SetRawPose(_pose->Data());
-
 
         if (this->staticEntities.find(_parent->Data()) !=
             this->staticEntities.end())
@@ -1172,7 +1170,6 @@ void PhysicsPrivate::CreateLinkEntities(const EntityComponentManager &_ecm)
                 std::abs(gravity->Data().Y()) <= 1e-5 &&
                 std::abs(gravity->Data().Z()) <= 1e-5) {
                 link.SetEnableGravity(false);
-                // ignmsg << "CreateLinkEntity, EnableGravity = " << link.EnableGravity() << std::endl;
             } else {
                 link.SetEnableGravity(true);
             }

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -1161,18 +1161,21 @@ void PhysicsPrivate::CreateLinkEntities(const EntityComponentManager &_ecm)
         }
 
         // get link gravity
-        const components::Gravity *gravity = _ecm.Component<components::Gravity>(_entity);
-        if (nullptr != gravity) {
-            // Entity has a gravity component that is all zeros when
-            // <gravity> is set to false
-            // See SdfEntityCreator::CreateEntities()
-            if (std::abs(gravity->Data().X()) <= 1e-5 &&
-                std::abs(gravity->Data().Y()) <= 1e-5 &&
-                std::abs(gravity->Data().Z()) <= 1e-5) {
-                link.SetEnableGravity(false);
-            } else {
-                link.SetEnableGravity(true);
-            }
+        const components::Gravity *gravity =
+            _ecm.Component<components::Gravity>(_entity);
+        if (nullptr != gravity)
+        {
+          // Entity has a gravity component that is all zeros when
+          // <gravity> is set to false
+          // See SdfEntityCreator::CreateEntities()
+          if (gravity->Data() == math::Vector3d::Zero)
+          {
+            link.SetEnableGravity(false);
+          }
+          else
+          {
+            link.SetEnableGravity(true);
+          }
         }
 
         auto linkPtrPhys = modelPtrPhys->ConstructLink(link);

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -1143,9 +1143,11 @@ void PhysicsPrivate::CreateLinkEntities(const EntityComponentManager &_ecm)
         auto modelPtrPhys =
             this->entityModelMap.Get(_parent->Data());
 
+
         sdf::Link link;
         link.SetName(_name->Data());
         link.SetRawPose(_pose->Data());
+
 
         if (this->staticEntities.find(_parent->Data()) !=
             this->staticEntities.end())
@@ -1158,6 +1160,22 @@ void PhysicsPrivate::CreateLinkEntities(const EntityComponentManager &_ecm)
         if (inertial)
         {
           link.SetInertial(inertial->Data());
+        }
+
+        // get link gravity
+        const components::Gravity *gravity = _ecm.Component<components::Gravity>(_entity);
+        if (nullptr != gravity) {
+            // Entity has a gravity component that is all zeros when
+            // <gravity> is set to false
+            // See SdfEntityCreator::CreateEntities()
+            if (std::abs(gravity->Data().X()) <= 1e-5 &&
+                std::abs(gravity->Data().Y()) <= 1e-5 &&
+                std::abs(gravity->Data().Z()) <= 1e-5) {
+                link.SetEnableGravity(false);
+                // ignmsg << "CreateLinkEntity, EnableGravity = " << link.EnableGravity() << std::endl;
+            } else {
+                link.SetEnableGravity(true);
+            }
         }
 
         auto linkPtrPhys = modelPtrPhys->ConstructLink(link);


### PR DESCRIPTION
# 🎉 New feature

Original issue: #504

A feature I find very useful when I use Gazebo Classic but surprisingly unavailable in Ignition.

I'm targeting Gazebo Fortress because I need this feature for my projects on Fortress. Might need some back/forward porting.

Changes in other repo:
gz-physics: gazebosim/gz-physics#633
sdformat: gazebosim/sdformat#1410

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Add parsing and support for no gravity link when using DartSim engine

Implementation for other physics engines should be easy if they have link no gravity API.

## Test it
<!--Explain how reviewers can test this new feature manually.-->
Spawn the following entity to gazebo.
```
<?xml version="1.0" ?>
    <sdf version='1.7'>
      <model name='sphere'>
        <link name='link'>
          <gravity>false</gravity>
          <pose>0 0 0.5 0 0 0</pose>
          <visual name='visual'>
            <geometry><sphere><radius>1</radius></sphere></geometry>
          </visual>
          <collision name='collision'>
            <geometry><sphere><radius>1</radius></sphere></geometry>
          </collision>
        </link>
      </model>
</sdf>
``` 
The way I do this is to add `<gravity>false</gravity>` to `gz-sim/examples/standalone/entity_creation`'s inline sdf and run the example.

The black sphere has link gravity disabled and the cube is spawned with GUI and has gravity by default.
![no grav link](https://github.com/gazebosim/gz-sim/assets/50132891/8bf39dc3-be60-4b35-aafc-734d06416f91)


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
