### PR TITLE
Fix ModelCommandAPI unit test

### DIFF
--- a/src/ModelCommandAPI_TEST.cc
+++ b/src/ModelCommandAPI_TEST.cc
@@ -657,7 +657,7 @@ TEST(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_MAC(RgbdCameraSensor))
       "  - Lens intrinsics Fy: 277\n"
       "  - Lens intrinsics Cx: 160\n"
       "  - Lens intrinsics Cy: 120\n"
-      "  - Lens intrinsics skew: 1\n"
+      "  - Lens intrinsics skew: 0\n"
       "  - Visibility mask: 4294967295\n";
       EXPECT_EQ(expectedOutput, output);
   }


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

Fixed test by updating the expected model command output string - the skew value changed from 1 to 0 in https://github.com/gazebosim/sdformat/pull/1423


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
