### PR TITLE
Backport #2232 to Fortress

### DIFF
--- a/examples/worlds/shader_param.sdf
+++ b/examples/worlds/shader_param.sdf
@@ -182,12 +182,12 @@ ShaderParam visual plugin over time.
     <include>
       <name>deformable_sphere</name>
       <pose>0 0 1.5 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/deformable_sphere</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/deformable_sphere/5</uri>
     </include>
     <include>
       <name>waves</name>
       <pose>0 0 0 0 0 0</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/waves</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/waves/4</uri>
     </include>
 
     <model name="camera">

--- a/include/gz/sim/EntityComponentManager.hh
+++ b/include/gz/sim/EntityComponentManager.hh
@@ -836,6 +836,9 @@ namespace ignition
       friend class GuiRunner;
       friend class SimulationRunner;
 
+      // Make SystemManager friend so it has access to removals
+      friend class SystemManager;
+
       // Make network managers friends so they have control over component
       // states. Like the runners, the managers are internal.
       friend class NetworkManagerPrimary;

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -532,6 +532,9 @@ namespace ignition
       /// at the appropriate time.
       private: std::unique_ptr<msgs::WorldControlState> newWorldControlState;
 
+      /// \brief Set if we need to remove systems due to entity removal
+      private: bool threadsNeedCleanUp;
+
       friend class LevelManager;
     };
     }

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -533,7 +533,7 @@ namespace ignition
       private: std::unique_ptr<msgs::WorldControlState> newWorldControlState;
 
       /// \brief Set if we need to remove systems due to entity removal
-      private: bool threadsNeedCleanUp;
+      private: bool threadsNeedCleanUp{false};
 
       friend class LevelManager;
     };

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -105,7 +105,6 @@ void rootClockCb(const msgs::Clock &_msg)
   rootClockMsgs.push_back(_msg);
 }
 
-
 /////////////////////////////////////////////////
 TEST_P(SimulationRunnerTest, CreateEntities)
 {
@@ -1503,8 +1502,7 @@ TEST_P(SimulationRunnerTest,
   EXPECT_TRUE(runner.EntityCompMgr().EntityHasComponentType(sphereEntity,
       componentId)) << componentId;
 
-  // Remove entities that have plugin - this is not unloading or destroying
-  // the plugin though!
+  // Remove entities that have plugin
   auto entityCount = runner.EntityCompMgr().EntityCount();
   const_cast<EntityComponentManager &>(
       runner.EntityCompMgr()).RequestRemoveEntity(boxEntity);
@@ -1552,8 +1550,16 @@ TEST_P(SimulationRunnerTest,
   SimulationRunner runner(rootWithout.WorldByIndex(0), systemLoader,
       serverConfig);
 
-  // 1 model plugin from SDF and 2 world plugins from config
-  ASSERT_EQ(3u, runner.SystemCount());
+  // 1 model plugin from SDF and 1 world plugin from config
+  // and 1 model plugin from theconfig
+  EXPECT_EQ(3u, runner.SystemCount());
+  runner.SetPaused(false);
+  runner.Run(1);
+
+  // Remove the model. Only 1 world plugin should remain.
+  EXPECT_TRUE(runner.RequestRemoveEntity("box"));
+  runner.Run(2);
+  EXPECT_EQ(1u, runner.SystemCount());
 }
 
 /////////////////////////////////////////////////

--- a/src/SystemManager.hh
+++ b/src/SystemManager.hh
@@ -127,6 +127,14 @@ namespace ignition
       /// \brief Process system messages and add systems to entities
       public: void ProcessPendingEntitySystems();
 
+      /// \brief Remove systems that are attached to removed entities
+      /// \param[in] _entityCompMgr - ECM with entities marked for removal
+      /// \param[out] _needsCleanUp - Set to true if a system with a
+      /// PostUpdate was removed, and its thread needs to be terminated
+      public: void ProcessRemovedEntities(
+        const EntityComponentManager &_entityCompMgr,
+        bool &_needsCleanUp);
+
       /// \brief Implementation for AddSystem functions that takes an SDF
       /// element. This calls the AddSystemImpl that accepts an SDF Plugin.
       /// \param[in] _system Generic representation of a system.


### PR DESCRIPTION
# :back:  Backward port


This PR backports #2232 from `main` to fortress. The reason for this backport is that #2232 would greatly improve our UX (#2217, #2464, #2465, #2466).

@azeey has voiced his support for this here: https://github.com/gazebosim/gz-sim/pull/2232#issuecomment-2229487570

Branch comparison (not of much use): https://github.com/gazebosim/gz-sim/compare/ign-gazebo6...main

**Note to maintainers**: Remember to **Rebase and merge** with commit (not squash-merge or merge-commit)