### PR TITLE
Disable detachable_joint integration test case on Windows

### DIFF
--- a/test/integration/detachable_joint.cc
+++ b/test/integration/detachable_joint.cc
@@ -217,7 +217,8 @@ TEST_F(DetachableJointTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(LinksInSameModel))
 }
 
 /////////////////////////////////////////////////
-TEST_F(DetachableJointTest, NestedModelsWithSameName)
+TEST_F(DetachableJointTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(NestedModelsWithSameName))
 {
   using namespace std::chrono_literals;
 


### PR DESCRIPTION
# 🦟 Bug fix

The `NestedModelsWithSameName` test case was added in https://github.com/gazebosim/gz-sim/pull/1097 but fails on Windows. 
https://build.osrfoundation.org/job/gz_sim-pr-win/741/testReport/(root)/DetachableJointTest/NestedModelsWithSameName/

Other test cases in test/integration/detachable_joint.cc are already disabled on Windows. The fix here is to also disable the new test case on Windows.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
