### PR TITLE
Update added-mass of lrauv model and remove added mass definitions from examples

### DIFF
--- a/examples/worlds/acoustic_comms_demo.sdf
+++ b/examples/worlds/acoustic_comms_demo.sdf
@@ -71,7 +71,7 @@
 
     <include>
       <pose>0 0 1 0 0 1.57</pose>
-      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <uri>https://fuel.gazebosim.org/1.0/arjo129/models/LRAUV-PostIonic</uri>
 
       <!-- Acoustic comms endpoint -->
       <plugin
@@ -148,12 +148,6 @@
         filename="gz-sim-hydrodynamics-system"
         name="gz::sim::systems::Hydrodynamics">
         <link_name>base_link</link_name>
-        <xDotU>-4.876161</xDotU>
-        <yDotV>-126.324739</yDotV>
-        <zDotW>-126.324739</zDotW>
-        <kDotP>0</kDotP>
-        <mDotQ>-33.46</mDotQ>
-        <nDotR>-33.46</nDotR>
         <xUU>-6.2282</xUU>
         <xU>0</xU>
         <yVV>-601.27</yVV>
@@ -172,7 +166,7 @@
 
     <include>
       <pose>15 0 1 0 0 1.57</pose>
-      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <uri>https://fuel.gazebosim.org/1.0/arjo129/models/LRAUV-PostIonic</uri>
       <name>triton</name>
 
       <!-- Acoustic comms endpoint -->
@@ -250,12 +244,6 @@
         filename="gz-sim-hydrodynamics-system"
         name="gz::sim::systems::Hydrodynamics">
         <link_name>base_link</link_name>
-        <xDotU>-4.876161</xDotU>
-        <yDotV>-126.324739</yDotV>
-        <zDotW>-126.324739</zDotW>
-        <kDotP>0</kDotP>
-        <mDotQ>-33.46</mDotQ>
-        <nDotR>-33.46</nDotR>
         <xUU>-6.2282</xUU>
         <xU>0</xU>
         <yVV>-601.27</yVV>
@@ -274,7 +262,7 @@
 
     <include>
       <pose>-15 0 1 0 0 1.57</pose>
-      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <uri>https://fuel.gazebosim.org/1.0/arjo129/models/LRAUV-PostIonic</uri>
       <name>daphne</name>
 
       <!-- Acoustic comms endpoint -->
@@ -352,12 +340,6 @@
         filename="gz-sim-hydrodynamics-system"
         name="gz::sim::systems::Hydrodynamics">
         <link_name>base_link</link_name>
-        <xDotU>-4.876161</xDotU>
-        <yDotV>-126.324739</yDotV>
-        <zDotW>-126.324739</zDotW>
-        <kDotP>0</kDotP>
-        <mDotQ>-33.46</mDotQ>
-        <nDotR>-33.46</nDotR>
         <xUU>-6.2282</xUU>
         <xU>0</xU>
         <yVV>-601.27</yVV>

--- a/examples/worlds/auv_controls.sdf
+++ b/examples/worlds/auv_controls.sdf
@@ -71,7 +71,7 @@
 
     <include>
       <pose>0 0 1 0 0 1.57</pose>
-      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI%20Tethys%20LRAUV</uri>
+      <uri>https://fuel.gazebosim.org/1.0/arjo129/models/LRAUV-PostIonic</uri>
 
       <!-- Joint controllers -->
       <plugin
@@ -141,12 +141,6 @@
         filename="gz-sim-hydrodynamics-system"
         name="gz::sim::systems::Hydrodynamics">
         <link_name>base_link</link_name>
-        <xDotU>-4.876161</xDotU>
-        <yDotV>-126.324739</yDotV>
-        <zDotW>-126.324739</zDotW>
-        <kDotP>0</kDotP>
-        <mDotQ>-33.46</mDotQ>
-        <nDotR>-33.46</nDotR>
         <xUabsU>-6.2282</xUabsU>
         <xU>0</xU>
         <yVabsV>-601.27</yVabsV>

--- a/examples/worlds/dvl_world.sdf
+++ b/examples/worlds/dvl_world.sdf
@@ -134,12 +134,11 @@
         </visual>
       </link>
     </model>
-
     <include>
       <pose>0 0 -80 0 0 1.57</pose>
-      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <uri>https://fuel.gazebosim.org/1.0/arjo129/models/LRAUV-PostIonic</uri>
 
-      <experimental:params>
+      <experimental:params>U
         <sensor
             element_id="base_link" action="add"
             name="teledyne_pathfinder_dvl"
@@ -267,13 +266,6 @@
         filename="gz-sim-hydrodynamics-system"
         name="gz::sim::systems::Hydrodynamics">
         <link_name>base_link</link_name>
-        <xDotU>-4.876161</xDotU>
-        <yDotV>-126.324739</yDotV>
-        <zDotW>-126.324739</zDotW>
-        <kDotP>0</kDotP>
-        <mDotQ>-33.46</mDotQ>
-        <nDotR>-33.46</nDotR>
-        <xUabsU>-6.2282</xUabsU>
         <xU>0</xU>
         <yVabsV>-601.27</yVabsV>
         <yV>0</yV>

