### PR TITLE
Add example about using joint control components

### DIFF
--- a/examples/plugin/joint_control_components/CMakeLists.txt
+++ b/examples/plugin/joint_control_components/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
+
+project(BouncePlugins)
+
+find_package(gz-plugin3 REQUIRED COMPONENTS register)
+set(GZ_PLUGIN_VER ${gz-plugin3_VERSION_MAJOR})
+
+find_package(gz-sim9 REQUIRED)
+set(GZ_SIM_VER ${gz-sim9_VERSION_MAJOR})
+
+add_library(PulseJointVelocityCommand SHARED PulseJointVelocityCommand.cc)
+target_link_libraries(PulseJointVelocityCommand
+  PRIVATE gz-plugin${GZ_PLUGIN_VER}::gz-plugin${GZ_PLUGIN_VER}
+  PRIVATE gz-sim${GZ_SIM_VER}::core)
+
+add_library(ResetJointVelocityNearPosition SHARED ResetJointVelocityNearPosition.cc)
+target_link_libraries(ResetJointVelocityNearPosition
+  PRIVATE gz-plugin${GZ_PLUGIN_VER}::gz-plugin${GZ_PLUGIN_VER}
+  PRIVATE gz-sim${GZ_SIM_VER}::core)

--- a/examples/plugin/joint_control_components/PulseJointVelocityCommand.cc
+++ b/examples/plugin/joint_control_components/PulseJointVelocityCommand.cc
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gz/sim/Joint.hh>
+#include <gz/sim/Model.hh>
+#include <gz/sim/System.hh>
+#include "gz/sim/components/JointForceCmd.hh"
+#include <gz/plugin/Register.hh>
+
+using namespace gz::sim;
+namespace joint_control
+{
+class PulseJointVelocityCommand: public System,
+                                 public ISystemConfigure,
+                                 public ISystemPreUpdate
+{
+  void Configure(const Entity &_entity,
+                 const std::shared_ptr<const sdf::Element> &_sdf,
+                 EntityComponentManager &_ecm, EventManager &) override
+  {
+    this->model = Model(_entity);
+
+    if (_sdf->HasElement("pulse_seconds"))
+    {
+      this->pulse_seconds = _sdf->Get<double>("pulse_seconds");
+    }
+
+    if (_sdf->HasElement("velocity_command"))
+    {
+      this->velocity_command = _sdf->Get<double>("velocity_command");
+    }
+  }
+
+  void PreUpdate(const UpdateInfo &_info,
+                 EntityComponentManager &_ecm) override
+  {
+    double time = std::chrono::duration<double>(_info.simTime).count();
+    bool pulse = static_cast<int>(std::floor(time / pulse_seconds)) % 2;
+
+    for (auto jointEntity : this->model.Joints(_ecm))
+    {
+      Joint joint(jointEntity);
+      if (pulse)
+      {
+        joint.SetVelocity(_ecm, {this->velocity_command});
+        _ecm.RemoveComponent<components::JointForceCmd>(jointEntity);
+      }
+      else
+      {
+        // Setting the JointForceCmd is required to disengage the velocity
+        // controller, otherwise the velocity controller remains engaged with a
+        // JointVelocityCmd of 0.
+        joint.SetForce(_ecm, {0.0});
+      }
+    }
+  }
+
+  private: Model model;
+  private: double pulse_seconds = 2.0;
+  // Internal variable stored in rad/s
+  private: double velocity_command = 0.4;
+};
+}  // namespace joint_control
+
+GZ_ADD_PLUGIN(joint_control::PulseJointVelocityCommand,
+              gz::sim::System,
+              joint_control::PulseJointVelocityCommand::ISystemConfigure,
+              joint_control::PulseJointVelocityCommand::ISystemPreUpdate)

