### PR TITLE
Use VERSION_GREATER_EQUAL in cmake logic

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -255,7 +255,7 @@ foreach(CMD_TEST
   # to the PATH. This is done via the ENVIRONMENT_MODIFICATION that is only available
   # since CMake 3.22. However, if an older CMake is used another trick to install the libraries
   # beforehand
-  if (WIN32 AND CMAKE_VERSION STRGREATER "3.22")
+  if (WIN32 AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.22")
     set_tests_properties(${CMD_TEST} PROPERTIES
       ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
   endif()


### PR DESCRIPTION
# 🦟 Bug fix

Small improvement to cmake logic

## Summary

While updating cmake logic as part of https://github.com/gazebosim/gz-cmake/issues/350, I noticed a version comparison using `STRGREATER` when `VERSION_GREATER_EQUAL` looks more appropriate to me, since the feature was added in cmake 3.22.

cc @traversaro who added this in https://github.com/gazebosim/gz-sim/pull/1764

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
