### PR TITLE
Remove <gz:system_priority/> from test worlds

### DIFF
--- a/python/test/joint_test.sdf
+++ b/python/test/joint_test.sdf
@@ -2,9 +2,7 @@
 <sdf version="1.6">
     <world name="world_test">
         <plugin filename="gz-sim-physics-system" name="gz::sim::systems::Physics" />
-        <plugin filename="gz-sim-forcetorque-system" name="gz::sim::systems::ForceTorque">
-            <gz:system_priority>10</gz:system_priority>
-        </plugin>
+        <plugin filename="gz-sim-forcetorque-system" name="gz::sim::systems::ForceTorque"/>
         <model name="model_test">
 
             <link name="link_test_1">

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -767,7 +767,7 @@ Physics::Physics() : System(), dataPtr(std::make_unique<PhysicsPrivate>())
 //////////////////////////////////////////////////
 System::PriorityType Physics::ConfigurePriority()
 {
-  // Use constant from SystemPriorityConstants.hh
+  // Use constant from System.hh
   return ::gz::sim::systems::kPhysicsPriority;
 }
 

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -621,7 +621,7 @@ bool UserCommandsInterface::HasContactSensor(const Entity _collision)
 //////////////////////////////////////////////////
 System::PriorityType UserCommands::ConfigurePriority()
 {
-  // Use constant from SystemPriorityConstants.hh
+  // Use constant from System.hh
   return ::gz::sim::systems::kUserCommandsPriority;
 }
 

--- a/test/worlds/force_torque.sdf
+++ b/test/worlds/force_torque.sdf
@@ -5,9 +5,7 @@
       <real_time_factor>0</real_time_factor>
     </physics>
     <plugin filename="gz-sim-physics-system" name="gz::sim::systems::Physics" />
-    <plugin filename="gz-sim-forcetorque-system" name="gz::sim::systems::ForceTorque">
-      <gz:system_priority>10</gz:system_priority>
-    </plugin>
+    <plugin filename="gz-sim-forcetorque-system" name="gz::sim::systems::ForceTorque"/>
     <plugin filename='gz-sim-scene-broadcaster-system' name='gz::sim::systems::SceneBroadcaster' />
     <model name="ground_plane">
       <static>true</static>


### PR DESCRIPTION
# 🦟 Bug fix

Follow-up to #2494 and #2500.

## Summary

The system priority for the force-torque system was explicitly set using XML tags in several test worlds in #2494. These XML tags are no longer needed since #2500 was merged, so remove them now.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
