### PR TITLE
Restore behavior change by reverting #2527

### DIFF
--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -319,9 +319,6 @@ void SdfEntityCreator::CreateEntities(const sdf::World *_world,
         components::SphericalCoordinates(*_world->SphericalCoordinates()));
   }
 
-  this->dataPtr->eventManager->Emit<events::LoadSdfPlugins>(_worldEntity,
-      _world->Plugins());
-
   // Models
   for (uint64_t modelIndex = 0; modelIndex < _world->ModelCount();
       ++modelIndex)
@@ -331,7 +328,7 @@ void SdfEntityCreator::CreateEntities(const sdf::World *_world,
         levelEntityNames.find(model->Name()) != levelEntityNames.end())
 
     {
-      Entity modelEntity = this->CreateEntities(model);
+      Entity modelEntity = this->CreateEntities(model, false);
 
       this->SetParent(modelEntity, _worldEntity);
     }
@@ -381,7 +378,7 @@ void SdfEntityCreator::CreateEntities(const sdf::World *_world,
       if (_world->ModelNameExists(_ref->Data()))
       {
         const sdf::Model *model = _world->ModelByName(_ref->Data());
-        Entity modelEntity = this->CreateEntities(model);
+        Entity modelEntity = this->CreateEntities(model, false);
         this->SetParent(modelEntity, _worldEntity);
         this->SetParent(_entity, modelEntity);
       }
@@ -456,6 +453,12 @@ void SdfEntityCreator::CreateEntities(const sdf::World *_world,
   // Store the world's SDF DOM to be used when saving the world to file
   this->dataPtr->ecm->CreateComponent(
       _worldEntity, components::WorldSdf(*_world));
+
+  this->dataPtr->eventManager->Emit<events::LoadSdfPlugins>(_worldEntity,
+      _world->Plugins());
+
+  // Load model plugins after the world plugin.
+  this->LoadModelPlugins();
 }
 
 //////////////////////////////////////////////////

--- a/src/systems/logical_audio_sensor_plugin/LogicalAudioSensorPlugin.cc
+++ b/src/systems/logical_audio_sensor_plugin/LogicalAudioSensorPlugin.cc
@@ -405,7 +405,7 @@ void LogicalAudioSensorPluginPrivate::CreateAudioSource(
     };
 
   // create services for this source
-  const auto validName = topicFromScopedName(entity, _ecm, false);
+  const auto validName = topicFromScopedName(entity, _ecm, true);
   if (validName.empty())
   {
     gzerr << "Failed to create valid topics with entity scoped name ["
@@ -503,7 +503,7 @@ void LogicalAudioSensorPluginPrivate::CreateMicrophone(
 
   // create the detection publisher for this microphone
   auto pub = this->node.Advertise<msgs::Double>(
-      topicFromScopedName(entity, _ecm, false) + "/detection");
+      topicFromScopedName(entity, _ecm, true) + "/detection");
   if (!pub)
   {
     gzerr << "Error creating a detection publisher for microphone "

--- a/src/systems/pose_publisher/PosePublisher.cc
+++ b/src/systems/pose_publisher/PosePublisher.cc
@@ -252,7 +252,7 @@ void PosePublisher::Configure(const Entity &_entity,
   this->dataPtr->usePoseV =
     _sdf->Get<bool>("use_pose_vector_msg", this->dataPtr->usePoseV).first;
 
-  std::string poseTopic = topicFromScopedName(_entity, _ecm, false) + "/pose";
+  std::string poseTopic = topicFromScopedName(_entity, _ecm, true) + "/pose";
   if (poseTopic.empty())
   {
     poseTopic = "/pose";


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

https://github.com/gazebosim/gz-sim/pull/2527 reverted the changes introduced in https://github.com/gazebosim/gz-sim/pull/2452 because it's a behavior breaking change. 

This PR restores the behavior change for `main` by undoing the changes in https://github.com/gazebosim/gz-sim/pull/2527. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
