### PR TITLE
Update GZ_DISTRIBUTION to Jetty

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 # Initialize the project
 #============================================================================
 project(gz-sim10 VERSION 10.0.0)
-set (GZ_DISTRIBUTION "Ionic")
+set (GZ_DISTRIBUTION "Jetty")
 
 #============================================================================
 # Find gz-cmake


### PR DESCRIPTION



# 🎉 New feature


## Summary

 Set `GZ_DISTRIBUTION` in CMakeLists.txt to `Jetty`

This is shown in the QuickStart dialog 

## Test it

Run gz sim without a world argument. 

```
gz sim
```

QuickStart dialog should pop up and you should now `Jetty` displayed in top right corner of the dialog.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
