### PR TITLE
Fix illegal anchor warnings

### DIFF
--- a/src/gui/plugins/entity_context_menu/EntityContextMenuPlugin.qml
+++ b/src/gui/plugins/entity_context_menu/EntityContextMenuPlugin.qml
@@ -52,7 +52,6 @@ ColumnLayout {
   RenderWindowOverlay {
     id: renderWindowOverlay
     objectName: "renderWindowOverlay"
-    anchors.fill: parent
 
     Connections {
       target: renderWindowOverlay
@@ -66,6 +65,5 @@ ColumnLayout {
 
   GzSim.EntityContextMenu {
     id: entityContextMenu
-    anchors.fill: parent
   }
 }

--- a/src/gui/plugins/entity_tree/EntityTree.qml
+++ b/src/gui/plugins/entity_tree/EntityTree.qml
@@ -146,7 +146,7 @@ Rectangle {
       }
 
       ToolButton {
-        anchors.right: parent.right
+        Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
         id: addEntity
         ToolTip.text: "Add an entity to the world"
         ToolTip.visible: hovered


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
Anchors should not be used when objects are inside Layouts. Doing so causes the following warning

```
Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
