### PR TITLE
Extend shapes gui plugin width to include the ellipsoid button

### DIFF
--- a/src/gui/gui.config
+++ b/src/gui/gui.config
@@ -171,7 +171,7 @@
     <property key="resizable" type="bool">false</property>
     <property key="x" type="double">0</property>
     <property key="y" type="double">0</property>
-    <property key="width" type="double">250</property>
+    <property key="width" type="double">300</property>
     <property key="height" type="double">50</property>
     <property key="state" type="string">floating</property>
     <property key="showTitleBar" type="bool">false</property>
@@ -183,7 +183,7 @@
 <plugin filename="Lights" name="Lights">
   <gz-gui>
     <property key="resizable" type="bool">false</property>
-    <property key="x" type="double">250</property>
+    <property key="x" type="double">300</property>
     <property key="y" type="double">0</property>
     <property key="width" type="double">150</property>
     <property key="height" type="double">50</property>


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

The shapes gui plugin in gui config was not wide enough to show the ellipsoid tool button. So updated the gui config to reveal the button.

Before:

![shapes_gui_width_before](https://github.com/user-attachments/assets/5082c721-34fe-4fbd-a869-3d99246a45db)

After:

<img width="448" alt="shapes_gui_width" src="https://github.com/user-attachments/assets/ded139e9-b1cc-43c4-a3f4-25fd7fd5ee55" />



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

