### PR TITLE
Check if any entity actually has a ContactSensorData component before…

### DIFF
--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -3797,8 +3797,8 @@ void PhysicsPrivate::UpdateCollisions(EntityComponentManager &_ecm)
   // Also check if any entity currently has a ContactSensorData component.
   bool need_contact_sensor_data = false;
   _ecm.Each<components::Collision, components::ContactSensorData>(
-      [&](const Entity &_collEntity1, components::Collision *,
-          components::ContactSensorData *_contacts) -> bool
+      [&](const Entity &/*unused*/, components::Collision *,
+          components::ContactSensorData */*unused*/) -> bool
       {
         need_contact_sensor_data = true;
         return false;

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -3794,6 +3794,17 @@ void PhysicsPrivate::UpdateCollisions(EntityComponentManager &_ecm)
   if (!_ecm.HasComponentType(components::ContactSensorData::typeId))
     return;
 
+  // Also check if any entity currently has a ContactSensorData component.
+  bool need_contact_sensor_data = false;
+  _ecm.Each<components::Collision, components::ContactSensorData>(
+      [&](const Entity &_collEntity1, components::Collision *,
+          components::ContactSensorData *_contacts) -> bool
+      {
+        need_contact_sensor_data = true;
+        return false;
+      });
+  if (!need_contact_sensor_data) return;
+
   // TODO(addisu) If systems are assumed to only have one world, we should
   // capture the world Entity in a Configure call
   Entity worldEntity = _ecm.EntityByComponents(components::World());

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -3795,15 +3795,16 @@ void PhysicsPrivate::UpdateCollisions(EntityComponentManager &_ecm)
     return;
 
   // Also check if any entity currently has a ContactSensorData component.
-  bool need_contact_sensor_data = false;
+  bool needContactSensorData = false;
   _ecm.Each<components::Collision, components::ContactSensorData>(
       [&](const Entity &/*unused*/, components::Collision *,
           components::ContactSensorData */*unused*/) -> bool
       {
-        need_contact_sensor_data = true;
+        needContactSensorData = true;
         return false;
       });
-  if (!need_contact_sensor_data) return;
+  if (!needContactSensorData)
+    return;
 
   // TODO(addisu) If systems are assumed to only have one world, we should
   // capture the world Entity in a Configure call


### PR DESCRIPTION
… calling GetContactsFromLastStep

`GetContactsFromLastStep` can be an expensive call if there are a lot of contact points in the scene. Currently we call this method in the Physics System when the ECM has the `ContactSensorData` component type. However, this will still be true if the `ContactSensorData` component has been removed for all entities.

I have updated the Physics System to additionally check if there is at least one entity with the `ContactSensorData` component before calling `GetContactsFromLastStep`. This enables consuming Systems to optimize their computational footprint by only adding the `ContactSensorData` for relevant entities when needed and remove it when not needed.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
