### PR TITLE
Don't install vendored backward files

### DIFF
--- a/test/backward_vendor/backward-cpp/CMakeLists.txt
+++ b/test/backward_vendor/backward-cpp/CMakeLists.txt
@@ -115,16 +115,16 @@ set_target_properties(backward PROPERTIES EXPORT_NAME Backward)
 target_link_libraries(backward PUBLIC Backward::Interface)
 add_library(Backward::Backward ALIAS backward)
 
-install(
-    FILES "backward.hpp"
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
-install(
-    FILES "BackwardConfig.cmake"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
-)
 # check if Backward is being used as a top-level project or included as a subproject
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    install(
+        FILES "backward.hpp"
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+    install(
+        FILES "BackwardConfig.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    )
     # export the targets (note that exporting backward_object does not make sense)
     install(TARGETS backward_interface backward EXPORT BackwardTargets)
     # install a CMake file for the exported targets


### PR DESCRIPTION
# 🦟 Bug fix

Follow-up to #2776

## Summary

We vendored backward-cpp in #2776 to use in integration tests, but I noticed while investigating an unstable nightly build that some vendored files are being installed with gz-sim. I don't think these should be installed with our packages, so I am modifying the cmake logic to prevent their installation here.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
