### PR TITLE
Add Track and  Follow options in gui EntityContextMenu

### DIFF
--- a/src/gui/plugins/modules/EntityContextMenu.cc
+++ b/src/gui/plugins/modules/EntityContextMenu.cc
@@ -19,13 +19,13 @@
 #include "EntityContextMenu.hh"
 
 #include <gz/msgs/boolean.pb.h>
-#include <gz/msgs/stringmsg.pb.h>
 #include <gz/msgs/cameratrack.pb.h>
+#include <gz/msgs/stringmsg.pb.h>
 #include <gz/msgs/entity.pb.h>
 
 #include <iostream>
-#include <string>
 #include <mutex>
+#include <string>
 
 #include <gz/common/Console.hh>
 #include <gz/sim/Conversions.hh>
@@ -86,7 +86,7 @@ namespace gz::sim
     /// \brief Name of world.
     public: std::string worldName;
 
-    /// \brief storing last follow target for look at.
+    /// \brief Storing last follow target for look at.
     public: std::string followTargetLookAt;
 
     /// \brief Flag used to disable look at when not following target.
@@ -108,7 +108,6 @@ void EntityContextMenu::OnCurrentlyTrackedSub(const msgs::CameraTrack &_msg)
       _msg.track_mode() == gz::msgs::CameraTrack::FOLLOW_LOOK_AT ||
       _msg.track_mode() == gz::msgs::CameraTrack::FOLLOW_FREE_LOOK)
   {
-    // gzmsg << "Currently following a target: Look At enabled."<< std::endl;
     this->dataPtr->followingTarget = true;
     this->FollowingTargetChanged();
   }
@@ -177,14 +176,13 @@ EntityContextMenu::EntityContextMenu()
 
   this->dataPtr->trackPub =
     this->dataPtr->node.Advertise<msgs::CameraTrack>(this->dataPtr->trackTopic);
-
 }
 
 /////////////////////////////////////////////////
 EntityContextMenu::~EntityContextMenu() = default;
 
 /////////////////////////////////////////////////
