### PR TITLE
Fix xml and image in create maritime vehicle tutorial

### DIFF
--- a/tutorials/create_vehicle.md
+++ b/tutorials/create_vehicle.md
@@ -101,4 +101,4 @@ gz sim ~/gazebo_maritime/models/my_turtle/model.sdf
 You should see your model visualized as a cylinder and the Gazebo `Entity Tree`
 should capture its structure.
 
-![Basic Model](files/create_vehicle/basic_model.png)
+@image html files/create_vehicle/basic_model.png

--- a/tutorials/create_vehicle.md
+++ b/tutorials/create_vehicle.md
@@ -46,8 +46,8 @@ Create a `model.sdf` file that contains the Simulator Description Format of the
 model. You can find more information on the [SDF website](http://sdformat.org/).
 
 ```xml
-<?xml version='1.0'?>
-<sdf version='1.6'>
+<?xml version="1.0"?>
+<sdf version="1.6">
   <model name="my_turtle">
     <static>true</static>
     <link name='base_link'>
@@ -65,7 +65,7 @@ model. You can find more information on the [SDF website](http://sdformat.org/).
         </inertia>
       </inertial>
 
-      <collision name='collision'>
+      <collision name="collision">
         <geometry>
           <box>
             <size>1 1 0.009948450858321252</size>
@@ -73,7 +73,7 @@ model. You can find more information on the [SDF website](http://sdformat.org/).
         </geometry>
       </collision>
 
-      <visual name='visual'>
+      <visual name="visual">
         <pose>0.08 0 0.05 0 0 0</pose>
         <geometry>
           <cylinder>
@@ -101,4 +101,4 @@ gz sim ~/gazebo_maritime/models/my_turtle/model.sdf
 You should see your model visualized as a cylinder and the Gazebo `Entity Tree`
 should capture its structure.
 
-@image html files/create_vehicle/basic_model.png
+![Basic Model](files/create_vehicle/basic_model.png)


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #

## Summary
Replaced single quotes '' to double quotes "" in XML (my XML parser did not accept the single quotes), and fixed the path to the image in order to be displayed.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
