### PR TITLE
Update camera sensors to use the `//sensor/camera/pose` sdf element.

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -12,6 +12,9 @@ release will remove the deprecated code.
      each time step, whereas previously the component values were set to `0`
      after each time step. Persistent velocity commands should be reapplied at
      each time step.
+   + For camera baesd sensors, their pose now takes into account the
+     `//sensor/camera/pose` sdf element. Previously only the `//sensor/pose`
+     sdf element was used and `//sensor/camera/pose` was ignored.
 
 ## Gazebo Sim 7.x to 8.0
 * **Deprecated**

--- a/Migration.md
+++ b/Migration.md
@@ -12,7 +12,7 @@ release will remove the deprecated code.
      each time step, whereas previously the component values were set to `0`
      after each time step. Persistent velocity commands should be reapplied at
      each time step.
-   + For camera baesd sensors, their pose now takes into account the
+   + For camera based sensors, their pose now takes into account the
      `//sensor/camera/pose` sdf element. Previously only the `//sensor/pose`
      sdf element was used and `//sensor/camera/pose` was ignored.
 

--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -1334,6 +1334,10 @@ void RenderUtil::Update()
           {
             sensorPose = dataSdf.RawPose();
           }
+          if (dataSdf.CameraSensor())
+          {
+            sensorPose = sensorPose * dataSdf.CameraSensor()->RawPose();
+          }
           sensorNode->SetLocalPose(sensorPose);
         }
       }


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

Follow-up on https://github.com/gazebosim/gz-sim/pull/2425#issuecomment-2148165722. This is a behavior change so targeting `main`. The camera sensors will now take into account the `//sensor/camera/pose` sdf element. I also added an entry to Migration guide.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

