### PR TITLE
Disable rendering tests that are failing on GitHub actions

### DIFF
--- a/test/integration/camera_video_record_system.cc
+++ b/test/integration/camera_video_record_system.cc
@@ -43,6 +43,15 @@ class CameraVideoRecorderTest : public InternalFixture<::testing::Test>
 /////////////////////////////////////////////////
 TEST_F(CameraVideoRecorderTest, GZ_UTILS_TEST_DISABLED_ON_MAC(RecordVideo))
 {
+  // This test fails on Github Actions. Skip it for now.
+  // Note: The GITHUB_ACTIONS environment variable is automatically set when
+  // running on Github Actions.
+  std::string githubAction;
+  if (common::env("GITHUB_ACTIONS", githubAction))
+  {
+    GTEST_SKIP();
+  }
+
   // Start server
   ServerConfig serverConfig;
   serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +

--- a/test/integration/distortion_camera.cc
+++ b/test/integration/distortion_camera.cc
@@ -69,6 +69,15 @@ void imageCb(const msgs::Image &_msg)
 TEST_F(DistortionCameraTest,
     GZ_UTILS_TEST_DISABLED_ON_MAC(DistortionCameraBox))
 {
+  // This test fails on Github Actions. Skip it for now.
+  // Note: The GITHUB_ACTIONS environment variable is automatically set when
+  // running on Github Actions.
+  std::string githubAction;
+  if (common::env("GITHUB_ACTIONS", githubAction))
+  {
+    GTEST_SKIP();
+  }
+
   // Start server
   ServerConfig serverConfig;
   const auto sdfFile = common::joinPaths(std::string(PROJECT_SOURCE_PATH),

--- a/test/integration/reset_sensors.cc
+++ b/test/integration/reset_sensors.cc
@@ -140,6 +140,15 @@ common::Image toImage(const msgs::Image &_msg)
 /// are removed and then added back
 TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
 {
+  // This test fails on Github Actions. Skip it for now.
+  // Note: The GITHUB_ACTIONS environment variable is automatically set when
+  // running on Github Actions.
+  std::string githubAction;
+  if (common::env("GITHUB_ACTIONS", githubAction))
+  {
+    GTEST_SKIP();
+  }
+
   gz::sim::ServerConfig serverConfig;
 
   const std::string sdfFile = common::joinPaths(PROJECT_SOURCE_PATH,

--- a/test/integration/shader_param_system.cc
+++ b/test/integration/shader_param_system.cc
@@ -62,6 +62,15 @@ void imageCb(const msgs::Image &_msg)
 // custom material shaders
 TEST_F(ShaderParamTest, GZ_UTILS_TEST_DISABLED_ON_MAC(ShaderParam))
 {
+  // This test fails on Github Actions. Skip it for now.
+  // Note: The GITHUB_ACTIONS environment variable is automatically set when
+  // running on Github Actions.
+  std::string githubAction;
+  if (common::env("GITHUB_ACTIONS", githubAction))
+  {
+    GTEST_SKIP();
+  }
+
   // Start server
   ServerConfig serverConfig;
   const auto sdfFile = common::joinPaths(std::string(PROJECT_SOURCE_PATH),

--- a/test/integration/wide_angle_camera.cc
+++ b/test/integration/wide_angle_camera.cc
@@ -63,6 +63,15 @@ void imageCb(const msgs::Image &_msg)
 // The test checks the Wide Angle Camera readings
 TEST_F(WideAngleCameraTest, GZ_UTILS_TEST_DISABLED_ON_MAC(WideAngleCameraBox))
 {
+  // This test fails on Github Actions. Skip it for now.
+  // Note: The GITHUB_ACTIONS environment variable is automatically set when
+  // running on Github Actions.
+  std::string githubAction;
+  if (common::env("GITHUB_ACTIONS", githubAction))
+  {
+    GTEST_SKIP();
+  }
+
   // Start server
   ServerConfig serverConfig;
   const auto sdfFile = common::joinPaths(std::string(PROJECT_SOURCE_PATH),


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

Follow-up to #2477, see https://github.com/gazebosim/gz-sim/pull/2477#pullrequestreview-2175792328. With xvfb enabled, more rendering tests are run and some of them are failing. This PR disables the failing tests.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

