### PR TITLE
Specify System::PreUpdate, Update execution order

### DIFF
--- a/examples/plugin/priority_printer_plugin/CMakeLists.txt
+++ b/examples/plugin/priority_printer_plugin/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
+
+find_package(gz-cmake4 REQUIRED)
+
+project(Priority_printer)
+
+gz_find_package(gz-plugin3 REQUIRED COMPONENTS register)
+set(GZ_PLUGIN_VER ${gz-plugin3_VERSION_MAJOR})
+
+gz_find_package(gz-sim9 REQUIRED)
+set(GZ_SIM_VER ${gz-sim9_VERSION_MAJOR})
+
+add_library(PriorityPrinter SHARED PriorityPrinter.cc)
+set_property(TARGET PriorityPrinter PROPERTY CXX_STANDARD 17)
+target_link_libraries(PriorityPrinter
+  PRIVATE gz-plugin${GZ_PLUGIN_VER}::gz-plugin${GZ_PLUGIN_VER}
+  PRIVATE gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER})

--- a/examples/plugin/priority_printer_plugin/PriorityPrinter.cc
+++ b/examples/plugin/priority_printer_plugin/PriorityPrinter.cc
@@ -17,6 +17,7 @@
 
 // We'll use a string and the gzmsg command below for a brief example.
 // Remove these includes if your plugin doesn't need them.
+#include <memory>
 #include <string>
 #include <gz/common/Console.hh>
 

--- a/examples/plugin/priority_printer_plugin/PriorityPrinter.cc
+++ b/examples/plugin/priority_printer_plugin/PriorityPrinter.cc
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+// We'll use a string and the gzmsg command below for a brief example.
+// Remove these includes if your plugin doesn't need them.
+#include <string>
+#include <gz/common/Console.hh>
+
+// This header is required to register plugins. It's good practice to place it
+// in the cc file, like it's done here.
+#include <gz/plugin/Register.hh>
+
+// Don't forget to include the plugin's header.
+#include "PriorityPrinter.hh"
+
+// This is required to register the plugin. Make sure the interfaces match
+// what's in the header.
+GZ_ADD_PLUGIN(
+    priority_printer::PriorityPrinter,
+    gz::sim::System,
+    priority_printer::PriorityPrinter::ISystemConfigure,
+    priority_printer::PriorityPrinter::ISystemPreUpdate,
+    priority_printer::PriorityPrinter::ISystemUpdate)
+
+using namespace priority_printer;
+
+void PriorityPrinter::Configure(
+        const gz::sim::Entity &_entity,
+        const std::shared_ptr<const sdf::Element> &_sdf,
+        gz::sim::EntityComponentManager &_ecm,
+        gz::sim::EventManager &_eventMgr)
+{
+  // Parse priority value as a string for printing
+  const std::string priorityElementName {gz::sim::System::kPriorityElementName};
+  if (_sdf && _sdf->HasElement(priorityElementName))
+  {
+    this->systemPriority = _sdf->Get<std::string>(priorityElementName);
+  }
+
+  const std::string labelElementName {"label"};
+  if (_sdf && _sdf->HasElement(labelElementName))
+  {
+    this->systemLabel = _sdf->Get<std::string>(labelElementName);
+  }
+}
+
+void PriorityPrinter::PreUpdate(const gz::sim::UpdateInfo &_info,
+    gz::sim::EntityComponentManager &/*_ecm*/)
+{
+  gzmsg << "PreUpdate: "
+        << "Iteration " << _info.iterations
+        << ", system priority " << this->systemPriority
+        << ", system label " << this->systemLabel
+        << '\n';
+}
+
+void PriorityPrinter::Update(const gz::sim::UpdateInfo &_info,
+    gz::sim::EntityComponentManager &/*_ecm*/)
+{
+  gzmsg << "Update: "
+        << "Iteration " << _info.iterations
+        << ", system priority " << this->systemPriority
+        << ", system label " << this->systemLabel
+        << '\n';
+}

