### PR TITLE
Update install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ introspection and control.
 
 # Install
 
-See the [installation tutorial](https://gazebosim.org/api/sim/9/install.html).
+See the [installation tutorial](https://gazebosim.org/docs/latest/getstarted/).
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ introspection and control.
 
 # Install
 
-See the [installation tutorial](https://gazebosim.org/docs/latest/getstarted/).
+For installing Gazebo, see the [getting started guide](https://gazebosim.org/docs/latest/getstarted/). If you want to use `libgz-sim` as a library, see the [installation tutorial](https://gazebosim.org/api/sim/9/install.html)
 
 # Usage
 


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

This changes the "install" link in the README, to link to the docs, instead of the api, as it has better information, such as a link to "ROS/Gazebo installation" which is important for people using ROS.

In the old link I couldn't find the table (which is at  "ROS/Gazebo installation") and I also couldn't find where the "api" instalation page is located to add the link. So I updated the link in the readme.