### PR TITLE
Fix SimtimeArgument test on homebrew

### DIFF
--- a/src/cmd/gz_TEST.cc
+++ b/src/cmd/gz_TEST.cc
@@ -143,11 +143,6 @@ TEST(CmdLine, GazeboServer)
 /////////////////////////////////////////////////
 TEST(CmdLine, SimtimeArgument)
 {
-  std::string cmd =
-    kGzCommand + " -r -v 4 --iterations 500 --initial-sim-time 1000.5 " +
-    std::string(PROJECT_SOURCE_PATH) + "/test/worlds/plugins.sdf -z 1000";
-
-  std::cout << "Running command [" << cmd << "]" << std::endl;
   int msgCount = 0;
 
   gz::transport::Node node;
@@ -160,6 +155,12 @@ TEST(CmdLine, SimtimeArgument)
 
   auto cbFcn = std::function<void(const gz::msgs::Clock &)>(cb);
   EXPECT_TRUE(node.Subscribe(std::string("/clock"), cbFcn));
+
+  std::string cmd =
+    kGzCommand + " -r -v 4 --iterations 500 --initial-sim-time 1000.5 " +
+    std::string(PROJECT_SOURCE_PATH) + "/test/worlds/plugins.sdf -z 1000";
+
+  std::cout << "Running command [" << cmd << "]" << std::endl;
 
   std::string output = customExecStr(cmd);
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The test has been failing recently, likely flaky.

Fixed by moving the logic to run sim *after* the subscriber is ready (so it can listen to msgs published by sim for the test).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

