### PR TITLE
Revert behavior change introduced in #2452

### DIFF
--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -328,6 +328,14 @@ void SdfEntityCreator::CreateEntities(const sdf::World *_world,
         components::SphericalCoordinates(*_world->SphericalCoordinates()));
   }
 
+  this->dataPtr->eventManager->Emit<events::LoadSdfPlugins>(_worldEntity,
+      _world->Plugins());
+
+  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
+  this->dataPtr->eventManager->Emit<events::LoadPlugins>(_worldEntity,
+        _world->ToElement());
+  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
+
   // Models
   for (uint64_t modelIndex = 0; modelIndex < _world->ModelCount();
       ++modelIndex)
@@ -449,14 +457,6 @@ void SdfEntityCreator::CreateEntities(const sdf::World *_world,
   // Store the world's SDF DOM to be used when saving the world to file
   this->dataPtr->ecm->CreateComponent(
       _worldEntity, components::WorldSdf(*_world));
-
-  this->dataPtr->eventManager->Emit<events::LoadSdfPlugins>(_worldEntity,
-      _world->Plugins());
-
-  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
-  this->dataPtr->eventManager->Emit<events::LoadPlugins>(_worldEntity,
-        _world->ToElement());
-  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
 }
 
 //////////////////////////////////////////////////

--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -337,7 +337,7 @@ void SdfEntityCreator::CreateEntities(const sdf::World *_world,
         levelEntityNames.find(model->Name()) != levelEntityNames.end())
 
     {
-      Entity modelEntity = this->CreateEntities(model, false);
+      Entity modelEntity = this->CreateEntities(model);
 
       this->SetParent(modelEntity, _worldEntity);
     }
@@ -387,7 +387,7 @@ void SdfEntityCreator::CreateEntities(const sdf::World *_world,
       if (_world->ModelNameExists(_ref->Data()))
       {
         const sdf::Model *model = _world->ModelByName(_ref->Data());
-        Entity modelEntity = this->CreateEntities(model, false);
+        Entity modelEntity = this->CreateEntities(model);
         this->SetParent(modelEntity, _worldEntity);
         this->SetParent(_entity, modelEntity);
       }
@@ -450,7 +450,6 @@ void SdfEntityCreator::CreateEntities(const sdf::World *_world,
   this->dataPtr->ecm->CreateComponent(
       _worldEntity, components::WorldSdf(*_world));
 
-  // Load world plugins first.
   this->dataPtr->eventManager->Emit<events::LoadSdfPlugins>(_worldEntity,
       _world->Plugins());
 
@@ -458,9 +457,6 @@ void SdfEntityCreator::CreateEntities(const sdf::World *_world,
   this->dataPtr->eventManager->Emit<events::LoadPlugins>(_worldEntity,
         _world->ToElement());
   GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
-
-  // Load model plugins after the world plugin.
-  this->LoadModelPlugins();
 }
 
 //////////////////////////////////////////////////

--- a/src/systems/logical_audio_sensor_plugin/LogicalAudioSensorPlugin.cc
+++ b/src/systems/logical_audio_sensor_plugin/LogicalAudioSensorPlugin.cc
@@ -405,7 +405,7 @@ void LogicalAudioSensorPluginPrivate::CreateAudioSource(
     };
 
   // create services for this source
-  const auto validName = topicFromScopedName(entity, _ecm, true);
+  const auto validName = topicFromScopedName(entity, _ecm, false);
   if (validName.empty())
   {
     gzerr << "Failed to create valid topics with entity scoped name ["
@@ -503,7 +503,7 @@ void LogicalAudioSensorPluginPrivate::CreateMicrophone(
 
   // create the detection publisher for this microphone
   auto pub = this->node.Advertise<msgs::Double>(
-      topicFromScopedName(entity, _ecm, true) + "/detection");
+      topicFromScopedName(entity, _ecm, false) + "/detection");
   if (!pub)
   {
     gzerr << "Error creating a detection publisher for microphone "

--- a/src/systems/pose_publisher/PosePublisher.cc
+++ b/src/systems/pose_publisher/PosePublisher.cc
@@ -250,7 +250,7 @@ void PosePublisher::Configure(const Entity &_entity,
   this->dataPtr->usePoseV =
     _sdf->Get<bool>("use_pose_vector_msg", this->dataPtr->usePoseV).first;
 
-  std::string poseTopic = topicFromScopedName(_entity, _ecm, true) + "/pose";
+  std::string poseTopic = topicFromScopedName(_entity, _ecm, false) + "/pose";
   if (poseTopic.empty())
   {
     poseTopic = "/pose";


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
PR #2452 changed the loading order of plugins attached to worlds and models. While the change is desirable, it changed the behavior of functions like `topicFromScopedName`. This reverts the behavior and the changes in associated tests.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
