### PR TITLE
Add parameter for adjust current sign in battery plugin

### DIFF
--- a/src/systems/battery_plugin/LinearBatteryPlugin.cc
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.cc
@@ -723,7 +723,7 @@ double LinearBatteryPlugin::OnUpdateVoltage(
         + this->dataPtr->r * this->dataPtr->ismooth;
   else
     voltage = this->dataPtr->e0 + this->dataPtr->e1 * (
-      1 - this->dataPtr->q / this->c)
+      1 - this->dataPtr->q / this->dataPtr->c)
         - this->dataPtr->r * this->dataPtr->ismooth;
 
   // Estimate state of charge


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #2685 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

A parameter has been added to adjust the sign of the battery current value to comply with ROS conventions.
By default, it is set to `false`, so the existing behavior remains unchanged.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
