### PR TITLE
Find gz-gui without major version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,8 +113,7 @@ set(GZ_FUEL_TOOLS_VER ${gz-fuel_tools10_VERSION_MAJOR})
 
 #--------------------------------------
 # Find gz-gui
-gz_find_package(gz-gui10 REQUIRED)
-set(GZ_GUI_VER ${gz-gui10_VERSION_MAJOR})
+gz_find_package(gz-gui REQUIRED)
 gz_find_package (Qt5
   COMPONENTS
     Core

--- a/examples/plugin/rendering_plugins/CMakeLists.txt
+++ b/examples/plugin/rendering_plugins/CMakeLists.txt
@@ -14,7 +14,7 @@ set(GUI_PLUGIN RenderingGuiPlugin)
 
 set(CMAKE_AUTOMOC ON)
 
-find_package(gz-gui10 REQUIRED)
+find_package(gz-gui REQUIRED)
 
 QT5_ADD_RESOURCES(resources_RCC ${GUI_PLUGIN}.qrc)
 
@@ -24,7 +24,7 @@ add_library(${GUI_PLUGIN} SHARED
 )
 target_link_libraries(${GUI_PLUGIN}
   PRIVATE
-    gz-gui10::gz-gui10
+    gz-gui::gz-gui
     gz-rendering9::gz-rendering9
 )
 

--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,7 @@
   <depend>gz-cmake4</depend>
   <depend>gz-common6</depend>
   <depend>gz-fuel_tools10</depend>
-  <depend>gz-gui10</depend>
+  <depend>gz-gui</depend>
   <depend>gz-math8</depend>
   <depend>gz-msgs11</depend>
   <depend>gz-physics8</depend>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -205,7 +205,7 @@ target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
   gz-common${GZ_COMMON_VER}::graphics
   gz-common${GZ_COMMON_VER}::profiler
   gz-fuel_tools${GZ_FUEL_TOOLS_VER}::gz-fuel_tools${GZ_FUEL_TOOLS_VER}
-  gz-gui${GZ_GUI_VER}::gz-gui${GZ_GUI_VER}
+  gz-gui::gz-gui
   gz-physics${GZ_PHYSICS_VER}::core
   gz-rendering${GZ_RENDERING_VER}::core
   gz-transport${GZ_TRANSPORT_VER}::gz-transport${GZ_TRANSPORT_VER}

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -48,7 +48,7 @@ target_link_libraries(${gui_target}
   PUBLIC
     ${PROJECT_LIBRARY_TARGET_NAME}
     gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
-    gz-gui${GZ_GUI_VER}::gz-gui${GZ_GUI_VER}
+    gz-gui::gz-gui
     gz-transport${GZ_TRANSPORT_VER}::gz-transport${GZ_TRANSPORT_VER}
     gz-utils${GZ_UTILS_VER}::gz-utils${GZ_UTILS_VER}
     ${Qt5Core_LIBRARIES}


### PR DESCRIPTION

# 🎉 New feature

Part of https://github.com/gazebo-tooling/release-tools/issues/1244, companion to gazebosim/gz-gui#670.

## Summary

The major version is removed from the cmake project name for gz-gui in gazebosim/gz-gui#670, so update the `find_package` and `target_link_libraries` calls accordingly.

## Test it

* Build gazebosim/gz-gui#670 from source
* Compile this branch against it
* Confirm this builds successfully

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
