### PR TITLE
TrackedVehicle: Added docs for body_link option

### DIFF
--- a/src/systems/tracked_vehicle/TrackedVehicle.hh
+++ b/src/systems/tracked_vehicle/TrackedVehicle.hh
@@ -42,6 +42,11 @@ namespace systems
   ///
   /// ## System Parameters
   ///
+  /// - `<body_link>`: Name of the link that should be considered the center
+  ///   of rotation. This plugin cannot correctly simulate the effect of CoM
+  ///   on rotation center. Instead, the rotation center is always in the CoM
+  ///   of this specified link. If not specified, the canonical link is used.
+  ///
   /// - `<left_track>`: Configuration of a left track link. This element can
   ///   appear multiple times, and must appear at least once.
   ///


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2650

## Summary

This PR adds forgotten documentation for the `<body_link>` tag in TrackedVehicle system.

The docs refer to source code at https://github.com/gazebosim/gz-sim/blob/gz-sim9/src/systems/tracked_vehicle/TrackedVehicle.cc#L238 and https://github.com/gazebosim/gz-sim/blob/gz-sim9/src/systems/tracked_vehicle/TrackedVehicle.cc#L475 .

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.