### PR TITLE
Upgrades OdometryPublisher system plugin

### DIFF
--- a/src/systems/odometry_publisher/OdometryPublisher.cc
+++ b/src/systems/odometry_publisher/OdometryPublisher.cc
@@ -40,6 +40,7 @@
 #include "gz/sim/components/Pose.hh"
 #include "gz/sim/components/JointPosition.hh"
 #include "gz/sim/Model.hh"
+#include "gz/sim/Link.hh"
 #include "gz/sim/Util.hh"
 
 using namespace gz;


### PR DESCRIPTION
# 🎉 New feature

Closes #2803

## Summary
Allows OdometryPublisher to publish odometry for a non-fixed link of the robot model. Introduces the possibility to publish the odometry of a point after a non-fixed joint.  This commit does not change the default behavior of the plugin.
