### PR TITLE
Remove unneeded mesh_inertia_calculation test expectations

### DIFF
--- a/test/integration/mesh_inertia_calculation.cc
+++ b/test/integration/mesh_inertia_calculation.cc
@@ -144,7 +144,6 @@ void cylinderColladaMeshInertiaCalculation(
 
   // Check the Inertial Pose and Link Pose. Their world poses should be the
   // same since the inertial pose relative to the link is zero.
-  EXPECT_EQ(link.WorldPose(*ecm).value(), worldPose(linkEntity, *ecm));
   EXPECT_EQ(link.WorldInertialPose(*ecm).value(),
     worldPose(linkEntity, *ecm) * gz::math::Pose3d::Zero);
 }
@@ -221,9 +220,7 @@ void cylinderColladaMeshWithNonCenterOriginInertiaCalculation(
   EXPECT_TRUE(
     link.WorldInertiaMatrix(*ecm).value().Equal(inertiaMatrix, 0.005));
 
-  // Check the Inertial Pose and Link Pose
-  EXPECT_EQ(link.WorldPose(*ecm).value(), worldPose(linkEntity, *ecm));
-
+  // Check the Inertial Pose
   // Since the height of cylinder is 2m and origin is at center of bottom face
   // the center of mass (inertial pose) will be 1m above the ground
   EXPECT_EQ(link.WorldInertialPose(*ecm).value(),
@@ -319,8 +316,7 @@ TEST(MeshInertiaCalculationTest, CylinderColladaOptimizedMeshInertiaCalculation)
               ixxyyzzTol));
   EXPECT_TRUE(actualIxyxzyz.Equal(
               meshInertial.MassMatrix().OffDiagonalMoments(), 3.5));
-  // Check the Inertial Pose and Link Pose
-  EXPECT_EQ(link.WorldPose(*ecm).value(), worldPose(linkEntity, *ecm));
+  // Check the Inertial Pose
   EXPECT_TRUE(link.WorldInertialPose(*ecm).value().Equal(
               worldPose(linkEntity, *ecm) * gz::math::Pose3d::Zero, 1e-2));
 }


### PR DESCRIPTION
# 🦟 Bug fix

Follow-up to #2777.

## Summary

The mesh_inertia_calculation test was updated in #2777 (thanks to @gabrielfpacheco for the contribution), and I'm addressing some unresolved comments here by removing unneeded test expectations.

* [ ] https://github.com/gazebosim/gz-sim/pull/2777#discussion_r1976057963
* [ ] https://github.com/gazebosim/gz-sim/pull/2777#discussion_r1976058461
* [ ] https://github.com/gazebosim/gz-sim/pull/2777#discussion_r1976059193

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
