### PR TITLE
Add GravityEnabled boolean component

### DIFF
--- a/include/gz/sim/components/Gravity.hh
+++ b/include/gz/sim/components/Gravity.hh
@@ -36,6 +36,11 @@ namespace components
   /// \brief Store the gravity acceleration.
   using Gravity = Component<math::Vector3d, class GravityTag>;
   IGN_GAZEBO_REGISTER_COMPONENT("ign_gazebo_components.Gravity", Gravity)
+
+  /// \brief Store the gravity acceleration.
+  using GravityEnabled = Component<bool, class GravityEnabledTag>;
+  IGN_GAZEBO_REGISTER_COMPONENT(
+      "ign_gazebo_components.GravityEnabled", GravityEnabled)
 }
 }
 }

--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -590,10 +590,9 @@ Entity SdfEntityCreator::CreateEntities(const sdf::Link *_link)
 
   if (!_link->EnableGravity())
   {
-    // If disable gravity, create a gravity component to the entity
-    // This gravity will have value 0,0,0
+    // If disable gravity, create a GravityEnabled component to the entity
     this->dataPtr->ecm->CreateComponent(
-        linkEntity, components::Gravity());
+        linkEntity, components::GravityEnabled(false));
   }
 
   // Visuals

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -1161,21 +1161,12 @@ void PhysicsPrivate::CreateLinkEntities(const EntityComponentManager &_ecm)
         }
 
         // get link gravity
-        const components::Gravity *gravity =
-            _ecm.Component<components::Gravity>(_entity);
-        if (nullptr != gravity)
+        const components::GravityEnabled *gravityEnabled =
+            _ecm.Component<components::GravityEnabled>(_entity);
+        if (nullptr != gravityEnabled)
         {
-          // Entity has a gravity component that is all zeros when
-          // <gravity> is set to false
-          // See SdfEntityCreator::CreateEntities()
-          if (gravity->Data() == math::Vector3d::Zero)
-          {
-            link.SetEnableGravity(false);
-          }
-          else
-          {
-            link.SetEnableGravity(true);
-          }
+          // gravityEnabled set in SdfEntityCreator::CreateEntities()
+          link.SetEnableGravity(gravityEnabled->Data());
         }
 
         auto linkPtrPhys = modelPtrPhys->ConstructLink(link);


### PR DESCRIPTION
# 🎉 New feature

Follow-up to https://github.com/gazebosim/gz-sim/pull/2398, needed for https://github.com/gazebosim/gz-sim/pull/2447

## Summary

This adds a boolean `GravityEnabled` component to the existing `gz/sim/components/Gravity.hh` header file, which should be used with Link entities instead of the `Vector3` gravity component.

cc @AzulRadio 

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
