### PR TITLE
Make sure steering joints exist before updating velocity / odometry in AckermannSteering plugin

### DIFF
--- a/src/systems/ackermann_steering/AckermannSteering.cc
+++ b/src/systems/ackermann_steering/AckermannSteering.cc
@@ -677,6 +677,11 @@ void AckermannSteering::PostUpdate(const UpdateInfo &_info,
   // Nothing left to do if paused.
   if (_info.paused)
     return;
+
+  if (this->dataPtr->leftSteeringJoints.empty() ||
+      this->dataPtr->rightSteeringJoints.empty())
+    return;
+
   if (this->dataPtr->steeringOnly)
   {
     this->dataPtr->UpdateAngle(_info, _ecm);


### PR DESCRIPTION

# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/2507

## Summary

Don't update if joints are not found. This prevents a crash found in https://github.com/gazebosim/gz-sim/issues/2507.

The user should see warning msgs like:

```
[Wrn] [AckermannSteering.cc:530] Failed to find left joint [front_left_wheel_joint] for model [box]
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

