### PR TITLE
Fix typos in joint-tutorial readme.

### DIFF
--- a/tutorials/joint_controller.md
+++ b/tutorials/joint_controller.md
@@ -385,7 +385,7 @@ Let’s set up a new model for this example. A two-linked manipulator arm which 
 - SDF file:
 
 ```xml
-<?xml version="1.0"
+<?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="default">
     <scene>
@@ -653,7 +653,7 @@ gz topic -t "topic_name" -m gz.msgs.JointTrajectory -p '
         sec: 1
         nsec: 0
       }
-    }
+    }'
 ```
 
 <div style="text-align:center;">


### PR DESCRIPTION
# 🦟 Bug fix
Trivial typo fixes to allow users to properly follow tutorial.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
