### PR TITLE
Gui.cc: return "" instead of nullptr

### DIFF
--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -89,7 +89,7 @@ std::string defaultGuiConfigFile(bool _isPlayback,
       {
         gzerr << "Failed to create the default config folder ["
           << defaultConfigFolder << "]\n";
-        return nullptr;
+        return "";
       }
     }
 
@@ -100,7 +100,7 @@ std::string defaultGuiConfigFile(bool _isPlayback,
       gzerr << "Failed to copy installed config [" << installedConfig
              << "] to default config [" << defaultConfig << "]."
              << std::endl;
-      return nullptr;
+      return "";
     }
     else
     {


### PR DESCRIPTION
# 🦟 Bug fix

Fixes return values in a function

## Summary

The `defaultGuiConfigFile` function returns type `std::string`, so return an empty string instead of `nullptr` in error cases.


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
