### PR TITLE
Link.hh: add Sensor accessor APIs

### DIFF
--- a/include/gz/sim/Link.hh
+++ b/include/gz/sim/Link.hh
@@ -136,6 +136,14 @@ namespace gz
       public: sim::Entity CollisionByName(const EntityComponentManager &_ecm,
           const std::string &_name) const;
 
+      /// \brief Get the ID of a sensor entity which is an immediate child of
+      /// this link.
+      /// \param[in] _ecm Entity-component manager.
+      /// \param[in] _name Sensor name.
+      /// \return Sensor entity.
+      public: sim::Entity SensorByName(const EntityComponentManager &_ecm,
+          const std::string &_name) const;
+
       /// \brief Get the ID of a visual entity which is an immediate child of
       /// this link.
       /// \param[in] _ecm Entity-component manager.
@@ -150,6 +158,12 @@ namespace gz
       public: std::vector<sim::Entity> Collisions(
           const EntityComponentManager &_ecm) const;
 
+      /// \brief Get all sensors which are immediate children of this link.
+      /// \param[in] _ecm Entity-component manager.
+      /// \return All sensors in this link.
+      public: std::vector<sim::Entity> Sensors(
+          const EntityComponentManager &_ecm) const;
+
       /// \brief Get all visuals which are immediate children of this link.
       /// \param[in] _ecm Entity-component manager.
       /// \return All visuals in this link.
@@ -161,6 +175,12 @@ namespace gz
       /// \param[in] _ecm Entity-component manager.
       /// \return Number of collisions in this link.
       public: uint64_t CollisionCount(const EntityComponentManager &_ecm) const;
+
+      /// \brief Get the number of sensors which are immediate children of this
+      /// link.
+      /// \param[in] _ecm Entity-component manager.
+      /// \return Number of sensors in this link.
+      public: uint64_t SensorCount(const EntityComponentManager &_ecm) const;
 
       /// \brief Get the number of visuals which are immediate children of this
       /// link.

--- a/python/src/gz/sim/Link.cc
+++ b/python/src/gz/sim/Link.cc
@@ -57,6 +57,11 @@ void defineSimLink(py::object module)
       py::arg("name"),
       "Get the ID of a collision entity which is an immediate child of "
       "this link.")
+  .def("sensor_by_name", &gz::sim::Link::SensorByName,
+      py::arg("ecm"),
+      py::arg("name"),
+      "Get the ID of a sensor entity which is an immediate child of "
+      "this link.")
   .def("visual_by_name", &gz::sim::Link::VisualByName,
       py::arg("ecm"),
       py::arg("name"),
@@ -65,6 +70,9 @@ void defineSimLink(py::object module)
   .def("collisions", &gz::sim::Link::Collisions,
       py::arg("ecm"),
       "Get all collisions which are immediate children of this link.")
+  .def("sensors", &gz::sim::Link::Sensors,
+      py::arg("ecm"),
+      "Get all sensors which are immediate children of this link.")
   .def("visuals", &gz::sim::Link::Visuals,
       py::arg("ecm"),
       "Get all visuals which are immediate children of this link.")
@@ -72,6 +80,10 @@ void defineSimLink(py::object module)
       py::arg("ecm"),
       "Get the number of collisions which are immediate children of "
       "this link.")
