### PR TITLE
Fix Qt warnings on shutdown

### DIFF
--- a/src/gui/plugins/entity_tree/EntityTree.cc
+++ b/src/gui/plugins/entity_tree/EntityTree.cc
@@ -122,6 +122,15 @@ TreeModel::TreeModel() : QStandardItemModel()
 }
 
 /////////////////////////////////////////////////
+TreeModel::~TreeModel()
+{
+  // Disconnect all signals/slots manually. This prevents Qt from printing
+  // warnings when closing the plugin as it tries to disconnect signals/slots
+  // from the (already deleted) model.
+  this->disconnect();
+}
+
+/////////////////////////////////////////////////
 void TreeModel::AddEntity(Entity _entity, const QString &_entityName,
     Entity _parentEntity, const QString &_type)
 {
@@ -297,7 +306,9 @@ EntityTree::EntityTree()
 }
 
 /////////////////////////////////////////////////
-EntityTree::~EntityTree() = default;
+EntityTree::~EntityTree()
+{
+}
 
 /////////////////////////////////////////////////
 void EntityTree::LoadConfig(const tinyxml2::XMLElement *)

--- a/src/gui/plugins/entity_tree/EntityTree.cc
+++ b/src/gui/plugins/entity_tree/EntityTree.cc
@@ -306,9 +306,7 @@ EntityTree::EntityTree()
 }
 
 /////////////////////////////////////////////////
-EntityTree::~EntityTree()
-{
-}
+EntityTree::~EntityTree() = default;
 
 /////////////////////////////////////////////////
 void EntityTree::LoadConfig(const tinyxml2::XMLElement *)

--- a/src/gui/plugins/entity_tree/EntityTree.hh
+++ b/src/gui/plugins/entity_tree/EntityTree.hh
@@ -40,7 +40,7 @@ namespace sim
     public: explicit TreeModel();
 
     /// \brief Destructor
-    public: ~TreeModel() override = default;
+    public: ~TreeModel() override;
 
     // Documentation inherited
     public: QHash<int, QByteArray> roleNames() const override;

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.cc
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.cc
@@ -113,6 +113,15 @@ PathModel::PathModel() : QStandardItemModel()
 }
 
 /////////////////////////////////////////////////
+PathModel::~PathModel()
+{
+  // Disconnect all signals/slots manually. This prevents Qt from printing
+  // warnings when closing the plugin as it tries to disconnect signals/slots
+  // from the (already deleted) model.
+  this->disconnect();
+}
+
+/////////////////////////////////////////////////
 void PathModel::AddPath(const std::string &_path)
 {
   GZ_PROFILE_THREAD_NAME("Qt thread");
@@ -152,6 +161,15 @@ QHash<int, QByteArray> PathModel::roleNames() const
 /////////////////////////////////////////////////
 ResourceModel::ResourceModel() : QStandardItemModel()
 {
+}
+
+/////////////////////////////////////////////////
+ResourceModel::~ResourceModel()
+{
+  // Disconnect all signals/slots manually. This prevents Qt from printing
+  // warnings when closing the plugin as it tries to disconnect signals/slots
+  // from the (already deleted) model.
+  this->disconnect();
 }
 
 /////////////////////////////////////////////////

--- a/src/gui/plugins/resource_spawner/ResourceSpawner.hh
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.hh
@@ -94,7 +94,7 @@ namespace sim
     public: explicit PathModel();
 
     /// \brief Destructor
-    public: ~PathModel() override = default;
+    public: ~PathModel() override;
 
     /// \brief Add a path.
     /// param[in] _path The path to be added.
@@ -122,7 +122,7 @@ namespace sim
     public: explicit ResourceModel();
 
     /// \brief Destructor
-    public: ~ResourceModel() override = default;
+    public: ~ResourceModel() override;
 
     /// \brief Add a resource to the grid view.
     /// param[in] _resource The local resource to be added


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/2871

## Summary

This fixes the Qt warnings when closing gz sim.

More info:

When a plugin with TreeView is closed, we see warnings about failing to disconnect Qt signals / slots. This is because the tree model used by the TreeView is already destroyed by Qt so the TreeView fails to disconnect their signals / slots. This fix is to manually disconnect all these signals and slots in the tree model destructor so that when deleting the TreeView, it no longer attempts to disconnect them again.

Quick Test:

Launch `gz sim -v 4 shapes.sdf`, close the window -> you should no longer see Qt warnings like:

```
(2025-04-22 21:59:49.928) [warning] [Application.cc:922] [GUI] [QT] QObject::disconnect: No such signal QObject::rowsAboutToBeRemoved(QModelIndex,int,int)
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