--- a/examples/plugin/priority_printer_plugin/PriorityPrinter.hh
+++ b/examples/plugin/priority_printer_plugin/PriorityPrinter.hh
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef EXAMPLE_PLUGIN_PRIORITYPRINTER_HH_
+#define EXAMPLE_PLUGIN_PRIORITYPRINTER_HH_
+
+#include <string>
+#include <gz/sim/System.hh>
+
+namespace priority_printer
+{
+  // This plugin prints the number of elapsed simulation iterations,
+  // this system's priority value from the XML configuration,
+  // and a custom label from the XML configuration during the Update callback.
+  class PriorityPrinter:
+    public gz::sim::System,
+    public gz::sim::ISystemConfigure,
+    public gz::sim::ISystemPreUpdate,
+    public gz::sim::ISystemUpdate
+  {
+    public: void Configure(const gz::sim::Entity &_entity,
+                 const std::shared_ptr<const sdf::Element> &_sdf,
+                 gz::sim::EntityComponentManager &_ecm,
+                 gz::sim::EventManager &_eventMgr) override;
+
+    public: void PreUpdate(const gz::sim::UpdateInfo &_info,
+                           gz::sim::EntityComponentManager &_ecm) override;
+
+    public: void Update(const gz::sim::UpdateInfo &_info,
+                        gz::sim::EntityComponentManager &_ecm) override;
+
+    public: std::string systemPriority{"unset"};
+    public: std::string systemLabel{"unset"};
+  };
+}
+#endif

--- a/examples/plugin/priority_printer_plugin/PriorityPrinter.hh
+++ b/examples/plugin/priority_printer_plugin/PriorityPrinter.hh
@@ -18,6 +18,7 @@
 #ifndef EXAMPLE_PLUGIN_PRIORITYPRINTER_HH_
 #define EXAMPLE_PLUGIN_PRIORITYPRINTER_HH_
 
+#include <memory>
 #include <string>
 #include <gz/sim/System.hh>
 

--- a/examples/plugin/priority_printer_plugin/README.md
+++ b/examples/plugin/priority_printer_plugin/README.md
@@ -1,7 +1,14 @@
 # Priority Printer
 
 This example illustrates how to control the order of execution of System
