### PR TITLE
Remove detachable joints when a model is removed

### DIFF
--- a/test/integration/entity_erase.cc
+++ b/test/integration/entity_erase.cc
@@ -94,8 +94,8 @@ TEST_F(PhysicsSystemFixture,
 {
   ServerConfig serverConfig;
 
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-    "/examples/worlds/detachable_joint.sdf");
+  serverConfig.SetSdfFile(common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+    "examples", "worlds", "detachable_joint.sdf"));
 
   Server server(serverConfig);
 

--- a/test/integration/entity_erase.cc
+++ b/test/integration/entity_erase.cc
@@ -21,9 +21,11 @@
 
 #include <gz/utils/ExtraTestMacros.hh>
 
+#include "gz/sim/components/DetachableJoint.hh"
 #include "gz/sim/Server.hh"
 #include "test_config.hh"  // NOLINT(build/include)
 #include "../helpers/EnvTestFixture.hh"
+#include "../helpers/Relay.hh"
 
 using namespace gz;
 using namespace sim;
@@ -83,4 +85,68 @@ TEST_F(PhysicsSystemFixture,
   EXPECT_TRUE(server.HasEntity("capsule"));
   EXPECT_TRUE(server.HasEntity("ellipsoid"));
   EXPECT_FALSE(server.HasEntity("sphere"));
+}
+
+/////////////////////////////////////////////////
+// See https://github.com/gazebosim/gz-sim/issues/1175
+TEST_F(PhysicsSystemFixture,
+       GZ_UTILS_TEST_DISABLED_ON_WIN32(RemoveModelWithDetachableJoints))
+{
+  ServerConfig serverConfig;
+
+  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
+    "/examples/worlds/detachable_joint.sdf");
+
+  Server server(serverConfig);
+
+  unsigned int detachableJointCount = 0u;
+  test::Relay testSystem;
+  testSystem.OnPostUpdate([&](const UpdateInfo &,
+    const EntityComponentManager &_ecm)
+    {
+      _ecm.Each<components::DetachableJoint>(
+              [&](const Entity &,
+                  const components::DetachableJoint *) -> bool
+              {
+                detachableJointCount++;
+                return true;
+              });
+    });
+  server.AddSystem(testSystem.systemPtr);
+
+  server.Run(true, 1, false);
+  EXPECT_TRUE(server.HasEntity("vehicle_blue"));
+  EXPECT_TRUE(server.HasEntity("chassis"));
+  EXPECT_TRUE(server.HasEntity("front_left_wheel"));
+  EXPECT_TRUE(server.HasEntity("front_right_wheel"));
+  EXPECT_TRUE(server.HasEntity("rear_left_wheel"));
+  EXPECT_TRUE(server.HasEntity("rear_right_wheel"));
+  EXPECT_TRUE(server.HasEntity("front_left_wheel_joint"));
+  EXPECT_TRUE(server.HasEntity("front_right_wheel_joint"));
+  EXPECT_TRUE(server.HasEntity("rear_left_wheel_joint"));
+  EXPECT_TRUE(server.HasEntity("rear_right_wheel_joint"));
+  EXPECT_TRUE(server.HasEntity("B1"));
+  EXPECT_TRUE(server.HasEntity("B2"));
+  EXPECT_TRUE(server.HasEntity("B3"));
+  EXPECT_EQ(3u, detachableJointCount);
+
+  EXPECT_TRUE(server.RequestRemoveEntity("vehicle_blue"));
+  server.Run(true, 1, false);
+
+  detachableJointCount = 0u;
+  server.Run(true, 1, false);
+  EXPECT_FALSE(server.HasEntity("vehicle_blue"));
+  EXPECT_FALSE(server.HasEntity("chassis"));
+  EXPECT_FALSE(server.HasEntity("front_left_wheel"));
+  EXPECT_FALSE(server.HasEntity("front_right_wheel"));
+  EXPECT_FALSE(server.HasEntity("rear_left_wheel"));
+  EXPECT_FALSE(server.HasEntity("rear_right_wheel"));
+  EXPECT_FALSE(server.HasEntity("front_left_wheel_joint"));
+  EXPECT_FALSE(server.HasEntity("front_right_wheel_joint"));
+  EXPECT_FALSE(server.HasEntity("rear_left_wheel_joint"));
+  EXPECT_FALSE(server.HasEntity("rear_right_wheel_joint"));
+  EXPECT_TRUE(server.HasEntity("B1"));
+  EXPECT_TRUE(server.HasEntity("B2"));
+  EXPECT_TRUE(server.HasEntity("B3"));
+  EXPECT_EQ(0u, detachableJointCount);
 }


### PR DESCRIPTION

# 🦟 Bug fix

Partially fixes #2624

## Summary

Remove detachable joints from the ECM when a model is removed. The physics engine will then also remove any associated detachable joint physics objects. I also made a change in physics system to let physics engine remove the detachable joints first before models.

Now when you delete a model, the detachable joints should be deleted causing objects to be detached.

To test:

launch `detachable_joint.sdf` world

```
gz sim -v 4 -r ./src/gz-sim/examples/worlds/detachable_joint.sdf
```

Delete `vehicle_blue` and the breadcrumbs should now fall to the ground.

Try resetting the world it should no longer crash (#2624). However, the breadcrumbs remain detached, which I think it's a separate issue related to reset.

![detach_remove](https://github.com/user-attachments/assets/d56fdcef-cbb5-484e-8582-0e025bb59033)



## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.


