### PR TITLE
Physics: Ray intersections

### DIFF
--- a/include/gz/sim/components/MultiRay.hh
+++ b/include/gz/sim/components/MultiRay.hh
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GZ_SIM_COMPONENTS_MULTIRAY_HH_
+#define GZ_SIM_COMPONENTS_MULTIRAY_HH_
+
+#include <gz/math/Vector3.hh>
+#include <gz/sim/components/Factory.hh>
+#include <gz/sim/components/Component.hh>
+#include <gz/sim/config.hh>
+
+#include <vector>
+
+namespace gz
+{
+namespace sim
+{
+// Inline bracket to help doxygen filtering.
+inline namespace GZ_SIM_VERSION_NAMESPACE {
+namespace components
+{
+/// \brief A struct that holds the information of a ray.
+struct RayInfo
+{
+  /// \brief Starting point of the ray in world coordinates
+  gz::math::Vector3d start;
+
+  /// \brief Ending point of the ray in world coordinates
+  gz::math::Vector3d end;
+};
+
+/// \brief A struct that holds the results of raycasting.
+struct RayIntersectionInfo
+{
+  /// \brief The hit point in the world coordinates
+  gz::math::Vector3d point;
+
+  /// \brief The fraction of the ray length at the intersection/hit point.
+  double fraction;
+
+  /// \brief The normal at the hit point in the world coordinates
+  gz::math::Vector3d normal;
+};
+
+/// \brief A component type that contains multiple rays from an entity.
+using MultiRay =
+  gz::sim::components::Component<std::vector<RayInfo>, class MultiRayTag>;
+
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.MultiRay", MultiRay)
+
+/// \brief A component type that contains the raycasting results from multiple
+// rays from an entity into a physics world.
+using MultiRayIntersections =
+  gz::sim::components::Component<std::vector<RayIntersectionInfo>, class MultiRayIntersectionsTag>;
+
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.MultiRayIntersections", MultiRayIntersections)
+}
+}
+}
+}
+#endif  // GZ_SIM_COMPONENTS_MULTIRAY_HH_

--- a/include/gz/sim/components/MultiRay.hh
+++ b/include/gz/sim/components/MultiRay.hh
@@ -65,9 +65,11 @@ GZ_SIM_REGISTER_COMPONENT("gz_sim_components.MultiRay", MultiRay)
 /// \brief A component type that contains the raycasting results from multiple
 // rays from an entity into a physics world.
 using MultiRayIntersections =
-  gz::sim::components::Component<std::vector<RayIntersectionInfo>, class MultiRayIntersectionsTag>;
+  gz::sim::components::Component<std::vector<RayIntersectionInfo>,
+  class MultiRayIntersectionsTag>;
 
-GZ_SIM_REGISTER_COMPONENT("gz_sim_components.MultiRayIntersections", MultiRayIntersections)
+GZ_SIM_REGISTER_COMPONENT(
+  "gz_sim_components.MultiRayIntersections", MultiRayIntersections)
 }
 }
 }

--- a/include/gz/sim/components/RaycastData.hh
+++ b/include/gz/sim/components/RaycastData.hh
@@ -15,8 +15,8 @@
  *
 */
 
-#ifndef GZ_SIM_COMPONENTS_MULTIRAY_HH_
-#define GZ_SIM_COMPONENTS_MULTIRAY_HH_
+#ifndef GZ_SIM_COMPONENTS_RAYCASTDATA_HH_
+#define GZ_SIM_COMPONENTS_RAYCASTDATA_HH_
 
 #include <gz/math/Vector3.hh>
 #include <gz/sim/components/Factory.hh>
@@ -43,8 +43,8 @@ struct RayInfo
   gz::math::Vector3d end;
 };
 
-/// \brief A struct that holds the results of raycasting.
-struct RayIntersectionInfo
+/// \brief A struct that holds the result of a raycasting operation.
+struct RaycastResultInfo
 {
   /// \brief The hit point in the world coordinates
   gz::math::Vector3d point;
@@ -56,22 +56,23 @@ struct RayIntersectionInfo
   gz::math::Vector3d normal;
 };
 
