### PR TITLE
Set GZ_IP=127.0.0.1 in gz cmd tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -297,6 +297,7 @@ foreach(CMD_TEST
 
   set(_env_vars)
   list(APPEND _env_vars "GZ_CONFIG_PATH=${CMAKE_BINARY_DIR}/test/conf")
+  list(APPEND _env_vars "GZ_IP=127.0.0.1")
   list(APPEND _env_vars "GZ_SIM_SYSTEM_PLUGIN_PATH=$<TARGET_FILE_DIR:TestModelSystem>")
 
   set_tests_properties(${CMD_TEST} PROPERTIES


### PR DESCRIPTION
# 🦟 Bug fix

Manual backport of #2884

## Summary

This backports a patch applied in #2884 and copied from https://github.com/gazebosim/gz-transport/pull/595 to fix networking issues on macOS CI tests.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
