### PR TITLE
Create a surface vehicle: libSurface.so undefined symbol triggers SIGKILL

### DIFF
--- a/examples/worlds/ground_spacecraft_testbed.sdf
+++ b/examples/worlds/ground_spacecraft_testbed.sdf
@@ -2,9 +2,9 @@
 <!--
   Spacecraft thruster plugin demo
 
-  Send commands to a single thruster:
+  Send commands to a single thruster (corrected 09/01/24):
 
-      gz topic -p 'normalized:[1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]' -t /dart/command/duty_cycle --msgtype gz.msgs.Actuators
+      gz topic -p 'normalized:[1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]' -t /kth_freeflyer/command/duty_cycle --msgtype gz.msgs.Actuators
 -->
 <sdf version="1.6">
   <world name="ground_testbed">

--- a/tutorials/surface_vehicles.md
+++ b/tutorials/surface_vehicles.md
@@ -6,6 +6,10 @@ This tutorial explains how to create and load a maritime surface vehicle in
 Gazebo. This type of vehicle usually has multiple thrusters and navigate
 with the presence of waves and wind.
 
+## Fatal bug: ``libSurface.so``` undefined symbol triggers SIGKILL
+
+I have opened a public repository for easily reproducing this error here [gazebo_ionic_surface_vehicle](https://github.com/Mechazo11/gazebo_ionic_surface_vehicle?tab=readme-ov-file)
+
 ## Related tutorials
 
 https://gazebosim.org/api/sim/8/create_vehicle.html

--- a/tutorials/surface_vehicles.md
+++ b/tutorials/surface_vehicles.md
@@ -6,7 +6,11 @@ This tutorial explains how to create and load a maritime surface vehicle in
 Gazebo. This type of vehicle usually has multiple thrusters and navigate
 with the presence of waves and wind.
 
-## Fatal bug: ``libSurface.so``` undefined symbol triggers SIGKILL
+## Fatal bug 1: Cmake dependencies triggered build error.
+
+Updated cmake. Build passes in Ubuntu 24.04
+
+## Fatal bug 2: ``libSurface.so``` undefined symbol triggers SIGKILL
 
 I have opened a public repository for easily reproducing this error here [gazebo_ionic_surface_vehicle](https://github.com/Mechazo11/gazebo_ionic_surface_vehicle?tab=readme-ov-file)
 


### PR DESCRIPTION
# 🦟 Bug 
Cmake dependencies triggers build error and undefined symbol by libSurface.so triggers SIGKILL.

## Summary
Will not build without updating Cmake. After build, WAM-V vehicle can be spwaned without hydrodynamics. When activating hydrodynamics, undefined symbol ```libSurface.so``` fatal error occurs and a depreciation warning.

I have fixed the first part of the problem and have created a public repo [here](https://github.com/Mechazo11/gazebo_ionic_surface_vehicle) to aid in reproducing the 2nd error.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