### PR TITLE
Fix mesh import filters not displaying correctly on KDE #2731

### DIFF
--- a/src/gui/plugins/entity_tree/EntityTree.qml
+++ b/src/gui/plugins/entity_tree/EntityTree.qml
@@ -164,7 +164,7 @@ Rectangle {
           id: loadFileDialog
           title: "Load mesh"
           folder: shortcuts.home
-          nameFilters: [ "Collada files (*.dae)", "(*.stl)", "(*.obj)" ]
+          nameFilters: [ "Collada files (*.dae)", "STL (*.stl)", "Wavefront OBJ (*.obj)" ]
           selectMultiple: false
           selectExisting: true
           onAccepted: {


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2731

## Summary
Adds labels for mesh import type filter to compensate for a bug ([related?](https://bugs.kde.org/show_bug.cgi?id=467868)) in KDE, but is probably good practice anyway.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

