### PR TITLE
Update custom sensor system example to make the sensor respect update rate

### DIFF
--- a/examples/plugin/custom_sensor_system/OdometerSystem.cc
+++ b/examples/plugin/custom_sensor_system/OdometerSystem.cc
@@ -100,7 +100,19 @@ void OdometerSystem::PostUpdate(const gz::sim::UpdateInfo &_info,
     for (auto &[entity, sensor] : this->entitySensorMap)
     {
       sensor->NewPosition(gz::sim::worldPose(entity, _ecm).Pos());
-      sensor->Update(_info.simTime);
+      // Call base Sensor class' Update function with force = false
+      // to make the sensor respect the specified update rate.
+      auto baseSensor = std::dynamic_pointer_cast<gz::sensors::Sensor>(sensor);
+      if (baseSensor)
+      {
+        baseSensor->Update(_info.simTime, false);
+      }
+      else
+      {
+        sensor->Update(_info.simTime);
+        gzerr << "Error casting custom sensor to base Sensor class. "
+              << "This should not happen." << std::endl;
+      }
     }
   }
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/2290

## Summary

In the custom sensor example, the sensor calls its own `Update` function on every `PostUpdate` callback, which results in the sensor updating and publishing at 1000Hz. This PR updates the call to the base Sensor class's [Update](https://github.com/gazebosim/gz-sensors/blob/8aff340be1c422e2898964c1ba62864c047fccb6/src/Sensor.cc#L481) function which has logic to throttle the updates.

To test, build the example following the README instructions, run the world with the custom sensor system, and check the topic frequency:

```bash
gz sim -v 4 odometer.sdf
gz topic -f -t /world/odometer_world/model/model_with_sensor/link/link/sensor/an_odometer/odometer
```

It should drop down to 30Hz

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

