### PR TITLE
Fix uncontrolled cast of size_t to uint

### DIFF
--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -495,7 +495,8 @@ void SimulationRunner::ProcessSystemQueue()
 
   this->systemMgr->ActivatePendingSystems();
 
-  auto threadCount = this->systemMgr->SystemsPostUpdate().size() + 1u;
+  unsigned int threadCount = static_cast<unsigned int>(
+    this->systemMgr->SystemsPostUpdate().size() + 1u);
 
   igndbg << "Creating PostUpdate worker threads: "
     << threadCount << std::endl;


### PR DESCRIPTION
# 🦟 Bug fix

Remove warning existing in Conda Windows builds. See https://build.osrfoundation.org/view/conda/job/gz_sim-ign-gazebo6-cwin/1/msbuild/

## Summary

Fix the warning:
```
'argument': conversion from 'size_t' to 'unsigned int', possible loss of data (compiling source file C:\J\workspace\gz_sim-ign-gazebo6-cwin\ws\gz-sim\src\SimulationRunner.cc)
```
by controlling the cast from site_t to unsigned int.

Fixed here: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_conda_gz_sim-pr-win&build=20)](https://build.osrfoundation.org/job/_test_conda_gz_sim-pr-win/20/)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.