### PR TITLE
Fix for GUI wait screen bug in standalone executable

### DIFF
--- a/src/cmd/gui_main.cc
+++ b/src/cmd/gui_main.cc
@@ -41,7 +41,7 @@ struct GuiOptions
   std::string renderEngineGuiApiBackend{""};
 
   /// \brief Show the world loading menu
-  int waitGui{1};
+  int waitGui{0};
 };
 
 //////////////////////////////////////////////////
@@ -93,13 +93,6 @@ void addGuiFlags(CLI::App &_app)
 
   _app.callback([opt](){
 
-    // Get verbosity level from environment
-    std::string verbosity;
-    if(utils::env("GZ_SIM_VERBOSITY", verbosity))
-    {
-      cmdVerbosity(std::stoi(verbosity));
-    }
-
     if (opt->file != "") {
       // Check SDF file and parse into string
       if(checkFile(opt->file) < 0)
@@ -123,6 +116,16 @@ void addGuiFlags(CLI::App &_app)
 int main(int argc, char** argv)
 {
   CLI::App app{"Run and manage Gazebo GUI."};
+
+  app.add_option_function<int>("-v,--verbose",
+    [](const int _verbosity){
+      cmdVerbosity(_verbosity);
+    },
+    "Adjust the level of console output (0~4).\n"
+    "The default verbosity level is 1. Use -v\n"
+    "without arguments for level 3.\n")
+    ->expected(0, 1)
+    ->default_val(3);
 
   addGuiFlags(app);
   app.formatter(std::make_shared<GzFormatter>(&app));


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Related to https://github.com/gazebosim/gz-tools/issues/7. Fix for https://github.com/gazebosim/gz-sim/pull/2849

## Summary

This PR fixes a bug related to the GUI executable (`gz-sim-gui-client`). Previously, invoking the GUI executable individually made the world selection screen show up. Now that does not happen.

Additionally, the GUI executable was missing the `--verbose` argument which has been added.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.