### PR TITLE
Improve signal handling

### DIFF
--- a/src/Server.cc
+++ b/src/Server.cc
@@ -214,6 +214,11 @@ Server::Server(const ServerConfig &_config)
     this->dataPtr->AddRecordPlugin(_config);
   }
 
+  // If we've received a signal before we create entities, the Stop event
+  // won't be propagated to them. Instead, we just quit early here.
+  if (this->dataPtr->signalReceived)
+    return;
+
   this->dataPtr->CreateEntities();
 
   // Set the desired update period, this will override the desired RTF given in

--- a/src/ServerPrivate.hh
+++ b/src/ServerPrivate.hh
@@ -169,6 +169,10 @@ namespace gz
       /// \brief Our signal handler.
       public: gz::common::SignalHandler sigHandler;
 
+      /// \brief Set to true from signal handler. This will be used to
+      /// terminate the server where checking `running` is not sufficient.
+      public: std::atomic<bool> signalReceived{false};
+
       /// \brief Our system loader.
       public: SystemLoaderPtr systemLoader;
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This mainly deals with the problem where a signal is ignored if it occurs right before `ServerPrivate::Run` is called because we generally rely on the `running` variable to know when to stop, but that variable is set to true at the beginning of `ServerPrivate::Run`.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