### PR TITLE
Update description of reset_sensors test

### DIFF
--- a/test/integration/reset_sensors.cc
+++ b/test/integration/reset_sensors.cc
@@ -140,8 +140,8 @@ common::Image toImage(const msgs::Image &_msg)
 }
 
 /////////////////////////////////////////////////
-/// This test checks that that the sensors system handles cases where entities
-/// are removed and then added back
+/// This test checks that that air-pressure and camera sensor systems
+/// handle Reset events
 TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
 {
   gz::sim::ServerConfig serverConfig;


### PR DESCRIPTION
# 🦟 Bug fix

Fixes comments describing a test

## Summary

I noticed that the `INTEGRATION_reset_sensors` test is failing in #2232, and while reading through the test I noticed that the test description doesn't seem to match what the test is doing and appears to be copied from [test/integration/sensors_system.cc](https://github.com/gazebosim/gz-sim/blob/b8bbf1d9dee47af68fd1c85fa8382afc47732ff2/test/integration/sensors_system.cc#L184-L185). This updates the comment with my understanding of what the test appears to do.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
