### PR TITLE
Provides step size via CLI interface and `ServerConfig`

### DIFF
--- a/include/gz/sim/ServerConfig.hh
+++ b/include/gz/sim/ServerConfig.hh
@@ -451,6 +451,12 @@ namespace gz
       /// \return The source type.
       public: SourceType Source() const;
 
+      public: void SetPhysicsRtf(double val);
+      public: std::optional<double> PhysicsRtf() const;
+
+      public: void SetPhysicsStepSize(double val);
+      public: std::optional<double> PhysicsStepSize() const;
+
       /// \brief Private data pointer
       private: std::unique_ptr<ServerConfigPrivate> dataPtr;
     };

--- a/include/gz/sim/ServerConfig.hh
+++ b/include/gz/sim/ServerConfig.hh
@@ -398,12 +398,12 @@ namespace gz
 
       /// \brief Set the server behavior when SDF errors are encountered while
       //// loading the server.
-      /// \param[in] _behavior Server behavior when SDF errors are encounted.
+      /// \param[in] _behavior Server behavior when SDF errors are encountered.
       public: void SetBehaviorOnSdfErrors(SdfErrorBehavior _behavior);
 
       /// \brief Get the behavior when SDF errors are encountered while
       //// loading the server.
-      /// \return Server behavior when SDF errors are encounted.
+      /// \return Server behavior when SDF errors are encountered.
       public: SdfErrorBehavior BehaviorOnSdfErrors() const;
 
       /// \brief Instruct simulation to attach a plugin to a specific
@@ -451,10 +451,20 @@ namespace gz
       /// \return The source type.
       public: SourceType Source() const;
 
+      /// Set Desired Physics RTF. If value is zero or less, we don't
+      /// set anything.
       public: void SetPhysicsRtf(double val);
+
+      /// Get desired RTF value. If no value is set returns `std::nullopt`
+      /// Defaults to `std::nullopt`.
       public: std::optional<double> PhysicsRtf() const;
 
+      /// Set Desired Physics step size. If value is zero or less, we don't
+      /// set anything.
       public: void SetPhysicsStepSize(double val);
+
+      /// Get desired Step Size value. If no value is set returns `std::nullopt`
+      /// Defaults to `std::nullopt`.
       public: std::optional<double> PhysicsStepSize() const;
 
       /// \brief Private data pointer

--- a/src/ServerConfig.cc
+++ b/src/ServerConfig.cc
@@ -209,7 +209,10 @@ class gz::sim::ServerConfigPrivate
             logRecordTopics(_cfg->logRecordTopics),
             isHeadlessRendering(_cfg->isHeadlessRendering),
             source(_cfg->source),
-            behaviorOnSdfErrors(_cfg->behaviorOnSdfErrors){ }
+            behaviorOnSdfErrors(_cfg->behaviorOnSdfErrors),
+            physicsStepSize(_cfg->physicsStepSize),
+            physicsRtf(_cfg->physicsRtf){ }
+
 
   // \brief The SDF file that the server should load
   public: std::string sdfFile = "";
@@ -290,6 +293,12 @@ class gz::sim::ServerConfigPrivate
 
   /// \brief Optional SDF root object.
   public: std::optional<sdf::Root> sdfRoot;
+
+  /// \brief Physics step size
+  public: std::optional<double> physicsStepSize;
+
+  /// \brief Physics RTF
+  public: std::optional<double> physicsRtf;
 
   /// \brief Type of source used.
   public: ServerConfig::SourceType source{ServerConfig::SourceType::kNone};
@@ -503,6 +512,36 @@ std::string ServerConfig::LogRecordCompressPath() const
 void ServerConfig::SetLogRecordCompressPath(const std::string &_path)
 {
   this->dataPtr->logRecordCompressPath = _path;
+}
+
+/////////////////////////////////////////////////
+void ServerConfig::SetPhysicsStepSize(double _dbl)
+{
+  if (_dbl > 0)
+  {
+    this->dataPtr->physicsStepSize = _dbl;
+  }
+}
+
+/////////////////////////////////////////////////
+std::optional<double> ServerConfig::PhysicsStepSize() const
+{
+  return this->dataPtr->physicsStepSize;
+}
+
+/////////////////////////////////////////////////
+void ServerConfig::SetPhysicsRtf(double _dbl)
+{
+  if (_dbl > 0)
+  {
+    this->dataPtr->physicsRtf = _dbl;
+  }
+}
+
+/////////////////////////////////////////////////
+std::optional<double> ServerConfig::PhysicsRtf() const
+{
+  return this->dataPtr->physicsRtf;
 }
 
 /////////////////////////////////////////////////

