### PR TITLE
Do not create light visuals on server side

### DIFF
--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -1261,14 +1261,17 @@ void RenderUtil::Update()
 
       if (newLightRendering)
       {
-        rendering::VisualPtr lightVisual =
-          this->dataPtr->sceneManager.CreateLightVisual(
-            std::get<0>(light) + 1,
-            std::get<1>(light),
-            std::get<2>(light),
-            std::get<0>(light));
-        this->dataPtr->matchLightWithVisuals[std::get<0>(light)] =
-          std::get<0>(light) + 1;
+        if (!this->dataPtr->enableSensors)
+        {
+          rendering::VisualPtr lightVisual =
+            this->dataPtr->sceneManager.CreateLightVisual(
+              std::get<0>(light) + 1,
+              std::get<1>(light),
+              std::get<2>(light),
+              std::get<0>(light));
+          this->dataPtr->matchLightWithVisuals[std::get<0>(light)] =
+            std::get<0>(light) + 1;
+        }
       }
       else
       {


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-rendering/issues/1122

## Summary

Light visuals (green lines) were always created, even on server side where sensors are enabled. Looks like a regression introduced in https://github.com/gazebosim/gz-sim/pull/1818. This PR adds the ` if (!this->dataPtr->enableSensors)` check back to make sure we only create light visuals if sensors are not enabled.

This was causing segmentation camera to crash if the light visual is in its view (see https://github.com/gazebosim/gz-rendering/issues/1122).

To Test:

Apply this diff below to `segmentation_camera.sdf` to position the directional light in the view of the segmentation camera. With the changes in this PR, gz sim should no longer crash.

```diff
diff --git a/examples/worlds/segmentation_camera.sdf b/examples/worlds/segmentation_camera.sdf
index c5f4df7de..10cf19963 100644
--- a/examples/worlds/segmentation_camera.sdf
+++ b/examples/worlds/segmentation_camera.sdf
@@ -158,7 +158,8 @@
 
     <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>
-      <pose>0 0 10 0 0 0</pose>
+      <visualize>true</visualize>
+      <pose>0 0 2 0 0 0</pose>
       <diffuse>0.8 0.8 0.8 1</diffuse>
       <specular>0.2 0.2 0.2 1</specular>
```



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
