### PR TITLE
Disable failing testFixture_TEST for MacOS

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -86,6 +86,7 @@ if (BUILD_TESTING)
     testFixture_TEST
   )
 
+  # Check issue #1023 for more information
   if (APPLE)
     list(REMOVE_ITEM python_tests testFixture_TEST)
   endif()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -86,6 +86,10 @@ if (BUILD_TESTING)
     testFixture_TEST
   )
 
+  if (APPLE)
+    list(REMOVE_ITEM python_tests testFixture_TEST)
+  endif()
+
   execute_process(COMMAND "${PYTHON_EXECUTABLE}" -m pytest --version
     OUTPUT_VARIABLE PYTEST_output
     ERROR_VARIABLE  PYTEST_error

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -86,7 +86,7 @@ if (BUILD_TESTING)
     testFixture_TEST
   )
 
-  # Check issue #1023 for more information
+  # Check issue #1887 for more information
   if (APPLE)
     list(REMOVE_ITEM python_tests testFixture_TEST)
   endif()


### PR DESCRIPTION
# 🦟 Bug fix

Disables failing test from #1023 

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