+  .def("sensor_count", &gz::sim::Link::SensorCount,
+      py::arg("ecm"),
+      "Get the number of sensors which are immediate children of this "
+      "link.")
   .def("visual_count", &gz::sim::Link::VisualCount,
       py::arg("ecm"),
       "Get the number of visuals which are immediate children of this "

--- a/python/test/link_TEST.py
+++ b/python/test/link_TEST.py
@@ -56,6 +56,9 @@ class TestModel(unittest.TestCase):
             # Collisions Test
             self.assertNotEqual(K_NULL_ENTITY, link.collision_by_name(_ecm, 'collision_test'))
             self.assertEqual(1, link.collision_count(_ecm))
+            # Sensors Test
+            self.assertNotEqual(K_NULL_ENTITY, link.sensor_by_name(_ecm, 'my_sensor'))
+            self.assertEqual(1, link.sensor_count(_ecm))
             # Visuals Test
             self.assertNotEqual(K_NULL_ENTITY, link.visual_by_name(_ecm, 'visual_test'))
             self.assertEqual(1, link.visual_count(_ecm))

--- a/src/Link.cc
+++ b/src/Link.cc
@@ -37,6 +37,7 @@
 #include "gz/sim/components/Name.hh"
 #include "gz/sim/components/ParentEntity.hh"
 #include "gz/sim/components/Pose.hh"
+#include "gz/sim/components/Sensor.hh"
 #include "gz/sim/components/Visual.hh"
 #include "gz/sim/components/WindMode.hh"
 #include "gz/sim/Util.hh"
@@ -127,6 +128,16 @@ Entity Link::CollisionByName(const EntityComponentManager &_ecm,
 }
 
 //////////////////////////////////////////////////
+Entity Link::SensorByName(const EntityComponentManager &_ecm,
+    const std::string &_name) const
+{
+  return _ecm.EntityByComponents(
+      components::ParentEntity(this->dataPtr->id),
+      components::Name(_name),
+      components::Sensor());
+}
+
+//////////////////////////////////////////////////
 Entity Link::VisualByName(const EntityComponentManager &_ecm,
     const std::string &_name) const
 {
@@ -145,6 +156,14 @@ std::vector<Entity> Link::Collisions(const EntityComponentManager &_ecm) const
 }
 
 //////////////////////////////////////////////////
+std::vector<Entity> Link::Sensors(const EntityComponentManager &_ecm) const
+{
+  return _ecm.EntitiesByComponents(
+      components::ParentEntity(this->dataPtr->id),
+      components::Sensor());
+}
+
+//////////////////////////////////////////////////
 std::vector<Entity> Link::Visuals(const EntityComponentManager &_ecm) const
 {
   return _ecm.EntitiesByComponents(
@@ -156,6 +175,12 @@ std::vector<Entity> Link::Visuals(const EntityComponentManager &_ecm) const
 uint64_t Link::CollisionCount(const EntityComponentManager &_ecm) const
 {
   return this->Collisions(_ecm).size();
+}
+
+//////////////////////////////////////////////////
+uint64_t Link::SensorCount(const EntityComponentManager &_ecm) const
+{
+  return this->Sensors(_ecm).size();
 }
 
 //////////////////////////////////////////////////

--- a/test/integration/link.cc
+++ b/test/integration/link.cc
@@ -41,6 +41,7 @@
 #include <gz/sim/components/Name.hh>
 #include <gz/sim/components/ParentEntity.hh>
 #include <gz/sim/components/Pose.hh>
+#include <gz/sim/components/Sensor.hh>
 #include <gz/sim/components/Visual.hh>
 
 #include <gz/sim/EntityComponentManager.hh>
@@ -168,6 +169,30 @@ TEST_F(LinkIntegrationTest, VisualByName)
   // Check link
   EXPECT_EQ(eVisual, link.VisualByName(ecm, "visual_name"));
   EXPECT_EQ(1u, link.VisualCount(ecm));
+}
+
+//////////////////////////////////////////////////
+TEST_F(LinkIntegrationTest, SensorByName)
+{
+  EntityComponentManager ecm;
+
+  // Link
+  auto eLink = ecm.CreateEntity();
+  Link link(eLink);
+  EXPECT_EQ(eLink, link.Entity());
+  EXPECT_EQ(0u, link.SensorCount(ecm));
+
+  // Sensor
+  auto eSensor = ecm.CreateEntity();
+  ecm.CreateComponent<components::Sensor>(eSensor, components::Sensor());
+  ecm.CreateComponent<components::ParentEntity>(eSensor,
+      components::ParentEntity(eLink));
+  ecm.CreateComponent<components::Name>(eSensor,
+      components::Name("sensor_name"));
+
+  // Check link
+  EXPECT_EQ(eSensor, link.SensorByName(ecm, "sensor_name"));
+  EXPECT_EQ(1u, link.SensorCount(ecm));
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
# 🎉 New feature

Adds missing APIs

## Summary

This adds `SensorByName`, `Sensors`, and `SensorCount` accessors to the Link class.

## Test it

1. Build this branch
2. Run `UNIT_Link_TEST`
3. Run `INTEGRATION_link`

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
