### PR TITLE
Initialize threadsNeedCleanUp in SimulationRunner

### DIFF
--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -544,7 +544,7 @@ namespace gz
       private: std::unique_ptr<msgs::WorldControlState> newWorldControlState;
 
       /// \brief Set if we need to remove systems due to entity removal
-      private: bool threadsNeedCleanUp;
+      private: bool threadsNeedCleanUp{false};
 
       private: bool resetInitiated{false};
       friend class LevelManager;


### PR DESCRIPTION
Member variable `threadsNeedCleanUp` is uninitialized when it is first accessed in `ProcessSystemQueue` which causes failures in asan tests. The fix is to initialize it to false.