### PR TITLE
Fix configuring global illumination GUI plugin parameters

### DIFF
--- a/src/gui/plugins/global_illumination_civct/GlobalIlluminationCiVct.cc
+++ b/src/gui/plugins/global_illumination_civct/GlobalIlluminationCiVct.cc
@@ -209,7 +209,8 @@ bool GlobalIlluminationCiVct::LoadGlobalIlluminationCiVct()
     return false;
   }
 
-  if (!scene->IsInitialized() || scene->VisualCount() == 0)
+  if (!scene->IsInitialized() || scene->VisualCount() == 0 ||
+      scene->LightCount() ==  0)
   {
     return false;
   }

--- a/src/gui/plugins/global_illumination_civct/GlobalIlluminationCiVct.cc
+++ b/src/gui/plugins/global_illumination_civct/GlobalIlluminationCiVct.cc
@@ -172,13 +172,13 @@ GlobalIlluminationCiVct::~GlobalIlluminationCiVct()
 }
 
 /////////////////////////////////////////////////
-void GlobalIlluminationCiVct::LoadGlobalIlluminationCiVct()
+bool GlobalIlluminationCiVct::LoadGlobalIlluminationCiVct()
   REQUIRES(this->dataPtr->serviceMutex)
 {
   auto loadedEngNames = rendering::loadedEngines();
   if (loadedEngNames.empty())
   {
-    return;
+    return false;
   }
 
   // assume there is only one engine loaded
@@ -194,11 +194,11 @@ void GlobalIlluminationCiVct::LoadGlobalIlluminationCiVct()
   {
     gzerr << "Internal error: failed to load engine [" << engineName
           << "]. GlobalIlluminationCiVct plugin won't work." << std::endl;
-    return;
+    return false;
   }
 
   if (engine->SceneCount() == 0)
-    return;
+    return false;
 
   // assume there is only one scene
   // load scene
@@ -206,12 +206,12 @@ void GlobalIlluminationCiVct::LoadGlobalIlluminationCiVct()
   if (!scene)
   {
     gzerr << "Internal error: scene is null." << std::endl;
-    return;
+    return false;
   }
 
   if (!scene->IsInitialized() || scene->VisualCount() == 0)
   {
-    return;
+    return false;
   }
 
   // Create visual
@@ -225,6 +225,7 @@ void GlobalIlluminationCiVct::LoadGlobalIlluminationCiVct()
           << std::endl;
 
     gz::gui::App()->findChild<gz::gui::MainWindow *>()->removeEventFilter(this);
+    return false;
   }
   else
   {
@@ -254,6 +255,7 @@ void GlobalIlluminationCiVct::LoadGlobalIlluminationCiVct()
 
     this->OnRefreshCamerasImpl();
   }
+  return true;
 }
 
 /// \brief XML helper to retrieve values and handle errors
