### PR TITLE
Fix looking up camera sensor in lens flare system

### DIFF
--- a/src/systems/lens_flare/LensFlare.cc
+++ b/src/systems/lens_flare/LensFlare.cc
@@ -128,8 +128,9 @@ void LensFlare::Configure(
   }
 
   // Get Camera Name
-  this->dataPtr->cameraName = scopedName(this->dataPtr->entity,
-                      _ecm, "::", false);
+  this->dataPtr->cameraName =
+      removeParentScope(scopedName(this->dataPtr->entity,
+                      _ecm, "::", false), "::");
 
   // call function that connects to post render event
   this->dataPtr->postRenderConn =


### PR DESCRIPTION


# 🦟 Bug fix


## Summary


The `camera_lens_flare.sdf` world currently floods the console with the following msgs:

```
(2024-08-30 22:21:38.752) [error] Unable to find sensor: default::wide_angle_camera_lensflare::link::wide_angle_camera
(2024-08-30 22:21:38.752) [error] Unable to find sensor: default::camera_lensflare::link::camera
(2024-08-30 22:21:38.756) [error] Unable to find sensor: default::wide_angle_camera_lensflare::link::wide_angle_camera
(2024-08-30 22:21:38.756) [error] Unable to find sensor: default::camera_lensflare::link::camera
(2024-08-30 22:21:38.761) [error] Unable to find sensor: default::wide_angle_camera_lensflare::link::wide_angle_camera
(2024-08-30 22:21:38.762) [error] Unable to find sensor: default::camera_lensflare::link::camera
```

This is likely due to the behavior change introduced in https://github.com/gazebosim/gz-sim/pull/2546. The PR removes the world prefix from the camera name.

The camera and wide angle camera should now correctly generate images with lens flares 


<img width="395" alt="lens_flare_system" src="https://github.com/user-attachments/assets/bdefa417-1d43-4725-8d82-422230356e91">


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

