### PR TITLE
Magnetometer: correct field calculation

### DIFF
--- a/src/systems/magnetometer/Magnetometer.cc
+++ b/src/systems/magnetometer/Magnetometer.cc
@@ -135,10 +135,10 @@ class gz::sim::systems::MagnetometerPrivate
   /// True if the rendering component is initialized
   public: bool initialized = false;
 
-  /// /brief True if the magnetic field is reported in gauss rather than tesla. 
+  /// \brief True if the magnetic field is reported in gauss rather than tesla.
   public: bool useUnitsGauss = true;
 
-  /// /brief True if the magnetic field earth frame is NED rather than ENU. 
+  /// \brief True if the magnetic field earth frame is NED rather than ENU.
   public: bool useEarthFrameNED = true;
 
   /// \brief Create sensor

--- a/src/systems/magnetometer/Magnetometer.cc
+++ b/src/systems/magnetometer/Magnetometer.cc
@@ -24,7 +24,6 @@
 
 #include <gz/plugin/Register.hh>
 
-#include <sdf/sdf.hh>
 #include <sdf/Sensor.hh>
 
 #include <gz/common/Profiler.hh>

--- a/src/systems/magnetometer/Magnetometer.hh
+++ b/src/systems/magnetometer/Magnetometer.hh
@@ -37,6 +37,7 @@ namespace systems
   /// current location.
   class Magnetometer:
     public System,
+    public ISystemConfigure,
     public ISystemPreUpdate,
     public ISystemPostUpdate
   {
@@ -45,6 +46,12 @@ namespace systems
 
     /// \brief Destructor
     public: ~Magnetometer() override;
+
+// Documentation inherited
+    public: void Configure(const Entity &_entity,
+                           const std::shared_ptr<const sdf::Element> &_sdf,
+                           EntityComponentManager &_ecm,
+                           EventManager &_eventMgr) override;
 
     /// Documentation inherited
     public: void PreUpdate(const UpdateInfo &_info,

--- a/src/systems/magnetometer/Magnetometer.hh
+++ b/src/systems/magnetometer/Magnetometer.hh
@@ -47,7 +47,7 @@ namespace systems
     /// \brief Destructor
     public: ~Magnetometer() override;
 
-// Documentation inherited
+    // Documentation inherited
     public: void Configure(const Entity &_entity,
                            const std::shared_ptr<const sdf::Element> &_sdf,
                            EntityComponentManager &_ecm,


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Correct the magnitude and direction of the magnetic field calculation in the Magnetometer sensor.

## Details

- The magnetic intensity table has units centi gauss not centi tesla.
- Add a conversion to publish the magnetic field in tesla.
- The formula to calculate the field from the declination, inclination and intensity is in the NED frame.
- Convert the field orientation to the ENU frame to conform to the Gazebo world frame convention.

## Context

The issue was found during the development of external sensor support for ArduPilot using DDS to subscribe to ROS based sensor topics (in this case magnetic field strength published from Gazebo via the `ros_gz` bridge).

ArduPilot SITL and Gazebo use similar calculations to simulate the earth's magnetic field at a given location (lat, lon). There was an inconsistency between the two calculations which can be attributed to a combination of incorrect units and frame convention.

The attached notebook reproduces both calculations in Python for comparison.

[earth_mag_field.ipynb.zip](https://github.com/user-attachments/files/16053820/earth_mag_field.ipynb.zip)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.