### PR TITLE
Remove Cone shape from particle emitter msg conversion

### DIFF
--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -1728,9 +1728,6 @@ sdf::ParticleEmitter gz::sim::convert(const msgs::ParticleEmitter &_in)
     case msgs::ParticleEmitter::BOX:
       out.SetType(sdf::ParticleEmitterType::BOX);
       break;
-    case msgs::ParticleEmitter::CONE:
-      out.SetType(sdf::ParticleEmitterType::CONE);
-      break;
     case msgs::ParticleEmitter::CYLINDER:
       out.SetType(sdf::ParticleEmitterType::CYLINDER);
       break;


### PR DESCRIPTION


# 🦟 Bug fix

## Summary
Similar to https://github.com/gazebosim/sdformat/pull/1434, let's only add cone shape to particle emitters when there is support for it.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
