### PR TITLE
Fixes issue #2903

### DIFF
--- a/src/systems/lift_drag/LiftDrag.cc
+++ b/src/systems/lift_drag/LiftDrag.cc
@@ -148,6 +148,12 @@ class gz::sim::systems::LiftDragPrivate
 void LiftDragPrivate::Load(const EntityComponentManager &_ecm,
                            const sdf::ElementPtr &_sdf)
 {
+  if (!this->model.Valid(_ecm))
+  {
+    gzerr << "The LiftDrag system should be attached to a model entity. "
+           << "Failed to initialize." << std::endl;
+    return;
+  }
   this->cla = _sdf->Get<double>("cla", this->cla).first;
   this->cda = _sdf->Get<double>("cda", this->cda).first;
   this->cma = _sdf->Get<double>("cma", this->cma).first;
@@ -529,15 +535,9 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
 //////////////////////////////////////////////////
 void LiftDrag::Configure(const Entity &_entity,
                          const std::shared_ptr<const sdf::Element> &_sdf,
-                         EntityComponentManager &_ecm, EventManager &)
+                         EntityComponentManager &, EventManager &)
 {
   this->dataPtr->model = Model(_entity);
-  if (!this->dataPtr->model.Valid(_ecm))
-  {
-    gzerr << "The LiftDrag system should be attached to a model entity. "
-           << "Failed to initialize." << std::endl;
-    return;
-  }
   this->dataPtr->sdfConfig = _sdf->Clone();
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2903

## Summary
This PR fixes issue #2903 and prevents the server from segfaulting if the plugin fails to load correctly. It prints an error that the plugin was misconfigured and continues executing ahead.

At some point we should revisit our plugin loading interface. A lot of work is placed in the developers hands to understand internals of gazebo's lifecycle. For starters, we should try to call Configure _after_ the entities are created. It'd also be nice to be able to return an error during Configure and just not care about executing the plugin in the future. I'll open a ticket outlining how we can go about doing this with minimal interruptions to out currently existing codebase.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

