### PR TITLE
Use HeightmapUtil functions for loading HeightmapData

### DIFF
--- a/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc
+++ b/src/gui/plugins/visualization_capabilities/VisualizationCapabilities.cc
@@ -34,9 +34,8 @@
 #include <QQmlProperty>
 
 #include <gz/common/Console.hh>
-#include <gz/common/geospatial/Dem.hh>
 #include <gz/common/geospatial/HeightmapData.hh>
-#include <gz/common/geospatial/ImageHeightmap.hh>
+#include <gz/common/geospatial/HeightmapUtil.hh>
 #include <gz/common/MeshManager.hh>
 #include <gz/common/Profiler.hh>
 #include <gz/common/StringUtils.hh>
@@ -1285,32 +1284,20 @@ rendering::GeometryPtr VisualizationCapabilitiesPrivate::CreateGeometry(
     }
 
     std::shared_ptr<common::HeightmapData> data;
-    std::string lowerFullPath = common::lowercase(fullPath);
     // check if heightmap is an image
-    if (common::EndsWith(lowerFullPath, ".png")
-        || common::EndsWith(lowerFullPath, ".jpg")
-        || common::EndsWith(lowerFullPath, ".jpeg"))
+    if (common::isSupportedImageHeightmapFileExtension(fullPath))
     {
-      auto img = std::make_shared<common::ImageHeightmap>();
-      if (img->Load(fullPath) < 0)
-      {
-        gzerr << "Failed to load heightmap image data from ["
-               << fullPath << "]" << std::endl;
+      data = common::loadHeightmapData(fullPath);
+      if (!data)
         return geom;
-      }
-      data = img;
     }
     // DEM
     else
     {
-      auto dem = std::make_shared<common::Dem>();
-      if (dem->Load(fullPath) < 0)
-      {
-        gzerr << "Failed to load heightmap dem data from ["
-               << fullPath << "]" << std::endl;
+      // \todo(iche033) Load DEM with world spherical coordinates?
+      data = common::loadHeightmapData(fullPath);
+      if (!data)
         return geom;
-      }
-      data = dem;
     }
 
     rendering::HeightmapDescriptor descriptor;

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -36,9 +36,8 @@
 
 #include <gz/common/Animation.hh>
 #include <gz/common/Console.hh>
-#include <gz/common/geospatial/Dem.hh>
 #include <gz/common/geospatial/HeightmapData.hh>
-#include <gz/common/geospatial/ImageHeightmap.hh>
+#include <gz/common/geospatial/HeightmapUtil.hh>
 #include <gz/common/KeyFrame.hh>
 #include <gz/common/MeshManager.hh>
 #include <gz/common/Skeleton.hh>
@@ -739,35 +738,21 @@ rendering::GeometryPtr SceneManager::LoadGeometry(const sdf::Geometry &_geom,
       return geom;
     }
 
-
     std::shared_ptr<common::HeightmapData> data;
-    std::string lowerFullPath = common::lowercase(fullPath);
     // check if heightmap is an image
-    if (common::EndsWith(lowerFullPath, ".png")
-        || common::EndsWith(lowerFullPath, ".jpg")
-        || common::EndsWith(lowerFullPath, ".jpeg"))
+    if (common::isSupportedImageHeightmapFileExtension(fullPath))
     {
-      auto img = std::make_shared<common::ImageHeightmap>();
-      if (img->Load(fullPath) < 0)
-      {
-        gzerr << "Failed to load heightmap image data from ["
-               << fullPath << "]" << std::endl;
+      data = common::loadHeightmapData(fullPath);
+      if (!data)
         return geom;
-      }
-      data = img;
     }
     // DEM
     else
     {
-      auto dem = std::make_shared<common::Dem>();
-      dem->SetSphericalCoordinates(this->dataPtr->sphericalCoordinates);
-      if (dem->Load(fullPath) < 0)
-      {
-        gzerr << "Failed to load heightmap dem data from ["
-               << fullPath << "]" << std::endl;
+      data = common::loadHeightmapData(fullPath,
+          this->dataPtr->sphericalCoordinates);
+      if (!data)
         return geom;
-      }
-      data = dem;
     }
 
     rendering::HeightmapDescriptor descriptor;

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -33,9 +33,8 @@
 #include <vector>
 #include <utility>
 
-#include <gz/common/geospatial/Dem.hh>
 #include <gz/common/geospatial/HeightmapData.hh>
-#include <gz/common/geospatial/ImageHeightmap.hh>
+#include <gz/common/geospatial/HeightmapUtil.hh>
 #include <gz/common/MeshManager.hh>
 #include <gz/common/Profiler.hh>
 #include <gz/common/StringUtils.hh>
@@ -1538,20 +1537,12 @@ void PhysicsPrivate::CreateCollisionEntities(const EntityComponentManager &_ecm,
           }
 
           std::shared_ptr<common::HeightmapData> data;
-          std::string lowerFullPath = common::lowercase(fullPath);
           // check if heightmap is an image
-          if (common::EndsWith(lowerFullPath, ".png")
-              || common::EndsWith(lowerFullPath, ".jpg")
-              || common::EndsWith(lowerFullPath, ".jpeg"))
+          if (common::isSupportedImageHeightmapFileExtension(fullPath))
           {
-            auto img = std::make_shared<common::ImageHeightmap>();
-            if (img->Load(fullPath) < 0)
-            {
-              gzerr << "Failed to load heightmap image data from ["
-                     << fullPath << "]" << std::endl;
+            data = common::loadHeightmapData(fullPath);
+            if (!data)
               return true;
-            }
-            data = img;
           }
           // DEM
           else
@@ -1560,20 +1551,12 @@ void PhysicsPrivate::CreateCollisionEntities(const EntityComponentManager &_ecm,
             auto sphericalCoordinatesComponent =
               _ecm.Component<components::SphericalCoordinates>(
                 worldEntity);
-
-            auto dem = std::make_shared<common::Dem>();
+            math::SphericalCoordinates sphericalCoordinates;
             if (sphericalCoordinatesComponent)
-            {
-              dem->SetSphericalCoordinates(
-                  sphericalCoordinatesComponent->Data());
-            }
-            if (dem->Load(fullPath) < 0)
-            {
-              gzerr << "Failed to load heightmap dem data from ["
-                     << fullPath << "]" << std::endl;
+              sphericalCoordinates = sphericalCoordinatesComponent->Data();
+            data = common::loadHeightmapData(fullPath, sphericalCoordinates);
+            if (!data)
               return true;
-            }
-            data = dem;
           }
 
           collisionPtrPhys = linkHeightmapFeature->AttachHeightmapShape(


### PR DESCRIPTION
# 🎉 New feature

Depends on https://github.com/gazebosim/gz-common/pull/680

## Summary

Removed and replaced duplicate code for loading heightmap data with the new utility functions added in gz-common: https://github.com/gazebosim/gz-common/pull/680. 


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

