### PR TITLE
Enable tests on macOS

### DIFF
--- a/test/integration/actor_trajectory.cc
+++ b/test/integration/actor_trajectory.cc
@@ -99,7 +99,7 @@ class ActorFixture : public InternalFixture<InternalFixture<::testing::Test>>
 // Load the actor_trajectory.sdf world that animates a box (actor) to follow
 // a trajectory. Verify that the box pose changes over time on the rendering
 // side.
-TEST_F(ActorFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(ActorTrajectoryNoMesh))
+TEST_F(ActorFixture, ActorTrajectoryNoMesh)
 {
   sim::ServerConfig serverConfig;
 

--- a/test/integration/camera_sensor_background_from_scene.cc
+++ b/test/integration/camera_sensor_background_from_scene.cc
@@ -77,7 +77,7 @@ void cameraCb(const msgs::Image & _msg)
 /////////////////////////////////////////////////
 // Test sensors use the background color of <scene> by default
 TEST_F(CameraSensorBackgroundFixture,
-    GZ_UTILS_TEST_DISABLED_ON_MAC(RedBackgroundFromScene))
+       RedBackgroundFromScene)
 {
   const auto sdfFile = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
     "test", "worlds", "camera_sensor_scene_background.sdf");

--- a/test/integration/sensors_system.cc
+++ b/test/integration/sensors_system.cc
@@ -183,7 +183,7 @@ void testDefaultTopics(const std::vector<std::string> &_topics)
 /////////////////////////////////////////////////
 /// This test checks that that the sensors system handles cases where entities
 /// are removed and then added back
-TEST_F(SensorsFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleRemovedEntities))
+TEST_F(SensorsFixture, HandleRemovedEntities)
 {
   gz::sim::ServerConfig serverConfig;
 

--- a/test/integration/sensors_system_battery.cc
+++ b/test/integration/sensors_system_battery.cc
@@ -83,7 +83,7 @@ class SensorsFixture : public InternalFixture<InternalFixture<::testing::Test>>
 
 /////////////////////////////////////////////////
 // Battery
-TEST_F(SensorsFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(SensorsBatteryState))
+TEST_F(SensorsFixture, SensorsBatteryState)
 {
   const auto sdfPath = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
     "test", "worlds", "sensors_system_battery.sdf");

--- a/test/integration/sensors_system_update_rate.cc
+++ b/test/integration/sensors_system_update_rate.cc
@@ -76,7 +76,7 @@ class SensorsFixture : public InternalFixture<InternalFixture<::testing::Test>>
 };
 
 /////////////////////////////////////////////////
-TEST_F(SensorsFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(UpdateRate))
+TEST_F(SensorsFixture, UpdateRate)
 {
   gz::sim::ServerConfig serverConfig;
 

--- a/test/integration/thermal_sensor_system.cc
+++ b/test/integration/thermal_sensor_system.cc
@@ -74,7 +74,7 @@ void thermalCb(const msgs::Image &_msg)
 
 /////////////////////////////////////////////////
 TEST_F(ThermalSensorTest,
-    GZ_UTILS_TEST_DISABLED_ON_MAC(ThermalSensorSystemInvalidConfig))
+       ThermalSensorSystemInvalidConfig)
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/thermal_system.cc
+++ b/test/integration/thermal_system.cc
@@ -49,7 +49,7 @@ class ThermalTest : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(ThermalTest, GZ_UTILS_TEST_DISABLED_ON_MAC(TemperatureComponent))
+TEST_F(ThermalTest, TemperatureComponent)
 {
   // Start server
   ServerConfig serverConfig;
@@ -173,7 +173,7 @@ TEST_F(ThermalTest, GZ_UTILS_TEST_DISABLED_ON_MAC(TemperatureComponent))
 }
 
 /////////////////////////////////////////////////
-TEST_F(ThermalTest, GZ_UTILS_TEST_DISABLED_ON_MAC(ThermalSensorSystem))
+TEST_F(ThermalTest, ThermalSensorSystem)
 {
   // Start server
   ServerConfig serverConfig;

--- a/test/integration/wide_angle_camera.cc
+++ b/test/integration/wide_angle_camera.cc
@@ -61,7 +61,7 @@ void imageCb(const msgs::Image &_msg)
 
 /////////////////////////////////////////////////
 // The test checks the Wide Angle Camera readings
-TEST_F(WideAngleCameraTest, GZ_UTILS_TEST_DISABLED_ON_MAC(WideAngleCameraBox))
+TEST_F(WideAngleCameraTest, WideAngleCameraBox)
 {
   // Start server
   ServerConfig serverConfig;


### PR DESCRIPTION
# 🦟 Bug fix

Enables some tests that appear to be working now on macOS

## Summary

Many tests are disabled on macOS. Out of curiosity, I tried enabling some of them, and many of them pass locally on my laptop, so I'll try enabling them here and see if they pass CI.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
