### PR TITLE
Use ogre2 render engine in dem worlds

### DIFF
--- a/examples/worlds/dem_monterey_bay.sdf
+++ b/examples/worlds/dem_monterey_bay.sdf
@@ -22,7 +22,7 @@
           <property type="string" key="state">docked</property>
         </gz-gui>
 
-        <engine>ogre</engine>
+        <engine>ogre2</engine>
         <scene>scene</scene>
         <ambient_light>0 0 0</ambient_light>
         <background_color>0.8 0.8 0.8</background_color>

--- a/examples/worlds/dem_moon.sdf
+++ b/examples/worlds/dem_moon.sdf
@@ -29,7 +29,7 @@
           <property type="string" key="state">docked</property>
         </gz-gui>
 
-        <engine>ogre</engine>
+        <engine>ogre2</engine>
         <scene>scene</scene>
         <ambient_light>0 0 0</ambient_light>
         <background_color>0.8 0.8 0.8</background_color>

--- a/examples/worlds/dem_volcano.sdf
+++ b/examples/worlds/dem_volcano.sdf
@@ -21,7 +21,7 @@
           <property type="string" key="state">docked</property>
         </gz-gui>
 
-        <engine>ogre</engine>
+        <engine>ogre2</engine>
         <scene>scene</scene>
         <ambient_light>0 0 0</ambient_light>
         <background_color>0.8 0.8 0.8</background_color>


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

updated examples DEM worlds to use ogre2 as the functionality should be supported now.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

