### PR TITLE
Backport SystemConfigurePriority to harmonic

### DIFF
--- a/include/gz/sim/System.hh
+++ b/include/gz/sim/System.hh
@@ -124,6 +124,20 @@ namespace gz
                   EventManager &_eventMgr) = 0;
     };
 
+    /// \class ISystemConfigure ISystem.hh gz/sim/System.hh
+    /// \brief Interface for a system that implements optional configuration
+    /// of the default priority value.
+    ///
+    /// ConfigurePriority is called before the system is instantiated to
+    /// override System::kDefaultPriority. It can still be overridden by the
+    /// XML priority element.
+    class ISystemConfigurePriority {
+      /// \brief Configure the default priority of the system, which can still
+      /// be overridden by the XML priority element.
+      /// \return The default priority for the system.
+      public: virtual System::PriorityType ConfigurePriority() = 0;
+    };
+
     /// \class ISystemConfigureParameters ISystem.hh gz/sim/System.hh
     /// \brief Interface for a system that declares parameters.
     ///

--- a/src/SystemInternal.hh
+++ b/src/SystemInternal.hh
@@ -48,6 +48,8 @@ namespace gz
                 configure(systemPlugin->QueryInterface<ISystemConfigure>()),
                 configureParameters(
                   systemPlugin->QueryInterface<ISystemConfigureParameters>()),
+                configurePriority(
+                  systemPlugin->QueryInterface<ISystemConfigurePriority>()),
                 reset(systemPlugin->QueryInterface<ISystemReset>()),
                 preupdate(systemPlugin->QueryInterface<ISystemPreUpdate>()),
                 update(systemPlugin->QueryInterface<ISystemUpdate>()),
@@ -66,6 +68,8 @@ namespace gz
                 configure(dynamic_cast<ISystemConfigure *>(_system.get())),
                 configureParameters(
                   dynamic_cast<ISystemConfigureParameters *>(_system.get())),
+                configurePriority(
+                  dynamic_cast<ISystemConfigurePriority *>(_system.get())),
                 reset(dynamic_cast<ISystemReset *>(_system.get())),
                 preupdate(dynamic_cast<ISystemPreUpdate *>(_system.get())),
                 update(dynamic_cast<ISystemUpdate *>(_system.get())),
@@ -94,6 +98,11 @@ namespace gz
       ///   interface.
       /// Will be nullptr if the System doesn't implement this interface.
       public: ISystemConfigureParameters *configureParameters = nullptr;
+
+      /// \brief Access this system via the ISystemConfigurePriority
+      ///   interface.
+      /// Will be nullptr if the System doesn't implement this interface.
+      public: ISystemConfigurePriority *configurePriority = nullptr;
 
       /// \brief Access this system via the ISystemReset interface
       /// Will be nullptr if the System doesn't implement this interface.

--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -113,6 +113,10 @@ size_t SystemManager::ActivatePendingSystems()
     this->systems.push_back(system);
 
     PriorityType p {System::kDefaultPriority};
+    if (system.configurePriority)
+    {
+      p = system.configurePriority->ConfigurePriority();
+    }
     const std::string kPriorityElementName
         {gz::sim::System::kPriorityElementName};
     if (system.configureSdf &&
@@ -120,6 +124,9 @@ size_t SystemManager::ActivatePendingSystems()
     {
       PriorityType newPriority =
           system.configureSdf->Get<PriorityType>(kPriorityElementName);
+      gzdbg << "Changing priority for system [" << system.name
+            << "] from {" << p
+            << "} to {" << newPriority << "}\n";
       p = newPriority;
     }
 

--- a/src/SystemManager_TEST.cc
+++ b/src/SystemManager_TEST.cc
@@ -28,6 +28,8 @@
 
 using namespace gz::sim;
 
+constexpr System::PriorityType kPriority = 64;
+
 /////////////////////////////////////////////////
 class SystemWithConfigure:
   public System,
@@ -67,6 +69,16 @@ class SystemWithUpdates:
   // Documentation inherited
   public: void PostUpdate(const UpdateInfo &,
                 const EntityComponentManager &) override {};
+};
+
+/////////////////////////////////////////////////
+class SystemWithPrioritizedUpdates:
+  public SystemWithUpdates,
+  public ISystemConfigurePriority
+{
+  // Documentation inherited
+  public: System::PriorityType ConfigurePriority() override
+                { return kPriority; }
 };
 
 /////////////////////////////////////////////////
@@ -127,32 +139,40 @@ TEST(SystemManager, AddSystemNoEcm)
   EXPECT_EQ(1u, systemMgr.TotalByEntity(configEntity).size());
 
   auto updateSystem = std::make_shared<SystemWithUpdates>();