-void EntityContextMenu::SetFollowingTarget(const bool &_followingTarget)
+void EntityContextMenu::SetFollowingTarget(bool &_followingTarget)
 {
   this->dataPtr->followingTarget = _followingTarget;
   this->FollowingTargetChanged();

--- a/src/gui/plugins/modules/EntityContextMenu.cc
+++ b/src/gui/plugins/modules/EntityContextMenu.cc
@@ -20,8 +20,8 @@
 
 #include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/cameratrack.pb.h>
-#include <gz/msgs/stringmsg.pb.h>
 #include <gz/msgs/entity.pb.h>
+#include <gz/msgs/stringmsg.pb.h>
 
 #include <iostream>
 #include <mutex>
@@ -257,37 +257,38 @@ void EntityContextMenu::OnRequest(const QString &_request, const QString &_data)
   else if (request == "follow")
   {
     msgs::CameraTrack followMsg;
-    followMsg.set_follow_target(_data.toStdString());
+    followMsg.mutable_follow_target()->set_name(_data.toStdString());
     followMsg.set_track_mode(msgs::CameraTrack::FOLLOW);
-    this->dataPtr->followTargetLookAt = followMsg.follow_target();
-    gzmsg << "Follow target: " << followMsg.follow_target() << std::endl;
+    this->dataPtr->followTargetLookAt = followMsg.follow_target().name();
+    gzmsg << "Follow target: " << followMsg.follow_target().name() << std::endl;
     this->dataPtr->trackPub.Publish(followMsg);
   }
   else if (request == "free_look")
   {
     msgs::CameraTrack followMsg;
-    followMsg.set_follow_target(_data.toStdString());
+    followMsg.mutable_follow_target()->set_name(_data.toStdString());
     followMsg.set_track_mode(msgs::CameraTrack::FOLLOW_FREE_LOOK);
-    this->dataPtr->followTargetLookAt = followMsg.follow_target();
-    gzmsg << "Follow target: " << followMsg.follow_target() << std::endl;
+    this->dataPtr->followTargetLookAt = followMsg.follow_target().name();
+    gzmsg << "Follow target: " << followMsg.follow_target().name() << std::endl;
     this->dataPtr->trackPub.Publish(followMsg);
   }
   else if (request == "look_at")
   {
     msgs::CameraTrack followMsg;
-    followMsg.set_track_target(_data.toStdString());
+    followMsg.mutable_track_target()->set_name(_data.toStdString());
     followMsg.set_track_mode(msgs::CameraTrack::FOLLOW_LOOK_AT);
-    followMsg.set_follow_target(this->dataPtr->followTargetLookAt);
-    gzmsg << "Follow target: " << followMsg.follow_target() << std::endl;
-    gzmsg << "Look at target: " << followMsg.track_target() << std::endl;
+    followMsg.mutable_follow_target()->set_name(
+        this->dataPtr->followTargetLookAt);
+    gzmsg << "Follow target: " << followMsg.follow_target().name() << std::endl;
+    gzmsg << "Look at target: " << followMsg.track_target().name() << std::endl;
     this->dataPtr->trackPub.Publish(followMsg);
   }
   else if (request == "track")
   {
     msgs::CameraTrack trackMsg;
-    trackMsg.set_track_target(_data.toStdString());
+    trackMsg.mutable_track_target()->set_name(_data.toStdString());
     trackMsg.set_track_mode(msgs::CameraTrack::TRACK);
-    gzmsg << "Track target: " << trackMsg.track_target() << std::endl;
+    gzmsg << "Track target: " << trackMsg.track_target().name() << std::endl;
     this->dataPtr->trackPub.Publish(trackMsg);
   }
   else if (request == "view_transparent")

--- a/src/gui/plugins/modules/EntityContextMenu.cc
+++ b/src/gui/plugins/modules/EntityContextMenu.cc
@@ -43,7 +43,7 @@ namespace gz::sim
     public: std::string moveToService;
 
     /// \brief Follow topic name
-    public: std::string followTopic;
+    public: std::string trackTopic;
 
     /// \brief Remove service name
     public: std::string removeService;
@@ -78,8 +78,8 @@ namespace gz::sim
     /// \brief Name of world.
     public: std::string worldName;
 
-    /// \brief follow publisher
-    public: transport::Node::Publisher followPub;
+    /// \brief /gui/track publisher
+    public: transport::Node::Publisher trackPub;
   };
 }
 
@@ -101,8 +101,8 @@ EntityContextMenu::EntityContextMenu()
   // For move to service requests
   this->dataPtr->moveToService = "/gui/move_to";
 
-  // For follow topic message
-  this->dataPtr->followTopic = "/gui/track";
+  // For track topic message
+  this->dataPtr->trackTopic = "/gui/track";
 
   // For remove service requests
   this->dataPtr->removeService = "/world/default/remove";
@@ -134,8 +134,8 @@ EntityContextMenu::EntityContextMenu()
   // For paste service requests
   this->dataPtr->pasteService = "/gui/paste";
 
-  this->dataPtr->followPub =
-    this->dataPtr->node.Advertise<msgs::CameraTrack>(this->dataPtr->followTopic);
+  this->dataPtr->trackPub =
+    this->dataPtr->node.Advertise<msgs::CameraTrack>(this->dataPtr->trackTopic);
 }
 
 /////////////////////////////////////////////////
