### PR TITLE
shapes.sdf example: bump to 1.12, add cone shape

### DIFF
--- a/examples/worlds/shapes.sdf
+++ b/examples/worlds/shapes.sdf
@@ -1,12 +1,13 @@
 <?xml version="1.0" ?>
-<!--
-
-Try moving a model:
-
-    gz service -s /world/shapes/set_pose --reqtype gz.msgs.Pose --reptype gz.msgs.Boolean --timeout 300 --req 'name: "box", position: {z: 5.0}'
-
--->
-<sdf version="1.6">
+<sdf version="1.12">
+  <!--
+    Try moving a model using the command in the following CDATA block::
+  -->
+  <![CDATA[
+    gz service -s /world/shapes/set_pose \
+               --reqtype gz.msgs.Pose --reptype gz.msgs.Boolean \
+               --timeout 300 --req 'name: "box", position: {z: 5.0}'
+  ]]>
   <world name="shapes">
     <scene>
       <ambient>1.0 1.0 1.0</ambient>
@@ -236,6 +237,37 @@ Try moving a model:
             <ambient>1 0 1 1</ambient>
             <diffuse>1 0 1 1</diffuse>
             <specular>1 0 1 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="cone">
+      <pose>0 4.5 0.5 0 0 0</pose>
+      <link name="cone_link">
+        <inertial auto="true">
+          <density>1</density>
+        </inertial>
+        <collision name="cone_collision">
+          <geometry>
+            <cone>
+              <radius>0.5</radius>
+              <length>1.0</length>
+            </cone>
+          </geometry>
+        </collision>
+
+        <visual name="cone_visual">
+          <geometry>
+            <cone>
+              <radius>0.5</radius>
+              <length>1.0</length>
+            </cone>
+          </geometry>
+          <material>
+            <ambient>1 0.47 0 1</ambient>
+            <diffuse>1 0.47 0 1</diffuse>
+            <specular>1 0.47 0 1</specular>
           </material>
         </visual>
       </link>


### PR DESCRIPTION
# 🎉 New feature

Follow-up to #2410.

## Summary

This adds an orange cone to the `shapes.sdf` example world. It also fixes the XML syntax of the example command at the top of the world (using the approach adopted in #1838).

## Test it

`gz sim -v 4 src/gz-sim/examples/worlds/shapes.sdf`

<img width="512" alt="Screenshot 2024-06-17 at 10 00 10 AM" src="https://github.com/gazebosim/gz-sim/assets/3650755/2d2b959d-6593-4c3d-9bbb-96673ecbdf46">


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [X] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
