### PR TITLE
Support mesh optimization when using AttachMeshShapeFeature

### DIFF
--- a/include/gz/sim/Util.hh
+++ b/include/gz/sim/Util.hh
@@ -316,6 +316,13 @@ namespace gz
     /// \return The loaded mesh or null if the mesh can not be loaded.
     GZ_SIM_VISIBLE const common::Mesh *loadMesh(const sdf::Mesh &_meshSdf);
 
+    /// \brief Optimize input mesh.
+    /// \param[in] _meshSdf Mesh SDF DOM with mesh optimization parameters
+    /// \param[in] _mesh Input mesh to optimize.
+    /// \return The optimized mesh or null if the mesh can not be optimized.
+    GZ_SIM_VISIBLE const common::Mesh *optimizeMesh(const sdf::Mesh &_meshSdf,
+        const common::Mesh &_mesh);
+
     /// \brief Environment variable holding resource paths.
     const std::string kResourcePathEnv{"GZ_SIM_RESOURCE_PATH"};
 

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -15,12 +15,15 @@
  *
 */
 
+#include <cstddef>
+
 #include <gz/msgs/entity.pb.h>
 
 #include <gz/common/Filesystem.hh>
 #include <gz/common/Mesh.hh>
 #include <gz/common/MeshManager.hh>
 #include <gz/common/StringUtils.hh>
+#include <gz/common/SubMesh.hh>
 #include <gz/common/URI.hh>
 #include <gz/common/Util.hh>
 #include <gz/math/Helpers.hh>
@@ -862,8 +865,81 @@ const common::Mesh *loadMesh(const sdf::Mesh &_meshSdf)
            << "]." << std::endl;
     return nullptr;
   }
+
+  if (mesh && _meshSdf.Optimization() != sdf::MeshOptimization::NONE)
+  {
+    const common::Mesh *optimizedMesh = optimizeMesh(_meshSdf, *mesh);
+    if (optimizedMesh)
+      return optimizedMesh;
+    else
+      gzwarn << "Failed to optimize Mesh " << mesh->Name() << std::endl;
+  }
+
   return mesh;
 }
+
+const common::Mesh *optimizeMesh(const sdf::Mesh &_meshSdf,
+    const common::Mesh &_mesh)
+{
+  if (_meshSdf.Optimization() !=
+      sdf::MeshOptimization::CONVEX_DECOMPOSITION &&
+      _meshSdf.Optimization() !=
+      sdf::MeshOptimization::CONVEX_HULL)
+    return nullptr;
+
+  auto &meshManager = *common::MeshManager::Instance();
+  std::size_t maxConvexHulls = 16u;
+  if (_meshSdf.Optimization() == sdf::MeshOptimization::CONVEX_HULL)
+  {
+    /// create 1 convex hull for the whole submesh
+    maxConvexHulls = 1u;
+  }
+  else if (_meshSdf.ConvexDecomposition())
+  {
+    // limit max number of convex hulls to generate
+    maxConvexHulls = _meshSdf.ConvexDecomposition()->MaxConvexHulls();
+  }
+  // Check if MeshManager contains the decomposed mesh already. If not
+  // add it to the MeshManager so we do not need to decompose it again.
+  const std::string convexMeshName =
+      _mesh.Name() + "_CONVEX_" + std::to_string(maxConvexHulls);
+  auto *optimizedMesh = meshManager.MeshByName(convexMeshName);
+  if (!optimizedMesh)
+  {
+    // Merge meshes before convex decomposition
+    auto mergedMesh = gz::common::MeshManager::MergeSubMeshes(_mesh);
+    if (mergedMesh && mergedMesh->SubMeshCount() == 1u)
+    {
+      // Decompose and add mesh to MeshManager
+      auto mergedSubmesh = mergedMesh->SubMeshByIndex(0u).lock();
+      std::vector<common::SubMesh> decomposed =
+        gz::common::MeshManager::ConvexDecomposition(
+        *mergedSubmesh.get(), maxConvexHulls);
+      gzdbg << "Optimizing mesh (" << _meshSdf.OptimizationStr() << "): "
+            <<  _mesh.Name() << std::endl;
+      // Create decomposed mesh and add it to MeshManager
+      // Note: MeshManager will call delete on this mesh in its destructor
+      // \todo(iche033) Consider updating MeshManager to accept
+      // unique pointers instead
+      common::Mesh *convexMesh = new common::Mesh;
+      convexMesh->SetName(convexMeshName);
+      for (const auto & submesh : decomposed)
+        convexMesh->AddSubMesh(submesh);
+      meshManager.AddMesh(convexMesh);
+      if (decomposed.empty())
+      {
+        // Print an error if convex decomposition returned empty submeshes
+        // but still add it to MeshManager to avoid going through the
+        // expensive convex decomposition process for the same mesh again
+        gzerr << "Convex decomposition generated zero meshes: "
+               << _mesh.Name() << std::endl;
+      }
+      optimizedMesh = meshManager.MeshByName(convexMeshName);
+    }
+  }
+  return optimizedMesh;
+}
+
 }
 }
 }

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -16,6 +16,8 @@
 */
 
 #include <cstddef>
+#include <string>
+#include <vector>
 
 #include <gz/msgs/entity.pb.h>
 

--- a/src/Util_TEST.cc
+++ b/src/Util_TEST.cc
@@ -1023,4 +1023,12 @@ TEST_F(UtilTest, LoadMesh)
     "test", "media", "duck.dae");
   meshSdf.SetFilePath(filePath);
   EXPECT_NE(nullptr, loadMesh(meshSdf));
+
+  EXPECT_TRUE(meshSdf.SetOptimization("convex_decomposition"));
+  sdf::ConvexDecomposition convexDecomp;
+  convexDecomp.SetMaxConvexHulls(16u);
+  meshSdf.SetConvexDecomposition(convexDecomp);
+  auto *optimizedMesh = loadMesh(meshSdf);
+  EXPECT_NE(nullptr, optimizedMesh);
+  EXPECT_EQ(16u, optimizedMesh->SubMeshCount());
 }


### PR DESCRIPTION
# 🎉 New feature

## Summary

Add mesh optimization support in dartsim.

Dartsim uses `AttachMeshShapeFeature` for constructing meshes. It expects a `common::Mesh` to already be loaded and passed to it. So we need to optimize the mesh first in gz-sim (instead of doing mesh optimization inside gz-physics dartsim plugin). To support this, this PR adds logic to perform mesh optimization whenever a mesh is being loaded (e.g. via `loadMesh` [here](https://github.com/gazebosim/gz-sim/blob/8ca89f7c279400060b4fc4563442f6fa521380dc/src/systems/physics/Physics.cc#L1391) in physics system).

## Test it

You can test with the [cordless drill simplified](https://app.gazebosim.org/iche033/fuel/models/Cordless%20Drill%20Simplified) mesh.  Here's a [cordless_drill.sdf](https://gist.github.com/iche033/428fd4624393576d99045b67b78b1698) test world

Launch gz-sim with the optimized mesh

```
gz sim -v 4 cordless_drill.sdf
```

and you should see a debug msg like this:

```
[Dbg] [Util.cc:918] Optimizing mesh (convex_decomposition): <home>/.gz/fuel/fuel.gazebosim.org/iche033/models/cordless drill simplified/3/meshes/cordless_drill.stl
```

Mesh collision visualization support is in https://github.com/gazebosim/gz-sim/pull/2352. I'll refactor that PR to use the new `optimizeMesh` function introduced here once this PR gets in.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

