### PR TITLE
Set GZ_IP=127.0.0.1 in gz cmd tests

### DIFF
--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -63,8 +63,11 @@ foreach(CMD_TEST
   )
 
   if(${CMD_TEST} STREQUAL UNIT_ModelCommandAPI_TEST)
+    set(_env_vars)
+    list(APPEND _env_vars "GZ_CONFIG_PATH=${CMAKE_BINARY_DIR}/test/conf/$<CONFIG>")
+    list(APPEND _env_vars "GZ_IP=127.0.0.1")
     set_tests_properties(${CMD_TEST} PROPERTIES
-      ENVIRONMENT "GZ_CONFIG_PATH=${CMAKE_BINARY_DIR}/test/conf/$<CONFIG>")
+      ENVIRONMENT "${_env_vars}")
   endif()
 
   if(${CMD_TEST} STREQUAL UNIT_gz_TEST)
@@ -82,6 +85,7 @@ foreach(CMD_TEST
 
     set(_env_vars)
     list(APPEND _env_vars "GZ_CONFIG_PATH=${CMAKE_BINARY_DIR}/test/conf")
+    list(APPEND _env_vars "GZ_IP=127.0.0.1")
     list(APPEND _env_vars "GZ_SIM_SYSTEM_PLUGIN_PATH=$<TARGET_FILE_DIR:TestModelSystem>")
 
     set_tests_properties(${CMD_TEST} PROPERTIES


### PR DESCRIPTION
# 🦟 Bug fix

Fixes some tests using a cherry-pick from https://github.com/gazebosim/gz-sim/pull/2857

## Summary

This cherry-picks https://github.com/gazebosim/gz-sim/pull/2857/commits/93f25a4d4e8516d71e1dc0e2c18aa8d42123bcfd from https://github.com/gazebosim/gz-sim/pull/2857 to fix gz cmd test failures.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
