### PR TITLE
Fix UNIT_Server_TEST failure caused by change in behavior of `gz::common::SignalHandler`

### DIFF
--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -776,6 +776,7 @@ TEST_P(ServerFixture, SigInt)
   EXPECT_TRUE(*server.Running(0));
 
   std::raise(SIGTERM);
+  GZ_SLEEP_MS(20);
 
   EXPECT_FALSE(server.Running());
   EXPECT_FALSE(*server.Running(0));
@@ -880,6 +881,7 @@ TEST_P(ServerFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(AddSystemWhileRunning))
 
   // Stop the server
   std::raise(SIGTERM);
+  GZ_SLEEP_MS(20);
 
   EXPECT_FALSE(server.Running());
   EXPECT_FALSE(*server.Running(0));


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

https://github.com/gazebosim/gz-common/pull/618 changed the way `gz::common::SignalHandler` works in that the callback is invoked from a separate thread. This causes a slight difference in the timing of when callbacks get called. Adding a small delay after raising a signal fixes the problem.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
