### PR TITLE
Fix crash when closing Gazebo while a modal dialog is open

### DIFF
--- a/src/gui/plugins/joint_position_controller/JointPositionController.qml
+++ b/src/gui/plugins/joint_position_controller/JointPositionController.qml
@@ -16,7 +16,7 @@
 */
 import QtQuick 2.9
 
-import QtQuick.Controls 2.2
+import QtQuick.Controls
 import QtQuick.Controls.Material 2.1
 import QtQuick.Layouts 1.3
 
@@ -94,7 +94,7 @@ Rectangle {
 
       Popup {
         id: helpPopup
-        parent: ApplicationWindow.overlay
+        parent: Overlay.overlay
         // From Qt 5.12 use
         // anchors.centerIn: parent
         x: 10

--- a/src/gui/plugins/spawn/Spawn.qml
+++ b/src/gui/plugins/spawn/Spawn.qml
@@ -16,7 +16,7 @@
 */
 
 import QtQuick 2.9
-import QtQuick.Controls 2.2
+import QtQuick.Controls
 import QtQuick.Dialogs
 import QtQuick.Layouts 1.3
 
@@ -36,7 +36,7 @@ ColumnLayout {
 
   Dialog {
     id: errorPopup
-    parent: ApplicationWindow.overlay
+    parent: Overlay.overlay
     modal: true
     focus: true
     width: 500

--- a/src/gui/plugins/video_recorder/VideoRecorder.qml
+++ b/src/gui/plugins/video_recorder/VideoRecorder.qml
@@ -16,7 +16,7 @@
 */
 import QtCore
 import QtQuick 2.9
-import QtQuick.Controls 2.1
+import QtQuick.Controls
 import QtQuick.Controls.Material 2.2
 import QtQuick.Controls.Material.impl 2.2
 import QtQuick.Layouts 1.3
@@ -74,7 +74,7 @@ ToolBar {
       focus: false
       width: 700
       height: 200
-      parent: ApplicationWindow.overlay
+      parent: Overlay.overlay
       x: (parent.width - width) / 2
       y: (parent.height - height) / 2
       standardButtons: Dialog.Save | Dialog.Abort

--- a/src/gui/resources/GazeboDrawer.qml
+++ b/src/gui/resources/GazeboDrawer.qml
@@ -151,7 +151,6 @@ Rectangle {
     focus: true
     parent: Overlay.overlay
     width: parent.width / 3 > 500 ? 500 : parent.width / 3
-    // width: 500
     height: 300
     x: (parent.width - width) / 2
     y: (parent.height - height) / 2

--- a/src/gui/resources/GazeboDrawer.qml
+++ b/src/gui/resources/GazeboDrawer.qml
@@ -149,11 +149,9 @@ Rectangle {
     title: "Gazebo Sim"
     modal: true
     focus: true
-    parent: ApplicationWindow.overlay
-    // \todo(iche033) setting width, x, and y relative to parent does not seem
-    // to work so use hardcoded values for now
-    // width: parent.width / 3 > 500 ? 500 : parent.width / 3
-    width: 500
+    parent: Overlay.overlay
+    width: parent.width / 3 > 500 ? 500 : parent.width / 3
+    // width: 500
     height: 300
     x: (parent.width - width) / 2
     y: (parent.height - height) / 2
@@ -180,12 +178,8 @@ Rectangle {
     modal: true
     focus: true
     title: "File save options"
-    parent: ApplicationWindow.overlay
-    // \todo(iche033) setting width, x, and y relative to parent does not seem
-    // to work so use hardcoded values for now
-    // so use hardcoded values for now
-    // width: parent.width / 3 > 500 ? 500 : parent.width / 3
-    width: 500
+    parent: Overlay.overlay
+    width: parent.width / 3 > 500 ? 500 : parent.width / 3
     height: 300
     x: (parent.width - width) / 2
     y: (parent.height - height) / 2
@@ -269,7 +263,7 @@ Rectangle {
 
     modal: true
     focus: true
-    parent: ApplicationWindow.overlay
+    parent: Overlay.overlay
     width: messageText.implicitWidth
     x: (parent.width - width) / 2
     y: (parent.height - height) / 2


### PR DESCRIPTION


# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/2872

## Summary

Fixes the crash described in https://github.com/gazebosim/gz-sim/issues/2872. The fix is to set the popup dialog's parent to `Overlay.overlay` as seen in the example in https://doc.qt.io/qt-6/qml-qtquick-controls-overlay.html. Gazebo should no longer crash when being closed while a modal dialog is open, see steps to reproduce in #2827

This also fixes the positioning and width of the dialog so removed I the todo note. The main window should now also be grayed out in the background while the modal dialog is open.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