-/// \brief A component type that contains multiple rays from an entity.
-using MultiRay =
-  gz::sim::components::Component<std::vector<RayInfo>, class MultiRayTag>;
+/// @brief A struct that holds the raycasting data, including ray and results
+struct RaycastDataInfo
+{
+  /// @brief The rays to cast from the entity.
+  std::vector<RayInfo> rays;
 
-GZ_SIM_REGISTER_COMPONENT("gz_sim_components.MultiRay", MultiRay)
+  /// @brief The results of the raycasting.
+  std::vector<RaycastResultInfo> results;
+};
 
-/// \brief A component type that contains the raycasting results from multiple
-// rays from an entity into a physics world.
-using MultiRayIntersections =
-  gz::sim::components::Component<std::vector<RayIntersectionInfo>,
-  class MultiRayIntersectionsTag>;
+/// \brief A component type that contains the raycasting results from
+// multiple rays from an entity into a physics world.
+using RaycastData = Component<RaycastDataInfo, class RaycastDataTag>;
 
-GZ_SIM_REGISTER_COMPONENT(
-  "gz_sim_components.MultiRayIntersections", MultiRayIntersections)
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.RaycastData", RaycastData)
 }
 }
 }
 }
-#endif  // GZ_SIM_COMPONENTS_MULTIRAY_HH_
+#endif  // GZ_SIM_COMPONENTS_RAYCASTDATA_HH_

--- a/include/gz/sim/components/RaycastData.hh
+++ b/include/gz/sim/components/RaycastData.hh
@@ -21,8 +21,11 @@
 #include <gz/math/Vector3.hh>
 #include <gz/sim/components/Factory.hh>
 #include <gz/sim/components/Component.hh>
+#include <gz/sim/components/Serialization.hh>
 #include <gz/sim/config.hh>
 
+#include <istream>
+#include <ostream>
 #include <vector>
 
 namespace gz
@@ -65,14 +68,37 @@ struct RaycastDataInfo
   /// @brief The results of the raycasting.
   std::vector<RaycastResultInfo> results;
 };
+}
 
+namespace serializers
+{
+  /// \brief Specialization of DefaultSerializer for RaycastDataInfo
+  template<> class DefaultSerializer<components::RaycastDataInfo>
+  {
+    public: static std::ostream &Serialize(
+      std::ostream &_out, const components::RaycastDataInfo &)
+    {
+      return _out;
+    }
+
+    public: static std::istream &Deserialize(
+      std::istream &_in, components::RaycastDataInfo &)
+    {
+      return _in;
+    }
+  };
+}
+
+namespace components
+{
 /// \brief A component type that contains the rays traced from an entity
 /// into a physics world, along with the results of the raycasting operation.
 ///
 /// This component is primarily used for applications that require raycasting.
 /// The target application defines the rays, and the physics system plugin
 /// updates the raycasting results during each update loop.
-using RaycastData = Component<RaycastDataInfo, class RaycastDataTag>;
+using RaycastData = Component<RaycastDataInfo, class RaycastDataTag,
+                              serializers::DefaultSerializer<RaycastDataInfo>>;
 
 GZ_SIM_REGISTER_COMPONENT("gz_sim_components.RaycastData", RaycastData)
 }

--- a/include/gz/sim/components/RaycastData.hh
+++ b/include/gz/sim/components/RaycastData.hh
@@ -36,23 +36,23 @@ namespace components
 /// \brief A struct that holds the information of a ray.
 struct RayInfo
 {
-  /// \brief Starting point of the ray in world coordinates
+  /// \brief Starting point of the ray in entity frame
   gz::math::Vector3d start;
 
-  /// \brief Ending point of the ray in world coordinates
+  /// \brief Ending point of the ray in entity frame
   gz::math::Vector3d end;
 };
 
 /// \brief A struct that holds the result of a raycasting operation.
 struct RaycastResultInfo
 {
-  /// \brief The hit point in the world coordinates
+  /// \brief The hit point in entity frame
   gz::math::Vector3d point;
 
   /// \brief The fraction of the ray length at the intersection/hit point.
   double fraction;
 
-  /// \brief The normal at the hit point in the world coordinates
+  /// \brief The normal at the hit point in entity frame
   gz::math::Vector3d normal;
 };
 

