### PR TITLE
Handle sdf::Geometry::EMPTY in conversions

### DIFF
--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -259,6 +259,10 @@ msgs::Geometry gz::sim::convert(const sdf::Geometry &_in)
       }
     }
   }
+  else if (_in.Type() == sdf::GeometryType::EMPTY)
+  {
+    out.set_type(msgs::Geometry::EMPTY);
+  }
   else
   {
     gzerr << "Geometry type [" << static_cast<int>(_in.Type())

--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -1206,3 +1206,13 @@ TEST(Conversions, MsgsPluginToSdf)
   EXPECT_EQ(innerXml, sdfPlugins[1].Contents()[0]->ToString(""));
   EXPECT_EQ(innerXml2, sdfPlugins[1].Contents()[1]->ToString(""));
 }
+
+/////////////////////////////////////////////////
+TEST(Conversions, GeometryEmpty)
+{
+  sdf::Geometry geometry;
+  geometry.SetType(sdf::GeometryType::EMPTY);
+
+  auto geometryMsg = convert<msgs::Geometry>(geometry);
+  EXPECT_EQ(msgs::Geometry::EMPTY, geometryMsg.type());
+}


### PR DESCRIPTION
# 🎉 New feature

## Summary

Handle sdf::Geometry::EMPTY in Conversions.cc.

## Test it

Test added to Conversions_TEST.cc

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.