+  auto prioritizedSystem =
+      std::make_shared<SystemWithPrioritizedUpdates>();
   Entity updateEntity{456u};
   systemMgr.AddSystem(updateSystem, updateEntity, nullptr);
+  systemMgr.AddSystem(prioritizedSystem, updateEntity, nullptr);
   EXPECT_EQ(1u, systemMgr.ActiveCount());
-  EXPECT_EQ(1u, systemMgr.PendingCount());
-  EXPECT_EQ(2u, systemMgr.TotalCount());
+  EXPECT_EQ(2u, systemMgr.PendingCount());
+  EXPECT_EQ(3u, systemMgr.TotalCount());
   EXPECT_EQ(1u, systemMgr.SystemsConfigure().size());
   EXPECT_EQ(0u, systemMgr.SystemsPreUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsPostUpdate().size());
-  EXPECT_EQ(1u, systemMgr.TotalByEntity(updateEntity).size());
+  EXPECT_EQ(2u, systemMgr.TotalByEntity(updateEntity).size());
 
   systemMgr.ActivatePendingSystems();
-  EXPECT_EQ(2u, systemMgr.ActiveCount());
+  EXPECT_EQ(3u, systemMgr.ActiveCount());
   EXPECT_EQ(0u, systemMgr.PendingCount());
-  EXPECT_EQ(2u, systemMgr.TotalCount());
+  EXPECT_EQ(3u, systemMgr.TotalCount());
   EXPECT_EQ(1u, systemMgr.SystemsConfigure().size());
-  // Expect PreUpdate and Update to contain one map entry with Priority 0 and
-  // a vector of length 1.
-  EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().size());
+  // Expect PreUpdate and Update to contain two map entries:
+  // 1. Priority {0} and a vector of length 1.
+  // 2. Priority {kPriority} and a vector of length 1.
+  EXPECT_EQ(2u, systemMgr.SystemsPreUpdate().size());
   EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().count(0));
+  EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().count(kPriority));
   EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().at(0).size());
-  EXPECT_EQ(1u, systemMgr.SystemsUpdate().size());
+  EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().at(kPriority).size());
+  EXPECT_EQ(2u, systemMgr.SystemsUpdate().size());
   EXPECT_EQ(1u, systemMgr.SystemsUpdate().count(0));
+  EXPECT_EQ(1u, systemMgr.SystemsUpdate().count(kPriority));
   EXPECT_EQ(1u, systemMgr.SystemsUpdate().at(0).size());
-  EXPECT_EQ(1u, systemMgr.SystemsPostUpdate().size());
-  EXPECT_EQ(1u, systemMgr.TotalByEntity(updateEntity).size());
+  EXPECT_EQ(1u, systemMgr.SystemsUpdate().at(kPriority).size());
+  EXPECT_EQ(2u, systemMgr.SystemsPostUpdate().size());
+  EXPECT_EQ(2u, systemMgr.TotalByEntity(updateEntity).size());
 }
 
 /////////////////////////////////////////////////
@@ -201,23 +221,37 @@ TEST(SystemManager, AddSystemEcm)
   EXPECT_EQ(0u, systemMgr.SystemsPostUpdate().size());
 
   auto updateSystem = std::make_shared<SystemWithUpdates>();
+  auto prioritizedSystem =
+      std::make_shared<SystemWithPrioritizedUpdates>();
   systemMgr.AddSystem(updateSystem, kNullEntity, nullptr);
+  systemMgr.AddSystem(prioritizedSystem, kNullEntity, nullptr);
   EXPECT_EQ(1u, systemMgr.ActiveCount());
-  EXPECT_EQ(1u, systemMgr.PendingCount());
-  EXPECT_EQ(2u, systemMgr.TotalCount());
+  EXPECT_EQ(2u, systemMgr.PendingCount());
+  EXPECT_EQ(3u, systemMgr.TotalCount());
   EXPECT_EQ(1u, systemMgr.SystemsConfigure().size());
   EXPECT_EQ(0u, systemMgr.SystemsPreUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsPostUpdate().size());
 
   systemMgr.ActivatePendingSystems();
-  EXPECT_EQ(2u, systemMgr.ActiveCount());
+  EXPECT_EQ(3u, systemMgr.ActiveCount());
   EXPECT_EQ(0u, systemMgr.PendingCount());
-  EXPECT_EQ(2u, systemMgr.TotalCount());
+  EXPECT_EQ(3u, systemMgr.TotalCount());
   EXPECT_EQ(1u, systemMgr.SystemsConfigure().size());