--- a/src/cmd/cmdsim.rb.in
+++ b/src/cmd/cmdsim.rb.in
@@ -178,7 +178,12 @@ COMMANDS = { 'sim' =>
   "  --version                    Print Gazebo version information.                \n"\
   "\n"\
   "  -z [arg]                     Update rate in Hertz.                            \n"\
+  "\n"\
+  "  --physics-rtf [arg]          Update the RTF of the physics engine.            \n"\
+  "\n"\
+  "  --physics-step-size [arg]    Update the step size\n"\
   "\n"+
+
   COMMON_OPTIONS + "\n\n" +
   "Environment variables:                                                          \n"\
   "  GZ_SIM_RESOURCE_PATH         Colon separated paths used to locate             \n"\
@@ -256,7 +261,9 @@ class Cmd
       'render_engine_server_api_backend' => '',
       'headless-rendering' => 0,
       'wait_gui' => 1,
-      'seed' => 0
+      'seed' => 0,
+      'physics_step_size' => 0,
+      'physics_rtf' => 0
     }
 
     usage = COMMANDS[args[0]]
@@ -362,6 +369,12 @@ class Cmd
       end
       opts.on('--seed [arg]', Integer) do |i|
         options['seed'] = i
+      end
+      opts.on('--physics-rtf [arg]', Float) do |i|
+        options['physics_rtf'] = i
+      end
+      opts.on('--physics-step-size [arg]', Float) do |i|
+        options['physics_step_size'] = i
       end
 
     end # opt_parser do
@@ -493,7 +506,7 @@ has properly set the DYLD_LIBRARY_PATH environment variables."
                                int, int, int, const char *, const char *,
                                const char *, const char *, const char *,
                                const char *, const char *,
-                               const char *, int, int, float, int)'
+                               const char *, int, int, float, int, double, double)'
 
       # Import the runGui function
       Importer.extern 'int runGui(const char *, const char *, int,
@@ -542,7 +555,9 @@ See https://github.com/gazebosim/gz-sim/issues/168 for more info."
             options['file'], options['record-topics'].join(':'),
             options['wait_gui'],
             options['headless-rendering'], options['record-period'],
-            options['seed'])
+            options['seed'],
+            options['physics_rtf'],
+            options['physics_step_size'])
         end
 
         guiPid = Process.fork do

--- a/src/gz.cc
+++ b/src/gz.cc
@@ -140,7 +140,8 @@ extern "C" int runServer(const char *_sdfString,
     const char *_renderEngineServer, const char *_renderEngineServerApiBackend,
     const char *_renderEngineGui, const char *_renderEngineGuiApiBackend,
     const char *_file, const char *_recordTopics, int _waitGui,
-    int _headless, float _recordPeriod, int _seed)
+    int _headless, float _recordPeriod, int _seed, double _physicsRtf,
+    double _physicsStepSize)
 {
   std::string startingWorldPath{""};
   sim::ServerConfig serverConfig;
@@ -375,6 +376,11 @@ extern "C" int runServer(const char *_sdfString,
     serverConfig.SetNetworkSecondaries(_networkSecondaries);
     serverConfig.SetUseLevels(true);
   }
+
+  gzerr << "Step size: " << _physicsStepSize << "\n";
+  serverConfig.SetPhysicsStepSize(_physicsStepSize);
+  gzerr << "RTF: " << _physicsRtf << "\n";
+  serverConfig.SetPhysicsRtf(_physicsRtf);
 
   if (_playback != nullptr && std::strlen(_playback) > 0)
   {

--- a/src/gz.hh
+++ b/src/gz.hh
@@ -61,6 +61,7 @@ extern "C" GZ_SIM_GZ_VISIBLE const char *worldInstallDir();
 /// \param[in] _headless True if server rendering should run headless
 /// \param[in] _recordPeriod --record-period option
 /// \param[in] _seed --seed value to be used for random number generator.
+/// \param[in] _physicsRtf --physics-rtf value used to run server
 /// \return 0 if successful, 1 if not.
 extern "C" GZ_SIM_GZ_VISIBLE int runServer(const char *_sdfString,
     int _iterations, int _run, float _hz, double _initialSimTime, int _levels,
@@ -71,7 +72,8 @@ extern "C" GZ_SIM_GZ_VISIBLE int runServer(const char *_sdfString,
     const char *_renderEngineServer, const char *_renderEngineServerApiBackend,
     const char *_renderEngineGui, const char *_renderEngineGuiApiBackend,
     const char *_file, const char *_recordTopics, int _waitGui, int _headless,
-    float _recordPeriod, int _seed);
+    float _recordPeriod, int _seed, double _physicsRtf,
+    double _physicsStepSize);
 
 /// \brief External hook to run simulation GUI.
 /// \param[in] _guiConfig Path to Gazebo GUI configuration file.


### PR DESCRIPTION



🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

# 🎉 New feature

Closes #<NUMBER>

## Summary
This is probably not the best time to be making this PR as we are in the middle of the release. However for another project, I'd like to be able to set the Step Size via CLI. This is particularly useful for when we are doing integration testing of that project. This PR provides two command line flags that allow you to set the physics update rate and step size via cli. To try it out run:

```
gz sim shapes.sdf --physics-rtf 5.0 --physics-step-size 0.01
```
Note: Setting parameters via CLI/`server_config` should overwrite the world configs.

TODO: Update tests.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
