### PR TITLE
Do not update sensors if it a triggered sensor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ set(GZ_PHYSICS_VER ${gz-physics7_VERSION_MAJOR})
 
 #--------------------------------------
 # Find gz-sensors
-gz_find_package(gz-sensors8 REQUIRED
+gz_find_package(gz-sensors8 REQUIRED VERSION 8.2.0
   # component order is important
   COMPONENTS
     # non-rendering

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -1034,6 +1034,11 @@ std::chrono::steady_clock::duration SensorsPrivate::NextUpdateTime(
       continue;
     }
 
+    if (rs->IsTriggered())
+    {
+      continue;
+    }
+
     std::chrono::steady_clock::duration time;
     // if sensor's next update tims is less or equal to current sim time then
     // it's in the process of being updated by the render loop


### PR DESCRIPTION
# 🦟 Bug fix

Depends on https://github.com/gazebosim/gz-sensors/pull/441

## Summary

Currently the logic for checking active sensors ignores the triggered property of a camera. So as the result, when you subscribe to any triggered sensors, they become "active" (added to the `activeSensors` list) and they perform unnecessary prerender updates even when they don't have pending triggers. This PR adds a check for the triggered property of the sensor to filter them out when checking for active sensors.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

