### PR TITLE
clang-tidy fixes: use empty(), fix includes

### DIFF
--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -20,6 +20,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <string>

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <optional>
 #include <gtest/gtest.h>
 
 #include <gz/common/Console.hh>

--- a/src/LevelManager.cc
+++ b/src/LevelManager.cc
@@ -18,18 +18,23 @@
 #include "LevelManager.hh"
 
 #include <algorithm>
+#include <optional>
 
 #include <sdf/Actor.hh>
 #include <sdf/Atmosphere.hh>
+#include <sdf/Element.hh>
 #include <sdf/Joint.hh>
 #include <sdf/Light.hh>
 #include <sdf/Model.hh>
+#include <sdf/Plugin.hh>
 #include <sdf/World.hh>
 
 #include <gz/math/SphericalCoordinates.hh>
+#include <gz/common/Console.hh>
 #include <gz/common/Profiler.hh>
 
 #include "gz/sim/Events.hh"
+#include "gz/sim/Entity.hh"
 #include "gz/sim/EntityComponentManager.hh"
 
 #include "gz/sim/components/Actor.hh"

--- a/src/LevelManager.cc
+++ b/src/LevelManager.cc
@@ -838,7 +838,7 @@ void LevelManager::UnloadLevel(const Entity &_entity,
     }
   }
 
-  if (entityNamesToUnload.size() > 0)
+  if (!entityNamesToUnload.empty())
   {
     this->UnloadInactiveEntities(entityNamesToUnload);
   }

--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -15,8 +15,13 @@
  *
 */
 
+#include <set>
+
 #include <gz/common/Console.hh>
 #include <gz/common/Profiler.hh>
+#include <sdf/Actor.hh>
+#include <sdf/Light.hh>
+#include <sdf/Model.hh>
 #include <sdf/Types.hh>
 
 #include "gz/sim/Events.hh"
@@ -68,7 +73,6 @@
 #include <gz/sim/components/ParticleEmitter.hh>
 #include "gz/sim/components/Performer.hh"
 #include "gz/sim/components/Physics.hh"
-#include "gz/sim/components/PhysicsEnginePlugin.hh"
 #include "gz/sim/components/Pose.hh"
 #include <gz/sim/components/Projector.hh>
 #include "gz/sim/components/RgbdCamera.hh"

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -18,6 +18,8 @@
 #include "SimulationRunner.hh"
 
 #include <algorithm>
+#include <memory>
+#include <ostream>
 #ifdef HAVE_PYBIND11
 #include <pybind11/pybind11.h>
 #endif
@@ -32,6 +34,7 @@
 #include <gz/msgs/world_control_state.pb.h>
 #include <gz/msgs/world_stats.pb.h>
 
+#include <sdf/Physics.hh>
 #include <sdf/Root.hh>
 #include <vector>
 
@@ -49,11 +52,14 @@
 #include "gz/sim/components/RenderEngineGuiPlugin.hh"
 #include "gz/sim/components/RenderEngineServerHeadless.hh"
 #include "gz/sim/components/RenderEngineServerPlugin.hh"
+#include "gz/sim/Conversions.hh"
 #include "gz/sim/Events.hh"
+#include "gz/sim/ServerConfig.hh"
 #include "gz/sim/SdfEntityCreator.hh"
 #include "gz/sim/Util.hh"
 #include "gz/transport/TopicUtils.hh"
 #include "network/NetworkManagerPrimary.hh"
+#include "LevelManager.hh"
 #include "SdfGenerator.hh"
 
 using namespace gz;

--- a/src/systems/spacecraft_thruster_model/SpacecraftThrusterModel.cc
+++ b/src/systems/spacecraft_thruster_model/SpacecraftThrusterModel.cc
@@ -25,13 +25,15 @@
 
 #include "SpacecraftThrusterModel.hh"
 
-#include <mutex>
-#include <string>
-#include <optional>
 #include <chrono>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
 
 #include <gz/msgs/actuators.pb.h>
 
+#include <gz/common/Console.hh>
 #include <gz/common/Profiler.hh>
 
 #include <gz/plugin/Register.hh>
@@ -47,8 +49,11 @@
 #include "gz/sim/components/Actuators.hh"
 #include "gz/sim/components/ExternalWorldWrenchCmd.hh"
 #include "gz/sim/components/Pose.hh"
+#include "gz/sim/Entity.hh"
+#include "gz/sim/EntityComponentManager.hh"
 #include "gz/sim/Link.hh"
 #include "gz/sim/Model.hh"
+#include "gz/sim/System.hh"
 #include "gz/sim/Util.hh"
 
 using namespace gz;


### PR DESCRIPTION
# 🦟 Bug fix

Fix assorted clang-tidy complaints

## Summary

* https://github.com/gazebosim/gz-sim/commit/e7c295146e52e26341492c272887ca112e87044e Check that a container is not `empty()` rather than compare `size() > 0`
* Assorted include-what-you-use fixes: add missing headers, remove unused headers, alphabetize

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
