### PR TITLE
Add UserCommands plugin to GPU lidar sensor example

### DIFF
--- a/examples/worlds/gpu_lidar_sensor.sdf
+++ b/examples/worlds/gpu_lidar_sensor.sdf
@@ -22,6 +22,10 @@
       filename="gz-sim-scene-broadcaster-system"
       name="gz::sim::systems::SceneBroadcaster">
     </plugin>
+    <plugin
+      filename="gz-sim-user-commands-system"
+      name="gz::sim::systems::UserCommands">
+    </plugin>
 
     <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>


### PR DESCRIPTION
# 🦟 Bug fix

Related to #2478

## Summary

Adds the `UserCommands` to enable the transform tool.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
