### PR TITLE
Add debug console messages to Server_TEST.cc

### DIFF
--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -338,9 +338,12 @@ TEST_P(ServerFixture,
   ASSERT_TRUE(test::waitForService(node, service));
   gzdbg << "Requesting " << service << std::endl;
   executed = node.Request(service, 1000, rep, result);
+  gzdbg << "Response: {executed: " << executed << ", result: " << result << '}'
+        << std::endl;
   EXPECT_TRUE(executed);
   EXPECT_TRUE(result);
   EXPECT_EQ("TestSensorSystem", rep.data());
+  gzdbg << "Shutting down" << std::endl;
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

Debugging https://github.com/osrf/buildfarm-tools/issues/129#issuecomment-2620273688

## Summary

The `ServerRepeat/ServerFixture.ServerConfigSensorPlugin/0` test is timing out flakily, so add some print statements to help identify where it is getting stuck.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