--- a/include/gz/sim/components/RaycastData.hh
+++ b/include/gz/sim/components/RaycastData.hh
@@ -66,8 +66,12 @@ struct RaycastDataInfo
   std::vector<RaycastResultInfo> results;
 };
 
-/// \brief A component type that contains the raycasting results from
-// multiple rays from an entity into a physics world.
+/// \brief A component type that contains the rays traced from an entity
+/// into a physics world, along with the results of the raycasting operation.
+///
+/// This component is primarily used for applications that require raycasting.
+/// The target application defines the rays, and the physics system plugin
+/// updates the raycasting results during each update loop.
 using RaycastData = Component<RaycastDataInfo, class RaycastDataTag>;
 
 GZ_SIM_REGISTER_COMPONENT("gz_sim_components.RaycastData", RaycastData)

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -4235,10 +4235,10 @@ void PhysicsPrivate::UpdateRayIntersections(EntityComponentManager &_ecm)
         for (const auto &ray : rays)
         {
           // Convert ray to world frame
-          const math::Vector3d rayStart =
-            entityWorldPose.Pos() + entityWorldPose.Rot().RotateVector(ray.start);
-          const math::Vector3d rayEnd =
-            entityWorldPose.Pos() + entityWorldPose.Rot().RotateVector(ray.end);
+          const math::Vector3d rayStart = entityWorldPose.Pos() +
+            entityWorldPose.Rot().RotateVector(ray.start);
+          const math::Vector3d rayEnd = entityWorldPose.Pos() +
+            entityWorldPose.Rot().RotateVector(ray.end);
 
           // Perform ray intersection
           auto rayIntersection =

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -4183,8 +4183,8 @@ void PhysicsPrivate::UpdateCollisions(EntityComponentManager &_ecm)
 void PhysicsPrivate::UpdateRayIntersections(EntityComponentManager &_ecm)
 {
   GZ_PROFILE("PhysicsPrivate::UpdateRayIntersections");
-  // Quit early if the MultiRayIntersections component hasn't been created. This means
-  // there are no systems that need contact information
+  // Quit early if the MultiRayIntersections component hasn't been created.
+  // This means there are no systems that need contact information
   if (!_ecm.HasComponentType(components::MultiRayIntersections::typeId))
     return;
 
@@ -4200,9 +4200,9 @@ void PhysicsPrivate::UpdateRayIntersections(EntityComponentManager &_ecm)
   auto worldRayIntersectionFeature =
       this->entityWorldMap.EntityCast<RayIntersectionFeatureList>(worldEntity);
 
-  // Go through each entity that has a MultiRay and MultiRayIntersections components,
-  // trace the rays and set the MultiRayIntersections component value to the list of
-  // intersections that correspond to the ray entity
+  // Go through each entity that has a MultiRay and MultiRayIntersections
+  // components, trace the rays and set the MultiRayIntersections component
+  // value to the list of intersections that correspond to the ray entity
   _ecm.Each<components::MultiRay,
             components::MultiRayIntersections>(
       [&](const Entity &/*_entity*/,
@@ -4212,7 +4212,7 @@ void PhysicsPrivate::UpdateRayIntersections(EntityComponentManager &_ecm)
         // Retrieve the rays from the MultiRay component
         const auto &rays = _multiRay->Data();
 
-        // Retrieve and clear the results from the MultiRayIntersections component
+        // Retrieve and clear results from MultiRayIntersections component
         auto &rayIntersections = _multiRayIntersections->Data();
         rayIntersections.clear();
 
@@ -4221,10 +4221,12 @@ void PhysicsPrivate::UpdateRayIntersections(EntityComponentManager &_ecm)
           // Compute the ray intersections
           auto rayIntersection =
             worldRayIntersectionFeature->GetRayIntersectionFromLastStep(
-              math::eigen3::convert(ray.start), math::eigen3::convert(ray.end));
+              math::eigen3::convert(ray.start),
+              math::eigen3::convert(ray.end));
 
           const auto result =
-            rayIntersection.Get<physics::World3d<RayIntersectionFeatureList>::RayIntersection>();
+            rayIntersection.Get<
+              physics::World3d<RayIntersectionFeatureList>::RayIntersection>();
 
           // Store the results into the MultiRayIntersections component
           components::RayIntersectionInfo info;

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -4184,7 +4184,7 @@ void PhysicsPrivate::UpdateRayIntersections(EntityComponentManager &_ecm)
 {
   GZ_PROFILE("PhysicsPrivate::UpdateRayIntersections");
   // Quit early if the MultiRayIntersections component hasn't been created.
-  // This means there are no systems that need contact information
+  // This means there are no systems that need raycasting information
   if (!_ecm.HasComponentType(components::MultiRayIntersections::typeId))
     return;
 

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -4200,6 +4200,20 @@ void PhysicsPrivate::UpdateRayIntersections(EntityComponentManager &_ecm)
   auto worldRayIntersectionFeature =
       this->entityWorldMap.EntityCast<RayIntersectionFeatureList>(worldEntity);
 
+  if (!worldRayIntersectionFeature)
+  {
+    static bool informed{false};
+    if (!informed)
+    {
+      gzdbg << "Attempting process ray intersections, but the physics "
+             << "engine doesn't support ray intersection features. "
+             << "Ray intersections won't be computed."
+             << std::endl;
+      informed = true;
+    }
+    return;
+  }
+
   // Go through each entity that has a MultiRay and MultiRayIntersections
   // components, trace the rays and set the MultiRayIntersections component
   // value to the list of intersections that correspond to the ray entity

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -4228,6 +4228,7 @@ void PhysicsPrivate::UpdateRayIntersections(EntityComponentManager &_ecm)
         // Clear the previous results
         auto &results = _raycastData->Data().results;
         results.clear();
+        results.reserve(rays.size());
 
         // Get the entity's world pose
         const auto &entityWorldPose = worldPose(_entity, _ecm);
@@ -4250,9 +4251,10 @@ void PhysicsPrivate::UpdateRayIntersections(EntityComponentManager &_ecm)
             rayIntersection.Get<
               physics::World3d<RayIntersectionFeatureList>::RayIntersection>();
 
-          // Convert result to entity frame and store
-          components::RaycastResultInfo result;
+          results.emplace_back();
+          auto &result = results.back();
 
+          // Convert result to entity frame and store
           const math::Vector3d intersectionPoint =
             math::eigen3::convert(rayIntersectionResult.point);
           result.point = entityWorldPose.Rot().RotateVectorReverse(
@@ -4263,8 +4265,6 @@ void PhysicsPrivate::UpdateRayIntersections(EntityComponentManager &_ecm)
           const math::Vector3d normal =
             math::eigen3::convert(rayIntersectionResult.normal);
           result.normal = entityWorldPose.Rot().RotateVectorReverse(normal);
-
-          results.push_back(result);
         }
         return true;
       });

--- a/test/integration/physics_system.cc
+++ b/test/integration/physics_system.cc
@@ -2980,10 +2980,10 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(RayIntersections))
         for (size_t i = 0; i < results1.size(); ++i) {
           ASSERT_EQ(results1[i].point, math::Vector3d::Zero);
           ASSERT_EQ(results1[i].normal, math::Vector3d(0, 0, 1));
-          double exp_fraction =
+          const double expFraction =
             (rays1[i].start - results1[i].point).Length() /
               (rays1[i].start - rays1[i].end).Length();
-          ASSERT_NEAR(results1[i].fraction, exp_fraction, 1e-6);
+          ASSERT_NEAR(results1[i].fraction, expFraction, 1e-6);
         }
 
         // check the raycasting results for testEntity2

--- a/test/integration/physics_system.cc
+++ b/test/integration/physics_system.cc
@@ -2909,7 +2909,7 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(JointsInWorld))
 }
 
 //////////////////////////////////////////////////
