### PR TITLE
Fix lidar visualization when gz_frame_id is specified

### DIFF
--- a/src/gui/plugins/visualize_lidar/VisualizeLidar.cc
+++ b/src/gui/plugins/visualize_lidar/VisualizeLidar.cc
@@ -82,9 +82,6 @@ inline namespace GZ_SIM_VERSION_NAMESPACE
     public: rendering::LidarVisualType visualType{
                             rendering::LidarVisualType::LVT_TRIANGLE_STRIPS};
 
-    /// \brief URI sequence to the lidar link
-    public: std::string lidarString{""};
-
     /// \brief LaserScan message from sensor
     public: msgs::LaserScan msg;
 
@@ -122,7 +119,7 @@ inline namespace GZ_SIM_VERSION_NAMESPACE
     public: bool visualDirty{false};
 
     /// \brief lidar sensor entity dirty flag
-    public: bool lidarEntityDirty{true};
+    public: bool lidarEntityDirty{false};
   };
 }
 }
@@ -264,65 +261,31 @@ void VisualizeLidar::Update(const UpdateInfo &,
 
   std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
 
+  if (this->dataPtr->topicName.empty())
+    return;
+
   if (this->dataPtr->lidarEntityDirty)
   {
-    auto lidarURIVec = common::split(common::trimmed(
-                  this->dataPtr->lidarString), "::");
-    if (lidarURIVec.size() > 0)
+    std::string topic = this->dataPtr->topicName;
+    auto lidarEnt =
+        _ecm.EntityByComponents(components::SensorTopic(topic));
+    if (lidarEnt == kNullEntity)
     {
-      auto baseEntity = _ecm.EntityByComponents(
-          components::Name(lidarURIVec[0]));
-      if (!baseEntity)
-      {
-        gzerr << "Error entity " << lidarURIVec[0]
-            << " doesn't exist and cannot be used to set lidar visual pose"
-            << std::endl;
-        return;
-      }
-      else
-      {
-        auto parent = baseEntity;
-        bool success = false;
-        for (size_t i = 0u; i < lidarURIVec.size()-1; i++)
-        {
-          auto children = _ecm.EntitiesByComponents(
-                            components::ParentEntity(parent));
-          bool foundChild = false;
-          for (auto child : children)
-          {
-            std::string nextstring = lidarURIVec[i+1];
-            auto comp = _ecm.Component<components::Name>(child);
-            if (!comp)
-            {
-              continue;
-            }
-            std::string childname = std::string(
-                            comp->Data());
-            if (nextstring.compare(childname) == 0)
-            {
-              parent = child;
-              foundChild = true;
-              if (i+1 == lidarURIVec.size()-1)
-              {
-                success = true;
-              }
-              break;
-            }
-          }
-          if (!foundChild)
-          {
-            gzerr << "The entity could not be found."
-                  << "Error displaying lidar visual" <<std::endl;
-            return;
-          }
-        }
-        if (success)
-        {
-          this->dataPtr->lidarEntity = parent;
-          this->dataPtr->lidarEntityDirty = false;
-        }
-      }
+      if (topic[0] == '/')
+        topic = topic.substr(1);
+      lidarEnt =
+        _ecm.EntityByComponents(components::SensorTopic(topic));
     }
+
+    if (lidarEnt == kNullEntity)
+    {
+      gzerr << "The lidar entity with topic '['" <<  this->dataPtr->topicName
+            << "'] could not be found. "
+            << "Error displaying lidar visual. " << std::endl;
+      return;
+    }
+    this->dataPtr->lidarEntity = lidarEnt;
+    this->dataPtr->lidarEntityDirty = false;
   }
 
   // Only update lidarPose if the lidarEntity exists and the lidar is
@@ -379,13 +342,17 @@ void VisualizeLidar::UpdateSize(int _size)
 //////////////////////////////////////////////////
 void VisualizeLidar::OnTopic(const QString &_topicName)
 {
+  std::string topic = _topicName.toStdString();
+  if (this->dataPtr->topicName == topic)
+    return;
+
   if (!this->dataPtr->topicName.empty() &&
       !this->dataPtr->node.Unsubscribe(this->dataPtr->topicName))
   {
     gzerr << "Unable to unsubscribe from topic ["
            << this->dataPtr->topicName <<"]" <<std::endl;
   }
-  this->dataPtr->topicName = _topicName.toStdString();
+  this->dataPtr->topicName = topic;
 
   std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
   // Reset visualization
@@ -401,6 +368,8 @@ void VisualizeLidar::OnTopic(const QString &_topicName)
   }
   this->dataPtr->visualDirty = false;
   gzmsg << "Subscribed to " << this->dataPtr->topicName << std::endl;
+
+  this->dataPtr->lidarEntityDirty = true;
 }
 
 //////////////////////////////////////////////////
@@ -489,27 +458,22 @@ void VisualizeLidar::OnScan(const msgs::LaserScan &_msg)
                                   this->dataPtr->msg.ranges().begin(),
                                   this->dataPtr->msg.ranges().end()));
 