-  EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().size());
-  EXPECT_EQ(1u, systemMgr.SystemsUpdate().size());
-  EXPECT_EQ(1u, systemMgr.SystemsPostUpdate().size());
+  // Expect PreUpdate and Update to contain two map entries:
+  // 1. Priority {0} and a vector of length 1.
+  // 2. Priority {kPriority} and a vector of length 1.
+  EXPECT_EQ(2u, systemMgr.SystemsPreUpdate().size());
+  EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().count(0));
+  EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().count(kPriority));
+  EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().at(0).size());
+  EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().at(kPriority).size());
+  EXPECT_EQ(2u, systemMgr.SystemsUpdate().size());
+  EXPECT_EQ(1u, systemMgr.SystemsUpdate().count(0));
+  EXPECT_EQ(1u, systemMgr.SystemsUpdate().count(kPriority));
+  EXPECT_EQ(1u, systemMgr.SystemsUpdate().at(0).size());
+  EXPECT_EQ(1u, systemMgr.SystemsUpdate().at(kPriority).size());
+  EXPECT_EQ(2u, systemMgr.SystemsPostUpdate().size());
 }
 
 /////////////////////////////////////////////////
@@ -247,28 +281,42 @@ TEST(SystemManager, AddAndRemoveSystemEcm)
   auto entity = ecm.CreateEntity();
 
   auto updateSystemWithChild = std::make_shared<SystemWithUpdates>();
+  auto prioritizedSystemWithChild =
+      std::make_shared<SystemWithPrioritizedUpdates>();
   systemMgr.AddSystem(updateSystemWithChild, entity, nullptr);
+  systemMgr.AddSystem(prioritizedSystemWithChild, entity, nullptr);
 
   // Configure called during AddSystem
   EXPECT_EQ(1, configSystem->configured);
   EXPECT_EQ(1, configSystem->configuredParameters);
 
   EXPECT_EQ(0u, systemMgr.ActiveCount());
-  EXPECT_EQ(2u, systemMgr.PendingCount());
-  EXPECT_EQ(2u, systemMgr.TotalCount());
+  EXPECT_EQ(3u, systemMgr.PendingCount());
+  EXPECT_EQ(3u, systemMgr.TotalCount());
   EXPECT_EQ(0u, systemMgr.SystemsConfigure().size());
   EXPECT_EQ(0u, systemMgr.SystemsPreUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsUpdate().size());
   EXPECT_EQ(0u, systemMgr.SystemsPostUpdate().size());
 
   systemMgr.ActivatePendingSystems();
-  EXPECT_EQ(2u, systemMgr.ActiveCount());
+  EXPECT_EQ(3u, systemMgr.ActiveCount());
   EXPECT_EQ(0u, systemMgr.PendingCount());
-  EXPECT_EQ(2u, systemMgr.TotalCount());
+  EXPECT_EQ(3u, systemMgr.TotalCount());
   EXPECT_EQ(1u, systemMgr.SystemsConfigure().size());
-  EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().size());
-  EXPECT_EQ(1u, systemMgr.SystemsUpdate().size());
-  EXPECT_EQ(1u, systemMgr.SystemsPostUpdate().size());
+  // Expect PreUpdate and Update to contain two map entries:
+  // 1. Priority {0} and a vector of length 1.
+  // 2. Priority {kPriority} and a vector of length 1.
+  EXPECT_EQ(2u, systemMgr.SystemsPreUpdate().size());
+  EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().count(0));
+  EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().count(kPriority));
+  EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().at(0).size());
+  EXPECT_EQ(1u, systemMgr.SystemsPreUpdate().at(kPriority).size());
+  EXPECT_EQ(2u, systemMgr.SystemsUpdate().size());
+  EXPECT_EQ(1u, systemMgr.SystemsUpdate().count(0));
+  EXPECT_EQ(1u, systemMgr.SystemsUpdate().count(kPriority));
+  EXPECT_EQ(1u, systemMgr.SystemsUpdate().at(0).size());
+  EXPECT_EQ(1u, systemMgr.SystemsUpdate().at(kPriority).size());
+  EXPECT_EQ(2u, systemMgr.SystemsPostUpdate().size());
 
   // Remove the entity
   ecm.RequestRemoveEntity(entity);


### PR DESCRIPTION
# 🎉 New feature

Backport part of #2500

## Summary

This is part of #2500 that can be backported without breaking anything. None of the default system priorities are changed to preserve existing behavior, but this allows users to take advantage of setting default priority values in their own systems.

## Test it

Run the `UNIT_SystemManager_TEST`

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
