### PR TITLE
Joint Tutorial needs topic_name in SDF examples.

### DIFF
--- a/tutorials/joint_controller.md
+++ b/tutorials/joint_controller.md
@@ -166,10 +166,10 @@ This is how the model will look:
 
 ```xml
 <plugin
- filename="gz-sim-joint-controller-system"
- name="gz::sim::systems::JointController">
- <joint_name>j1</joint_name>
- <initial_velocity>1.0</initial_velocity>
+  filename="gz-sim-joint-controller-system"
+  name="gz::sim::systems::JointController">
+  <joint_name>j1</joint_name>
+  <initial_velocity>1.0</initial_velocity>
 </plugin>
 ```
 
@@ -203,12 +203,13 @@ Replace the velocity mode plugin mentioned above with the following lines in the
 
 ```xml
 <plugin
- filename="gz-sim-joint-controller-system"
- name="gz::sim::systems::JointController">
- <joint_name>j1</joint_name>
- <use_force_commands>true</use_force_commands>
- <p_gain>0.2</p_gain>
- <i_gain>0.01</i_gain>
+  filename="gz-sim-joint-controller-system"
+  name="gz::sim::systems::JointController">
+  <joint_name>j1</joint_name>
+  <use_force_commands>true</use_force_commands>
+  <p_gain>0.2</p_gain>
+  <i_gain>0.01</i_gain>
+  <topic>topic_name</topic>
 </plugin>
 ```
 
@@ -309,17 +310,17 @@ For this let's use the previously discussed SDF file.
 
 ```xml
 <plugin
- filename="gz-sim-joint-position-controller-system"
- name="gz::sim::systems::JointPositionController">
- <joint_name>j1</joint_name>
- <topic>topic_name</topic>
- <p_gain>1</p_gain>
- <i_gain>0.1</i_gain>
- <d_gain>0.01</d_gain>
- <i_max>1</i_max>
- <i_min>-1</i_min>
- <cmd_max>1000</cmd_max>
- <cmd_min>-1000</cmd_min>
+  filename="gz-sim-joint-position-controller-system"
+  name="gz::sim::systems::JointPositionController">
+  <joint_name>j1</joint_name>
+  <topic>topic_name</topic>
+  <p_gain>1</p_gain>
+  <i_gain>0.1</i_gain>
+  <d_gain>0.01</d_gain>
+  <i_max>1</i_max>
+  <i_min>-1</i_min>
+  <cmd_max>1000</cmd_max>
+  <cmd_min>-1000</cmd_min>
 </plugin>
 ```
 
@@ -591,28 +592,28 @@ This is how the model will look:
 Append the following lines before `</model>` tag in the SDF file.
 
 ```xml
- <plugin
- filename="gz-sim-joint-trajectory-controller-system"
- name="gz::sim::systems::JointTrajectoryController">
- <joint_name>RR_position_control_joint1</joint_name>
- <initial_position>0.7854</initial_position>
- <position_p_gain>20</position_p_gain>
- <position_i_gain>0.4</position_i_gain>
- <position_d_gain>1.0</position_d_gain>
- <position_i_min>-1</position_i_min>
- <position_i_max>1</position_i_max>
- <position_cmd_min>-20</position_cmd_min>
- <position_cmd_max>20</position_cmd_max>
-
- <joint_name>RR_position_control_joint2</joint_name>
- <initial_position>-1.5708</initial_position>
- <position_p_gain>10</position_p_gain>
- <position_i_gain>0.2</position_i_gain>
- <position_d_gain>0.5</position_d_gain>
- <position_i_min>-1</position_i_min>
- <position_i_max>1</position_i_max>
- <position_cmd_min>-10</position_cmd_min>
- <position_cmd_max>10</position_cmd_max>
+<plugin
+  filename="gz-sim-joint-trajectory-controller-system"
+  name="gz::sim::systems::JointTrajectoryController">
+  <joint_name>RR_position_control_joint1</joint_name>
+  <initial_position>0.7854</initial_position>
+  <position_p_gain>20</position_p_gain>
+  <position_i_gain>0.4</position_i_gain>
+  <position_d_gain>1.0</position_d_gain>
+  <position_i_min>-1</position_i_min>
+  <position_i_max>1</position_i_max>
+  <position_cmd_min>-20</position_cmd_min>
+  <position_cmd_max>20</position_cmd_max>
+  <topic>topic_name</topic>
+  <joint_name>RR_position_control_joint2</joint_name>
+  <initial_position>-1.5708</initial_position>
+  <position_p_gain>10</position_p_gain>
+  <position_i_gain>0.2</position_i_gain>
+  <position_d_gain>0.5</position_d_gain>
+  <position_i_min>-1</position_i_min>
+  <position_i_max>1</position_i_max>
+  <position_cmd_min>-10</position_cmd_min>
+  <position_cmd_max>10</position_cmd_max>
 </plugin>
 ```
 
@@ -667,7 +668,7 @@ In case, PID gains are not specified then by default force mode will work.
 4) Checking the progress of the commanded trajectory.
 
 ```bash
-gz topic -e -t "/model/RR_position_control/joint_trajectory_progress"
+gz topic -e -t "/topic_name_progress"
 ```
 
 This returns the progress of the commanded trajectory which is a value between (0,1].


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This is my bad on not pushing up the final commit on adding `topic_name` in a few places so that the trajectory control portion works properly. 🤦🏻‍♂️ 

This also fixes the indents so they match when copying and pasting through tutorial.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.