### PR TITLE
Fix publishing only top level model pose in pose publisher

### DIFF
--- a/src/systems/pose_publisher/PosePublisher.cc
+++ b/src/systems/pose_publisher/PosePublisher.cc
@@ -204,6 +204,8 @@ void PosePublisher::Configure(const Entity &_entity,
 
   // for backward compatibility, publish_model_pose will be set to the
   // same value as publish_nested_model_pose if it is not specified.
+  // todo(iche033) Remove backward compatibility and decouple model and
+  // nested model pose parameter value in gz-sim10
   this->dataPtr->publishModelPose =
     _sdf->Get<bool>("publish_model_pose",
         this->dataPtr->publishNestedModelPose).first;
@@ -394,9 +396,6 @@ void PosePublisherPrivate::InitializeEntitiesToPublish(
         (collision && this->publishCollisionPose) ||
         (sensor && this->publishSensorPose);
 
-    // for backward compatibility, top level model pose will be published
-    // if publishNestedModelPose is set to true unless the user explicity
-    // disables this by setting publishModelPose to false
     if (isModel)
     {
       if (parent)
@@ -404,10 +403,8 @@ void PosePublisherPrivate::InitializeEntitiesToPublish(
         auto nestedModel = _ecm.Component<components::Model>(parent->Data());
         if (nestedModel)
           fillPose = this->publishNestedModelPose;
-      }
-      if (!fillPose)
-      {
-        fillPose = this->publishNestedModelPose && this->publishModelPose;
+        else
+          fillPose = this->publishModelPose;
       }
     }
 

--- a/test/integration/pose_publisher_system.cc
+++ b/test/integration/pose_publisher_system.cc
@@ -778,8 +778,7 @@ TEST_F(PosePublisherTest,
 
   poseMsgs.clear();
 
-  // test that the pose publisher plugin can be loaded by a nested model
-  // by subscribe to the its topic
+  // subscribe to the pose publisher
   transport::Node node;
   node.Subscribe(std::string("/model/test_publish_only_model_pose/pose"),
                  &poseCb);

--- a/test/integration/pose_publisher_system.cc
+++ b/test/integration/pose_publisher_system.cc
@@ -761,5 +761,52 @@ TEST_F(PosePublisherTest,
     auto p = msgs::Convert(poseMsgs[0]);
     EXPECT_EQ(expectedEntityPose, p);
   }
+}
 
+/////////////////////////////////////////////////
+TEST_F(PosePublisherTest,
+       GZ_UTILS_TEST_DISABLED_ON_WIN32(ModelPoseOnly))
+{
+  // Start server
+  ServerConfig serverConfig;
+  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
+      "/test/worlds/pose_publisher.sdf");
+
+  Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  poseMsgs.clear();
+
+  // test that the pose publisher plugin can be loaded by a nested model
+  // by subscribe to the its topic
+  transport::Node node;
+  node.Subscribe(std::string("/model/test_publish_only_model_pose/pose"),
+                 &poseCb);
+
+  // Run server
+  unsigned int iters = 1000u;
+  server.Run(true, iters, false);
+
+  // Wait for messages to be received
+  int sleep = 0;
+  while (poseMsgs.empty() && sleep++ < 30)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  EXPECT_TRUE(!poseMsgs.empty());
+
+  // only the pose of the model should be published and no other entity
+  std::string expectedEntityName = "test_publish_only_model_pose";
+  math::Pose3d expectedEntityPose(5, 5, 0, 0, 0, 0);
+  for (auto &msg : poseMsgs)
+  {
+    ASSERT_LT(1, msg.header().data_size());
+    ASSERT_LT(0, msg.header().data(1).value_size());
+    std::string childFrameId = msg.header().data(1).value(0);
+    EXPECT_EQ(expectedEntityName, childFrameId);
+    auto p = msgs::Convert(poseMsgs[0]);
+    EXPECT_EQ(expectedEntityPose, p);
+  }
 }

--- a/test/worlds/pose_publisher.sdf
+++ b/test/worlds/pose_publisher.sdf
@@ -514,5 +514,20 @@
       </plugin>
     </model>
 
+    <model name="test_publish_only_model_pose">
+      <pose>5 5 0 0 0 0</pose>
+      <link name="link1"/>
+      <plugin
+         filename="gz-sim-pose-publisher-system"
+         name="gz::sim::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
+        <publish_model_pose>true</publish_model_pose>
+      </plugin>
+    </model>
+
   </world>
 </sdf>


### PR DESCRIPTION

# 🦟 Bug fix

Fixes #2690

## Summary

The pose publisher system should now publish top level model pose with these settings:

```xml
        <publish_model_pose>true</publish_model_pose>
        <publish_nested_model_pose>false</publish_nested_model_pose>
```

This PR preserves the behavior and backward compatibility logic that were added in #1342, i.e.

1. The system should only publish nested model pose with these params:

    ```xml
            <publish_model_pose>false</publish_model_pose>
            <publish_nested_model_pose>true</publish_nested_model_pose>
    ```

2. Backward behavior - if `<publish_model_pose>` is not specified, it defaults to the same value as `<publish_nested_model_pose>` - we should remove this behavior in gz-sim10 / jetty. I added a todo note for this.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
