### PR TITLE
Fix airspeed calculation under wind influence by wind triangle

### DIFF
--- a/src/systems/air_speed/AirSpeed.cc
+++ b/src/systems/air_speed/AirSpeed.cc
@@ -39,6 +39,9 @@
 #include "gz/sim/components/Name.hh"
 #include "gz/sim/components/ParentEntity.hh"
 #include "gz/sim/components/Pose.hh"
+#include "gz/sim/components/Wind.hh"
+#include "gz/sim/components/WindMode.hh"
+#include "gz/sim/components/LinearVelocitySeed.hh"
 #include "gz/sim/components/Sensor.hh"
 #include "gz/sim/EntityComponentManager.hh"
 #include "gz/sim/Util.hh"
@@ -66,6 +69,12 @@ class gz::sim::systems::AirSpeedPrivate
   public: bool initialized = false;
 
   public: Entity entity;
+
+  /// \brief Wind entity on which this sytem operates.
+  public: Entity windEntity;
+
+  /// \param[in] _ecm Mutable reference to the EntityComponentManager.
+  public: void Load(EntityComponentManager &_ecm);
 
   /// \brief Create sensor
   /// \param[in] _ecm Immutable reference to ECM.
@@ -102,11 +111,19 @@ AirSpeed::AirSpeed() :
 AirSpeed::~AirSpeed() = default;
 
 //////////////////////////////////////////////////
+void AirSpeed::Configure(const Entity &_entity,
+    const std::shared_ptr<const sdf::Element> &_sdf,
+    EntityComponentManager &_ecm,
+    EventManager &)
+{
+  this->dataPtr->Load(_ecm);
+}
+
+//////////////////////////////////////////////////
 void AirSpeed::PreUpdate(const UpdateInfo &/*_info*/,
     EntityComponentManager &_ecm)
 {
   GZ_PROFILE("AirSpeed::PreUpdate");
-
   // Create components
   for (auto entity : this->dataPtr->newSensors)
   {
@@ -137,7 +154,6 @@ void AirSpeed::PostUpdate(const UpdateInfo &_info,
            << std::chrono::duration<double>(_info.dt).count()
            << "s]. System may not work properly." << std::endl;
   }
-
   this->dataPtr->CreateSensors(_ecm);
 
   if (!_info.paused)
@@ -170,6 +186,13 @@ void AirSpeed::PostUpdate(const UpdateInfo &_info,
   }
 
   this->dataPtr->RemoveAirSpeedEntities(_ecm);
+}
+
+//////////////////////////////////////////////////
+void AirSpeedPrivate::Load(
+    EntityComponentManager &_ecm)
+{
+  this->windEntity = _ecm.EntityByComponents(components::Wind());
 }
 
 //////////////////////////////////////////////////
@@ -265,6 +288,14 @@ void AirSpeedPrivate::UpdateAirSpeeds(const EntityComponentManager &_ecm)
 
           math::Vector3d sensorRelativeVel = relativeVel(_entity, _ecm);
           it->second->SetVelocity(sensorRelativeVel);
+
+          // update wind velocity
+          auto windVelSeed =
+          _ecm.Component<components::WorldLinearVelocitySeed>(this->windEntity);
+          math::Vector3d windVel{windVelSeed->Data().X(),
+                                 windVelSeed->Data().Y(),
+                                 windVelSeed->Data().Z()};
+          it->second->SetWindVelocity(windVel);
         }
         else
         {
@@ -300,6 +331,7 @@ void AirSpeedPrivate::RemoveAirSpeedEntities(
 }
 
 GZ_ADD_PLUGIN(AirSpeed, System,
+  AirSpeed::ISystemConfigure,
   AirSpeed::ISystemPreUpdate,
   AirSpeed::ISystemPostUpdate
 )

--- a/src/systems/air_speed/AirSpeed.hh
+++ b/src/systems/air_speed/AirSpeed.hh
@@ -37,6 +37,7 @@ namespace systems
   /// readings over gz transport
   class AirSpeed:
     public System,
+    public ISystemConfigure,
     public ISystemPreUpdate,
     public ISystemPostUpdate
   {
@@ -45,6 +46,12 @@ namespace systems
 
     /// \brief Destructor
     public: ~AirSpeed() override;
+
+    // Documentation inherited
+    public: void Configure(const Entity &_entity,
+                           const std::shared_ptr<const sdf::Element> &_sdf,
+                           EntityComponentManager &_ecm,
+                           EventManager &_eventMgr) final;
 
     /// Documentation inherited
     public: void PreUpdate(const UpdateInfo &_info,


### PR DESCRIPTION


<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Result from the discussion in https://github.com/PX4/PX4-Autopilot/pull/24452
Depends on
* https://github.com/gazebosim/gz-sensors/pull/512

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Refer to `windEffect` plugin, the airspeed plugin obtains wind information through ECM and transmits it to the airspeed sensor to calculate true airspeed considering wind influence.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.