-/// This test verifies that ray intersections are computed by physics system during Update loop.
+/// Test ray intersections computed by physics system during Update loop.
 TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(RayIntersections))
 {
   ServerConfig serverConfig;
@@ -2930,9 +2930,10 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(RayIntersections))
   testSystem.OnPreUpdate(
       [&](const UpdateInfo &/*_info*/, EntityComponentManager &_ecm)
       {
-        // Set the physics collision detector to bullet (that supports ray intersections).
+        // Set collision detector to bullet (supports ray intersections).
         auto worldEntity = _ecm.EntityByComponents(components::World());
-        _ecm.CreateComponent(worldEntity, components::PhysicsCollisionDetector("bullet"));
+        _ecm.CreateComponent(
+          worldEntity, components::PhysicsCollisionDetector("bullet"));
 
         // Create MultiRay and MultiRayIntersections components for testEntity1
         testEntity1 = _ecm.CreateEntity();
@@ -2945,7 +2946,8 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(RayIntersections))
         _ecm.CreateComponent(testEntity2, components::MultiRayIntersections());
 
         // Add 5 rays to testEntity1 that intersect with the ground plane
-        auto &rays1 = _ecm.Component<components::MultiRay>(testEntity1)->Data();
+        auto &rays1 =
+          _ecm.Component<components::MultiRay>(testEntity1)->Data();
         for (size_t i = 0; i < 5; ++i)
         {
           components::RayInfo ray;
@@ -2954,7 +2956,7 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(RayIntersections))
           rays1.push_back(ray);
         }
 