@@ -205,8 +205,17 @@ void EntityContextMenu::OnRequest(const QString &_request, const QString &_data)
   {
     msgs::CameraTrack followMsg;
     followMsg.set_target(_data.toStdString());
+    followMsg.set_track_mode(msgs::CameraTrack::FOLLOW);
     gzmsg << "Follow target: " << followMsg.target() << std::endl;
-    this->dataPtr->followPub.Publish(followMsg);
+    this->dataPtr->trackPub.Publish(followMsg);
+  }
+  else if (request == "track")
+  {
+    msgs::CameraTrack trackMsg;
+    trackMsg.set_target(_data.toStdString());
+    trackMsg.set_track_mode(msgs::CameraTrack::TRACK);
+    gzmsg << "Follow target: " << trackMsg.target() << std::endl;
+    this->dataPtr->trackPub.Publish(trackMsg);
   }
   else if (request == "view_transparent")
   {

--- a/src/gui/plugins/modules/EntityContextMenu.cc
+++ b/src/gui/plugins/modules/EntityContextMenu.cc
@@ -37,10 +37,10 @@ namespace gz::sim
   /// \brief Private data class for EntityContextMenu
   class EntityContextMenuPrivate
   {
-    
+
     /// \brief Protects variable changed through services.
     public: std::mutex mutex;
-    
+
     /// \brief Gazebo communication node.
     public: transport::Node node;
 
@@ -117,7 +117,7 @@ void EntityContextMenu::OnCurrentlyTrackedSub(const msgs::CameraTrack &_msg)
     this->dataPtr->followingTarget = false;
     this->FollowingTargetChanged();
   }
-  
+
   return;
 }
 

--- a/src/gui/plugins/modules/EntityContextMenu.cc
+++ b/src/gui/plugins/modules/EntityContextMenu.cc
@@ -78,6 +78,9 @@ namespace gz::sim
     /// \brief Name of world.
     public: std::string worldName;
 
+    /// \brief storing last follow target for look at.
+    public: std::string followTargetLookAt;
+
     /// \brief /gui/track publisher
     public: transport::Node::Publisher trackPub;
   };
@@ -204,17 +207,37 @@ void EntityContextMenu::OnRequest(const QString &_request, const QString &_data)
   else if (request == "follow")
   {
     msgs::CameraTrack followMsg;
-    followMsg.set_target(_data.toStdString());
+    followMsg.set_follow_target(_data.toStdString());
     followMsg.set_track_mode(msgs::CameraTrack::FOLLOW);
-    gzmsg << "Follow target: " << followMsg.target() << std::endl;
+    this->dataPtr->followTargetLookAt = followMsg.follow_target();
+    gzmsg << "Follow target: " << followMsg.follow_target() << std::endl;
+    this->dataPtr->trackPub.Publish(followMsg);
+  }
+  else if (request == "free_look")
+  {
+    msgs::CameraTrack followMsg;
+    followMsg.set_follow_target(_data.toStdString());
+    followMsg.set_track_mode(msgs::CameraTrack::FOLLOW_FREE_LOOK);
+    this->dataPtr->followTargetLookAt = followMsg.follow_target();
+    gzmsg << "Follow target: " << followMsg.follow_target() << std::endl;
+    this->dataPtr->trackPub.Publish(followMsg);
+  }
+  else if (request == "look_at")
+  {
+    msgs::CameraTrack followMsg;
+    followMsg.set_track_target(_data.toStdString());
+    followMsg.set_track_mode(msgs::CameraTrack::FOLLOW_LOOK_AT);
+    followMsg.set_follow_target(this->dataPtr->followTargetLookAt);
+    gzmsg << "Follow target: " << followMsg.follow_target() << std::endl;
+    gzmsg << "Look at target: " << followMsg.track_target() << std::endl;
     this->dataPtr->trackPub.Publish(followMsg);
   }
   else if (request == "track")
   {
     msgs::CameraTrack trackMsg;
-    trackMsg.set_target(_data.toStdString());
+    trackMsg.set_track_target(_data.toStdString());
     trackMsg.set_track_mode(msgs::CameraTrack::TRACK);
-    gzmsg << "Follow target: " << trackMsg.target() << std::endl;
+    gzmsg << "Track target: " << trackMsg.track_target() << std::endl;
     this->dataPtr->trackPub.Publish(trackMsg);
   }
   else if (request == "view_transparent")

