### PR TITLE
Optimize rendering sensor pose updates

### DIFF
--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include <sdf/Actor.hh>
+#include <sdf/Camera.hh>
 #include <sdf/Collision.hh>
 #include <sdf/Element.hh>
 #include <sdf/Joint.hh>
@@ -1323,6 +1324,22 @@ void RenderUtil::Update()
           gzerr << "Failed to create sensor [" << sensorName << "]"
                  << std::endl;
         }
+        else
+        {
+          auto sensorNode = this->dataPtr->sceneManager.NodeById(entity);
+          auto semPose = dataSdf.SemanticPose();
+          math::Pose3d sensorPose;
+          sdf::Errors errors = semPose.Resolve(sensorPose);
+          if (!errors.empty())
+          {
+            sensorPose = dataSdf.RawPose();
+          }
+          if (dataSdf.CameraSensor())
+          {
+            sensorPose = sensorPose * dataSdf.CameraSensor()->RawPose();
+          }
+          sensorNode->SetLocalPose(sensorPose);
+        }
       }
     }
   }
@@ -2383,86 +2400,6 @@ void RenderUtilPrivate::UpdateRenderingEntities(
   _ecm.Each<components::Light, components::Pose>(
       [&](const Entity &_entity,
         const components::Light *,
-        const components::Pose *_pose)->bool
-      {
-        this->entityPoses[_entity] = _pose->Data();
-        return true;
-      });
-
-  // Update cameras
-  _ecm.Each<components::Camera, components::Pose>(
-      [&](const Entity &_entity,
-        const components::Camera *,
-        const components::Pose *_pose)->bool
-      {
-        this->entityPoses[_entity] = _pose->Data();
-        return true;
-      });
-
-  // Update depth cameras
-  _ecm.Each<components::DepthCamera, components::Pose>(
-      [&](const Entity &_entity,
-        const components::DepthCamera *,
-        const components::Pose *_pose)->bool
-      {
-        this->entityPoses[_entity] = _pose->Data();
-        return true;
-      });
-
-  // Update RGBD cameras
-  _ecm.Each<components::RgbdCamera, components::Pose>(
-      [&](const Entity &_entity,
-        const components::RgbdCamera *,
-        const components::Pose *_pose)->bool
-      {
-        this->entityPoses[_entity] = _pose->Data();
-        return true;
-      });
-
-  // Update gpu_lidar
-  _ecm.Each<components::GpuLidar, components::Pose>(
-      [&](const Entity &_entity,
-        const components::GpuLidar *,
-        const components::Pose *_pose)->bool
-      {
-        this->entityPoses[_entity] = _pose->Data();
-        return true;
-      });
-
-  // Update thermal cameras
-  _ecm.Each<components::ThermalCamera, components::Pose>(
-      [&](const Entity &_entity,
-        const components::ThermalCamera *,
-        const components::Pose *_pose)->bool
-      {
-        this->entityPoses[_entity] = _pose->Data();
-        return true;
-      });
-
-  // Update segmentation cameras
-  _ecm.Each<components::SegmentationCamera, components::Pose>(
-      [&](const Entity &_entity,
-        const components::SegmentationCamera *,
-        const components::Pose *_pose)->bool
-      {
-        this->entityPoses[_entity] = _pose->Data();
-        return true;
-      });
-
-  // Update bounding box cameras
-  _ecm.Each<components::BoundingBoxCamera, components::Pose>(
-      [&](const Entity &_entity,
-        const components::BoundingBoxCamera *,
-        const components::Pose *_pose)->bool
-      {
-        this->entityPoses[_entity] = _pose->Data();
-        return true;
-      });
-
-  // Update wide angle cameras
-  _ecm.Each<components::WideAngleCamera, components::Pose>(
-      [&](const Entity &_entity,
-        const components::WideAngleCamera *,
         const components::Pose *_pose)->bool
       {
         this->entityPoses[_entity] = _pose->Data();

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -1334,10 +1334,6 @@ void RenderUtil::Update()
           {
             sensorPose = dataSdf.RawPose();
           }
-          if (dataSdf.CameraSensor())
-          {
-            sensorPose = sensorPose * dataSdf.CameraSensor()->RawPose();
-          }
           sensorNode->SetLocalPose(sensorPose);
         }
       }


### PR DESCRIPTION
# 🦟 Bug fix

Related PR: https://github.com/gazebosim/gz-sensors/pull/439

## Summary
Currently we are updating the pose of all rendering sensors every iteration. This is not necessary as we currently do not expect sensor pose to change at runtime. This PR removes the pose updates every iteration and it now just sets the pose of these rendering sensors once they created. For camera based sensors, their pose transform is the combined result of `//sensor/pose` and `//sensor/camera/pose` (previously the `//sensor/camera/pose` sdf element was ignored and never used). 

Here is an example world for test: [camera_test.sdf](https://gist.github.com/iche033/91616a5620cc64c89a9571c2ea2db767). The world consists of 2 cameras sensors (rgb and depth) with pose offsets in `//sensor/pose` and `//sensor/camera/pose`. Together with https://github.com/gazebosim/gz-sensors/pull/439, the camera sensor pose should be set correctly and you should see images like below:

<img width="710" alt="camera_pose_offset" src="https://github.com/gazebosim/gz-sim/assets/4000684/ce577fdf-6f6e-4b1c-a25c-3f11a1829afd">


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