-    this->dataPtr->visualDirty = true;
-
-    for (auto data_values : this->dataPtr->msg.header().data())
+    if (!math::equal(this->dataPtr->maxVisualRange,
+        this->dataPtr->msg.range_max()))
     {
-      if (data_values.key() == "frame_id")
-      {
-        if (this->dataPtr->lidarString.compare(
-                common::trimmed(data_values.value(0))) != 0)
-        {
-          this->dataPtr->lidarString = common::trimmed(data_values.value(0));
-          this->dataPtr->lidarEntityDirty = true;
-          this->dataPtr->maxVisualRange = this->dataPtr->msg.range_max();
-          this->dataPtr->minVisualRange = this->dataPtr->msg.range_min();
-          this->dataPtr->lidar->SetMaxRange(this->dataPtr->maxVisualRange);
-          this->dataPtr->lidar->SetMinRange(this->dataPtr->minVisualRange);
-          this->MinRangeChanged();
-          this->MaxRangeChanged();
-          break;
-        }
-      }
+      this->dataPtr->maxVisualRange = this->dataPtr->msg.range_max();
+      this->dataPtr->lidar->SetMaxRange(this->dataPtr->maxVisualRange);
+      this->MaxRangeChanged();
     }
+    if (!math::equal(this->dataPtr->minVisualRange,
+        this->dataPtr->msg.range_min()))
+    {
+      this->dataPtr->minVisualRange = this->dataPtr->msg.range_min();
+      this->dataPtr->lidar->SetMinRange(this->dataPtr->minVisualRange);
+      this->MinRangeChanged();
+    }
+
+    this->dataPtr->visualDirty = true;
   }
 }
 

--- a/src/gui/plugins/visualize_lidar/VisualizeLidar.cc
+++ b/src/gui/plugins/visualize_lidar/VisualizeLidar.cc
@@ -277,15 +277,28 @@ void VisualizeLidar::Update(const UpdateInfo &,
         _ecm.EntityByComponents(components::SensorTopic(topic));
     }
 
+    static bool informed{false};
     if (lidarEnt == kNullEntity)
     {
-      gzerr << "The lidar entity with topic '['" <<  this->dataPtr->topicName
-            << "'] could not be found. "
-            << "Error displaying lidar visual. " << std::endl;
+      if (!informed)
+      {
+        gzerr << "The lidar entity with topic '['" <<  this->dataPtr->topicName
+              << "'] could not be found. "
+              << "Error displaying lidar visual. " << std::endl;
+        informed = true;
+      }
       return;
     }
+    informed = false;
     this->dataPtr->lidarEntity = lidarEnt;
     this->dataPtr->lidarEntityDirty = false;
+  }
+
+  if (!_ecm.HasEntity(this->dataPtr->lidarEntity))
+  {
+    this->dataPtr->resetVisual = true;
+    this->dataPtr->topicName = "";
+    return;
   }
 
   // Only update lidarPose if the lidarEntity exists and the lidar is
@@ -295,7 +308,7 @@ void VisualizeLidar::Update(const UpdateInfo &,
   // data arrives, the visual is offset from the obstacle if the sensor is
   // moving fast.
   if (!this->dataPtr->lidarEntityDirty && this->dataPtr->initialized &&
-                                          !this->dataPtr->visualDirty)
+      !this->dataPtr->visualDirty)
   {
     this->dataPtr->lidarPose = worldPose(this->dataPtr->lidarEntity, _ecm);
   }


### PR DESCRIPTION


# 🦟 Bug fix



## Summary

The lidar visualization plugin has an assumption that the `frame_id` in the lidar scan msg is the name of the lidar sensor and uses this to find the lidar entity in the ECM. With the changes in https://github.com/gazebosim/gz-sensors/pull/447, this is no longer true. The lidar scan msg's `frame_id` is now correctly set to `<gz_frame_id>` or the sensor name if `gz_frame_id` is not supplied. This PR fixes lidar visualization by finding the lidar entity based on the subscribed topic name.

manually tested using [gpu_lidar_sensor.sdf](https://github.com/gazebosim/gz-sim/blob/gz-sim8/examples/worlds/gpu_lidar_sensor.sdf) by adding ` <gz_frame_id`> to the lidar sensor and verifying lidar visualization still works:

<details><summary>gpu_lidar_sensor.patch</summary>

```diff
diff --git a/examples/worlds/gpu_lidar_sensor.sdf b/examples/worlds/gpu_lidar_sensor.sdf
index 756de3eb3..8a7781f8c 100644
--- a/examples/worlds/gpu_lidar_sensor.sdf
+++ b/examples/worlds/gpu_lidar_sensor.sdf
@@ -139,6 +139,7 @@
         </visual>
 
         <sensor name='gpu_lidar' type='gpu_lidar'>
+          <gz_frame_id>my_lidar_frame_id</gz_frame_id>
           <topic>lidar</topic>
           <update_rate>10</update_rate>
           <lidar>

```

</details>

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

