### PR TITLE
Remove python3-distutils from package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -31,7 +31,6 @@
   <depend>libxmu-dev</depend>
   <depend>protobuf-dev</depend>
   <depend>pybind11-dev</depend>
-  <depend>python3-distutils</depend>
   <depend>qml-module-qt-labs-folderlistmodel</depend>
   <depend>qml-module-qt-labs-settings</depend>
   <depend>qml-module-qtgraphicaleffects</depend>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
distutils was removed in python-3.12 and I can not find any reference to it in the main branch.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.