### PR TITLE
Fix bug where iterator was used after the underlying item was erased from the container

### DIFF
--- a/src/systems/physics/EntityFeatureMap.hh
+++ b/src/systems/physics/EntityFeatureMap.hh
@@ -226,8 +226,8 @@ namespace systems::physics_system
       if (it != this->entityMap.end())
       {
         this->reverseMap.erase(it->second);
-        this->entityMap.erase(it);
         this->castCache.erase(_entity);
+        this->entityMap.erase(it);
         return true;
       }
       return false;
@@ -242,8 +242,8 @@ namespace systems::physics_system
       if (it != this->reverseMap.end())
       {
         this->entityMap.erase(it->second);
-        this->reverseMap.erase(it);
         this->castCache.erase(it->second);
+        this->reverseMap.erase(it);
         return true;
       }
       return false;


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2198

## Summary
Reorders the `erase` operations to avoid using an invalidated iterator. This is already done in the `ign-gazebo6` branch: https://github.com/gazebosim/gz-sim/blob/fb3f3d43eee648e387f89d611dd2a9973fff201e/src/systems/physics/EntityFeatureMap.hh#L255-L286

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.