@@ -358,9 +360,7 @@ void GlobalIlluminationCiVct::LoadConfig(
   const tinyxml2::XMLElement *_pluginElem)
 {
   if (this->title.empty())
-    this->title = "Global Illumination (VCT)";
-
-  std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
+    this->title = "Global Illumination (CI VCT)";
 
   if (auto elem = _pluginElem->FirstChildElement("enabled"))
   {
@@ -447,15 +447,25 @@ bool GlobalIlluminationCiVct::eventFilter(QObject *_obj, QEvent *_event)
 {
   if (_event->type() == gz::gui::events::Render::kType)
   {
-    // This event is called in Scene3d's RenderThread, so it's safe to make
+    // This event is called in the render thread, so it's safe to make
     // rendering calls here
 
-    std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
     if (!this->dataPtr->initialized)
     {
-      this->LoadGlobalIlluminationCiVct();
+      if (this->LoadGlobalIlluminationCiVct())
+      {
+        this->SetEnabled(this->dataPtr->enabled);
+        this->SetBounceCount(this->dataPtr->bounceCount);
+        this->SetHighQuality(this->dataPtr->highQuality);
+        this->SetAnisotropic(this->dataPtr->anisotropic);
+        this->SetDebugVisualizationMode(this->dataPtr->debugVisMode);
+        this->EnabledChanged();
+        this->LightingChanged();
+        this->DebugVisualizationModeChanged();
+      }
     }
 
+    std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
     if (this->dataPtr->gi)
     {
       if (!this->dataPtr->visualDirty && !this->dataPtr->gi->Enabled() &&
@@ -562,10 +572,6 @@ bool GlobalIlluminationCiVct::eventFilter(QObject *_obj, QEvent *_event)
 
         this->dataPtr->resetRequested = false;
       }
-    }
-    else
-    {
-      gzerr << "GI pointer is not set" << std::endl;
     }
   }
 

--- a/src/gui/plugins/global_illumination_civct/GlobalIlluminationCiVct.hh
+++ b/src/gui/plugins/global_illumination_civct/GlobalIlluminationCiVct.hh
@@ -103,7 +103,8 @@ inline namespace GZ_SIM_VERSION_NAMESPACE
     public: bool eventFilter(QObject *_obj, QEvent *_event) override;
 
     /// \brief Load the scene and attach LidarVisual to the scene
-    public: void LoadGlobalIlluminationCiVct();
+    /// \return True if GI CIVCT is loaded successfully, false otherwise.
+    public: bool LoadGlobalIlluminationCiVct();
 
     /// \brief Set debug visualization mode GlogbalIllumination
     /// \param[in] _mode Index of selected debug visualization mode

--- a/src/gui/plugins/global_illumination_vct/GlobalIlluminationVct.cc
+++ b/src/gui/plugins/global_illumination_vct/GlobalIlluminationVct.cc
@@ -394,7 +394,7 @@ bool GlobalIlluminationVct::eventFilter(QObject *_obj, QEvent *_event)
 {
   if (_event->type() == gz::gui::events::Render::kType)
   {
-    // This event is called in Scene3d's RenderThread, so it's safe to make
+    // This event is called in render thread, so it's safe to make
     // rendering calls here
 
     if (!this->dataPtr->initialized)

--- a/src/gui/plugins/global_illumination_vct/GlobalIlluminationVct.cc
+++ b/src/gui/plugins/global_illumination_vct/GlobalIlluminationVct.cc
@@ -203,7 +203,8 @@ bool GlobalIlluminationVct::LoadGlobalIlluminationVct()
     return false;
   }
 
-  if (!scene->IsInitialized() || scene->VisualCount() == 0)
+  if (!scene->IsInitialized() || scene->VisualCount() == 0 ||
+      scene->LightCount() ==  0)
   {
     return false;
   }

--- a/src/gui/plugins/global_illumination_vct/GlobalIlluminationVct.cc
+++ b/src/gui/plugins/global_illumination_vct/GlobalIlluminationVct.cc
@@ -166,13 +166,13 @@ GlobalIlluminationVct::~GlobalIlluminationVct()
 }
 
 /////////////////////////////////////////////////
-void GlobalIlluminationVct::LoadGlobalIlluminationVct()
+bool GlobalIlluminationVct::LoadGlobalIlluminationVct()
   REQUIRES(this->dataPtr->serviceMutex)
 {
   auto loadedEngNames = rendering::loadedEngines();
   if (loadedEngNames.empty())
   {
-    return;
+    return false;
   }
 
   // assume there is only one engine loaded
@@ -188,11 +188,11 @@ void GlobalIlluminationVct::LoadGlobalIlluminationVct()
   {
     gzerr << "Internal error: failed to load engine [" << engineName
           << "]. GlobalIlluminationVct plugin won't work." << std::endl;
-    return;
+    return false;
   }
 
   if (engine->SceneCount() == 0)
-    return;
+    return false;
 
   // assume there is only one scene
   // load scene
@@ -200,15 +200,15 @@ void GlobalIlluminationVct::LoadGlobalIlluminationVct()
   if (!scene)
   {
     gzerr << "Internal error: scene is null." << std::endl;
-    return;
+    return false;
   }
 
   if (!scene->IsInitialized() || scene->VisualCount() == 0)
   {
-    return;
+    return false;
   }
 
-  // Create lidar visual
+  // Create GI
   gzdbg << "Creating GlobalIlluminationVct" << std::endl;
 
   auto root = scene->RootVisual();
@@ -219,6 +219,7 @@ void GlobalIlluminationVct::LoadGlobalIlluminationVct()
            << std::endl;
 
     gz::gui::App()->findChild<gz::gui::MainWindow *>()->removeEventFilter(this);
+    return false;
   }
   else
   {
@@ -228,6 +229,7 @@ void GlobalIlluminationVct::LoadGlobalIlluminationVct()
     this->dataPtr->scene = scene;
     this->dataPtr->initialized = true;
   }
+  return true;
 }
 
 /// \brief XML helper to retrieve values and handle errors
@@ -319,8 +321,6 @@ void GlobalIlluminationVct::LoadConfig(const tinyxml2::XMLElement *_pluginElem)
   if (this->title.empty())
     this->title = "Global Illumination (VCT)";
 
-  std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
-
   if (auto elem = _pluginElem->FirstChildElement("enabled"))
   {
     GetXmlBool(elem, this->dataPtr->enabled);
@@ -397,12 +397,32 @@ bool GlobalIlluminationVct::eventFilter(QObject *_obj, QEvent *_event)
     // This event is called in Scene3d's RenderThread, so it's safe to make
     // rendering calls here
 
-    std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
     if (!this->dataPtr->initialized)
     {
-      this->LoadGlobalIlluminationVct();
+      if (this->LoadGlobalIlluminationVct())
+      {
+        // update properties and notify QML
+        this->SetEnabled(this->dataPtr->enabled);
+        this->SetResolutionX(this->dataPtr->resolution[0]);
+        this->SetResolutionY(this->dataPtr->resolution[1]);
+        this->SetResolutionZ(this->dataPtr->resolution[2]);
+        this->SetOctantCountX(this->dataPtr->octantCount[0]);
+        this->SetOctantCountY(this->dataPtr->octantCount[1]);
+        this->SetOctantCountZ(this->dataPtr->octantCount[2]);
+        this->SetBounceCount(this->dataPtr->bounceCount);
+        this->SetHighQuality(this->dataPtr->highQuality);
+        this->SetAnisotropic(this->dataPtr->anisotropic);
+        this->SetConserveMemory(this->dataPtr->conserveMemory);
+        this->SetThinWallCounter(this->dataPtr->thinWallCounter);
+        this->SetDebugVisualizationMode(this->dataPtr->debugVisMode);
+        this->EnabledChanged();
+        this->LightingChanged();
+        this->SettingsChanged();
+        this->DebugVisualizationModeChanged();
+      }
     }
 
+    std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
     if (this->dataPtr->gi)
     {
       if (this->dataPtr->resetVisual)
@@ -484,10 +504,6 @@ bool GlobalIlluminationVct::eventFilter(QObject *_obj, QEvent *_event)
             this->dataPtr->debugVisMode));
         this->dataPtr->debugVisualizationDirty = false;
       }
-    }
-    else
-    {
-      gzerr << "GI pointer is not set" << std::endl;
     }
   }
 

