### PR TITLE
Fix error resolving gazebo classic material when loading world

### DIFF
--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -85,6 +85,7 @@
 #include "gz/sim/components/World.hh"
 
 #include "rendering/MaterialParser/MaterialParser.hh"
+#include "ServerPrivate.hh"
 
 class gz::sim::SdfEntityCreatorPrivate
 {
@@ -808,7 +809,8 @@ Entity SdfEntityCreator::CreateEntities(const sdf::Visual *_visual)
       "https://gazebosim.org/api/sim/8/migrationsdf.html#:~:text=Materials " <<
       "for details." << std::endl;
       std::string scriptUri = visualMaterial.ScriptUri();
-      if (scriptUri != "file://media/materials/scripts/gazebo.material") {
+      if (scriptUri != ServerPrivate::kClassicMaterialScriptUri)
+      {
         gzwarn << "Custom material scripts are not supported."
           << std::endl;
       }

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -159,7 +159,8 @@ Server::Server(const ServerConfig &_config)
       // 'src/gui_main.cc'.
       errors = sdfRoot.Load(filePath, sdfParserConfig);
       if (errors.empty() || _config.BehaviorOnSdfErrors() !=
-          ServerConfig::SdfErrorBehavior::EXIT_IMMEDIATELY) {
+          ServerConfig::SdfErrorBehavior::EXIT_IMMEDIATELY)
+      {
         if (sdfRoot.Model() == nullptr) {
           this->dataPtr->sdfRoot = std::move(sdfRoot);
         }

--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -37,7 +37,7 @@
 using namespace gz;
 using namespace sim;
 
-const std::string ServerPrivate::kClassicMaterialScriptUri =
+const char ServerPrivate::kClassicMaterialScriptUri[] =
     "file://media/materials/scripts/gazebo.material";
 
 /// \brief This struct provides access to the record plugin SDF string

--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -549,8 +549,8 @@ bool ServerPrivate::ResourcePathsResolveService(
 //////////////////////////////////////////////////
 std::string ServerPrivate::FetchResource(const std::string &_uri)
 {
-  // Check if it is a gazebo classic material URI
-  // Return original URI string. The MaterialParser will handle this URI.
+  // Handle gazebo classic material URIs.
+  // Return original URI string as the SdfEntityCreator checks for this URI
   if (_uri == kClassicMaterialScriptUri)
     return _uri;
 

--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -37,6 +37,9 @@
 using namespace gz;
 using namespace sim;
 
+const std::string ServerPrivate::kClassicMaterialScriptUri =
+    "file://media/materials/scripts/gazebo.material";
+
 /// \brief This struct provides access to the record plugin SDF string
 struct LoggingPlugin
 {
@@ -546,6 +549,12 @@ bool ServerPrivate::ResourcePathsResolveService(
 //////////////////////////////////////////////////
 std::string ServerPrivate::FetchResource(const std::string &_uri)
 {
+  // Check if it is a gazebo classic material URI
+  // Return original URI string. The MaterialParser will handle this URI.
+  if (_uri == kClassicMaterialScriptUri)
+    return _uri;
+
+  // Fetch resource from fuel
   auto path =
       fuel_tools::fetchResourceWithClient(_uri, *this->fuelClient.get());
 

--- a/src/ServerPrivate.hh
+++ b/src/ServerPrivate.hh
@@ -188,8 +188,8 @@ namespace gz
       public: std::unordered_map<std::string, std::string> fuelUriMap;
 
       /// \brief Gazebo classic material URI string
-      /// Only gazebo classic material script uri matching this still will be
-      /// migrated to gz.
+      /// A URI matching this string indicates that it is a gazebo classic
+      /// material.
       public: static const std::string kClassicMaterialScriptUri;
 
       /// \brief List of names for all worlds loaded in this server.

--- a/src/ServerPrivate.hh
+++ b/src/ServerPrivate.hh
@@ -187,6 +187,11 @@ namespace gz
       /// Server. It is used in the SDFormat world generator when saving worlds
       public: std::unordered_map<std::string, std::string> fuelUriMap;
 
+      /// \brief Gazebo classic material URI string
+      /// Only gazebo classic material script uri matching this still will be
+      /// migrated to gz.
+      public: static const std::string kClassicMaterialScriptUri;
+
       /// \brief List of names for all worlds loaded in this server.
       private: std::vector<std::string> worldNames;
 

--- a/src/ServerPrivate.hh
+++ b/src/ServerPrivate.hh
@@ -190,7 +190,7 @@ namespace gz
       /// \brief Gazebo classic material URI string
       /// A URI matching this string indicates that it is a gazebo classic
       /// material.
-      public: static const std::string kClassicMaterialScriptUri;
+      public: static const char kClassicMaterialScriptUri[];
 
       /// \brief List of names for all worlds loaded in this server.
       private: std::vector<std::string> worldNames;

--- a/test/integration/material.cc
+++ b/test/integration/material.cc
@@ -296,3 +296,30 @@ TEST_F(MaterialTest, InvalidColor)
   EXPECT_EQ(math::Color(0.0f, 0.0f, 0.0f, 1.0f),
             boxVisualComp->Data().Specular());
 }
+
+TEST_F(MaterialTest, WorldWithClassicMaterial)
+{
+  ServerConfig serverConfig;
+  serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
+      "test/worlds/classic_material.sdf"));
+
+  std::cout << "Loading: " << serverConfig.SdfFile() << std::endl;
+  this->StartServer(serverConfig);
+
+  auto model = this->GetModel("box");
+  ASSERT_TRUE(model.Valid(*this->ecm));
+
+  auto boxVisualEntity =
+    this->ecm->EntityByComponents(components::Name("box_visual"));
+  ASSERT_NE(kNullEntity, boxVisualEntity);
+
+  // Blue color
+  auto boxVisualComp =
+    this->ecm->Component<components::Material>(boxVisualEntity);
+  EXPECT_EQ(math::Color(0.0f, 0.0f, 1.0f, 1.0f),
+            boxVisualComp->Data().Ambient());
+  EXPECT_EQ(math::Color(0.0f, 0.0f, 1.0f, 1.0f),
+            boxVisualComp->Data().Diffuse());
+  EXPECT_EQ(math::Color(0.1f, 0.1f, 0.1f, 1.0f),
+            boxVisualComp->Data().Specular());
+}

--- a/test/integration/material.cc
+++ b/test/integration/material.cc
@@ -301,7 +301,7 @@ TEST_F(MaterialTest, WorldWithClassicMaterial)
 {
   ServerConfig serverConfig;
   serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
-      "test/worlds/classic_material.sdf"));
+      "test", "worlds", "classic_material.sdf"));
 
   std::cout << "Loading: " << serverConfig.SdfFile() << std::endl;
   this->StartServer(serverConfig);

--- a/test/worlds/classic_material.sdf
+++ b/test/worlds/classic_material.sdf
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="default">
+
+    <model name="box">
+      <link name="box_link">
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+
+        <visual name="box_visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Blue</name>
+            </script>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #2488

## Summary

Added special handling in SDF find file callback for gazebo classic materials. We currently check for the [hardcoded classic material URI](https://github.com/gazebosim/gz-sim/blob/a2011f30f9873b5247b56c04cceee12a01221d00/src/SdfEntityCreator.cc#L812) in SDFEntityCreator so do not attempt to resolve the material script URI when loading the world. 

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
