### PR TITLE
Restrict docker-nightly workflow to base branch

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -2,6 +2,8 @@ name: nightly docker image builds
 
 on:
   push:
+    branches:
+      - 'gz-sim9'
   schedule:
     - cron: '0 6 * * *'
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes extra triggering of nightly workflow

## Summary

Currently the nightly workflow is triggered for any branch that receives a push, but we just want it to run on the base branch, so restrict it to `gz-sim9`.

When merging forward to `main`, I expect to change this to `main`.

Note that I originally noticed this when it ran and failed during https://github.com/gazebosim/gz-sim/pull/2826.


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
