### PR TITLE
LinearBatteryPlugin stability improvement

### DIFF
--- a/src/systems/battery_plugin/LinearBatteryPlugin.cc
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.cc
@@ -97,13 +97,6 @@ class gz::sim::systems::LinearBatteryPluginPrivate
   /// \brief Pointer to battery contained in link.
   public: common::BatteryPtr battery;
 
-  /// \brief Whether warning that battery has drained has been printed once.
-  public: bool drainPrinted{false};
-
-  /// \brief Battery consumer identifier.
-  /// Current implementation limits one consumer (Model) per battery.
-  public: int32_t consumerId;
-
   /// \brief Battery entity
   public: Entity batteryEntity{kNullEntity};
 
@@ -136,15 +129,11 @@ class gz::sim::systems::LinearBatteryPluginPrivate
   /// \brief State of charge [0, 1].
   public: double soc{1.0};
 
-  /// \brief Recharge status
-  public: std::atomic_bool startCharging{false};
-
   /// \brief Hours taken to fully charge battery
   public: double tCharge{0.0};
 
-  /// \TODO(caguero) Remove this flag in Gazebo Dome.
-  /// \brief Flag to enable some battery fixes.
-  public: bool fixIssue225{false};
+  /// \brief Initial power load set trough config
+  public: double initialPowerLoad{0.0};
 
   /// \TODO(caguero) Remove in Gazebo Dome.
   /// \brief Battery current for a historic time window
@@ -157,16 +146,6 @@ class gz::sim::systems::LinearBatteryPluginPrivate
   /// \brief Simulation time handled during a single update.
   public: std::chrono::steady_clock::duration stepSize;
 
-  /// \brief Flag on whether the battery should start draining
-  public: bool startDraining = false;
-
-  /// \brief The start time when battery starts draining in seconds
-  public: int drainStartTime = -1;
-
-  /// \brief Book keep the last time printed, so as to not pollute dbg messages
-  /// in minutes
-  public: int lastPrintTime = -1;
-
   /// \brief Model interface
   public: Model model{kNullEntity};
 
@@ -176,11 +155,32 @@ class gz::sim::systems::LinearBatteryPluginPrivate
   /// \brief Battery state of charge message publisher
   public: transport::Node::Publisher statePub;
 
-  /// \brief Initial power load set trough config
-  public: double initialPowerLoad = 0.0;
+  /// \brief Battery consumer identifier.
+  /// Current implementation limits one consumer (Model) per battery.
+  public: int32_t consumerId;
+
+  /// \brief The start time when battery starts draining in seconds
+  public: int drainStartTime{-1};
+
+  /// \brief Book keep the last time printed, so as to not pollute dbg messages
+  /// in minutes
+  public: int lastPrintTime{-1};
+
+  /// \brief Recharge status
+  public: std::atomic_bool startCharging{false};
+
+  /// \brief Flag on whether the battery should start draining
+  public: std::atomic_bool startDraining{false};
+
+  /// \brief Whether warning that battery has drained has been printed once.
+  public: bool drainPrinted{false};
 
   /// \brief Flag to invert the current sign
   public: bool invertCurrentSign{false};
+
+  /// \TODO(caguero) Remove this flag in Gazebo Dome.
+  /// \brief Flag to enable some battery fixes.
+  public: bool fixIssue225{false};
 };
 
 /////////////////////////////////////////////////

--- a/test/integration/battery_plugin.cc
+++ b/test/integration/battery_plugin.cc
@@ -400,22 +400,25 @@ TEST_F(BatteryPluginTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(PowerDrainTopic))
   // Send a message on one of the <power_draining_topic> topics, which will
   // start the battery draining when the server starts again.
   gz::transport::Node node;
-  auto pub = node.Advertise<msgs::StringMsg>("/battery/discharge");
+  auto discharge_pub = node.Advertise<msgs::StringMsg>("/battery/discharge");
   msgs::StringMsg msg;
-  pub.Publish(msg);
+  discharge_pub.Publish(msg);
 
   // Run the server again.
   server.Run(true, 100, false);
 
-  // The state of charge should be <1, since the battery has started
-  // draining.
-  double stateOfCharge = batComp->Data();
-  EXPECT_LT(batComp->Data(), 1.0);
-
   // Send a message on one of the <stop_power_draining_topic> topics, which
   // will stop the battery draining when the server starts again.
-  auto pub2 = node.Advertise<msgs::StringMsg>("/battery/stop_discharge");
-  pub2.Publish(msg);
+  auto stop_pub = node.Advertise<msgs::StringMsg>("/battery/stop_discharge");
+  stop_pub.Publish(msg);
+
+  // Run the server a little bit to allow msg be propagated inside plugin
+  server.Run(true, 50, false);
+
+  // The state of charge should be <1, since the battery has started
+  // draining.
+  const double stateOfCharge = batComp->Data();
+  EXPECT_LT(batComp->Data(), 1.0);
 
   // Run the server again.
   server.Run(true, 100, false);

--- a/test/integration/battery_plugin.cc
+++ b/test/integration/battery_plugin.cc
@@ -400,17 +400,17 @@ TEST_F(BatteryPluginTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(PowerDrainTopic))
   // Send a message on one of the <power_draining_topic> topics, which will
   // start the battery draining when the server starts again.
   gz::transport::Node node;
-  auto discharge_pub = node.Advertise<msgs::StringMsg>("/battery/discharge");
+  auto dischargePub = node.Advertise<msgs::StringMsg>("/battery/discharge");
   msgs::StringMsg msg;
-  discharge_pub.Publish(msg);
+  dischargePub.Publish(msg);
 
   // Run the server again.
   server.Run(true, 100, false);
 
   // Send a message on one of the <stop_power_draining_topic> topics, which
   // will stop the battery draining when the server starts again.
-  auto stop_pub = node.Advertise<msgs::StringMsg>("/battery/stop_discharge");
-  stop_pub.Publish(msg);
+  auto stopPub = node.Advertise<msgs::StringMsg>("/battery/stop_discharge");
+  stopPub.Publish(msg);
 
   // Run the server a little bit to allow msg be propagated inside plugin
   server.Run(true, 50, false);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
This PR contain 3 different changes
* LinearBatteryPlugin: `startDraining` should be atomic due to we are changing it in callback which can be called from other thread (valgrind --tool=drd or helgrind)
* LinearBatteryPlugin: In a C++ each type has own [alignment](https://en.cppreference.com/w/cpp/language/object#Alignment) and rule of thumb: sort fields in order from bigger to smaller to avoid creation padding between fields. For structures we can add compiler option [-Wpadded](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wpadded) to get warnings, but we can't do it for a project due to reports not only padding between fields but also in case of inheritance (and we have some case with quite base types). So I propose to reorder some members to avoid such padding
* battery_plugin: in this test we had a logical race condition: when we publishing message, propagation can took some time. And if we are starting simulation immediately in some cases(e.g. VM or overloaded CPU) we can get couple of iterations of simulation until we receive the message. So it's more durable to send message and spin a little bit to be sure of delivery

It's quite simple to add some keys to compiler just by defining some [env.variables](https://cmake.org/cmake/help/latest/envvar/CXXFLAGS.html) before a clean build execution

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.