### PR TITLE
Fix #2458 - Checking linkEnity is empty

### DIFF
--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -583,6 +583,12 @@ UserCommands::~UserCommands() = default;
 bool UserCommandsInterface::HasContactSensor(const Entity _collision)
 {
   auto *linkEntity = ecm->Component<components::ParentEntity>(_collision);
+
+  if (linkEntity == nullptr)
+  {
+    return false; 
+  }
+
   auto allLinkSensors =
     ecm->EntitiesByComponents(components::Sensor(),
       components::ParentEntity(*linkEntity));

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -586,7 +586,7 @@ bool UserCommandsInterface::HasContactSensor(const Entity _collision)
 
   if (linkEntity == nullptr)
   {
-    return false; 
+    return false;
   }
 
   auto allLinkSensors =


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
Added a if condition for checking whether the linkEntity is empty or not , if this condition is removed then the issue comes again

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
