### PR TITLE
Use parentEntity available in `systems` instead of storing it for each interface

### DIFF
--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -571,12 +571,10 @@ void SimulationRunner::ProcessSystemQueue()
         this->postUpdateStartBarrier->Wait();
         if (this->postUpdateThreadsRunning)
         {
-          system->PostUpdate(this->currentInfo,
-            this->entityCompMgr);
+          system->PostUpdate(this->currentInfo, this->entityCompMgr);
         }
         this->postUpdateStopBarrier->Wait();
       }
-
       gzdbg << "Exiting postupdate worker thread ("
         << id << ")" << std::endl;
     }));
@@ -604,13 +602,13 @@ void SimulationRunner::UpdateSystems()
   {
     GZ_PROFILE("PreUpdate");
     for (auto& system : this->systemMgr->SystemsPreUpdate())
-      system.system->PreUpdate(this->currentInfo, this->entityCompMgr);
+      system->PreUpdate(this->currentInfo, this->entityCompMgr);
   }
 
   {
     GZ_PROFILE("Update");
     for (auto& system : this->systemMgr->SystemsUpdate())
-      system.system->Update(this->currentInfo, this->entityCompMgr);
+      system->Update(this->currentInfo, this->entityCompMgr);
   }
 
   {
@@ -894,7 +892,6 @@ void SimulationRunner::Step(const UpdateInfo &_info)
 
   // Update all the systems.
   this->UpdateSystems();
-
 
   if (!this->Paused() && this->requestedRunToSimTime &&
        this->requestedRunToSimTime.value() > this->simTimeEpoch &&

--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -453,7 +453,7 @@ void SystemManager::ProcessRemovedEntities(
   }
 
   std::vector<SystemInternal> markedForRemoval;
-  for (const auto &system: this->systems)
+  for (const auto &system : this->systems)
   {
     if (_ecm.IsMarkedForRemoval(system.parentEntity))
     {
@@ -461,7 +461,7 @@ void SystemManager::ProcessRemovedEntities(
     }
   }
 
-  for (const auto &system: markedForRemoval)
+  for (const auto &system : markedForRemoval)
   {
     removeFromVector(this->systemsReset, system.reset);
     removeFromVector(this->systemsPreupdate, system.preupdate);
@@ -476,7 +476,8 @@ void SystemManager::ProcessRemovedEntities(
 
     removeFromVector(this->systemsPostupdate, system.postupdate);
     removeFromVector(this->systemsConfigure, system.configure);
-    removeFromVector(this->systemsConfigureParameters, system.configureParameters);
+    removeFromVector(this->systemsConfigureParameters,
+                     system.configureParameters);
     RemoveFromVectorIf(this->systems,
                        [&](const SystemInternal& _arg) {
                        return _arg.parentEntity == system.parentEntity;

--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -18,6 +18,7 @@
 #include <list>
 #include <mutex>
 #include <set>
+#include <unordered_set>
 
 #include <gz/common/StringUtils.hh>
 
@@ -430,13 +431,6 @@ void RemoveFromVectorIf(std::vector<Tp>& vec,
 {
   vec.erase(std::remove_if(vec.begin(), vec.end(), pred), vec.end());
 }
-template <typename Tp>
-void removeFromVector(std::vector<Tp> &_vec, const Tp &_value)
-{
-  _vec.erase(std::remove_if(_vec.begin(), _vec.end(),
-                            [&](const auto &_arg) { return _arg == _value; }),
-             _vec.end());
-}
 
 //////////////////////////////////////////////////
 void SystemManager::ProcessRemovedEntities(
@@ -452,37 +446,95 @@ void SystemManager::ProcessRemovedEntities(
     return;
   }
 
-  std::vector<SystemInternal> markedForRemoval;
+  std::unordered_set<ISystemReset *> resetSystemsToBeRemoved;
+  std::unordered_set<ISystemPreUpdate *> preupdateSystemsToBeRemoved;
+  std::unordered_set<ISystemUpdate *> updateSystemsToBeRemoved;
+  std::unordered_set<ISystemPostUpdate *> postupdateSystemsToBeRemoved;
+  std::unordered_set<ISystemConfigure *> configureSystemsToBeRemoved;
+  std::unordered_set<ISystemConfigureParameters *>
+    configureParametersSystemsToBeRemoved;
   for (const auto &system : this->systems)
   {
     if (_ecm.IsMarkedForRemoval(system.parentEntity))
     {
-      markedForRemoval.push_back(system);
+      if (system.reset)
+      {
+        resetSystemsToBeRemoved.insert(system.reset);
+      }
+      if (system.preupdate)
+      {
+        preupdateSystemsToBeRemoved.insert(system.preupdate);
+      }
+      if (system.update)
+      {
+        updateSystemsToBeRemoved.insert(system.update);
+      }
+      if (system.postupdate)
+      {
+        postupdateSystemsToBeRemoved.insert(system.postupdate);
+        // If system with a PostUpdate is marked for removal
+        // mark all worker threads for removal.
+        _needsCleanUp = true;
+      }
+      if (system.configure)
+      {
+        configureSystemsToBeRemoved.insert(system.configure);
+      }
+      if (system.configureParameters)
+      {
+        configureParametersSystemsToBeRemoved.insert(
+          system.configureParameters);
+      }
     }
   }
 
-  for (const auto &system : markedForRemoval)
-  {
-    removeFromVector(this->systemsReset, system.reset);
-    removeFromVector(this->systemsPreupdate, system.preupdate);
-    removeFromVector(this->systemsUpdate, system.update);
+  RemoveFromVectorIf(this->systemsReset,
+    [&](const auto system) {
+      if (resetSystemsToBeRemoved.count(system)) {
+        return true;
+      }
+      return false;
+    });
+  RemoveFromVectorIf(this->systemsPreupdate,
+    [&](const auto& system) {
+      if (preupdateSystemsToBeRemoved.count(system)) {
+        return true;
+      }
+      return false;
+    });
+  RemoveFromVectorIf(this->systemsUpdate,
+    [&](const auto& system) {
+      if (updateSystemsToBeRemoved.count(system)) {
+        return true;
+      }
+      return false;
+    });
 
-    if (system.postupdate)
-    {
-      // If system with a PostUpdate is marked for removal
-      // mark all worker threads for removal.
-      _needsCleanUp = true;
-    }
-
-    removeFromVector(this->systemsPostupdate, system.postupdate);
-    removeFromVector(this->systemsConfigure, system.configure);
-    removeFromVector(this->systemsConfigureParameters,
-                     system.configureParameters);
-    RemoveFromVectorIf(this->systems,
-                       [&](const SystemInternal& _arg) {
-                       return _arg.parentEntity == system.parentEntity;
-                       });
-  }
+  RemoveFromVectorIf(this->systemsPostupdate,
+    [&](const auto& system) {
+      if (postupdateSystemsToBeRemoved.count(system)) {
+        return true;
+      }
+      return false;
+    });
+  RemoveFromVectorIf(this->systemsConfigure,
+    [&](const auto& system) {
+      if (configureSystemsToBeRemoved.count(system)) {
+        return true;
+      }
+      return false;
+    });
+  RemoveFromVectorIf(this->systemsConfigureParameters,
+    [&](const auto& system) {
+      if (configureParametersSystemsToBeRemoved.count(system)) {
+        return true;
+      }
+      return false;
+    });
+  RemoveFromVectorIf(this->systems,
+    [&](const SystemInternal& _arg) {
+      return _ecm.IsMarkedForRemoval(_arg.parentEntity);
+    });
 
   std::lock_guard lock(this->pendingSystemsMutex);
   RemoveFromVectorIf(this->pendingSystems,

--- a/src/SystemManager.hh
+++ b/src/SystemManager.hh
@@ -21,8 +21,6 @@
 
 #include <memory>
 #include <string>
-#include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include <sdf/Plugin.hh>
@@ -42,21 +40,6 @@ namespace gz
   {
     // Inline bracket to help doxygen filtering.
     inline namespace GZ_SIM_VERSION_NAMESPACE {
-
-    /// \brief Helper container to keep track of
-    /// system interfaces and their parents
-    template<typename IFace>
-    struct SystemIfaceWithParent {
-      /// Parent entity of system
-      Entity parent;
-
-      /// Interface pointer
-      IFace* system;
-
-      /// \brief constructor
-      SystemIfaceWithParent(Entity _parent, IFace* _iface):
-        parent(_parent), system(_iface) {}
-    };
 
     /// \brief Used to load / unload sysetms as well as iterate over them.
     class GZ_SIM_VISIBLE SystemManager
@@ -131,35 +114,29 @@ namespace gz
 
       /// \brief Get a vector of all systems implementing "Configure"
       /// \return Vector of systems' configure interfaces.
-      public: const std::vector<SystemIfaceWithParent<ISystemConfigure>>&
-        SystemsConfigure();
+      public: const std::vector<ISystemConfigure *>& SystemsConfigure();
 
       /// \brief Get an vector of all active systems implementing
       ///   "ConfigureParameters"
       /// \return Vector of systems's configure interfaces.
-      public: const std::vector<
-        SystemIfaceWithParent<ISystemConfigureParameters>>&
-        SystemsConfigureParameters();
+      public: const std::vector<ISystemConfigureParameters *>&
+      SystemsConfigureParameters();
 
       /// \brief Get an vector of all active systems implementing "Reset"
       /// \return Vector of systems' reset interfaces.
-      public: const std::vector<SystemIfaceWithParent<ISystemReset>>&
-        SystemsReset();
+      public: const std::vector<ISystemReset *>& SystemsReset();
 
       /// \brief Get an vector of all active systems implementing "PreUpdate"
       /// \return Vector of systems's pre-update interfaces.
-      public: const std::vector<SystemIfaceWithParent<ISystemPreUpdate>>&
-        SystemsPreUpdate();
+      public: const std::vector<ISystemPreUpdate *>& SystemsPreUpdate();
 
       /// \brief Get an vector of all active systems implementing "Update"
       /// \return Vector of systems's update interfaces.
-      public: const std::vector<SystemIfaceWithParent<ISystemUpdate>>&
-        SystemsUpdate();
+      public: const std::vector<ISystemUpdate *>& SystemsUpdate();
 
       /// \brief Get an vector of all active systems implementing "PostUpdate"
       /// \return Vector of systems's post-update interfaces.
-      public: const std::vector<ISystemPostUpdate *>&
-        SystemsPostUpdate();
+      public: const std::vector<ISystemPostUpdate *>& SystemsPostUpdate();
 
       /// \brief Get an vector of all systems attached to a given entity.
       /// \return Vector of systems.
@@ -218,28 +195,23 @@ namespace gz
       private: mutable std::mutex pendingSystemsMutex;
 
       /// \brief Systems implementing Configure
-      private: std::vector<SystemIfaceWithParent<ISystemConfigure>>
-        systemsConfigure;
+      private: std::vector<ISystemConfigure *> systemsConfigure;
 
       /// \brief Systems implementing ConfigureParameters
-      private: std::vector<SystemIfaceWithParent<ISystemConfigureParameters>>
+      private: std::vector<ISystemConfigureParameters *>
         systemsConfigureParameters;
 
       /// \brief Systems implementing Reset
-      private: std::vector<SystemIfaceWithParent<ISystemReset>> systemsReset;
+      private: std::vector<ISystemReset *> systemsReset;
 
       /// \brief Systems implementing PreUpdate
-      private: std::vector<SystemIfaceWithParent<ISystemPreUpdate>>
-        systemsPreupdate;
+      private: std::vector<ISystemPreUpdate *> systemsPreupdate;
 
       /// \brief Systems implementing Update
-      private: std::vector<SystemIfaceWithParent<ISystemUpdate>> systemsUpdate;
+      private: std::vector<ISystemUpdate *> systemsUpdate;
 
       /// \brief Systems implementing PostUpdate
       private: std::vector<ISystemPostUpdate *> systemsPostupdate;
-
-      /// \brief Parents of post update systems.
-      private: std::vector<Entity> postUpdateParents;
 
       /// \brief System loader, for loading system plugins.
       private: SystemLoaderPtr systemLoader;


### PR DESCRIPTION
@arjo129 I think it's possible to further simplify #2232 by using the `parentEntity` already available in the `systems` vector. I haven't fully tested this yet, but I wanted get your feedback if there's a downside to this approach. 

cc @scpeters 