### PR TITLE
Backport nonbreaking changes from ionic

### DIFF
--- a/include/gz/sim/Model.hh
+++ b/include/gz/sim/Model.hh
@@ -137,6 +137,14 @@ namespace gz
       public: sim::Entity LinkByName(const EntityComponentManager &_ecm,
           const std::string &_name) const;
 
+      /// \brief Get the ID of a nested model entity which is an immediate
+      /// child of this model.
+      /// \param[in] _ecm Entity-component manager.
+      /// \param[in] _name Nested model name.
+      /// \return Nested model entity.
+      public: sim::Entity ModelByName(const EntityComponentManager &_ecm,
+          const std::string &_name) const;
+
       /// \brief Get all joints which are immediate children of this model.
       /// \param[in] _ecm Entity-component manager.
       /// \return All joints in this model.
@@ -166,6 +174,12 @@ namespace gz
       /// \param[in] _ecm Entity-component manager.
       /// \return Number of links in this model.
       public: uint64_t LinkCount(const EntityComponentManager &_ecm) const;
+
+      /// \brief Get the number of nested models which are immediate children
+      /// of this model.
+      /// \param[in] _ecm Entity-component manager.
+      /// \return Number of nested models in this model.
+      public: uint64_t ModelCount(const EntityComponentManager &_ecm) const;
 
       /// \brief Set a command to change the model's pose.
       /// \param[in] _ecm Entity-component manager.

--- a/include/gz/sim/components/WrenchMeasured.hh
+++ b/include/gz/sim/components/WrenchMeasured.hh
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef GZ_SIM_COMPONENTS_WRENCHMEASURED_HH_
+#define GZ_SIM_COMPONENTS_WRENCHMEASURED_HH_
+
+#include <gz/msgs/wrench.pb.h>
+
+#include <gz/sim/components/Factory.hh>
+#include <gz/sim/components/Component.hh>
+#include <gz/sim/components/Serialization.hh>
+#include <gz/sim/config.hh>
+
+namespace gz
+{
+namespace sim
+{
+// Inline bracket to help doxygen filtering.
+inline namespace GZ_SIM_VERSION_NAMESPACE {
+
+namespace components
+{
+/// \brief Wrench measured by a ForceTorqueSensor in SI units (Nm for torque,
+/// N for force).
+/// The wrench is expressed in the Sensor frame and the force component is
+/// applied at the sensor origin.
+/// \note The term Wrench is used here to mean a pair of 3D vectors representing
+/// torque and force quantities expressed in a given frame and where the force
+/// is applied at the origin of the frame. This is different from the Wrench
+/// used in screw theory.
+/// \note The value of force_offset in msgs::Wrench is ignored for this
+/// component. The force is assumed to be applied at the origin of the sensor
+/// frame.
+using WrenchMeasured =
+    Component<msgs::Wrench, class WrenchMeasuredTag,
+              serializers::MsgSerializer>;
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.WrenchMeasured",
+                          WrenchMeasured)
+}  // namespace components
+}
+}
+}
+
+#endif

--- a/python/test/sensor_TEST.py
+++ b/python/test/sensor_TEST.py
@@ -36,8 +36,8 @@ class TestSensor(unittest.TestCase):
         def on_post_udpate_cb(_info, _ecm):
             self.post_iterations += 1
 
-        def on_pre_udpate_cb(_info, _ecm):
-            self.pre_iterations += 1
+        def on_update_cb(_info, _ecm):
+            self.iterations += 1
             world_e = world_entity(_ecm)
             self.assertNotEqual(K_NULL_ENTITY, world_e)
             w = World(world_e)
@@ -53,19 +53,19 @@ class TestSensor(unittest.TestCase):
             # Pose Test
             self.assertEqual(Pose3d(0, 1, 0, 0, 0, 0), sensor.pose(_ecm))
             # Topic Test
-            if self.pre_iterations <= 1:
+            if self.iterations <= 1:
                 self.assertEqual(None, sensor.topic(_ecm))
             else:
                 self.assertEqual('sensor_topic_test', sensor.topic(_ecm))
             # Parent Test
             self.assertEqual(j.entity(), sensor.parent(_ecm))
 
-        def on_udpate_cb(_info, _ecm):
-            self.iterations += 1
+        def on_pre_update_cb(_info, _ecm):
+            self.pre_iterations += 1
 
         fixture.on_post_update(on_post_udpate_cb)
-        fixture.on_update(on_udpate_cb)
-        fixture.on_pre_update(on_pre_udpate_cb)
+        fixture.on_update(on_update_cb)
+        fixture.on_pre_update(on_pre_update_cb)
         fixture.finalize()
 
         server = fixture.server()

--- a/python/test/sensor_TEST.py
+++ b/python/test/sensor_TEST.py
@@ -33,7 +33,7 @@ class TestSensor(unittest.TestCase):
         file_path = os.path.dirname(os.path.realpath(__file__))
         fixture = TestFixture(os.path.join(file_path, 'joint_test.sdf'))
 
-        def on_post_udpate_cb(_info, _ecm):
+        def on_post_update_cb(_info, _ecm):
             self.post_iterations += 1
 
         def on_update_cb(_info, _ecm):
@@ -63,7 +63,7 @@ class TestSensor(unittest.TestCase):
         def on_pre_update_cb(_info, _ecm):
             self.pre_iterations += 1
 
-        fixture.on_post_update(on_post_udpate_cb)
+        fixture.on_post_update(on_post_update_cb)
         fixture.on_update(on_update_cb)
         fixture.on_pre_update(on_pre_update_cb)
         fixture.finalize()

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -149,6 +149,16 @@ Entity Model::LinkByName(const EntityComponentManager &_ecm,
 }
 
 //////////////////////////////////////////////////
