### PR TITLE
Fix elevator system crash when empty laser scan msg is received.

### DIFF
--- a/src/systems/elevator/Elevator.cc
+++ b/src/systems/elevator/Elevator.cc
@@ -421,6 +421,9 @@ void ElevatorPrivate::UpdateState(const gz::sim::UpdateInfo &_info,
 void ElevatorPrivate::OnLidarMsg(size_t _floorLevel,
                                  const msgs::LaserScan &_msg)
 {
+  if (_msg.ranges_size() <= 0)
+    return;
+
   bool isDoorwayBlocked = _msg.ranges(0) < _msg.range_max() - 0.005;
   if (isDoorwayBlocked == this->isDoorwayBlockedStates[_floorLevel]) return;
   std::lock_guard<std::recursive_mutex> lock(this->mutex);


### PR DESCRIPTION

# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/2531

## Summary

See https://github.com/gazebosim/gz-sim/issues/2531 for instructions on reproducing the crash.

Added a check for non-empty laser scan ranges before accessing the elements.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

