### PR TITLE
Fix warnings generated by NetworkConfigTest

### DIFF
--- a/src/network/NetworkConfig_TEST.cc
+++ b/src/network/NetworkConfig_TEST.cc
@@ -15,6 +15,7 @@
  *
  */
 
+
 #include <gtest/gtest.h>
 
 #include <gz/common/Console.hh>
@@ -30,38 +31,33 @@ TEST(NetworkManager, ValueConstructor)
   {
     // Primary without number of secondaries is invalid
     auto config = NetworkConfig::FromValues("PRIMARY", 0);
-    assert(config.role == NetworkRole::None);
-    assert(config.numSecondariesExpected == 0);
+    ASSERT_EQ(config.role, NetworkRole::None);
+    ASSERT_EQ(config.numSecondariesExpected, 0);
     // Expect console warning as well
-    (void) config;
   }
 
   {
     // Primary with number of secondaries is valid
     auto config = NetworkConfig::FromValues("PRIMARY", 3);
-    assert(config.role == NetworkRole::SimulationPrimary);
-    assert(config.numSecondariesExpected == 3);
-    (void) config;
+    ASSERT_EQ(config.role, NetworkRole::SimulationPrimary);
+    ASSERT_EQ(config.numSecondariesExpected, 3);
   }
 
   {
     // Secondary is always valid
     auto config = NetworkConfig::FromValues("SECONDARY", 0);
-    assert(config.role == NetworkRole::SimulationSecondary);
-    (void) config;
+    ASSERT_EQ(config.role, NetworkRole::SimulationSecondary);
   }
 
   {
     // Readonly is always valid
     auto config = NetworkConfig::FromValues("READONLY");
-    assert(config.role == NetworkRole::ReadOnly);
-    (void) config;
+    ASSERT_EQ(config.role, NetworkRole::ReadOnly);
   }
 
   {
     // Anything else is invalid
     auto config = NetworkConfig::FromValues("READ_WRITE");
-    assert(config.role == NetworkRole::None);
-    (void) config;
+    ASSERT_EQ(config.role, NetworkRole::None);
   }
 }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
This test was generating a warning about unused vairables. Unless built in debug mode, `aserts`are often optimized out we should be using the `ASSERT` macros from `gtest` instead.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