--- a/src/gui/plugins/global_illumination_vct/GlobalIlluminationVct.hh
+++ b/src/gui/plugins/global_illumination_vct/GlobalIlluminationVct.hh
@@ -156,7 +156,8 @@ inline namespace GZ_SIM_VERSION_NAMESPACE
     public: bool eventFilter(QObject *_obj, QEvent *_event) override;
 
     /// \brief Load the scene and attach LidarVisual to the scene
-    public: void LoadGlobalIlluminationVct();
+    /// \return True if GI VCT is loaded successfully, false otherwise.
+    public: bool LoadGlobalIlluminationVct();
 
     /// \brief Set debug visualization mode GlogbalIllumination
     /// \param[in] _mode Index of selected debug visualization mode


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

The Global illumination GUI plugin's parameters specified through SDF are currently parsed by the plugin but they have no effect. This PR fixes the issue for both plugins (Vct and CiVct). 

To test, you can run this world:

<details><summary>gi_gui.sdf</summary>

```
<?xml version="1.0" encoding="UTF-8"?>

<sdf version="1.10">
  <world name="default">
    <gui fullscreen="0">
      <plugin filename="GlobalIlluminationVct" name="GI">
        <gz-gui>
          <property type="string" key="state">docked_collapsed</property>
        </gz-gui>
        <enabled>true</enabled>
        <highQuality>false</highQuality>
        <resolution>32 32 32</resolution>
        <octantCount>2 2 2</octantCount>
        <conserveMemory>false</conserveMemory>
        <thinWallCounter>1.1</thinWallCounter>
        <anisotropic>false</anisotropic>
        <bounceCount>7</bounceCount>
      </plugin>
    </gui>

    <model name="ground_plane">
      <static>true</static>
      <link name="link">
        <collision name="collision">
          <geometry>
            <plane>
              <normal>0 0 1</normal>
              <size>100 100</size>
            </plane>
          </geometry>
        </collision>
        <visual name="visual">
          <geometry>
            <plane>
              <normal>0 0 1</normal>
              <size>100 100</size>
            </plane>
          </geometry>
        </visual>
      </link>
    </model>
  </world>
</sdf>

```

</details>

and verify that the GI properties displayed in the GUI match those specified in SDF:


<img width="1043" alt="gi_parameters" src="https://github.com/user-attachments/assets/9a284247-e039-493a-8242-ab77966292c9">

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