--- a/src/gui/plugins/modules/EntityContextMenu.cc
+++ b/src/gui/plugins/modules/EntityContextMenu.cc
@@ -104,18 +104,14 @@ using namespace sim;
 void EntityContextMenu::OnCurrentlyTrackedSub(const msgs::CameraTrack &_msg)
 {
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
+  this->dataPtr->followingTarget = false;
   if (_msg.track_mode() == gz::msgs::CameraTrack::FOLLOW ||
       _msg.track_mode() == gz::msgs::CameraTrack::FOLLOW_LOOK_AT ||
       _msg.track_mode() == gz::msgs::CameraTrack::FOLLOW_FREE_LOOK)
   {
     this->dataPtr->followingTarget = true;
-    this->FollowingTargetChanged();
   }
-  else
-  {
-    this->dataPtr->followingTarget = false;
     this->FollowingTargetChanged();
-  }
 
   return;
 }

--- a/src/gui/plugins/modules/EntityContextMenu.cc
+++ b/src/gui/plugins/modules/EntityContextMenu.cc
@@ -20,6 +20,7 @@
 
 #include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/stringmsg.pb.h>
+#include <gz/msgs/cameratrack.pb.h>
 #include <gz/msgs/entity.pb.h>
 
 #include <iostream>
@@ -41,8 +42,8 @@ namespace gz::sim
     /// \brief Move to service name
     public: std::string moveToService;
 
-    /// \brief Follow service name
-    public: std::string followService;
+    /// \brief Follow topic name
+    public: std::string followTopic;
 
     /// \brief Remove service name
     public: std::string removeService;
@@ -76,6 +77,9 @@ namespace gz::sim
 
     /// \brief Name of world.
     public: std::string worldName;
+
+    /// \brief follow publisher
+    public: transport::Node::Publisher followPub;
   };
 }
 
@@ -97,8 +101,8 @@ EntityContextMenu::EntityContextMenu()
   // For move to service requests
   this->dataPtr->moveToService = "/gui/move_to";
 
-  // For follow service requests
-  this->dataPtr->followService = "/gui/follow";
+  // For follow topic message
+  this->dataPtr->followTopic = "/gui/track";
 
   // For remove service requests
   this->dataPtr->removeService = "/world/default/remove";
@@ -129,6 +133,9 @@ EntityContextMenu::EntityContextMenu()
 
   // For paste service requests
   this->dataPtr->pasteService = "/gui/paste";
+
+  this->dataPtr->followPub =
+    this->dataPtr->node.Advertise<msgs::CameraTrack>(this->dataPtr->followTopic);
 }
 
 /////////////////////////////////////////////////
