### PR TITLE
Fix crash on windows due to invalid log directory path

### DIFF
--- a/src/ServerConfig.cc
+++ b/src/ServerConfig.cc
@@ -168,9 +168,13 @@ class gz::sim::ServerConfigPrivate
 
     this->timestamp = GZ_SYSTEM_TIME();
 
+    std::string timeInIso = common::timeToIso(this->timestamp);
+    #ifdef _WIN32
+      std::replace(timeInIso.begin(), timeInIso.end(), ':', '-');
+    #endif
     // Set a default log record path
     this->logRecordPath = common::joinPaths(home,
-        ".gz", "sim", "log", common::timeToIso(this->timestamp));
+        ".gz", "sim", "log", timeInIso);
 
     // If directory already exists, do not overwrite. This could potentially
     // happen if multiple simulation instances are started in rapid


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gazebo_test_cases/issues/1701#issuecomment-2325598928

## Summary

Trying to create the `server_console.log` file throws an exception from `spdlog` because the containing directory, obtained from ISO formatted time, had `:` characters which are apparently considered invalid for a directory name in windows.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
