### PR TITLE
Prevent crash in optical tactile plugin by adding a sanity check on point cloud data size

### DIFF
--- a/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
+++ b/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
@@ -753,6 +753,15 @@ void OpticalTactilePluginPrivate::ComputeNormalForces(
   if (!this->initialized)
     return;
 
+  // sanity check to make sure point cloud data size matches other fields
+  if (_msg.data().size() !=  _msg.row_step() * _msg.height())
+  {
+    gzerr << "Invalid point cloud message. "
+          << "Point cloud data size != row_step * height."
+          << std::endl;
+    return;
+  }
+
   // Get data from the message
   const char *msgBuffer = _msg.data().data();
 


### PR DESCRIPTION


# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/2541

## Summary

See instructions in https://github.com/gazebosim/gz-sim/issues/2541 for reproducing the crash.

Adds a sanity check on point cloud data size before attempting to access the char array buffer.

`data` size should be equal to `row_step * height`, see [data field description](https://github.com/gazebosim/gz-msgs/blob/0da35a8b1239c3186e398ac4ed2dbe1762f3aaa4/proto/gz/msgs/pointcloud_packed.proto#L95-L96)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
