### PR TITLE
Rephrase cmake comment about CMP0077

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ option(USE_DIST_PACKAGES_FOR_PYTHON
 #============================================================================
 
 # Setting this policy enables using the protobuf_MODULE_COMPATIBLE
-# set command in CMake versions older than 13.13
+# set command when cmake_minimum_required is less than 3.13
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 # This option is needed to use the PROTOBUF_GENERATE_CPP
 # in case protobuf is found with the CMake config files


### PR DESCRIPTION
# 🦟 Bug fix

Improves a cmake comment

## Summary

While updating cmake logic as part of https://github.com/gazebosim/gz-cmake/issues/350, I noticed a typo in the cmake version in a comment about setting [policy CMP0077](https://cmake.org/cmake/help/latest/policy/CMP0077.html) (13.13 instead of 3.13), so I've fixed the typo and also rephrased the comment to refer to the `cmake_minimum_version` instead of the cmake version, since the policy would have no effect on old versions of cmake; it only affects newer versions of cmake while the `cmake_minimum_version` is set to a version older than 3.13.

cc @Blast545 

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
