### PR TITLE
Parse voxel resolution SDF param when decomposing meshes

### DIFF
--- a/src/Util.cc
+++ b/src/Util.cc
@@ -907,7 +907,7 @@ const common::Mesh *optimizeMesh(const sdf::Mesh &_meshSdf,
   // Check if MeshManager contains the decomposed mesh already. If not
   // add it to the MeshManager so we do not need to decompose it again.
   const std::string convexMeshName =
-      _mesh.Name() + " " + _meshSdf.Submesh() + "_CONVEX_" +
+      _mesh.Name() + "_" + _meshSdf.Submesh() + "_CONVEX_" +
       std::to_string(maxConvexHulls) + "_" + std::to_string(voxelResolution);
   auto *optimizedMesh = meshManager.MeshByName(convexMeshName);
   if (!optimizedMesh)

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -891,20 +891,24 @@ const common::Mesh *optimizeMesh(const sdf::Mesh &_meshSdf,
 
   auto &meshManager = *common::MeshManager::Instance();
   std::size_t maxConvexHulls = 16u;
+  std::size_t voxelResolution = 200000u;
+  if (_meshSdf.ConvexDecomposition())
+  {
+    // limit max number of convex hulls to generate
+    maxConvexHulls = _meshSdf.ConvexDecomposition()->MaxConvexHulls();
+    voxelResolution = _meshSdf.ConvexDecomposition()->VoxelResolution();
+  }
   if (_meshSdf.Optimization() == sdf::MeshOptimization::CONVEX_HULL)
   {
     /// create 1 convex hull for the whole submesh
     maxConvexHulls = 1u;
   }
-  else if (_meshSdf.ConvexDecomposition())
-  {
-    // limit max number of convex hulls to generate
-    maxConvexHulls = _meshSdf.ConvexDecomposition()->MaxConvexHulls();
-  }
+
   // Check if MeshManager contains the decomposed mesh already. If not
   // add it to the MeshManager so we do not need to decompose it again.
   const std::string convexMeshName =
-      _mesh.Name() + "_CONVEX_" + std::to_string(maxConvexHulls);
+      _mesh.Name() + " " + _meshSdf.Submesh() + "_CONVEX_" +
+      std::to_string(maxConvexHulls) + "_" + std::to_string(voxelResolution);
   auto *optimizedMesh = meshManager.MeshByName(convexMeshName);
   if (!optimizedMesh)
   {
@@ -916,7 +920,7 @@ const common::Mesh *optimizeMesh(const sdf::Mesh &_meshSdf,
       auto mergedSubmesh = mergedMesh->SubMeshByIndex(0u).lock();
       std::vector<common::SubMesh> decomposed =
         gz::common::MeshManager::ConvexDecomposition(
-        *mergedSubmesh.get(), maxConvexHulls);
+        *mergedSubmesh.get(), maxConvexHulls, voxelResolution);
       gzdbg << "Optimizing mesh (" << _meshSdf.OptimizationStr() << "): "
             <<  _mesh.Name() << std::endl;
       // Create decomposed mesh and add it to MeshManager

--- a/src/Util_TEST.cc
+++ b/src/Util_TEST.cc
@@ -17,7 +17,6 @@
 
 #include <gtest/gtest.h>
 #include <gz/common/Console.hh>
-#include <gz/common/testing/TestPaths.hh>
 #include <sdf/Actor.hh>
 #include <sdf/Light.hh>
 #include <sdf/Types.hh>
@@ -1020,7 +1019,8 @@ TEST_F(UtilTest, LoadMesh)
   EXPECT_NE(nullptr, loadMesh(meshSdf));
 
   meshSdf.SetUri("duck.dae");
-  std::string filePath = common::testing::TestFile("media", "duck.dae");
+  std::string filePath = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+    "test", "media", "duck.dae");
   meshSdf.SetFilePath(filePath);
   EXPECT_NE(nullptr, loadMesh(meshSdf));
 

--- a/src/Util_TEST.cc
+++ b/src/Util_TEST.cc
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 #include <gz/common/Console.hh>
+#include <gz/common/testing/TestPaths.hh>
 #include <sdf/Actor.hh>
 #include <sdf/Light.hh>
 #include <sdf/Types.hh>
@@ -1019,8 +1020,7 @@ TEST_F(UtilTest, LoadMesh)
   EXPECT_NE(nullptr, loadMesh(meshSdf));
 
   meshSdf.SetUri("duck.dae");
-  std::string filePath = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
-    "test", "media", "duck.dae");
+  std::string filePath = common::testing::TestFile("media", "duck.dae");
   meshSdf.SetFilePath(filePath);
   EXPECT_NE(nullptr, loadMesh(meshSdf));
 


### PR DESCRIPTION


# 🎉 New feature

## Summary

Similar to https://github.com/gazebosim/gz-physics/pull/655 but applies the changes here for dartsim.


## Test it

The same changes are also available in https://github.com/gazebosim/gz-sim/pull/2352. With that PR, you can visualize the decomposed mesh. Here's an example with the cordless drill model

Left: voxel resolution 80000
Right: voxel resolution 800000 (10x)

<img width="527" alt="voxel_resolution" src="https://github.com/gazebosim/gz-sim/assets/4000684/febc8b8f-281c-4319-9098-5b68175b7c9e">

This mesh is relatively simple so the difference is small but on right drill with higher voxel resolution, the collision wraps more tightly to the actual mesh.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