-        // Add 2 rays to testEntity2 that does not intersect with the ground plane
+        // Add 2 rays to testEntity2 that don't intersect with the ground plane
         auto &rays2 = _ecm.Component<components::MultiRay>(testEntity2)->Data();
         for (size_t i = 0; i < 2; ++i)
         {
@@ -2964,13 +2966,15 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(RayIntersections))
           rays2.push_back(ray);
         }
       });
-  // During PostUpdate, check the ray intersections for testEntity1 and testEntity2
+  // Check ray intersections for testEntity1 and testEntity2
   testSystem.OnPostUpdate(
       [&](const UpdateInfo &/*_info*/, const EntityComponentManager &_ecm)
       {
         // check the raycasting results for testEntity1
         auto &rays1 = _ecm.Component<components::MultiRay>(testEntity1)->Data();
-        auto &results1 = _ecm.Component<components::MultiRayIntersections>(testEntity1)->Data();
+        auto &results1 =
+          _ecm.Component<components::MultiRayIntersections>(
+            testEntity1)->Data();
         ASSERT_EQ(rays1.size(), results1.size());
 
         for (size_t i = 0; i < results1.size(); ++i) {
@@ -2983,14 +2987,20 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(RayIntersections))
         }
 
         // check the raycasting results for testEntity2
-        auto &rays2 = _ecm.Component<components::MultiRay>(testEntity2)->Data();
-        auto &results2 = _ecm.Component<components::MultiRayIntersections>(testEntity2)->Data();
+        auto &rays2 =
+          _ecm.Component<components::MultiRay>(testEntity2)->Data();
+        auto &results2 =
+          _ecm.Component<components::MultiRayIntersections>(
+            testEntity2)->Data();
         ASSERT_EQ(rays2.size(), results2.size());
 
         for (size_t i = 0; i < results2.size(); ++i) {
-          ASSERT_TRUE(math::eigen3::convert(results2[i].point).array().isNaN().all());
-          ASSERT_TRUE(math::eigen3::convert(results2[i].normal).array().isNaN().all());
-          ASSERT_TRUE(std::isnan(results2[i].fraction));
+          ASSERT_TRUE(
+            math::eigen3::convert(results2[i].point).array().isNaN().all());
+          ASSERT_TRUE(
+            math::eigen3::convert(results2[i].normal).array().isNaN().all());
+          ASSERT_TRUE(
+            std::isnan(results2[i].fraction));
         }
       });
 