@@ -196,9 +203,10 @@ void EntityContextMenu::OnRequest(const QString &_request, const QString &_data)
   }
   else if (request == "follow")
   {
-    msgs::StringMsg req;
-    req.set_data(_data.toStdString());
-    this->dataPtr->node.Request(this->dataPtr->followService, req, cb);
+    msgs::CameraTrack followMsg;
+    followMsg.set_target(_data.toStdString());
+    gzmsg << "Follow target: " << followMsg.target() << std::endl;
+    this->dataPtr->followPub.Publish(followMsg);
   }
   else if (request == "view_transparent")
   {

--- a/src/gui/plugins/modules/EntityContextMenu.hh
+++ b/src/gui/plugins/modules/EntityContextMenu.hh
@@ -19,6 +19,7 @@
 #define GZ_SIM_GUI_ENTITYCONTEXTMENU_HH_
 
 #include <gz/gui/qt.h>
+#include <gz/msgs/cameratrack.pb.h>
 #include <QtQml/QQmlExtensionPlugin>
 #include <memory>
 
@@ -46,12 +47,34 @@ namespace sim
   class EntityContextMenu : public QQuickItem
   {
     Q_OBJECT
+    /// \brief followingTarget
+    Q_PROPERTY(
+      bool followingTarget
+      READ FollowingTarget
+      WRITE SetFollowingTarget
+      NOTIFY FollowingTargetChanged
+    )
 
     /// \brief Constructor
     public: EntityContextMenu();
 
     /// \brief Destructor
     public: ~EntityContextMenu() override;
+
+    /// \brief Get whether it is following target
+    /// \return True if followingTarget
+    public: Q_INVOKABLE bool FollowingTarget() const;
+
+    /// \brief Set whether followingTarget
+    /// \param[in] _followingTarget True if followingTarget
+    public: Q_INVOKABLE void SetFollowingTarget(const bool &_followingTarget);
+
+    /// \brief Notify that followingTarget has changed
+    signals: void FollowingTargetChanged();
+
+    /// \brief Callback function to get data from the message
+    /// \param[in]_msg CameraTrack message
+    public: void OnCurrentlyTrackedSub(const msgs::CameraTrack &_msg);
 
     /// \brief Callback when a context menu item is invoked
     /// \param[in] _data Request data

--- a/src/gui/plugins/modules/EntityContextMenu.hh
+++ b/src/gui/plugins/modules/EntityContextMenu.hh
@@ -67,7 +67,7 @@ namespace sim
 
     /// \brief Set whether followingTarget
     /// \param[in] _followingTarget True if followingTarget
-    public: Q_INVOKABLE void SetFollowingTarget(const bool &_followingTarget);
+    public: Q_INVOKABLE void SetFollowingTarget(bool &_followingTarget);
 
     /// \brief Notify that followingTarget has changed
     signals: void FollowingTargetChanged();

--- a/src/gui/plugins/modules/EntityContextMenu.hh
+++ b/src/gui/plugins/modules/EntityContextMenu.hh
@@ -73,7 +73,7 @@ namespace sim
     signals: void FollowingTargetChanged();
 
     /// \brief Callback function to get data from the message
-    /// \param[in]_msg CameraTrack message
+    /// \param[in] _msg CameraTrack message
     public: void OnCurrentlyTrackedSub(const msgs::CameraTrack &_msg);
 
     /// \brief Callback when a context menu item is invoked

--- a/src/gui/plugins/modules/EntityContextMenu.qml
+++ b/src/gui/plugins/modules/EntityContextMenu.qml
@@ -238,7 +238,6 @@ Item {
   GzSim.EntityContextMenuItem {
     id: context
     property string entity
-    property bool followingTarget: true
     property string type
   }
 }

--- a/src/gui/plugins/modules/EntityContextMenu.qml
+++ b/src/gui/plugins/modules/EntityContextMenu.qml
@@ -28,9 +28,14 @@ Item {
       onTriggered: context.OnRequest("move_to", context.entity)
     }
     MenuItem {
-      id: followMenu
-      text: "Follow"
-      onTriggered: context.OnRequest("follow", context.entity)
+      id: followOptionsSubmenu
+      text: "Follow Options >"
+      MouseArea {
+        id: followOptionsSubMouseArea
+        anchors.fill: parent
+        hoverEnabled: true
+        onEntered: secondMenu.open()
+      }
     }
     MenuItem {
       id: trackMenu
@@ -72,12 +77,41 @@ Item {
         id: viewSubMouseArea
         anchors.fill: parent
         hoverEnabled: true
-        onEntered: secondMenu.open()
+        onEntered: thirdMenu.open()
       }
     }
   }
   Menu {
     id: secondMenu
+    x: menu.x + menu.width
+    y: menu.y + followOptionsSubmenu.y
+    MenuItem {
+      id: followMenu
+      text: "Follow"
+      onTriggered: {
+        menu.close()
+        context.OnRequest("follow", context.entity)
+      }
+    }
+    MenuItem {
+      id: followFreeLookMenu
+      text: "Free Look"
+      onTriggered: {
+        menu.close()
+        context.OnRequest("free_look", context.entity)
+      }
+    }
+    MenuItem {
+      id: followLookAtMenu
+      text: "Look At"
+      onTriggered: {
+        menu.close()
+        context.OnRequest("look_at", context.entity)
+      }
+    }
+  }
+  Menu {
+    id: thirdMenu
     x: menu.x + menu.width
     y: menu.y + viewSubmenu.y
     MenuItem {
@@ -145,6 +179,9 @@ Item {
     context.type = _type
     moveToMenu.enabled = false
     followMenu.enabled = false
+    followFreeLookMenu.enabled = false
+    followLookAtMenu.enabled = false
+    trackMenu.enabled = false
     removeMenu.enabled = false
     viewTransparentMenu.enabled = false;
     viewCOMMenu.enabled = false;
@@ -161,6 +198,12 @@ Item {
     {
       moveToMenu.enabled = true
       followMenu.enabled = true
+      followFreeLookMenu.enabled = true
+      if (context.followingTarget)
+      {
+        followLookAtMenu.enabled = true
+      }
+      trackMenu.enabled = true
     }
 
     if (context.type == "model" || context.type == "light")
@@ -195,6 +238,7 @@ Item {
   GzSim.EntityContextMenuItem {
     id: context
     property string entity
+    property bool followingTarget: true
     property string type
   }
 }

--- a/src/gui/plugins/modules/EntityContextMenu.qml
+++ b/src/gui/plugins/modules/EntityContextMenu.qml
@@ -33,6 +33,11 @@ Item {
       onTriggered: context.OnRequest("follow", context.entity)
     }
     MenuItem {
+      id: trackMenu
+      text: "Track"
+      onTriggered: context.OnRequest("track", context.entity)
+    }
+    MenuItem {
       id: removeMenu
       text: "Remove"
       onTriggered: context.OnRemove(context.entity, context.type)


### PR DESCRIPTION
# 🎉 New feature

## Summary
I would like to thank [NXP](https://nxp.gitbook.io/mobilerobotics) for their support in enabling this work.

Depends on:
- https://github.com/gazebosim/gz-gui/pull/619
- https://github.com/gazebosim/gz-msgs/pull/440

This adds a new `/gui/track` topic using the *CameraTrack* message to control multiple types of tracking and associated pgain(s), target(s) and offset(s). Furthermore it publishes a tracking camera status  *CameraTrack* message on `/gui/currently_tracked`

This also adds an 3 unique follow modes and a tracking mode all able to be set from either the `/gui/track` topic or more ideally from the user gui.

The 3 follow modes are in a submenu under the *right click* top level menu `Follow Options >` and are: 
- **Follow** - *Traditional follow mode where camera follows and tracks the same target.*
![follow](https://github.com/gazebosim/gz-gui/assets/10233412/065dac94-e377-488f-a728-1a708835a3eb)

- **Free Look** - *Enables a user to follow a target while still using an input device (IE mouse) to look around.*
![follow_free_look](https://github.com/gazebosim/gz-gui/assets/10233412/c5bd2f8b-ad33-4034-8053-40192d3f2b72)

- **Look At** - *Only enabled after already selecting a primary object to follow, this allows a user to track a unique secondary target while following the primary target.*
![follow_look_at](https://github.com/gazebosim/gz-gui/assets/10233412/883a7899-9160-42b8-9136-b0e318d4f985)

The other *right click* top level menu item added is `Track`, where the gui camera can be moved anywhere in the simulator but will always track the selected object.
![track](https://github.com/gazebosim/gz-gui/assets/10233412/80063052-2930-4712-942c-5de7df8472f2)

These all respect using the escape key to stop any form of tracking.

## Test it
Use these changes for [collection-harmonic.yaml](https://github.com/gazebo-tooling/gazebodistro/blob/master/collection-harmonic.yaml):
```yaml
repositories:
  gz-gui:
    type: git
    url: https://github.com/rudislabs/gz-gui.git
    version: pr-track-follow
  gz-msgs:
    type: git
    url: https://github.com/rudislabs/gz-msgs.git
    version: pr-track-follow
  gz-sim:
    type: git
    url: https://github.com/rudislabs/gz-sim.git
    version: pr-track-follow
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
