### PR TITLE
Wheelslip plugin parameter addition

### DIFF
--- a/src/systems/wheel_slip/WheelSlip.cc
+++ b/src/systems/wheel_slip/WheelSlip.cc
@@ -263,7 +263,6 @@ void WheelSlipPrivate::Update(EntityComponentManager &_ecm)
     // Here the scoped name starts with "wheel_slip."
     // In `ConfigureParameters()` that doesn't happen!
     auto paramName = std::string("systems.") + scopedName;
-    //transport::parameters::ParameterResult value;
     msgs::WheelSlipParametersCmd msg;
 
     auto result = this->registry->Parameter(paramName, msg);

--- a/src/systems/wheel_slip/WheelSlip.cc
+++ b/src/systems/wheel_slip/WheelSlip.cc
@@ -36,7 +36,7 @@
 #include "gz/sim/components/SlipComplianceCmd.hh"
 #include "gz/sim/components/WheelSlipCmd.hh"
 
-#include <gz/msgs/wheel_slip_parameters.pb.h>
+#include <gz/msgs/wheel_slip_parameters_cmd.pb.h>
 
 
 using namespace gz;
@@ -255,7 +255,7 @@ void WheelSlipPrivate::Update(EntityComponentManager &_ecm)
   for (auto &linkSurface : this->mapLinkSurfaceParams)
   {
     auto &params = linkSurface.second;
-      std::string scopedName = ignition::gazebo::scopedName(
+      std::string scopedName = gz::sim::scopedName(
       linkSurface.first, _ecm, ".", false);
 
     // TODO(ivanpauno): WHY THE SCOPED NAME CHANGES BETWEEN HERE AND
@@ -270,7 +270,7 @@ void WheelSlipPrivate::Update(EntityComponentManager &_ecm)
       ignerr << "WheelSlip system Update(): failed to get parameter ["
               << paramName << "]: " << ex.what() << std::endl;
     }
-    auto * msg = dynamic_cast<msgs::WheelSlipParameters *>(value.msg.get());
+    auto * msg = dynamic_cast<msgs::WheelSlipParametersCmd *>(value.msg.get());
     if (msg)
     {
       const auto & wheelSlipCmdParams = wheelSlipCmdComp->Data();
@@ -373,16 +373,16 @@ void WheelSlip::Configure(const Entity &_entity,
 }
 
 void WheelSlip::ConfigureParameters(
-  ignition::transport::parameters::ParametersRegistry & _registry,
+  gz::transport::parameters::ParametersRegistry & _registry,
   EntityComponentManager &_ecm)
 {
   this->dataPtr->registry = &_registry;
   for (const auto & linkParamsPair : this->dataPtr->mapLinkSurfaceParams) {
-    std::string scopedName = ignition::gazebo::scopedName(
+    std::string scopedName = gz::sim::scopedName(
       linkParamsPair.first, _ecm, ".", false);
 
     auto paramName = std::string("systems.wheel_slip.") + scopedName;
-    auto wsParams = std::make_unique<ignition::msgs::WheelSlipParameters>();
+    auto wsParams = std::make_unique<gz::msgs::WheelSlipParametersCmd>();
     wsParams->set_slip_compliance_lateral(
       linkParamsPair.second.slipComplianceLateral);
     wsParams->set_slip_compliance_longitudinal(

--- a/src/systems/wheel_slip/WheelSlip.hh
+++ b/src/systems/wheel_slip/WheelSlip.hh
@@ -118,6 +118,7 @@ namespace systems
   class WheelSlip
       : public System,
         public ISystemConfigure,
+        public ISystemConfigureParameters,
         public ISystemPreUpdate
   {
     /// \brief Constructor
@@ -131,6 +132,11 @@ namespace systems
                            const std::shared_ptr<const sdf::Element> &_sdf,
                            EntityComponentManager &_ecm,
                            EventManager &_eventMgr) override;
+
+    public: void ConfigureParameters(
+                gz::transport::parameters::ParametersRegistry &
+                  _registry,
+                EntityComponentManager &_ecm) override;
 
     // Documentation inherited
     public: void PreUpdate(


### PR DESCRIPTION
# 🎉 New feature

Helps with #1845

## Summary
Adds parameter change functionality using the gz param to the wheel slip system plugin. This is in preparation to be able to write a working tutorial that is described in this #1845. This PR is based on the associated branch of that issue namely https://github.com/gazebosim/gz-sim/compare/ign-gazebo6...ivanpauno/parameters-component-wheel-slip-demo6  from @ivanpauno but adjusted for gz-sim8

## Test it

I've based these instructions on the instructions given in #1845 by [scpeters](https://github.com/scpeters) adjusted to gz-sim8

Launch the trisphere cycle world
```
gz sim trisphere_cycle_wheel_slip.sdf
```

Another parameter check out the available parameters:
```
gz param -r /world/wheel_slip -l
```

<details>

<summary>Expected outcome</summary>

```

Listing parameters, registry namespace [/world/wheel_slip]...

systems.wheel_slip.trisphere_cycle1.wheel_front            [gz_msgs.WheelSlipParametersCmd]
systems.wheel_slip.trisphere_cycle1.wheel_rear_right            [gz_msgs.WheelSlipParametersCmd]
systems.wheel_slip.trisphere_cycle0.wheel_rear_right            [gz_msgs.WheelSlipParametersCmd]
systems.wheel_slip.trisphere_cycle1.wheel_rear_left            [gz_msgs.WheelSlipParametersCmd]
systems.wheel_slip.trisphere_cycle0.wheel_rear_left            [gz_msgs.WheelSlipParametersCmd]
systems.wheel_slip.trisphere_cycle0.wheel_front            [gz_msgs.WheelSlipParametersCmd]
```

</details>

Get the parameter of one of the wheels of the tricycles
```
gz param -r /world/wheel_slip -g -n systems.wheel_slip.trisphere_cycle1.wheel_front
```

<details>
<summary>Expected outcome</summary>

```
Getting parameter [systems.wheel_slip.trisphere_cycle1.wheel_front] for registry namespace [/world/wheel_slip]...
Message (gz.msgs.WheelSlipParametersCmd) was retrieved with non-fully qualified name. This behavior is deprecated in msgs10
Parameter type [gz_msgs.WheelSlipParametersCmd]

------------------------------------------------
slip_compliance_lateral: 1
slip_compliance_longitudinal: 1
------------------------------------------------
```
</details>

Set one parameter to a different number:
```
gz param -r /world/wheel_slip -s -n systems.w
heel_slip.trisphere_cycle1.wheel_front -t gz_msgs.WheelSlipParametersCmd -m "
  slip_compliance_lateral: 1
  slip_compliance_longitudinal: 2"
```

<details>
<summary>Expected outcome</summary>

```

Setting parameter [systems.wheel_slip.trisphere_cycle1.wheel_front] for registry namespace [/world/wheel_slip]...
Parameter successfully set!
```
</details>

Check the parameter again:
```
gz param -r /world/wheel_slip -g -n systems.wheel_slip.trisphere_cycle1.wheel_front
```

<details>
<summary>Expected outcome</summary>

```
Getting parameter [systems.wheel_slip.trisphere_cycle1.wheel_front] for registry namespace [/world/wheel_slip]...
Message (gz.msgs.WheelSlipParametersCmd) was retrieved with non-fully qualified name. This behavior is deprecated in msgs10
Parameter type [gz_msgs.WheelSlipParametersCmd]

------------------------------------------------
slip_compliance_lateral: 1
slip_compliance_longitudinal: 2
-----------------------------------------------
```
</details>

## Remaining Questions.

I've put the PR into draft for now as there are a couple things to solve first or what I need help with:
* Solving the issue associated to this: `Message (gz.msgs.WheelSlipParametersCmd) was retrieved with non-fully qualified name. This behavior is deprecated in msgs10`
* Try/Catch if parameter doesn't exist. This was the case in the associated branch (https://github.com/gazebosim/gz-sim/compare/ign-gazebo6...ivanpauno/parameters-component-wheel-slip-demo6) if issue #1845 , but now the parameter value is gotten in a different way. But it should be handled somehow... 
* Decide if we want to accommodate with a tutorial? I know this was started by @Gaurang-1402 in https://github.com/osrf/gazebo_tutorials/pull/175 but this was on the wrong location (also it doesn't work currently) but I don't like to take away work of others. But if you are okay with it I can add a tutorial here.
* There was a TODO that I retained from @ivanpauno that we need to see if that is still happening:    ``` // TODO(ivanpauno): WHY THE SCOPED NAME CHANGES BETWEEN HERE AND
    //   ConfigureParameters()?
    // Here the scoped name starts with "wheel_slip."
    // In `ConfigureParameters()` that doesn't happen ```


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