--- a/test/integration/physics_system.cc
+++ b/test/integration/physics_system.cc
@@ -2938,12 +2938,14 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(RayIntersections))
         // Create RaycastData component for testEntity1
         testEntity1 = _ecm.CreateEntity();
         _ecm.CreateComponent(testEntity1, components::RaycastData());
-        _ecm.CreateComponent(testEntity1, components::Pose(math::Pose3d(0, 0, 10, 0, 0, 0)));
+        _ecm.CreateComponent(
+          testEntity1, components::Pose(math::Pose3d(0, 0, 10, 0, 0, 0)));
 
         // Create RaycastData component for testEntity2
         testEntity2 = _ecm.CreateEntity();
         _ecm.CreateComponent(testEntity2, components::RaycastData());
-        _ecm.CreateComponent(testEntity2, components::Pose(math::Pose3d(0, 0, 10, 0, 0, 0)));
+        _ecm.CreateComponent(
+          testEntity2, components::Pose(math::Pose3d(0, 0, 10, 0, 0, 0)));
 
         // Add 5 rays to testEntity1 that intersect with the ground plane
         auto &rays1 =

--- a/test/integration/physics_system.cc
+++ b/test/integration/physics_system.cc
@@ -73,12 +73,12 @@
 #include "gz/sim/components/LinearVelocityReset.hh"
 #include "gz/sim/components/Material.hh"
 #include "gz/sim/components/Model.hh"
-#include "gz/sim/components/MultiRay.hh"
 #include "gz/sim/components/Name.hh"
 #include "gz/sim/components/ParentEntity.hh"
 #include "gz/sim/components/Physics.hh"
 #include "gz/sim/components/Pose.hh"
 #include "gz/sim/components/PoseCmd.hh"
+#include "gz/sim/components/RaycastData.hh"
 #include "gz/sim/components/Static.hh"
 #include "gz/sim/components/Visual.hh"
 #include "gz/sim/components/World.hh"
@@ -2935,19 +2935,17 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(RayIntersections))
         _ecm.CreateComponent(
           worldEntity, components::PhysicsCollisionDetector("bullet"));
 
-        // Create MultiRay and MultiRayIntersections components for testEntity1
+        // Create RaycastData component for testEntity1
         testEntity1 = _ecm.CreateEntity();
-        _ecm.CreateComponent(testEntity1, components::MultiRay());
-        _ecm.CreateComponent(testEntity1, components::MultiRayIntersections());
+        _ecm.CreateComponent(testEntity1, components::RaycastData());
 
-        // Create MultiRay and MultiRayIntersections components for testEntity2
+        // Create RaycastData component for testEntity2
         testEntity2 = _ecm.CreateEntity();
-        _ecm.CreateComponent(testEntity2, components::MultiRay());
-        _ecm.CreateComponent(testEntity2, components::MultiRayIntersections());
+        _ecm.CreateComponent(testEntity2, components::RaycastData());
 
         // Add 5 rays to testEntity1 that intersect with the ground plane
         auto &rays1 =
-          _ecm.Component<components::MultiRay>(testEntity1)->Data();
+          _ecm.Component<components::RaycastData>(testEntity1)->Data().rays;
         for (size_t i = 0; i < 5; ++i)
         {
           components::RayInfo ray;
@@ -2957,7 +2955,8 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(RayIntersections))
         }
 
         // Add 2 rays to testEntity2 that don't intersect with the ground plane