--- a/examples/plugin/joint_control_components/README.md
+++ b/examples/plugin/joint_control_components/README.md
@@ -1,0 +1,60 @@
+# Joint control components
+
+This example shows how to use three different
+[components](https://gazebosim.org/api/sim/9/namespacegz_1_1sim_1_1components.html)
+to create joint motion:
+
+* `JointForceCmd`: this component applies an effort to each degree of freedom
+  of the specified joint (force for translational joint axes and torque for
+  rotational joint axes).
+* `JointVelocityCmd`: this component specifies a desired velocity that a
+  controller attempts to match subject to joint effort limits.
+* `JointVelocityReset`: this component rewrites the joint velocity state,
+  in a similar way to setting a new initial condition.
+
+These components are demonstrated with the following plugins:
+
+* `ResetJointVelocityNearPosition`: this plugin sets the `JointVelocityReset`
+  component to a fixed value when the measured joint position is near a trigger
+  position. This can create a bouncing behavior of a pendulum if the trigger
+  position is the bottom stable equilibrium.
+* `PulseJointVelocityCommand`: this plugin applies pulses of joint velocity
+  commands as a square wave with a specified time period between pulses.
+
+## Build
+
+~~~
+cd examples/plugin/reset_plugin
+mkdir build
+cd build
+cmake ..
+make
+~~~
+
+This will build the `ResetJointVelocityNearPosition` and
+`PulseJointVelocityCommand` libraries under `build`.
+
+## Run
+
+Add the library to the path:
+
+~~~
+cd examples/plugin/joint_control_components
+export GZ_SIM_SYSTEM_PLUGIN_PATH=`pwd`/build
+~~~
+
+Then run a world that loads examples of these plugins.
+
+    gz sim -r -v 4 joint_control_components.sdf
+
+There should be 3 pendulums loaded.
+
+* On the far left, the pendulum has only the `ResetJointVelocityNearPosition`
+  with a trigger position at the downward stable eqilibrium point. This exhibits
+  a bouncing behavior.
+* On the far right, the pendulum has only the `PulseJointVelocityCommand`.
+  It starts out stationary, then alternates between moving at constant velocity
+  and swinging passively.
+* In the center, the pendulum has both plugins enabled and experiences pulses
+  of constant velocity alternating with passive swinging and bouncing at the
+  bottom.

--- a/examples/plugin/joint_control_components/ResetJointVelocityNearPosition.cc
+++ b/examples/plugin/joint_control_components/ResetJointVelocityNearPosition.cc
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gz/sim/Joint.hh>
+#include <gz/sim/Model.hh>
+#include <gz/sim/System.hh>
+#include <gz/plugin/Register.hh>
+
+using namespace gz::sim;
+namespace joint_control
+{
+class ResetJointVelocityNearPosition: public System,
+                                      public ISystemConfigure,
+                                      public ISystemPreUpdate
+{
+  void Configure(const Entity &_entity,
+                 const std::shared_ptr<const sdf::Element> &_sdf,
+                 EntityComponentManager &_ecm, EventManager &) override
+  {
+    this->model = Model(_entity);
+
+    for (auto jointEntity : this->model.Joints(_ecm))
+    {
+      Joint joint(jointEntity);
+      joint.EnablePositionCheck(_ecm, true);
+    }
+
+    if (_sdf->HasElement("position_tolerance"))
+    {
+      this->position_tolerance = _sdf->Get<double>("position_tolerance");
+    }
+
+    if (_sdf->HasElement("trigger_position"))
+    {
+      this->trigger_position = _sdf->Get<double>("trigger_position");
+    }
+
+    if (_sdf->HasElement("velocity_after_reset"))
+    {
+      this->velocity_after_reset = _sdf->Get<double>("velocity_after_reset");
+    }
+  }
+
+  void PreUpdate(const UpdateInfo &_info,
+                 EntityComponentManager &_ecm) override
+  {
+    auto jointEntities = this->model.Joints(_ecm);
+
+    for (auto jointEntity : jointEntities)
+    {
+      Joint joint(jointEntity);
+
+      auto optPositions = joint.Position(_ecm);
+      if (!optPositions.has_value() || optPositions->size() != 1)
+      {
+        // error message
+        continue;
+      }
+      double position = optPositions->at(0);
+
+      if (fabs(position - this->trigger_position) < position_tolerance)
+      {
+        joint.ResetVelocity(_ecm, {this->velocity_after_reset});
+      }
+    }
+  }
+
+  private: Model model;
+  // Internal variables stored in rad, rad/s
+  private: double trigger_position = 0.0;
+  private: double position_tolerance = 0.01;
+  private: double velocity_after_reset = 0.25;
+};
+}  // namespace joint_control
+
+GZ_ADD_PLUGIN(joint_control::ResetJointVelocityNearPosition,
+              gz::sim::System,
+              joint_control::ResetJointVelocityNearPosition::ISystemConfigure,
+              joint_control::ResetJointVelocityNearPosition::ISystemPreUpdate)

--- a/examples/plugin/joint_control_components/joint_control_components.sdf
+++ b/examples/plugin/joint_control_components/joint_control_components.sdf
@@ -1,0 +1,546 @@
+<sdf version="1.11">
+  <!-- This example uses the ResetJointVelocityNearPosition to reset the joint
+       velocity to a positive value when it is near the stable equilibrium
+       position. The joint appears to bounce upward near the bottom of its
+       swing.
+
+      To adjust the bounce height, modify the velocity_after_reset parameter
+      in the plugin at the end of this file.
+  -->
+
+  <world name="default">
+    <plugin filename="gz-sim-physics-system" name="gz::sim::systems::Physics"></plugin>
+    <plugin filename="gz-sim-user-commands-system" name="gz::sim::systems::UserCommands"></plugin>
+    <plugin filename="gz-sim-scene-broadcaster-system" name="gz::sim::systems::SceneBroadcaster"></plugin>
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <direction>0.3 -0.3 -0.9</direction>
+    </light>
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+
+
+    <model name="pendulum_bounce_at_bottom">
+      <pose degrees="true">0 3 0 0 0 180</pose>
+      <frame name="base_plate_center" attached_to="base">
+        <pose>0 0 0.01 0 0 0</pose>
+      </frame>
+      <frame name="base_pole_center" attached_to="base">
+        <pose>-0.275 0 1.1 0 0 0</pose>
+      </frame>
+      <link name="base">
+        <inertial>
+          <pose>-0.188749 0 0.75813399999999997 -0.13567899999999999 0 1.5708</pose>
+          <mass>2500</mass>
+          <inertia>
+            <ixx>154.202</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>152.286</iyy>
+            <iyz>0</iyz>
+            <izz>28.8249</izz>
+          </inertia>
+        </inertial>
+        <collision name="col_plate_on_ground">
+          <pose relative_to="base_plate_center"/>
+          <geometry>
+            <cylinder>
+              <radius>0.8</radius>
+              <length>0.02</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="vis_plate_on_ground">
+          <pose relative_to="base_plate_center"/>
+          <geometry>
+            <cylinder>
+              <radius>0.8</radius>
+              <length>0.02</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <collision name="col_pole">
+          <pose relative_to="base_pole_center"/>
+          <geometry>
+            <box>
+              <size>0.2 0.2 2.2</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="vis_pole">
+          <pose relative_to="base_pole_center"/>
+          <geometry>
+            <box>
+              <size>0.2 0.2 2.2</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <frame name="base_top_mount" attached_to="base">
+        <pose relative_to="base_pole_center">0.1 0 1.0 0 0 0</pose>
+      </frame>
+      <!-- upper link, length 1 -->
+      <link name="upper_link">
+        <pose degrees="true" relative_to="base_top_mount">0.15 0 0 -180 0 0</pose>
+        <self_collide>0</self_collide>
+        <inertial auto="true" />
+        <collision name="col_upper_joint">
+          <pose degrees="true">0 0 0 0 90 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.3</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="vis_upper_joint">
+          <pose degrees="true">0 0 0 0 90 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.3</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <collision name="col_bob">
+          <pose degrees="true">0 0 1.0 0 90 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.3</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="vis_bob">
+          <pose degrees="true">0 0 1.0 0 90 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.3</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <collision name="col_long_cylinder">
+          <pose>0 0 0.5 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.9</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="vis_long_cylinder">
+          <pose>0 0 0.5 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.9</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <!-- pin joint for upper link, at origin of upper link -->
+      <joint name="upper_joint" type="revolute">
+        <parent>base</parent>
+        <child>upper_link</child>
+        <axis>
+          <xyz>1.0 0 0</xyz>
+        </axis>
+      </joint>
+
+      <plugin name="joint_control::ResetJointVelocityNearPosition"
+          filename="libResetJointVelocityNearPosition.so">
+        <trigger_position>0.0</trigger_position>
+        <velocity_after_reset>2.0</velocity_after_reset>
+      </plugin>
+    </model>
+
+
+
+    <model name="pendulum_reset_and_pulse_velocity">
+      <pose degrees="true">0 0 0 0 0 180</pose>
+      <frame name="base_plate_center" attached_to="base">
+        <pose>0 0 0.01 0 0 0</pose>
+      </frame>
+      <frame name="base_pole_center" attached_to="base">
+        <pose>-0.275 0 1.1 0 0 0</pose>
+      </frame>
+      <link name="base">
+        <inertial>
+          <pose>-0.188749 0 0.75813399999999997 -0.13567899999999999 0 1.5708</pose>
+          <mass>2500</mass>
+          <inertia>
+            <ixx>154.202</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>152.286</iyy>
+            <iyz>0</iyz>
+            <izz>28.8249</izz>
+          </inertia>
+        </inertial>
+        <collision name="col_plate_on_ground">
+          <pose relative_to="base_plate_center"/>
+          <geometry>
+            <cylinder>
+              <radius>0.8</radius>
+              <length>0.02</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="vis_plate_on_ground">
+          <pose relative_to="base_plate_center"/>
+          <geometry>
+            <cylinder>
+              <radius>0.8</radius>
+              <length>0.02</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <collision name="col_pole">
+          <pose relative_to="base_pole_center"/>
+          <geometry>
+            <box>
+              <size>0.2 0.2 2.2</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="vis_pole">
+          <pose relative_to="base_pole_center"/>
+          <geometry>
+            <box>
+              <size>0.2 0.2 2.2</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <frame name="base_top_mount" attached_to="base">
+        <pose relative_to="base_pole_center">0.1 0 1.0 0 0 0</pose>
+      </frame>
+      <!-- upper link, length 1 -->
+      <link name="upper_link">
+        <pose degrees="true" relative_to="base_top_mount">0.15 0 0 -180 0 0</pose>
+        <self_collide>0</self_collide>
+        <inertial auto="true" />
+        <collision name="col_upper_joint">
+          <pose degrees="true">0 0 0 0 90 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.3</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="vis_upper_joint">
+          <pose degrees="true">0 0 0 0 90 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.3</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <collision name="col_bob">
+          <pose degrees="true">0 0 1.0 0 90 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.3</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="vis_bob">
+          <pose degrees="true">0 0 1.0 0 90 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.3</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <collision name="col_long_cylinder">
+          <pose>0 0 0.5 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.9</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="vis_long_cylinder">
+          <pose>0 0 0.5 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.9</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <!-- pin joint for upper link, at origin of upper link -->
+      <joint name="upper_joint" type="revolute">
+        <parent>base</parent>
+        <child>upper_link</child>
+        <axis>
+          <xyz>1.0 0 0</xyz>
+        </axis>
+      </joint>
+
+      <plugin name="joint_control::ResetJointVelocityNearPosition"
+          filename="libResetJointVelocityNearPosition.so">
+        <trigger_position>0.0</trigger_position>
+        <velocity_after_reset>2.0</velocity_after_reset>
+      </plugin>
+
+      <plugin name="joint_control::PulseJointVelocityCommand"
+          filename="libPulseJointVelocityCommand.so">
+        <pulse_seconds>2.0</pulse_seconds>
+        <velocity_command>1.0</velocity_command>
+      </plugin>
+    </model>
+
+
+
+    <model name="pendulum_with_velocity_pulses">
+      <pose degrees="true">0 -3 0 0 0 180</pose>
+      <frame name="base_plate_center" attached_to="base">
+        <pose>0 0 0.01 0 0 0</pose>
+      </frame>
+      <frame name="base_pole_center" attached_to="base">
+        <pose>-0.275 0 1.1 0 0 0</pose>
+      </frame>
+      <link name="base">
+        <inertial>
+          <pose>-0.188749 0 0.75813399999999997 -0.13567899999999999 0 1.5708</pose>
+          <mass>2500</mass>
+          <inertia>
+            <ixx>154.202</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>152.286</iyy>
+            <iyz>0</iyz>
+            <izz>28.8249</izz>
+          </inertia>
+        </inertial>
+        <collision name="col_plate_on_ground">
+          <pose relative_to="base_plate_center"/>
+          <geometry>
+            <cylinder>
+              <radius>0.8</radius>
+              <length>0.02</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="vis_plate_on_ground">
+          <pose relative_to="base_plate_center"/>
+          <geometry>
+            <cylinder>
+              <radius>0.8</radius>
+              <length>0.02</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <collision name="col_pole">
+          <pose relative_to="base_pole_center"/>
+          <geometry>
+            <box>
+              <size>0.2 0.2 2.2</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="vis_pole">
+          <pose relative_to="base_pole_center"/>
+          <geometry>
+            <box>
+              <size>0.2 0.2 2.2</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <frame name="base_top_mount" attached_to="base">
+        <pose relative_to="base_pole_center">0.1 0 1.0 0 0 0</pose>
+      </frame>
+      <!-- upper link, length 1 -->
+      <link name="upper_link">
+        <pose degrees="true" relative_to="base_top_mount">0.15 0 0 -180 0 0</pose>
+        <self_collide>0</self_collide>
+        <inertial auto="true" />
+        <collision name="col_upper_joint">
+          <pose degrees="true">0 0 0 0 90 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.3</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="vis_upper_joint">
+          <pose degrees="true">0 0 0 0 90 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.3</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <collision name="col_bob">
+          <pose degrees="true">0 0 1.0 0 90 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.3</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="vis_bob">
+          <pose degrees="true">0 0 1.0 0 90 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.3</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <collision name="col_long_cylinder">
+          <pose>0 0 0.5 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.9</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="vis_long_cylinder">
+          <pose>0 0 0.5 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.9</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <!-- pin joint for upper link, at origin of upper link -->
+      <joint name="upper_joint" type="revolute">
+        <parent>base</parent>
+        <child>upper_link</child>
+        <axis>
+          <xyz>1.0 0 0</xyz>
+        </axis>
+      </joint>
+
+      <plugin name="joint_control::PulseJointVelocityCommand"
+          filename="libPulseJointVelocityCommand.so">
+        <pulse_seconds>2.0</pulse_seconds>
+        <velocity_command>1.0</velocity_command>
+      </plugin>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
# 🎉 New feature

Demonstrate issues with joint control

## Summary

I was struggling to use both `JointVelocityCmd` and `JointVelocityReset` components when controlling joints until I noticed the following comment in [src/systems/physics/Physics.cc](https://github.com/gazebosim/gz-sim/blob/gz-sim9_9.0.0/src/systems/physics/Physics.cc#L2333-L2334):

~~~
        // Only set joint velocity if joint force is not set.
        // If both the cmd and reset components are found, cmd is ignored.
~~~

To demonstrate this interaction I created two example plugins:

* `ResetJointVelocityNearPosition`: this plugin sets the `JointVelocityReset`
  component to a fixed value when the measured joint position is near a trigger
  position. This can create a bouncing behavior of a pendulum if the trigger
  position is the bottom stable equilibrium.
* `PulseJointVelocityCommand`: this plugin applies pulses of joint velocity
  commands as a square wave with a specified time period between pulses.

The example world includes three pendulum models:

* On the far left, the pendulum has only the `ResetJointVelocityNearPosition`
  with a trigger position at the downward stable eqilibrium point. This exhibits
  a bouncing behavior.
* On the far right, the pendulum has only the `PulseJointVelocityCommand`.
  It starts out stationary, then alternates between moving at constant velocity
  and swinging passively.
* In the center, the pendulum has both plugins enabled and experiences pulses
  of constant velocity alternating with passive swinging and bouncing at the
  bottom.

### Screen capture with dartsim:

https://github.com/user-attachments/assets/f3050cff-9406-4ee9-85ce-ac44303eb7e1

### Screen capture with dartsim without setting JointForceCmd

If you comment out [PulseJointVelocityCommand.cc:67](https://github.com/gazebosim/gz-sim/blob/38e27ab91d8872d99f793864bfb867aab3d68d82/examples/plugin/joint_control_components/PulseJointVelocityCommand.cc#L67) which sets the `JointForceCmd` component to `0` during the inactive portion of the pulse, the velocity controller remains active with a velocity command of `0`.


https://github.com/user-attachments/assets/44f88c45-836b-4c7e-b839-aad0fca80c36

### Bullet

There is an issue with bullet-featherstone; I will file that separately.

## Test it

Follow the instructions in the example README to compile and run the examples

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
