### PR TITLE
Detect running server on startup

### DIFF
--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -192,6 +192,15 @@ SimulationRunner::SimulationRunner(const sdf::World &_world,
 
   this->node = std::make_unique<transport::Node>(opts);
 
+  std::vector<transport::MessagePublisher> pubs;
+  std::vector<transport::MessagePublisher> subs;
+  this->node->TopicInfo("/world/" + this->worldName + "/stats", pubs, subs);
+  if (!pubs.empty())
+  {
+    gzerr << "Another world of the same name is running" << std::endl;
+    return;
+  }
+
   // Create the system manager
   this->systemMgr = std::make_unique<SystemManager>(
       _systemLoader, &this->entityCompMgr, &this->eventMgr, validNs,

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -197,7 +197,7 @@ SimulationRunner::SimulationRunner(const sdf::World &_world,
   this->node->TopicInfo("/world/" + this->worldName + "/stats", pubs, subs);
   if (!pubs.empty())
   {
-    gzwarn << "Another world of the same name is running" << std::endl;
+    gzerr << "Another world of the same name is running" << std::endl;
   }
 
   // Create the system manager

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -197,8 +197,7 @@ SimulationRunner::SimulationRunner(const sdf::World &_world,
   this->node->TopicInfo("/world/" + this->worldName + "/stats", pubs, subs);
   if (!pubs.empty())
   {
-    gzerr << "Another world of the same name is running" << std::endl;
-    return;
+    gzwarn << "Another world of the same name is running" << std::endl;
   }
 
   // Create the system manager

--- a/src/gui/Gui_TEST.cc
+++ b/src/gui/Gui_TEST.cc
@@ -252,6 +252,8 @@ TEST_F(GuiTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(QuickStart))
     // Close the quick start window
     gzdbg << "Closing the quickstart window" << std::endl;
     ASSERT_EQ(1, gui::App()->allWindows().count());
+    while (!gui::App()->allWindows()[0]->isExposed())
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     gui::App()->allWindows()[0]->close();
 
     gzdbg << "Waiting for main window" << std::endl;

--- a/src/gui/QuickStartHandler.cc
+++ b/src/gui/QuickStartHandler.cc
@@ -27,7 +27,7 @@ using namespace sim::gui;
 QuickStartHandler::QuickStartHandler()
 {
   // Create the node if needed
-  this->node = std::make_unique<gz::transport::Node>();
+  this->node = gz::transport::Node();
 
   std::vector<transport::MessagePublisher> publishers;
   std::vector<transport::MessagePublisher> subscribers;

--- a/src/gui/QuickStartHandler.cc
+++ b/src/gui/QuickStartHandler.cc
@@ -31,7 +31,7 @@ QuickStartHandler::QuickStartHandler()
   this->node.TopicInfo("/stats", publishers, subscribers);
   if (!publishers.empty())
   {
-    gzwarn << "Detected an already running world on start" << std::endl;
+    gzerr << "Detected an already running world on start" << std::endl;
   }
 }
 

--- a/src/gui/QuickStartHandler.cc
+++ b/src/gui/QuickStartHandler.cc
@@ -26,12 +26,9 @@ using namespace sim::gui;
 
 QuickStartHandler::QuickStartHandler()
 {
-  // Create the node if needed
-  this->node = gz::transport::Node();
-
   std::vector<transport::MessagePublisher> publishers;
   std::vector<transport::MessagePublisher> subscribers;
-  this->node->TopicInfo("/stats", publishers, subscribers);
+  this->node.TopicInfo("/stats", publishers, subscribers);
   if (!publishers.empty())
   {
     gzwarn << "Detected an already running world on start" << std::endl;

--- a/src/gui/QuickStartHandler.cc
+++ b/src/gui/QuickStartHandler.cc
@@ -18,9 +18,26 @@
 #include "QuickStartHandler.hh"
 
 #include "gz/sim/InstallationDirectories.hh"
+#include <gz/transport/Node.hh>
+#include <gz/common/Console.hh>
 
 using namespace gz;
 using namespace sim::gui;
+
+QuickStartHandler::QuickStartHandler()
+{
+  // Create the node if needed
+  this->node = std::make_unique<gz::transport::Node>();
+
+  std::vector<transport::MessagePublisher> publishers;
+  std::vector<transport::MessagePublisher> subscribers;
+  this->node->TopicInfo("/stats", publishers, subscribers);
+  if (!publishers.empty())
+  {
+    gzwarn << "Detected an already running world on start" << std::endl;
+    return;
+  }
+}
 
 /////////////////////////////////////////////////
 QString QuickStartHandler::WorldsPath() const

--- a/src/gui/QuickStartHandler.cc
+++ b/src/gui/QuickStartHandler.cc
@@ -35,7 +35,6 @@ QuickStartHandler::QuickStartHandler()
   if (!publishers.empty())
   {
     gzwarn << "Detected an already running world on start" << std::endl;
-    return;
   }
 }
 

--- a/src/gui/QuickStartHandler.hh
+++ b/src/gui/QuickStartHandler.hh
@@ -45,7 +45,7 @@ class GZ_SIM_GUI_VISIBLE QuickStartHandler : public QObject
   Q_OBJECT
 
   // Explicitly declare the constructor
-  public:QuickStartHandler();
+public: QuickStartHandler();
 
   /// \brief Get worlds path
   /// \return worlds directory path

--- a/src/gui/QuickStartHandler.hh
+++ b/src/gui/QuickStartHandler.hh
@@ -26,10 +26,8 @@
 #include <gz/transport/Node.hh>
 #include <gz/common/Console.hh>
 
-
 #include <memory>
 #include <vector>
-#include "gz/sim/gui/Export.hh"
 
 namespace gz
 {
@@ -45,7 +43,7 @@ class GZ_SIM_GUI_VISIBLE QuickStartHandler : public QObject
   Q_OBJECT
 
   // Explicitly declare the constructor
-public: QuickStartHandler();
+  public: QuickStartHandler();
 
   /// \brief Get worlds path
   /// \return worlds directory path

--- a/src/gui/QuickStartHandler.hh
+++ b/src/gui/QuickStartHandler.hh
@@ -26,7 +26,9 @@
 #include <gz/transport/Node.hh>
 #include <gz/common/Console.hh>
 
-#include "gz/sim/config.hh"
+
+#include <memory>
+#include <vector>
 #include "gz/sim/gui/Export.hh"
 
 namespace gz

--- a/src/gui/QuickStartHandler.hh
+++ b/src/gui/QuickStartHandler.hh
@@ -80,7 +80,7 @@ class GZ_SIM_GUI_VISIBLE QuickStartHandler : public QObject
   private: std::string startingWorld{""};
 
   // Add a member for the transport node
-  private: std::unique_ptr<gz::transport::Node> node;
+  private: gz::transport::Node node;
 };
 }
 }

--- a/src/gui/QuickStartHandler.hh
+++ b/src/gui/QuickStartHandler.hh
@@ -23,6 +23,12 @@
 #include "gz/sim/config.hh"
 #include "gz/sim/gui/Export.hh"
 
+#include <gz/transport/Node.hh>
+#include <gz/common/Console.hh>
+
+#include "gz/sim/config.hh"
+#include "gz/sim/gui/Export.hh"
+
 namespace gz
 {
 namespace sim
@@ -35,6 +41,9 @@ namespace gui
 class GZ_SIM_GUI_VISIBLE QuickStartHandler : public QObject
 {
   Q_OBJECT
+
+  // Explicitly declare the constructor
+  public:QuickStartHandler();
 
   /// \brief Get worlds path
   /// \return worlds directory path
@@ -69,6 +78,9 @@ class GZ_SIM_GUI_VISIBLE QuickStartHandler : public QObject
 
   /// \brief Get starting world url.
   private: std::string startingWorld{""};
+
+  // Add a member for the transport node
+  private: std::unique_ptr<gz::transport::Node> node;
 };
 }
 }


### PR DESCRIPTION
# 🦟 Bug fix and New feature

Fixes #2806 

## Summary
Previously, when launching multiple GZ Sim servers, for instance, using the commands `gz sim -s shapes.sdf` and `gz sim -s default.sdf`,

If we had used the command `gz sim -g ‘fileName’`,
It would not have considered the `fileName` parameter and would have launched any of the servers at random. 

This pr introduces a new feature that allows you to - 
- Launch a file by passing the file name as an argument. For instance, you can utilize the command `gz sim -g ‘fileName’` to launch the GUI, provided that the server(s) are operational.
- Warn the user if there are multiple servers running in case where we don't pass the fileName as an argument. eg -  `gz sim -g`. In case there's just one server running it will simply launch the gui of the same. 