--- a/examples/worlds/lrauv_control_demo.sdf
+++ b/examples/worlds/lrauv_control_demo.sdf
@@ -175,7 +175,7 @@
 
     <include>
       <pose>0 0 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <uri>https://fuel.gazebosim.org/1.0/arjo129/models/LRAUV-PostIonic</uri>
 
       <plugin
         filename="gz-sim-odometry-publisher-system"
@@ -250,12 +250,6 @@
         filename="gz-sim-hydrodynamics-system"
         name="gz::sim::systems::Hydrodynamics">
         <link_name>base_link</link_name>
-        <xDotU>-4.876161</xDotU>
-        <yDotV>-126.324739</yDotV>
-        <zDotW>-126.324739</zDotW>
-        <kDotP>0</kDotP>
-        <mDotQ>-33.46</mDotQ>
-        <nDotR>-33.46</nDotR>
         <xUabsU>-6.2282</xUabsU>
         <xU>0</xU>
         <yVabsV>-601.27</yVabsV>

--- a/examples/worlds/multi_lrauv_race.sdf
+++ b/examples/worlds/multi_lrauv_race.sdf
@@ -59,7 +59,7 @@
 
     <include>
       <pose>0 0 1 0 0 1.57</pose>
-      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <uri>https://fuel.gazebosim.org/1.0/arjo129/models/LRAUV-PostIonic</uri>
 
       <!-- Joint controllers -->
       <plugin
@@ -128,12 +128,6 @@
         filename="gz-sim-hydrodynamics-system"
         name="gz::sim::systems::Hydrodynamics">
         <link_name>base_link</link_name>
-        <xDotU>-4.876161</xDotU>
-        <yDotV>-126.324739</yDotV>
-        <zDotW>-126.324739</zDotW>
-        <kDotP>0</kDotP>
-        <mDotQ>-33.46</mDotQ>
-        <nDotR>-33.46</nDotR>
         <yUabsU>-6.2282</yUabsU>
         <xU>0</xU>
         <yVabsV>-601.27</yVabsV>
@@ -152,7 +146,7 @@
 
     <include>
       <pose>5 0 1 0 0 1.57</pose>
-      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <uri>https://fuel.gazebosim.org/1.0/arjo129/models/LRAUV-PostIonic</uri>
       <name>triton</name>
 
       <!-- Joint controllers -->
@@ -222,13 +216,6 @@
         filename="gz-sim-hydrodynamics-system"
         name="gz::sim::systems::Hydrodynamics">
         <link_name>base_link</link_name>
-        <xDotU>-4.876161</xDotU>
-        <yDotV>-126.324739</yDotV>
-        <zDotW>-126.324739</zDotW>
-        <kDotP>0</kDotP>
-        <mDotQ>-33.46</mDotQ>
-        <nDotR>-33.46</nDotR>
-        <yUabsU>-6.2282</yUabsU>
         <xU>0</xU>
         <yVabsV>-601.27</yVabsV>
         <yV>0</yV>
@@ -246,7 +233,7 @@
 
     <include>
       <pose>-5 0 1 0 0 1.57</pose>
-      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <uri>https://fuel.gazebosim.org/1.0/arjo129/models/LRAUV-PostIonic</uri>
       <name>daphne</name>
 
       <!-- Joint controllers -->
@@ -316,12 +303,6 @@
         filename="gz-sim-hydrodynamics-system"
         name="gz::sim::systems::Hydrodynamics">
         <link_name>base_link</link_name>
-        <xDotU>-4.876161</xDotU>
-        <yDotV>-126.324739</yDotV>
-        <zDotW>-126.324739</zDotW>
-        <kDotP>0</kDotP>
-        <mDotQ>-33.46</mDotQ>
-        <nDotR>-33.46</nDotR>
         <yUabsU>-6.2282</yUabsU>
         <xU>0</xU>
         <yVabsV>-601.27</yVabsV>

--- a/test/worlds/bottomless_pit.sdf
+++ b/test/worlds/bottomless_pit.sdf
@@ -69,7 +69,7 @@
 
     <include>
       <pose>0 0 -80 0 0 1.57</pose>
-      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <uri>https://fuel.gazebosim.org/1.0/arjo129/models/LRAUV-PostIonic</uri>
 
       <experimental:params>
         <sensor

--- a/test/worlds/flat_seabed.sdf
+++ b/test/worlds/flat_seabed.sdf
@@ -98,7 +98,7 @@
 
     <include>
       <pose>0 0 -80 0 0 1.57</pose>
-      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <uri>https://fuel.gazebosim.org/1.0/arjo129/models/LRAUV-PostIonic</uri>
 
       <experimental:params>
         <sensor

--- a/test/worlds/underwater_currents.sdf
+++ b/test/worlds/underwater_currents.sdf
@@ -112,7 +112,7 @@
 
     <include>
       <pose>0 0 -0.5 0 0 1.57</pose>
-      <uri>https://fuel.gazebosim.org/1.0/accurrent/models/MBARI Tethys LRAUV</uri>
+      <uri>https://fuel.gazebosim.org/1.0/arjo129/models/LRAUV-PostIonic</uri>
 
       <experimental:params>
         <sensor


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2575

## Summary
Since, we have decided to deprecate added mass in the hydrodynamics plugin in favour of Rigid Bodies, we should update our examples to avoid the warning.

TODO: Update maritime tutorials and migration guide.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
