### PR TITLE
Use unique callback functions for Node::Subscribe calls

### DIFF
--- a/src/gui/PathManager.cc
+++ b/src/gui/PathManager.cc
@@ -27,7 +27,7 @@
 #include <gz/common/Console.hh>
 #include <gz/common/Profiler.hh>
 #include <gz/gui/Application.hh>
-#include "gz/transport/Node.hh"
+#include <gz/transport/Node.hh>
 
 #include "gz/sim/Util.hh"
 

--- a/src/gui/PathManager.cc
+++ b/src/gui/PathManager.cc
@@ -27,6 +27,7 @@
 #include <gz/common/Console.hh>
 #include <gz/common/Profiler.hh>
 #include <gz/gui/Application.hh>
+#include "gz/transport/Node.hh"
 
 #include "gz/sim/Util.hh"
 
@@ -47,7 +48,7 @@ void onAddResourcePaths(const msgs::StringMsg_V &_msg)
 }
 
 //////////////////////////////////////////////////
-void onAddResourcePaths(const msgs::StringMsg_V &_res, const bool _result)
+void onAddResourcePathsService(const msgs::StringMsg_V &_res, const bool _result)
 {
   if (!_result)
   {
@@ -67,7 +68,7 @@ PathManager::PathManager()
 
   gzdbg << "Requesting resource paths through [" << service << "]"
          << std::endl;
-  this->node.Request(service, onAddResourcePaths);
+  this->node.Request(service, onAddResourcePathsService);
 
   // Get path updates through this topic
   this->node.Subscribe("/gazebo/resource_paths", onAddResourcePaths);


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The `Node::Subscribe` functions undergoing some refactoring in https://github.com/gazebosim/gz-transport/pull/608. One side effect is that if a Subscribe callback function is an overloaded function, it will now introduce a compile error. This is likely an edge case but it is also a breaking change. This PR fixes preemptively fixes the error in gz-sim.

More Info from the migration guide in https://github.com/gazebosim/gz-transport/pull/608:

   All variants of the `bool Node::Subscribe` functions are combined into
   one `bool Subscribe(Args && ...args)` function that forwards arguments to
   various `Node::SubscribeImpl` private helper functions. All existing
   `Node::Subscribe` calls should continue to work without code changes.
   One exception is when the subscribe callback function is an overloaded
   function, e.g.
   ```cpp
   void cb(const msgs::StringMsg_V &_msg);
   void cb(const msgs::StringMsg_V &_res, const bool _result);
   ...
   bool res = node.Subscribe(topic, cb);
   ```
   This will now result in a compile error. The fix is to use unique callback
   function names, eg.
   ```cpp
   void topicCb(const msgs::StringMsg_V &_msg);
   void serviceCb(const msgs::StringMsg_V &_res, const bool _result);
   ...
   bool res = node.Subscribe(topic, topicCb);
   ```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

