### PR TITLE
dontmerge: test graph init changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# DONT MERGE: testing revert of gz-math graph init changes
+
 # Gazebo Sim : A Robotic Simulator
 
 **Maintainer:** michael AT openrobotics DOT org

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DONT MERGE: testing revert of gz-math graph init changes
+# DONT MERGE: testing reapplying fix for gz-math graph init
 
 # Gazebo Sim : A Robotic Simulator
 


### PR DESCRIPTION
Testing if reverting https://github.com/gazebosim/gz-math/pull/606 and https://github.com/gazebosim/sdformat/pull/1458 fixes the gz-sim test failures on macOS / homebrew discussed in https://github.com/osrf/buildfarm-tools/issues/67#issuecomment-2232120738 and https://github.com/gazebosim/gz-sim/pull/2232#issuecomment-2232062040.

Uses the `ci_matching_branch/` trick with https://github.com/osrf/homebrew-simulation/commit/6bdfaea6c9b5a30fed163c619e1f398b31937514