### PR TITLE
Corrected thrust command to move the kth_freeflyer spacecraft in gazebo_test-cases/#1624

### DIFF
--- a/examples/worlds/ground_spacecraft_testbed.sdf
+++ b/examples/worlds/ground_spacecraft_testbed.sdf
@@ -2,9 +2,9 @@
 <!--
   Spacecraft thruster plugin demo
 
-  Send commands to a single thruster:
+  Send commands to a single thruster (corrected 09/01/24):
 
-      gz topic -p 'normalized:[1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]' -t /dart/command/duty_cycle --msgtype gz.msgs.Actuators
+      gz topic -p 'normalized:[1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]' -t /kth_freeflyer/command/duty_cycle --msgtype gz.msgs.Actuators
 -->
 <sdf version="1.6">
   <world name="ground_testbed">


### PR DESCRIPTION
# 🦟 Bug fix
Corrected command to move the kth_freeflyer spacecraft testbed in gazebo_test-cases ticket [#1624](https://github.com/gazebosim/gazebo_test_cases/issues/1624)

Fixes: Spacecraft remained immobile after actuation commands to one of its thrusters was sent.

## Summary
To test ```ground_spacecraft_testbed.sdf``` for the upcoming Ionic release, the embedded in the comment section of [ground_spacecraft_testbed.sdf](https://github.com/gazebosim/gz-sim/blob/gz-sim9/examples/worlds/ground_spacecraft_testbed.sdf) is for the DART spacecraft. I have updated it for the ```KTH_FREEFLYER``` platform based on the topics published once the simulation starts. See [#1624](https://github.com/gazebosim/gazebo_test_cases/issues/1624) for a video that shows the moving in the world.

Corrected command: ```gz topic -p 'normalized:[1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]' -t /kth_freeflyer/command/duty_cycle --msgtype gz.msgs.Actuators```

---

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

