### PR TITLE
Update lrauv_control_demo.sdf

### DIFF
--- a/examples/worlds/lrauv_control_demo.sdf
+++ b/examples/worlds/lrauv_control_demo.sdf
@@ -268,6 +268,7 @@
         <mQ>0</mQ>
         <nRabsR>-632.698957</nRabsR>
         <nR>0</nR>
+        <disable_added_mass>true</disable_added_mass>
       </plugin>
 
     </include>


### PR DESCRIPTION
# 🦟 Bug fix

Related to [#1646](https://github.com/gazebosim/gazebo_test_cases/issues/1646)

## Summary
To reproduce the error run the simulation in gazebo ionic.
Output:
```
[error] The use of added mass through this plugin is deprecated and willbe removed in Gazebo J* as this formulation has instabilities. We recommend using the SDF `<fluid_added_mass>` tag based method[http://sdformat.org/spec?ver=1.11&elem=link#inertial_fluid_added_mass]To get rid of this warning we recommend setting`<disable_added_mass> to true.
```

By adding the suggested tag the warning is removed.