### PR TITLE
Slight Improvement in runtime for #2473

### DIFF
--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -18,6 +18,7 @@
 #include <list>
 #include <mutex>
 #include <set>
+#include <unordered_set>
 
 #include <gz/common/StringUtils.hh>
 
@@ -450,7 +451,8 @@ void SystemManager::ProcessRemovedEntities(
   std::unordered_set<ISystemUpdate *> updateSystemsToBeRemoved;
   std::unordered_set<ISystemPostUpdate *> postupdateSystemsToBeRemoved;
   std::unordered_set<ISystemConfigure *> configureSystemsToBeRemoved;
-  std::unordered_set<ISystemConfigureParameters *> configureParametersSystemsToBeRemoved;
+  std::unordered_set<ISystemConfigureParameters *>
+    configureParametersSystemsToBeRemoved;
   for (const auto &system : this->systems)
   {
     if (_ecm.IsMarkedForRemoval(system.parentEntity))
@@ -480,7 +482,8 @@ void SystemManager::ProcessRemovedEntities(
       }
       if (system.configureParameters)
       {
-        configureParametersSystemsToBeRemoved.insert(system.configureParameters);
+        configureParametersSystemsToBeRemoved.insert(
+          system.configureParameters);
       }
     }
   }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
This PR is a suggestion for how #2473 can run in O(m+n) time instead of O(mn) where m is number of entities removed and n is number of systems.

Compared to main: https://github.com/gazebosim/gz-sim/compare/main...arjo/suggestion/2473

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