-        auto &rays2 = _ecm.Component<components::MultiRay>(testEntity2)->Data();
+        auto &rays2 =
+           _ecm.Component<components::RaycastData>(testEntity2)->Data().rays;
         for (size_t i = 0; i < 2; ++i)
         {
           components::RayInfo ray;
@@ -2971,10 +2970,10 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(RayIntersections))
       [&](const UpdateInfo &/*_info*/, const EntityComponentManager &_ecm)
       {
         // check the raycasting results for testEntity1
-        auto &rays1 = _ecm.Component<components::MultiRay>(testEntity1)->Data();
+        auto &rays1 =
+          _ecm.Component<components::RaycastData>(testEntity1)->Data().rays;
         auto &results1 =
-          _ecm.Component<components::MultiRayIntersections>(
-            testEntity1)->Data();
+          _ecm.Component<components::RaycastData>(testEntity1)->Data().results;
         ASSERT_EQ(rays1.size(), results1.size());
 
         for (size_t i = 0; i < results1.size(); ++i) {
@@ -2988,10 +2987,9 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(RayIntersections))
 
         // check the raycasting results for testEntity2
         auto &rays2 =
-          _ecm.Component<components::MultiRay>(testEntity2)->Data();
+          _ecm.Component<components::RaycastData>(testEntity2)->Data().rays;
         auto &results2 =
-          _ecm.Component<components::MultiRayIntersections>(
-            testEntity2)->Data();
+          _ecm.Component<components::RaycastData>(testEntity2)->Data().results;
         ASSERT_EQ(rays2.size(), results2.size());
 
         for (size_t i = 0; i < results2.size(); ++i) {

--- a/test/integration/physics_system.cc
+++ b/test/integration/physics_system.cc
@@ -2938,29 +2938,31 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(RayIntersections))
         // Create RaycastData component for testEntity1
         testEntity1 = _ecm.CreateEntity();
         _ecm.CreateComponent(testEntity1, components::RaycastData());
+        _ecm.CreateComponent(testEntity1, components::Pose(math::Pose3d(0, 0, 10, 0, 0, 0)));
 
         // Create RaycastData component for testEntity2
         testEntity2 = _ecm.CreateEntity();
         _ecm.CreateComponent(testEntity2, components::RaycastData());
+        _ecm.CreateComponent(testEntity2, components::Pose(math::Pose3d(0, 0, 10, 0, 0, 0)));
 
         // Add 5 rays to testEntity1 that intersect with the ground plane
         auto &rays1 =
           _ecm.Component<components::RaycastData>(testEntity1)->Data().rays;
-        for (size_t i = 0; i < 5; ++i)
+        for (int i = 0; i < 5; ++i)
         {
           components::RayInfo ray;
-          ray.start = math::Vector3d(0, 0, 10 - i);
-          ray.end = math::Vector3d(0, 0, -10);
+          ray.start = math::Vector3d(0, 0, -i);
+          ray.end = math::Vector3d(0, 0, -20);
           rays1.push_back(ray);
         }
 
         // Add 2 rays to testEntity2 that don't intersect with the ground plane
         auto &rays2 =
            _ecm.Component<components::RaycastData>(testEntity2)->Data().rays;
-        for (size_t i = 0; i < 2; ++i)
+        for (int i = 0; i < 2; ++i)
         {
           components::RayInfo ray;
-          ray.start = math::Vector3d(0, 0, 10 - i);
+          ray.start = math::Vector3d(0, 0, -i);
           ray.end = math::Vector3d(0, 0, 5);
           rays2.push_back(ray);
         }
@@ -2977,7 +2979,7 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(RayIntersections))
         ASSERT_EQ(rays1.size(), results1.size());
 
         for (size_t i = 0; i < results1.size(); ++i) {
-          ASSERT_EQ(results1[i].point, math::Vector3d::Zero);
+          ASSERT_EQ(results1[i].point, math::Vector3d(0, 0, -10));
           ASSERT_EQ(results1[i].normal, math::Vector3d(0, 0, 1));
           const double expFraction =
             (rays1[i].start - results1[i].point).Length() /


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/gazebosim/gz-sensors/issues/26 and https://github.com/gazebosim/gz-physics/pull/641

## Summary
This PR introduces components to hold rays and ray intersections data (`MultiRay` and `MultiRayIntersections`, respectively), and updates the physics system to compute the ray castings during `Update` loop.

## Test it
Added a test case to physics system.

Build and run `./build/bin/INTEGRATION_physics_system --gtest_filter=PhysicsSystemFixture.RayIntersections`

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.