### PR TITLE
Disable standalone_gtest_setup example test on mac

### DIFF
--- a/examples/standalone/gtest_setup/CMakeLists.txt
+++ b/examples/standalone/gtest_setup/CMakeLists.txt
@@ -31,6 +31,11 @@ foreach(TEST_TARGET
     gtest_main
     gz-sim::gz-sim
   )
+
   include(GoogleTest)
-  gtest_discover_tests(${TEST_TARGET})
+  if (APPLE)
+    gtest_discover_tests(${TEST_TARGET} DISCOVERY_MODE PRE_TEST)
+  else()
+    gtest_discover_tests(${TEST_TARGET})
+  endif()
 endforeach()


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/2889

## Summary


The test was also failing locally on my mac but with a slightly different error msg from the output in #2889:

```
dyld[22115]: Library not loaded: libgz-sim.10.dylib
```

Setting `DISCOVERY_MODE` to `PRE_TEST` in `gtest_discover_tests` makes gtest delay test discovery until before test execution. By default it's done at build time with `POST_BUILD`.

From [cmake doc](https://cmake.org/cmake/help/latest/module/GoogleTest.html#command:gtest_discover_tests) on `PRE_TEST`:

> This way test discovery occurs in the target environment where the test has a better chance at finding appropriate runtime dependencies.

I was able to build and run the test locally with these changes.



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
