### PR TITLE
Fix SphericalCoordinates deprecation warnings

### DIFF
--- a/src/Util.cc
+++ b/src/Util.cc
@@ -711,12 +711,15 @@ std::optional<math::Vector3d> sphericalCoordinates(Entity _entity,
 
   // lat / lon / elevation in rad / rad / m
   auto rad = sphericalCoordinatesComp->Data().PositionTransform(
-      xyzPose.Pos(),
-      math::SphericalCoordinates::LOCAL2,
+      math::CoordinateVector3::Metric(xyzPose.Pos()),
+      math::SphericalCoordinates::LOCAL,
       math::SphericalCoordinates::SPHERICAL);
 
+  if (!rad.has_value())
+    return std::nullopt;
+
   // Return degrees
-  return math::Vector3d(GZ_RTOD(rad.X()), GZ_RTOD(rad.Y()), rad.Z());
+  return math::Vector3d(rad->Lat()->Degree(), rad->Lon()->Degree(), *rad->Z());
 }
 
 //////////////////////////////////////////////////
@@ -747,15 +750,29 @@ std::optional<math::Vector3d> getGridFieldCoordinates(
     }
   }
   auto position = origin->Data().PositionTransform(
-      _worldPosition, math::SphericalCoordinates::LOCAL2,
+      math::CoordinateVector3::Metric(_worldPosition),
+      math::SphericalCoordinates::LOCAL,
       _gridField->reference);
+  if (!position.has_value())
+    return std::nullopt;
+
+  if (position->IsMetric())
+    return position->AsMetricVector();
+
+  math::Vector3d out;
   if (_gridField->reference == math::SphericalCoordinates::SPHERICAL &&
     _gridField->units == components::EnvironmentalData::ReferenceUnits::DEGREES)
   {
-    position.X(GZ_RTOD(position.X()));
-    position.Y(GZ_RTOD(position.Y()));
+    out.X(position->Lat()->Degree());
+    out.Y(position->Lon()->Degree());
   }
-  return position;
+  else
+  {
+    out.X(position->Lat()->Radian());
+    out.Y(position->Lon()->Radian());
+  }
+  out.Z(*position->Z());
+  return out;
 }
 
 //////////////////////////////////////////////////

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -715,7 +715,7 @@ std::optional<math::Vector3d> sphericalCoordinates(Entity _entity,
       math::SphericalCoordinates::LOCAL,
       math::SphericalCoordinates::SPHERICAL);
 
-  if (!rad.has_value())
+  if (!rad.has_value() || !rad->IsSpherical())
     return std::nullopt;
 
   // Return degrees
@@ -772,6 +772,8 @@ std::optional<math::Vector3d> getGridFieldCoordinates(
     out.Y(position->Lon()->Radian());
   }
   out.Z(*position->Z());
+
+  // \todo(iche033) Change the return type to math::CoordinateVector3
   return out;
 }
 

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -1282,7 +1282,6 @@ bool CreateCommand::Execute()
   // Spherical coordinates
   if (createMsg->has_spherical_coordinates())
   {
-    gzerr << "HasSphericalCoordinates" << std::endl;
     auto scComp = this->iface->ecm->Component<components::SphericalCoordinates>(
         this->iface->worldEntity);
     if (nullptr == scComp)

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -1293,8 +1293,7 @@ bool CreateCommand::Execute()
     }
     else
     {
-      math::CoordinateVector3 vec;
-      vec.SetSpherical(
+      auto vec = math::CoordinateVector3::Spherical(
           GZ_DTOR(createMsg->spherical_coordinates().latitude_deg()),
           GZ_DTOR(createMsg->spherical_coordinates().longitude_deg()),
           createMsg->spherical_coordinates().elevation());
@@ -1302,7 +1301,7 @@ bool CreateCommand::Execute()
           math::SphericalCoordinates::SPHERICAL,
           math::SphericalCoordinates::LOCAL);
 
-      if (!pos.has_value())
+      if (!pos.has_value() || !pos->IsMetric())
       {
         gzerr << "Trying to create entity [" << desiredName
               << "] using spherical coordinates, but spherical to local "
@@ -1710,14 +1709,14 @@ bool SphericalCoordinatesCommand::Execute()
     return false;
   }
 
-  math::CoordinateVector3 vec;
-  vec.SetSpherical(GZ_DTOR(sphericalCoordinatesMsg->latitude_deg()),
-                   GZ_DTOR(sphericalCoordinatesMsg->longitude_deg()),
-                   sphericalCoordinatesMsg->elevation());
+  auto vec = math::CoordinateVector3::Spherical(
+      GZ_DTOR(sphericalCoordinatesMsg->latitude_deg()),
+      GZ_DTOR(sphericalCoordinatesMsg->longitude_deg()),
+      sphericalCoordinatesMsg->elevation());
   auto pos = scComp->Data().PositionTransform(vec,
       math::SphericalCoordinates::SPHERICAL,
       math::SphericalCoordinates::LOCAL);
-  if (!pos.has_value())
+  if (!pos.has_value() || !pos->IsMetric())
   {
     gzerr << "Trying to move entity [" << entity
            << "] using spherical coordinates, but spherical to local "


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The `math::SphericalCoordinates::LOCAL2` enum is deprecated in https://github.com/gazebosim/gz-math/pull/616. This PR updates the spherical coordinate conversion functions to use the new APIs that take `CoordinateVector3` arg  which work with the recommended `math::SphericalCoordinates::LOCAL` enum.

cc @peci1 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

