### PR TITLE
Reduce/Eliminate `sdf::Model` and `sdf::World` serialization warnings

### DIFF
--- a/include/gz/sim/components/Model.hh
+++ b/include/gz/sim/components/Model.hh
@@ -54,7 +54,7 @@ namespace serializers
       if (modelElem->HasElement("pose"))
       {
         sdf::ElementPtr poseElem = modelElem->GetElement("pose");
-        if (poseElem->HasAttribute("relative_to"))
+        if (poseElem->GetAttribute("relative_to")->GetSet())
         {
           // Skip serializing models with //pose/@relative_to attribute
           // since deserialization will fail. This could be a nested model.

--- a/include/gz/sim/components/World.hh
+++ b/include/gz/sim/components/World.hh
@@ -29,6 +29,29 @@ namespace sim
 {
 // Inline bracket to help doxygen filtering.
 inline namespace GZ_SIM_VERSION_NAMESPACE {
+
+namespace serializers
+{
+/// \brief Specialize the DefaultSerializer on sdf::World so we can
+/// skip serialization
+/// TODO(azeey) Do we ever want to serialize this component?
+template <>
+class DefaultSerializer<sdf::World>
+{
+  public:
+  static std::ostream &Serialize(std::ostream &_out, const sdf::World &)
+  {
+    return _out;
+  }
+
+  public:
+  static std::istream &Deserialize(std::istream &_in, sdf::World &)
+  {
+    return _in;
+  }
+};
+}
+
 namespace components
 {
   /// \brief A component that identifies an entity as being a world.


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Currently, when running any world in Gazebo, we get warnings similar to the following

```
(2025-01-28 23:15:59.539) [warning] [Model.hh:69] Skipping serialization / deserialization for models with //pose/@relative_to attribute.
(2025-01-28 23:15:59.540) [warning] [Component.hh:144] Trying to serialize component with data type [N3sdf3v155WorldE], which doesn't have `operator<<`. Component will not be serialized.
```

This PR:
- Reduces serialization warnings on `sdf::Model` so it only occurs when the `relative_to` attribute is set. This was the intended behavior originally, but there was a bug in the code.
- Eliminate `sdf::World` warnings by specializing the `DefaultSerializer` for `sdf::World`.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
