### PR TITLE
Fix doxygen page links

### DIFF
--- a/tutorials/adding_system_plugins.md
+++ b/tutorials/adding_system_plugins.md
@@ -1,4 +1,4 @@
-\page adding_system_plugins
+\page adding_system_plugins Adding system plugins
 
 # Overview
 
@@ -10,11 +10,11 @@ capabilities to it.
 Make sure to go through the following tutorial first, where you'll learn how
 to create the vehicle used in this tutorial.
 
-https://gazebosim.org/api/sim/8/create_vehicle.html
+\ref create_vehicle
 
 ## Related tutorials
 
-https://gazebosim.org/api/sim/8/createsystemplugins.html
+\ref createsystemplugins
 
 # Adding a system plugin
 

--- a/tutorials/adding_visuals.md
+++ b/tutorials/adding_visuals.md
@@ -1,4 +1,4 @@
-\page adding_visuals
+\page adding_visuals Adding visuals
 
 # Overview
 
@@ -8,7 +8,7 @@ mesh to our turtle, making it look much better.
 
 ## Related tutorials
 
-https://gazebosim.org/api/sim/8/meshtofuel.html
+\ref meshtofuel
 
 The next tutorials, although still relevant, are from an older version of Gazebo
 and some details might be different than the current versions:

--- a/tutorials/create_vehicle.md
+++ b/tutorials/create_vehicle.md
@@ -1,4 +1,4 @@
-\page create_vehicle
+\page create_vehicle Create a maritime vehicle
 
 # Overview
 

--- a/tutorials/frame_reference.md
+++ b/tutorials/frame_reference.md
@@ -1,4 +1,4 @@
-\page frame_reference
+\page frame_reference Frame of reference
 
 # Overview
 
@@ -7,7 +7,7 @@ the conventions used in Gazebo.
 
 ## Related tutorials
 
-https://gazebosim.org/api/sim/8/spherical_coordinates.html
+\ref spherical_coordinates
 
 # Gazebo world frame
 

--- a/tutorials/lander.md
+++ b/tutorials/lander.md
@@ -1,4 +1,4 @@
-\page lander
+\page lander Create a lander vehicle
 
 # Overview
 
@@ -9,17 +9,12 @@ to the surface while they collect sensor measurements.
 
 ## Related tutorials
 
-https://gazebosim.org/api/sim/8/create_vehicle.html
-
-https://gazebosim.org/api/sim/8/adding_visuals.html
-
-https://gazebosim.org/api/sim/8/frame_reference.html
-
-https://gazebosim.org/api/sim/8/adding_system_plugins.html
-
-https://gazebosim.org/api/sim/8/theory_buoyancy.html
-
-https://gazebosim.org/api/sim/8/theory_hydrodynamics.html
+\ref create_vehicle
+\ref adding_visuals
+\ref frame_reference
+\ref adding_system_plugins
+\ref theory_buoyancy
+\ref theory_hydrodynamics
 
 # Create your vehicle
 

--- a/tutorials/lander.md
+++ b/tutorials/lander.md
@@ -10,10 +10,15 @@ to the surface while they collect sensor measurements.
 ## Related tutorials
 
 \ref create_vehicle
+
 \ref adding_visuals
+
 \ref frame_reference
+
 \ref adding_system_plugins
+
 \ref theory_buoyancy
+
 \ref theory_hydrodynamics
 
 # Create your vehicle

--- a/tutorials/surface_vehicles.md
+++ b/tutorials/surface_vehicles.md
@@ -8,15 +8,11 @@ with the presence of waves and wind.
 
 ## Related tutorials
 
-https://gazebosim.org/api/sim/8/create_vehicle.html
-
-https://gazebosim.org/api/sim/8/adding_visuals.html
-
-https://gazebosim.org/api/sim/8/frame_reference.html
-
-https://gazebosim.org/api/sim/8/adding_system_plugins.html
-
-https://gazebosim.org/api/sim/8/theory_hydrodynamics.html
+\ref create_vehicle
+\ref adding_visuals
+\ref frame_reference
+\ref adding_system_plugins
+\ref theory_hydrodynamics
 
 # Adding an environment
 

--- a/tutorials/surface_vehicles.md
+++ b/tutorials/surface_vehicles.md
@@ -9,9 +9,13 @@ with the presence of waves and wind.
 ## Related tutorials
 
 \ref create_vehicle
+
 \ref adding_visuals
+
 \ref frame_reference
+
 \ref adding_system_plugins
+
 \ref theory_hydrodynamics
 
 # Adding an environment

--- a/tutorials/surface_vehicles.md
+++ b/tutorials/surface_vehicles.md
@@ -1,4 +1,4 @@
-\page surface_vehicles
+\page surface_vehicles Create a surface vehicle
 
 # Overview
 

--- a/tutorials/theory_buoyancy.md
+++ b/tutorials/theory_buoyancy.md
@@ -1,4 +1,4 @@
-\page theory_buoyancy
+\page theory_buoyancy Buoyancy
 
 # Overview
 

--- a/tutorials/theory_hydrodynamics.md
+++ b/tutorials/theory_hydrodynamics.md
@@ -1,4 +1,4 @@
-\page theory_hydrodynamics
+\page theory_hydrodynamics Hydrodynamics
 
 # Overview
 

--- a/tutorials/underwater_vehicles.md
+++ b/tutorials/underwater_vehicles.md
@@ -1,4 +1,4 @@
-\page underwater_vehicles
+\page underwater_vehicles Create an underwater vehicle
 
 # Overview
 
@@ -11,17 +11,12 @@ guide you through the setup of the [MBARI LRAUV](https://app.gazebosim.org/accur
 
 ## Related tutorials
 
-https://gazebosim.org/api/sim/8/create_vehicle.html
-
-https://gazebosim.org/api/sim/8/adding_visuals.html
-
-https://gazebosim.org/api/sim/8/frame_reference.html
-
-https://gazebosim.org/api/sim/8/adding_system_plugins.html
-
-https://gazebosim.org/api/sim/8/theory_buoyancy.html
-
-https://gazebosim.org/api/sim/8/theory_hydrodynamics.html
+\ref create_vehicle
+\ref adding_visuals
+\ref frame_reference
+\ref adding_system_plugins
+\ref theory_buoyancy
+\ref theory_hydrodynamics
 
 # Create your vehicle
 

--- a/tutorials/underwater_vehicles.md
+++ b/tutorials/underwater_vehicles.md
@@ -12,10 +12,15 @@ guide you through the setup of the [MBARI LRAUV](https://app.gazebosim.org/accur
 ## Related tutorials
 
 \ref create_vehicle
+
 \ref adding_visuals
+
 \ref frame_reference
+
 \ref adding_system_plugins
+
 \ref theory_buoyancy
+
 \ref theory_hydrodynamics
 
 # Create your vehicle


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Seems like there was a behavior change in doxygen that caused the the links in the Maritime section to change from what's expected. This breaks the tool we use to generate issues for the tutorial party. Adding the "title" argument to the `\page` comand seems to fix it

The link before this PR:

~/ws/ionic/build/gz-sim9/doxygen/html/md__2usr_2local_2google_2home_2addisuzt_2ws_2ionic_2src_2gz-sim_2tutorials_2theory__buoyancy.html#theory_buoyancy

After:
~/ws/ionic/build/gz-sim9/doxygen/html/theory_buoyancy.html

I also took the opportunity to change raw http links to `\ref` commands

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.