### PR TITLE
Address a couple of todos in Conversions.cc

### DIFF
--- a/src/Conversions.cc
+++ b/src/Conversions.cc
@@ -870,7 +870,7 @@ msgs::Atmosphere gz::sim::convert(const sdf::Atmosphere &_in)
     out.set_type(msgs::Atmosphere::ADIABATIC);
   }
   // todo(anyone) add mass density to sdf::Atmosphere?
-  // out.set_mass_density(_in.MassDensity());k
+  // out.set_mass_density(_in.MassDensity());
 
   return out;
 }
@@ -1703,15 +1703,7 @@ msgs::ParticleEmitter gz::sim::convert(const sdf::ParticleEmitter &_in)
     }
   }
 
-  /// \todo(nkoenig) Modify the particle_emitter.proto file to
-  /// have a topic field.
-  if (!_in.Topic().empty())
-  {
-    auto header = out.mutable_header()->add_data();
-    header->set_key("topic");
-    header->add_value(_in.Topic());
-  }
-
+  out.mutable_topic()->set_data(_in.Topic());
   out.mutable_particle_scatter_ratio()->set_data(_in.ScatterRatio());
   return out;
 }
@@ -1766,15 +1758,8 @@ sdf::ParticleEmitter gz::sim::convert(const msgs::ParticleEmitter &_in)
     out.SetColorRangeImage(_in.color_range_image().data());
   if (_in.has_particle_scatter_ratio())
     out.SetScatterRatio(_in.particle_scatter_ratio().data());
-
-  for (int i = 0; i < _in.header().data_size(); ++i)
-  {
-    auto data = _in.header().data(i);
-    if (data.key() == "topic" && data.value_size() > 0)
-    {
-      out.SetTopic(data.value(0));
-    }
-  }
+  if (_in.has_topic())
+    out.SetTopic(_in.topic().data());
 
   return out;
 }
@@ -1792,10 +1777,7 @@ msgs::Projector gz::sim::convert(const sdf::Projector &_in)
   out.set_fov(_in.HorizontalFov().Radian());
   out.set_texture(_in.Texture().empty() ? "" :
       asFullPath(_in.Texture(), _in.FilePath()));
-
-  auto header = out.mutable_header()->add_data();
-  header->set_key("visibility_flags");
-  header->add_value(std::to_string(_in.VisibilityFlags()));
+  out.set_visibility_flags(_in.VisibilityFlags());
 
   return out;
 }
@@ -1812,26 +1794,7 @@ sdf::Projector gz::sim::convert(const msgs::Projector &_in)
   out.SetHorizontalFov(math::Angle(_in.fov()));
   out.SetTexture(_in.texture());
   out.SetRawPose(msgs::Convert(_in.pose()));
-
-  /// \todo(anyone) add "visibility_flags" field to projector.proto
-  for (int i = 0; i < _in.header().data_size(); ++i)
-  {
-    auto data = _in.header().data(i);
-    if (data.key() == "visibility_flags" && data.value_size() > 0)
-    {
-      try
-      {
-        out.SetVisibilityFlags(std::stoul(data.value(0)));
-      }
-      catch (...)
-      {
-        gzerr << "Failed to parse projector <visibility_flags>: "
-              << data.value(0) << ". Using default value: 0xFFFFFFFF."
-              << std::endl;
-        out.SetVisibilityFlags(0xFFFFFFFF);
-      }
-    }
-  }
+  out.SetVisibilityFlags(_in.visibility_flags());
 
   return out;
 }

--- a/src/Conversions_TEST.cc
+++ b/src/Conversions_TEST.cc
@@ -1041,10 +1041,7 @@ TEST(Conversions, ParticleEmitter)
   EXPECT_EQ(math::Color(0.4f, 0.5f, 0.6f),
       msgs::Convert(emitterMsg.color_end()));
   EXPECT_EQ("range_image", emitterMsg.color_range_image().data());
-
-  auto header = emitterMsg.header().data(0);
-  EXPECT_EQ("topic", header.key());
-  EXPECT_EQ("my_topic", header.value(0));
+  EXPECT_EQ("my_topic", emitterMsg.topic().data());
 
   EXPECT_FLOAT_EQ(0.9f, emitterMsg.particle_scatter_ratio().data());
 
@@ -1094,10 +1091,7 @@ TEST(Conversions, Projector)
   EXPECT_NEAR(30, projectorMsg.far_clip(), 1e-3);
   EXPECT_NEAR(0.4, projectorMsg.fov(), 1e-3);
   EXPECT_EQ("projector.png", projectorMsg.texture());
-
-  auto header = projectorMsg.header().data(0);
-  EXPECT_EQ("visibility_flags", header.key());
-  EXPECT_EQ(0xFF, std::stoul(header.value(0)));
+  EXPECT_EQ(0xFF, projectorMsg.visibility_flags());
 
   // Convert the message back to SDF.
   sdf::Projector projector2 = convert<sdf::Projector>(projectorMsg);

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -1091,9 +1091,7 @@ TEST_P(SceneBroadcasterTest,
       EXPECT_DOUBLE_EQ(0.5, projector.fov());
       EXPECT_NE(std::string::npos,
           projector.texture().find("path/to/dummy_image.png"));
-      auto header = projector.header().data(0);
-      EXPECT_EQ("visibility_flags", header.key());
-      EXPECT_EQ(0x01, std::stoul(header.value(0)));
+      EXPECT_EQ(0x01, projector.visibility_flags());
     }
   }
 


### PR DESCRIPTION


# 🦟 Bug fix


## Summary

Updated conversions for ParticleEmitter's topic field and Projector's visibility flags field

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

