### PR TITLE
Fix adding system to non-existent entity

### DIFF
--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -25,6 +25,7 @@
 #include "SystemInternal.hh"
 #include "gz/sim/components/SystemPluginInfo.hh"
 #include "gz/sim/Conversions.hh"
+#include "gz/sim/Util.hh"
 #include "SystemManager.hh"
 
 using namespace gz;
@@ -400,6 +401,19 @@ void SystemManager::ProcessPendingEntitySystems()
     {
       gzwarn << "Unable to add plugins to Entity: '" << entity
              << "'. No plugins specified." << std::endl;
+       continue;
+    }
+
+    // set to world entity if entity id is not specified in the request.
+    if (entity == kNullEntity || entity == 0u)
+    {
+      entity = worldEntity(*this->entityCompMgr);
+    }
+    // otherwise check if entity exists before attempting to load the plugin.
+    else if (!this->entityCompMgr->HasEntity(entity))
+    {
+      gzwarn << "Unable to add plugins to Entity: '" << entity
+             << "'. Entity does not exist." << std::endl;
        continue;
     }
 

--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -340,6 +340,11 @@ bool SystemManager::EntitySystemAddService(const msgs::EntityPlugin_V &_req,
 {
   std::lock_guard<std::mutex> lock(this->systemsMsgMutex);
   this->systemsToAdd.push_back(_req);
+
+  // The response is set to true to indicate that the service request is
+  // handled but it does not necessarily mean the system is added
+  // successfully
+  // \todo(iche033) Return false if system is not added successfully?
   _res.set_data(true);
   return true;
 }
@@ -399,8 +404,8 @@ void SystemManager::ProcessPendingEntitySystems()
 
     if (req.plugins().empty())
     {
-      gzwarn << "Unable to add plugins to Entity: '" << entity
-             << "'. No plugins specified." << std::endl;
+      gzerr << "Unable to add plugins to Entity: '" << entity
+            << "'. No plugins specified." << std::endl;
        continue;
     }
 
@@ -412,8 +417,8 @@ void SystemManager::ProcessPendingEntitySystems()
     // otherwise check if entity exists before attempting to load the plugin.
     else if (!this->entityCompMgr->HasEntity(entity))
     {
-      gzwarn << "Unable to add plugins to Entity: '" << entity
-             << "'. Entity does not exist." << std::endl;
+      gzerr << "Unable to add plugins to Entity: '" << entity
+            << "'. Entity does not exist." << std::endl;
        continue;
     }
 

--- a/src/systems/battery_plugin/LinearBatteryPlugin.cc
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.cc
@@ -480,6 +480,9 @@ void LinearBatteryPlugin::PreUpdate(
 {
   GZ_PROFILE("LinearBatteryPlugin::PreUpdate");
 
+  if (!this->dataPtr->battery)
+    return;
+
   // Recalculate the total power load among consumers
   double total_power_load = this->dataPtr->initialPowerLoad;
   _ecm.Each<components::BatteryPowerLoad>(
@@ -546,6 +549,9 @@ void LinearBatteryPlugin::Update(const UpdateInfo &_info,
 {
   GZ_PROFILE("LinearBatteryPlugin::Update");
 
+  if (!this->dataPtr->battery)
+    return;
+
   // \TODO(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
@@ -608,6 +614,9 @@ void LinearBatteryPlugin::PostUpdate(const UpdateInfo &_info,
   GZ_PROFILE("LinearBatteryPlugin::PostUpdate");
   // Nothing left to do if paused or the publisher wasn't created.
   if (_info.paused || !this->dataPtr->statePub)
+    return;
+
+  if (!this->dataPtr->battery)
     return;
 
   // Publish battery state


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2508, #2511, and #2513

## Summary

* Added check for entity id before attempting to load the requested plugin.
* If entity id is not specified, default to world entity (same logic as the one implemented in [SimulationRunner](https://github.com/gazebosim/gz-sim/blob/907efc31f6ff5de0e5d32922f054601e643588f2/src/SimulationRunner.cc#L516))
* Added sanity checks for null battery objects in linear battery plugin (example plugin mentioned in #2511).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