-PreUpdate and Update callbacks.
+PreUpdate and Update callbacks. As documented in
+[gz/sim/System.hh](https://github.com/gazebosim/gz-sim/tree/main/include/gz/sim/System.hh),
+the PreUpdate and Update phases are executed sequentially in the same
+thread, and the order of execution of these phases can be
+controlled by specifying a signed integer priority value for the System
+in its XML configuration. The default priority value is zero, and
+smaller values are executed earlier. Systems with the same priority
+value are executed in the order in which they are loaded.
 
 ## Build
 
@@ -19,9 +26,15 @@ This will generate the `PriorityPrinter` library under `build`.
 
 ## Run
 
-Multiple instances of the `PriorityPrinter` plugin are added to the world
-with various priority values and unique labels in the
-`priority_printer_plugin.sdf` file that's going to be loaded.
+Multiple instances of the `PriorityPrinter` plugin are added to the
+[priority\_printer\_plugin.sdf](priority_printer_plugin.sdf) world file
+with various priority values and unique labels corresponding to the order
+in which the plugins are specified ("first" for the first plugin and so on).
+Without priority values, the systems would be executed in the order they are
+specified in XML ("first", then "second", etc.).
+With the priority values specified, the systems with smallest integer priority
+values are executed first. For systems with the same priority value, the
+system that is specified earlier in the XML file will be executed first.
 
 Before starting Gazebo, we must make sure it can find the plugin by doing:
 
@@ -34,7 +47,12 @@ Then load the example world and run for 5 iterations:
 
     gz sim -v 3 priority_printer_plugin.sdf -s -r --iterations 5
 
-You should see green messages on the terminal like:
+You should see green messages on the terminal like those given below.
+Note that the system with priority `-100` was executed first, despite being
+the fifth system in the XML ordering. There are two instances of systems with
+the same priority value: the fourth and sixth systems with priority 0 (with
+"unset" defaulting to 0) and the first and seventh systems with priority 100.
+In each case, the system declared earlier in XML executed first.
 
 ```
 [Msg] PreUpdate: Iteration 1, system priority -100, system label fifth

--- a/examples/plugin/priority_printer_plugin/README.md
+++ b/examples/plugin/priority_printer_plugin/README.md
@@ -1,7 +1,7 @@
 # Priority Printer
 
 This example illustrates how to control the order of execution of System
-Update callbacks.
+PreUpdate and Update callbacks.
 
 ## Build
 
@@ -30,7 +30,7 @@ cd gz-sim/examples/plugins/priority_printer
 export GZ_SIM_SYSTEM_PLUGIN_PATH=`pwd`/build
 ~~~
 
-Then load the example world:
+Then load the example world and run for 5 iterations:
 
     gz sim -v 3 priority_printer_plugin.sdf -s -r --iterations 5
 

--- a/examples/plugin/priority_printer_plugin/README.md
+++ b/examples/plugin/priority_printer_plugin/README.md
@@ -1,0 +1,110 @@
+# Priority Printer
+
+This example illustrates how to control the order of execution of System
+Update callbacks.
+
+## Build
+
+From the root of the `gz-sim` repository, do the following to build the example:
+
+~~~
+cd gz-sim/examples/plugins/priority_printer
+mkdir build
+cd build
+cmake ..
+make
+~~~
+
+This will generate the `PriorityPrinter` library under `build`.
+
+## Run
+
+Multiple instances of the `PriorityPrinter` plugin are added to the world
+with various priority values and unique labels in the
+`priority_printer_plugin.sdf` file that's going to be loaded.
+
+Before starting Gazebo, we must make sure it can find the plugin by doing:
+
+~~~
+cd gz-sim/examples/plugins/priority_printer
+export GZ_SIM_SYSTEM_PLUGIN_PATH=`pwd`/build
+~~~
+
+Then load the example world:
+
+    gz sim -v 3 priority_printer_plugin.sdf -s -r --iterations 5
+
+You should see green messages on the terminal like:
+
+```
+[Msg] PreUpdate: Iteration 1, system priority -100, system label fifth
+[Msg] PreUpdate: Iteration 1, system priority -10, system label third
+[Msg] PreUpdate: Iteration 1, system priority unset, system label fourth
+[Msg] PreUpdate: Iteration 1, system priority 0, system label sixth
+[Msg] PreUpdate: Iteration 1, system priority 10, system label second
+[Msg] PreUpdate: Iteration 1, system priority 100, system label first
+[Msg] PreUpdate: Iteration 1, system priority 100, system label seventh
+[Msg] Update: Iteration 1, system priority -100, system label fifth
+[Msg] Update: Iteration 1, system priority -10, system label third
+[Msg] Update: Iteration 1, system priority unset, system label fourth
+[Msg] Update: Iteration 1, system priority 0, system label sixth
+[Msg] Update: Iteration 1, system priority 10, system label second
+[Msg] Update: Iteration 1, system priority 100, system label first
+[Msg] Update: Iteration 1, system priority 100, system label seventh
+[Msg] PreUpdate: Iteration 2, system priority -100, system label fifth
+[Msg] PreUpdate: Iteration 2, system priority -10, system label third
+[Msg] PreUpdate: Iteration 2, system priority unset, system label fourth
+[Msg] PreUpdate: Iteration 2, system priority 0, system label sixth
+[Msg] PreUpdate: Iteration 2, system priority 10, system label second
+[Msg] PreUpdate: Iteration 2, system priority 100, system label first
+[Msg] PreUpdate: Iteration 2, system priority 100, system label seventh
+[Msg] Update: Iteration 2, system priority -100, system label fifth
+[Msg] Update: Iteration 2, system priority -10, system label third
+[Msg] Update: Iteration 2, system priority unset, system label fourth
+[Msg] Update: Iteration 2, system priority 0, system label sixth
+[Msg] Update: Iteration 2, system priority 10, system label second
+[Msg] Update: Iteration 2, system priority 100, system label first
+[Msg] Update: Iteration 2, system priority 100, system label seventh
+[Msg] PreUpdate: Iteration 3, system priority -100, system label fifth
+[Msg] PreUpdate: Iteration 3, system priority -10, system label third
+[Msg] PreUpdate: Iteration 3, system priority unset, system label fourth
+[Msg] PreUpdate: Iteration 3, system priority 0, system label sixth
+[Msg] PreUpdate: Iteration 3, system priority 10, system label second
+[Msg] PreUpdate: Iteration 3, system priority 100, system label first
+[Msg] PreUpdate: Iteration 3, system priority 100, system label seventh
+[Msg] Update: Iteration 3, system priority -100, system label fifth
+[Msg] Update: Iteration 3, system priority -10, system label third
+[Msg] Update: Iteration 3, system priority unset, system label fourth
+[Msg] Update: Iteration 3, system priority 0, system label sixth
+[Msg] Update: Iteration 3, system priority 10, system label second
+[Msg] Update: Iteration 3, system priority 100, system label first
+[Msg] Update: Iteration 3, system priority 100, system label seventh
+[Msg] PreUpdate: Iteration 4, system priority -100, system label fifth
+[Msg] PreUpdate: Iteration 4, system priority -10, system label third
+[Msg] PreUpdate: Iteration 4, system priority unset, system label fourth
+[Msg] PreUpdate: Iteration 4, system priority 0, system label sixth
+[Msg] PreUpdate: Iteration 4, system priority 10, system label second
+[Msg] PreUpdate: Iteration 4, system priority 100, system label first
+[Msg] PreUpdate: Iteration 4, system priority 100, system label seventh
+[Msg] Update: Iteration 4, system priority -100, system label fifth
+[Msg] Update: Iteration 4, system priority -10, system label third
+[Msg] Update: Iteration 4, system priority unset, system label fourth
+[Msg] Update: Iteration 4, system priority 0, system label sixth
+[Msg] Update: Iteration 4, system priority 10, system label second
+[Msg] Update: Iteration 4, system priority 100, system label first
+[Msg] Update: Iteration 4, system priority 100, system label seventh
+[Msg] PreUpdate: Iteration 5, system priority -100, system label fifth
+[Msg] PreUpdate: Iteration 5, system priority -10, system label third
+[Msg] PreUpdate: Iteration 5, system priority unset, system label fourth
+[Msg] PreUpdate: Iteration 5, system priority 0, system label sixth
+[Msg] PreUpdate: Iteration 5, system priority 10, system label second
+[Msg] PreUpdate: Iteration 5, system priority 100, system label first
+[Msg] PreUpdate: Iteration 5, system priority 100, system label seventh
+[Msg] Update: Iteration 5, system priority -100, system label fifth
+[Msg] Update: Iteration 5, system priority -10, system label third
+[Msg] Update: Iteration 5, system priority unset, system label fourth
+[Msg] Update: Iteration 5, system priority 0, system label sixth
+[Msg] Update: Iteration 5, system priority 10, system label second
+[Msg] Update: Iteration 5, system priority 100, system label first
+[Msg] Update: Iteration 5, system priority 100, system label seventh
+```

--- a/examples/plugin/priority_printer_plugin/priority_printer_plugin.sdf
+++ b/examples/plugin/priority_printer_plugin/priority_printer_plugin.sdf
@@ -1,0 +1,36 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="default">
+    <!--
+      System plugins can be loaded from <plugin> tags attached to entities like
+      the world, models, visuals, etc.
+    -->
+    <plugin filename="PriorityPrinter" name="priority_printer::PriorityPrinter">
+      <gz:system_priority>100</gz:system_priority>
+      <label>first</label>
+    </plugin>
+    <plugin filename="PriorityPrinter" name="priority_printer::PriorityPrinter">
+      <gz:system_priority>10</gz:system_priority>
+      <label>second</label>
+    </plugin>
+    <plugin filename="PriorityPrinter" name="priority_printer::PriorityPrinter">
+      <gz:system_priority>-10</gz:system_priority>
+      <label>third</label>
+    </plugin>
+    <plugin filename="PriorityPrinter" name="priority_printer::PriorityPrinter">
+      <label>fourth</label>
+    </plugin>
+    <plugin filename="PriorityPrinter" name="priority_printer::PriorityPrinter">
+      <gz:system_priority>-100</gz:system_priority>
+      <label>fifth</label>
+    </plugin>
+    <plugin filename="PriorityPrinter" name="priority_printer::PriorityPrinter">
+      <gz:system_priority>0</gz:system_priority>
+      <label>sixth</label>
+    </plugin>
+    <plugin filename="PriorityPrinter" name="priority_printer::PriorityPrinter">
+      <gz:system_priority>100</gz:system_priority>
+      <label>seventh</label>
+    </plugin>
+  </world>
+</sdf>

--- a/include/gz/sim/System.hh
+++ b/include/gz/sim/System.hh
@@ -64,6 +64,14 @@ namespace gz
     ///    * Used to read out results at the end of a simulation step to be used
     ///      for sensor or controller updates.
     ///
+    /// The PreUpdate and Update phases are executed sequentially in the same
+    /// thread, while the PostUpdate phase is executed in parallel in multiple
+    /// threads. The order of execution of PreUpdate and Update phases can be
+    /// controlled by specifying a signed integer Priority value for the System
+    /// in its XML configuration. The default Priority value is zero, and
+    /// smaller values are executed earlier. Systems with the same Priority
+    /// value are executed in the order in which they are loaded.
+    ///
     /// It's important to note that UpdateInfo::simTime does not refer to the
     /// current time, but the time reached after the PreUpdate and Update calls
     /// have finished. So, if any of the *Update functions are called with
@@ -74,6 +82,19 @@ namespace gz
     /// simulation is started un-paused.
     class System
     {
+      /// \brief Signed integer type used for specifying priority of the
+      /// execution order of PreUpdate and Update phases.
+      public: using PriorityType = int32_t;
+
+      /// \brief Default priority value for execution order of the PreUpdate
+      /// and Update phases.
+      public: constexpr static PriorityType kDefaultPriority = {0};
+
+      /// \brief Name of the XML element from which the priority value will be
+      /// parsed.
+      public: constexpr static std::string_view kPriorityElementName =
+          {"gz:system_priority"};
+
       /// \brief Constructor
       public: System() = default;
 

--- a/include/gz/sim/System.hh
+++ b/include/gz/sim/System.hh
@@ -17,6 +17,7 @@
 #ifndef GZ_SIM_SYSTEM_HH_
 #define GZ_SIM_SYSTEM_HH_
 
+#include <cstdint>
 #include <memory>
 
 #include <gz/sim/config.hh>

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -601,14 +601,24 @@ void SimulationRunner::UpdateSystems()
 
   {
     GZ_PROFILE("PreUpdate");
-    for (auto& system : this->systemMgr->SystemsPreUpdate())
-      system->PreUpdate(this->currentInfo, this->entityCompMgr);
+    for (auto& [priority, systems] : this->systemMgr->SystemsPreUpdate())
+    {
+      for (auto& system : systems)
+      {
+        system->PreUpdate(this->currentInfo, this->entityCompMgr);
+      }
+    }
   }
 
   {
     GZ_PROFILE("Update");
-    for (auto& system : this->systemMgr->SystemsUpdate())
-      system->Update(this->currentInfo, this->entityCompMgr);
+    for (auto& [priority, systems] : this->systemMgr->SystemsUpdate())
+    {
+      for (auto& system : systems)
+      {
+        system->Update(this->currentInfo, this->entityCompMgr);
+      }
+    }
   }
 
   {

--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -514,25 +514,35 @@ void SystemManager::ProcessRemovedEntities(
       }
       return false;
     });
-  for (auto& [priority, systemsVector] : this->systemsPreupdate)
+  for (auto it = this->systemsPreupdate.begin();
+            it != this->systemsPreupdate.end();)
   {
-    RemoveFromVectorIf(systemsVector,
+    RemoveFromVectorIf(it->second,
       [&](const auto& system) {
         if (preupdateSystemsToBeRemoved.count(system)) {
           return true;
         }
         return false;
       });
+    if (it->second.empty())
+      it = this->systemsPreupdate.erase(it);
+    else
+      ++it;
   }
-  for (auto& [priority, systemsVector] : this->systemsUpdate)
+  for (auto it = this->systemsUpdate.begin();
+            it != this->systemsUpdate.end();)
   {
-    RemoveFromVectorIf(systemsVector,
+    RemoveFromVectorIf(it->second,
       [&](const auto& system) {
         if (updateSystemsToBeRemoved.count(system)) {
           return true;
         }
         return false;
       });
+    if (it->second.empty())
+      it = this->systemsUpdate.erase(it);
+    else
+      ++it;
   }
 
   RemoveFromVectorIf(this->systemsPostupdate,

--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -513,9 +513,9 @@ void SystemManager::ProcessRemovedEntities(
       }
       return false;
     });
-  for (auto& [priority, systems] : this->systemsPreupdate)
+  for (auto& [priority, systemsVector] : this->systemsPreupdate)
   {
-    RemoveFromVectorIf(systems,
+    RemoveFromVectorIf(systemsVector,
       [&](const auto& system) {
         if (preupdateSystemsToBeRemoved.count(system)) {
           return true;
@@ -523,9 +523,9 @@ void SystemManager::ProcessRemovedEntities(
         return false;
       });
   }
-  for (auto& [priority, systems] : this->systemsUpdate)
+  for (auto& [priority, systemsVector] : this->systemsUpdate)
   {
-    RemoveFromVectorIf(systems,
+    RemoveFromVectorIf(systemsVector,
       [&](const auto& system) {
         if (updateSystemsToBeRemoved.count(system)) {
           return true;

--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -18,6 +18,7 @@
 #include <list>
 #include <mutex>
 #include <set>
+#include <string>
 #include <unordered_set>
 
 #include <gz/common/StringUtils.hh>

--- a/src/SystemManager.hh
+++ b/src/SystemManager.hh
@@ -19,6 +19,8 @@
 
 #include <gz/msgs/entity_plugin_v.pb.h>
 
+#include <cstdint>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -29,6 +31,7 @@
 #include "gz/sim/config.hh"
 #include "gz/sim/EntityComponentManager.hh"
 #include "gz/sim/Export.hh"
+#include "gz/sim/System.hh"
 #include "gz/sim/SystemLoader.hh"
 #include "gz/sim/Types.hh"
 
@@ -44,6 +47,13 @@ namespace gz
     /// \brief Used to load / unload sysetms as well as iterate over them.
     class GZ_SIM_VISIBLE SystemManager
     {
+      /// \brief Ordered map of priority values to a vector of System
+      /// interfaces.
+      using PriorityType = System::PriorityType;
+      template<typename S>
+      class PrioritizedSystems : public std::map<PriorityType, std::vector<S>>
+      {};
+
       /// \brief Constructor
       /// \param[in] _systemLoader A pointer to a SystemLoader to load plugins
       ///  from files
@@ -116,29 +126,31 @@ namespace gz
       /// \return Vector of systems' configure interfaces.
       public: const std::vector<ISystemConfigure *>& SystemsConfigure();
 
-      /// \brief Get an vector of all active systems implementing
+      /// \brief Get a vector of all active systems implementing
       ///   "ConfigureParameters"
       /// \return Vector of systems's configure interfaces.
       public: const std::vector<ISystemConfigureParameters *>&
       SystemsConfigureParameters();
 
-      /// \brief Get an vector of all active systems implementing "Reset"
+      /// \brief Get a vector of all active systems implementing "Reset"
       /// \return Vector of systems' reset interfaces.
       public: const std::vector<ISystemReset *>& SystemsReset();
 
-      /// \brief Get an vector of all active systems implementing "PreUpdate"
-      /// \return Vector of systems's pre-update interfaces.
-      public: const std::vector<ISystemPreUpdate *>& SystemsPreUpdate();
+      /// \brief Get an ordered map of systems by priority that implement
+      /// "PreUpdate"
+      /// \return Priortized map of systems's pre-update interfaces.
+      public: const PrioritizedSystems<ISystemPreUpdate *>& SystemsPreUpdate();
 
-      /// \brief Get an vector of all active systems implementing "Update"
-      /// \return Vector of systems's update interfaces.
-      public: const std::vector<ISystemUpdate *>& SystemsUpdate();
+      /// \brief Get an ordered map of systems by priority that implement
+      /// "Update"
+      /// \return Priortized map of systems's update interfaces.
+      public: const PrioritizedSystems<ISystemUpdate *>& SystemsUpdate();
 
-      /// \brief Get an vector of all active systems implementing "PostUpdate"
+      /// \brief Get a vector of all active systems implementing "PostUpdate"
       /// \return Vector of systems's post-update interfaces.
       public: const std::vector<ISystemPostUpdate *>& SystemsPostUpdate();
 
-      /// \brief Get an vector of all systems attached to a given entity.
+      /// \brief Get a vector of all systems attached to a given entity.
       /// \return Vector of systems.
       public: std::vector<SystemInternal> TotalByEntity(Entity _entity);
 
@@ -205,10 +217,10 @@ namespace gz
       private: std::vector<ISystemReset *> systemsReset;
 
       /// \brief Systems implementing PreUpdate
-      private: std::vector<ISystemPreUpdate *> systemsPreupdate;
+      private: PrioritizedSystems<ISystemPreUpdate *> systemsPreupdate;
 
       /// \brief Systems implementing Update
-      private: std::vector<ISystemUpdate *> systemsUpdate;
+      private: PrioritizedSystems<ISystemUpdate *> systemsUpdate;
 
       /// \brief Systems implementing PostUpdate
       private: std::vector<ISystemPostUpdate *> systemsPostupdate;

--- a/src/SystemManager_TEST.cc
+++ b/src/SystemManager_TEST.cc
@@ -143,8 +143,14 @@ TEST(SystemManager, AddSystemNoEcm)
   EXPECT_EQ(0u, systemMgr.PendingCount());
   EXPECT_EQ(2u, systemMgr.TotalCount());
   EXPECT_EQ(1u, systemMgr.SystemsConfigure().size());
+  // Expect PreUpdate and Update to contain one map entry with Priority 0 and
+  // a vector of length 1.
   EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().size());
+  EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().count(0));
+  EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().at(0).size());
   EXPECT_EQ(1u, systemMgr.SystemsUpdate().size());
+  EXPECT_EQ(1u, systemMgr.SystemsUpdate().count(0));
+  EXPECT_EQ(1u, systemMgr.SystemsUpdate().at(0).size());
   EXPECT_EQ(1u, systemMgr.SystemsPostUpdate().size());
   EXPECT_EQ(1u, systemMgr.TotalByEntity(updateEntity).size());
 }


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebosim/gz-sim/issues/2268 and https://github.com/gazebosim/gz-sim/issues/2391, second attempt at https://github.com/gazebosim/gz-sim/pull/2394

## Summary

While the `PreUpdate`, `Update`, and `PostUpdate` phases of gz-sim systems allow some control over the order in which code is executed, there are cases in which more control is desired. For example, as noted in #2268 and https://github.com/gazebosim/gz-sim/issues/2391, sensor systems currently update their data during `PostUpdate` (after the `Update` step of the physics system) but can't write their data to the ECM since `PostUpdate` has read-only access to the ECM. Moving sensor updates to `Update` would allow writing to the ECM, but would require ensuring that the sensor systems execute their `Update` step after the physics `Update`. Alternatively, if one wanted to implement a hierarchical cascade of systems acting on data sequentially, rather than adding `PrePreUpdate` and `PrePrePreUpdate` phases, one could specify the system priority during `PreUpdate` for the relevant systems instead.

This feature is used by specifying an integer value in a `<gz:system_priority>` tag for a system that will control the order in which System `PreUpdate` and `Update` callbacks are executed, with smaller priority values executing first.

## Test it

Follow the README instructions to build and run the `PriorityPrinter` example plugin to illustrate the feature.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [X] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
