### PR TITLE
Update physics system error msg when plugin can not be loaded

### DIFF
--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -851,8 +851,8 @@ void Physics::Configure(const Entity &_entity,
       physics::FeaturePolicy3d>>();
   if (classNames.empty())
   {
-    gzerr << "No physics plugins found in library [" << pathToLib << "]."
-           << std::endl;
+    gzerr << "No physics plugins implementing required interface found in "
+          << "library [" << pathToLib << "]." << std::endl;
     return;
   }
 

--- a/tutorials/physics.md
+++ b/tutorials/physics.md
@@ -127,6 +127,12 @@ that path to the environment variable as described above.
 There was some problem loading that file. Check that it exists, that you have
 permissions to access it, and that it's acually a physics engine plugin.
 
+> No physics plugins implementing required interface found in library
+> [/home/physics_engines/libCustomEngine.so]
+
+The library was found but none of the plugins in the library implement the
+required interface to be considered a physics plugin.
+
 > No plugins with all required features found in library
 > [/home/physics_engines/libCustomEngine.so]
 


### PR DESCRIPTION
# 🦟 Bug fix

Related to: https://github.com/gazebosim/gazebo_test_cases/issues/1260

## Summary

Update the error message to be more specific when the system can not find a plugin that implements the required interface.

Also updated troubleshooting guide in the physics plugin tutorial.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