+Entity Model::ModelByName(const EntityComponentManager &_ecm,
+    const std::string &_name) const
+{
+  return _ecm.EntityByComponents(
+      components::ParentEntity(this->dataPtr->id),
+      components::Name(_name),
+      components::Model());
+}
+
+//////////////////////////////////////////////////
 std::vector<Entity> Model::Joints(const EntityComponentManager &_ecm) const
 {
   return _ecm.EntitiesByComponents(
@@ -182,6 +192,12 @@ uint64_t Model::JointCount(const EntityComponentManager &_ecm) const
 uint64_t Model::LinkCount(const EntityComponentManager &_ecm) const
 {
   return this->Links(_ecm).size();
+}
+
+//////////////////////////////////////////////////
+uint64_t Model::ModelCount(const EntityComponentManager &_ecm) const
+{
+  return this->Models(_ecm).size();
 }
 
 //////////////////////////////////////////////////

--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -307,6 +307,7 @@ const std::vector<ISystemConfigure *>& SystemManager::SystemsConfigure()
   return this->systemsConfigure;
 }
 
+//////////////////////////////////////////////////
 const std::vector<ISystemConfigureParameters *>&
 SystemManager::SystemsConfigureParameters()
 {

--- a/src/systems/force_torque/ForceTorque.cc
+++ b/src/systems/force_torque/ForceTorque.cc
@@ -45,6 +45,7 @@
 #include "gz/sim/components/Sensor.hh"
 #include "gz/sim/components/World.hh"
 #include "gz/sim/EntityComponentManager.hh"
+#include "gz/sim/System.hh"
 #include "gz/sim/Util.hh"
 
 using namespace gz;

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -93,6 +93,7 @@
 
 #include "gz/sim/EntityComponentManager.hh"
 #include "gz/sim/Model.hh"
+#include "gz/sim/System.hh"
 #include "gz/sim/Util.hh"
 
 // Components

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -432,7 +432,7 @@ class gz::sim::systems::PhysicsPrivate
                       }
                       return true;
                     }};
-  /// \brief msgs::Contacts equality comparison function.
+  /// \brief msgs::Wrench equality comparison function.
   public: std::function<bool(const msgs::Wrench &, const msgs::Wrench &)>
           wrenchEql{
           [](const msgs::Wrench &_a, const msgs::Wrench &_b)

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -80,6 +80,7 @@
 #include "gz/sim/EntityComponentManager.hh"
 #include "gz/sim/Model.hh"
 #include "gz/sim/SdfEntityCreator.hh"
+#include "gz/sim/System.hh"
 #include "gz/sim/Util.hh"
 #include "gz/sim/World.hh"
 #include "gz/sim/components/ContactSensorData.hh"

--- a/test/integration/force_torque_system.cc
+++ b/test/integration/force_torque_system.cc
@@ -43,7 +43,7 @@ class ForceTorqueTest : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(ForceTorqueTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(MeasureWeight))
+TEST_F(ForceTorqueTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(MeasureWeightTopic))
 {
   using namespace std::chrono_literals;
   // Start server
@@ -59,8 +59,8 @@ TEST_F(ForceTorqueTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(MeasureWeight))
 
   // Having iters exactly in sync with update rate can lead to a race condition
   // in the test between simulation and transport
-  size_t iters = 999u;
-  size_t updates = 100u;
+  const size_t iters = 999u;
+  const size_t updates = 100u;
 
   std::vector<msgs::Wrench> wrenches;
   wrenches.reserve(updates);

--- a/test/integration/model.cc
+++ b/test/integration/model.cc
@@ -165,6 +165,30 @@ TEST_F(ModelIntegrationTest, SourceFilePath)
 }
 
 //////////////////////////////////////////////////
+TEST_F(ModelIntegrationTest, ModelByName)
+{
+  EntityComponentManager ecm;
+
+  // Model
+  auto eModel = ecm.CreateEntity();
+  Model model(eModel);
+  EXPECT_EQ(eModel, model.Entity());
+  EXPECT_EQ(0u, model.ModelCount(ecm));
+
+  // Nested Model
+  auto eNestedModel = ecm.CreateEntity();
+  ecm.CreateComponent<components::Model>(eNestedModel, components::Model());
+  ecm.CreateComponent<components::ParentEntity>(eNestedModel,
+      components::ParentEntity(eModel));
+  ecm.CreateComponent<components::Name>(eNestedModel,
+      components::Name("nested_model_name"));
+
+  // Check model
+  EXPECT_EQ(eNestedModel, model.ModelByName(ecm, "nested_model_name"));
+  EXPECT_EQ(1u, model.ModelCount(ecm));
+}
+
+//////////////////////////////////////////////////
 TEST_F(ModelIntegrationTest, LinkByName)
 {
   EntityComponentManager ecm;


### PR DESCRIPTION
# 🎉 New feature

Backports non-breaking changes from #2494 and #2500 to harmonic

## Summary

This backports the non-breaking changes from #2494 and #2500 to harmonic:

* https://github.com/gazebosim/gz-sim/commit/79ab869af051043bf5c38444d9ee20e1b3b6bee3: add `Model::ModelCount` and `Model::ModelByName` nested model accessor APIs
* https://github.com/gazebosim/gz-sim/commit/774f21c15c69c6dec4ef0230df160d8c4db2c121: add `WrenchMeasured` component. It's not currently used, but it's safe to add.
* https://github.com/gazebosim/gz-sim/commit/501d155ecc1c9584ea20462aac05ffd15d1fd141: since the `sensor_TEST.py` `PreUpdate` callback assumes that it executes after the `ForceTorque` `PreUpdate` callback, move the test callback to `Update` to guarantee it. Also fix a spelling error.

The remaining commits make minor non-breaking changes.

## Test it

Check CI results

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
