### PR TITLE
Prepare for 3.15.2 Release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 ## Gazebo Sim 3.x
 
+### Gazebo Sim 3.15.2 (2024-12-12)
+
+1. Fix bug where iterator was used after the underlying item was erased from the container
+    * [Pull request #2412](https://github.com/gazebosim/gz-sim/pull/2412)
+
+1. Setup rendering environment before cmake runs
+    * [Pull request #1965](https://github.com/gazebosim/gz-sim/pull/1965)
+
 ### Gazebo Sim 3.15.1 (2024-01-05)
 
 1. Update github action workflows


### PR DESCRIPTION
# 🎈 Release

https://github.com/gazebo-tooling/release-tools/issues/1223

This will be the **final** release if ign-gazebo3 as Citadel has reached EOL.

Preparation for 3.15.2 release.

Comparison to 3.15.1: https://github.com/gazebosim/gz-sim/compare/ignition-gazebo3_3.15.1...ign-gazebo3


## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.