### PR TITLE
Force Qt to use xcb plugin on Wayland

### DIFF
--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -221,6 +221,16 @@ std::unique_ptr<gz::gui::Application> createGui(
     qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", "1");
   }
 
+  // check for wayland and force to use X for rendering
+  if (QString::fromLocal8Bit(qgetenv("XDG_SESSION_TYPE")) == "wayland")
+  {
+    if (QString::fromLocal8Bit(qgetenv("QT_QPA_PLATFORM")).isEmpty())
+    {
+      qputenv("QT_QPA_PLATFORM", "xcb");
+    }
+  }
+
+
   bool isPlayback = (nullptr != _guiConfig &&
       std::string(_guiConfig) == "_playback_");
   auto defaultConfig = defaultGuiConfigFile(isPlayback, _defaultGuiConfig);

--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -226,6 +226,8 @@ std::unique_ptr<gz::gui::Application> createGui(
   {
     if (QString::fromLocal8Bit(qgetenv("QT_QPA_PLATFORM")).isEmpty())
     {
+      gzmsg << "Detected Wayland. Setting Qt to use the xcb plugin: "
+            << "'QT_QPA_PLATFORM=xcb'." << std::endl;
       qputenv("QT_QPA_PLATFORM", "xcb");
     }
   }


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

More and more users are running into the same issue on Wayland. We recently updated the troubleshooting guide for Wayland in https://gazebosim.org/docs/latest/troubleshooting/#wayland-issues. This PR just does the step described in the guide for the users. It sets Qt to use the xcb plugin if a) wayland is detected and b) only if the user has not explicitly set the `QT_QPA_PLATFORM` env var.

This is more of a quality of life fix to improve user experience and save them from having to go through the troubleshooting process.

Similar fix was done in rviz: https://github.com/ros2/rviz/pull/1253

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
