### PR TITLE
gz-sim-model: workaround cli11 bug

### DIFF
--- a/src/cmd/model_main.cc
+++ b/src/cmd/model_main.cc
@@ -150,7 +150,7 @@ void addModelFlags(CLI::App &_app)
                         "Print the pose of the model (only useful with --model).");
   // Don't specify that it needs --model for cli11 >= 2.2.0, < 2.5
   // See https://github.com/gazebosim/gz-sim/issues/2918
-  if (!(CLI11_VERSION_MAJOR >= 2 &&
+  if (!(CLI11_VERSION_MAJOR == 2 &&
         CLI11_VERSION_MINOR >= 2 &&
         CLI11_VERSION_MINOR < 5))
   {

--- a/src/cmd/model_main.cc
+++ b/src/cmd/model_main.cc
@@ -145,9 +145,17 @@ void addModelFlags(CLI::App &_app)
     ->expected(0, 1)
     ->default_val("");
 
-  command->add_flag("-p,--pose", opt->pose,
-                "Print the pose of the model.")
-                ->needs(modelCmd);
+  auto poseOption =
+      command->add_flag("-p,--pose", opt->pose,
+                        "Print the pose of the model (only useful with --model).");
+  // Don't specify that it needs --model for cli11 >= 2.2.0, < 2.5
+  // See https://github.com/gazebosim/gz-sim/issues/2918
+  if (!(CLI11_VERSION_MAJOR >= 2 &&
+        CLI11_VERSION_MINOR >= 2 &&
+        CLI11_VERSION_MINOR < 5))
+  {
+    poseOption->needs(modelCmd);
+  }
 
   _app.callback([opt](){ runModelCommand(*opt); });
 }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2918

## Summary

There is a bug in cli11 for versions >= 2.2 and < 2.5. This works around the bug for the affected versions, similar to the approached identified by @j-rivero in https://github.com/gazebosim/gz-sim/pull/2910#issuecomment-2898112530.

To test, I will run a colcon CI job on 24.04 (which has cli11 version 2.4.1) with vending of cli11 disabled by reverting https://github.com/gazebosim/gz-utils/pull/178.

<!--
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ci__colcon_any-manual_ubuntu_noble_amd64&build=37)](https://build.osrfoundation.org/job/ci__colcon_any-manual_ubuntu_noble_amd64/37/) ~~https://build.osrfoundation.org/job/ci__colcon_any-manual_ubuntu_noble_amd64/37/~~ (the test didn't run because there was no display / GPU)

~~~
-- Skipping ModelCommandAPI tests because a valid display was not found
~~~

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ci__colcon_gpu_any-manual_ubuntu_noble_amd64&build=5)](https://build.osrfoundation.org/job/ci__colcon_gpu_any-manual_ubuntu_noble_amd64/5/) ~~https://build.osrfoundation.org/job/ci__colcon_gpu_any-manual_ubuntu_noble_amd64/5/~~

~~~
-- Looking for display capabilities
-- Could not find 'xwininfo', which is needed for FindDRI. Please install the package 'x11-utils'
~~~

Building again with `x11-utils`

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ci__colcon_gpu_any-manual_ubuntu_noble_amd64&build=6)](https://build.osrfoundation.org/job/ci__colcon_gpu_any-manual_ubuntu_noble_amd64/6/) ~~https://build.osrfoundation.org/job/ci__colcon_gpu_any-manual_ubuntu_noble_amd64/6/~~

The `DISPLAY` variable isn't being set, so I just added `-DFORCE_GRAPHIC_TESTS_COMPILATION=ON`
-->

### Test summary

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ci__colcon_gpu_any-manual_ubuntu_noble_amd64&build=9)](https://build.osrfoundation.org/job/ci__colcon_gpu_any-manual_ubuntu_noble_amd64/9/) https://build.osrfoundation.org/job/ci__colcon_gpu_any-manual_ubuntu_noble_amd64/9/

~~~
--- output: gz-utils
...
-- Looking for CLI11 - found
...
83: [  PASSED  ] 8 tests.
 83/328 Test  #83: UNIT_ModelCommandAPI_TEST ...............................   Passed   15.53 sec
~~~

### Full console output

<details>

~~~
83: Running main() from /tmp/ws/src/gz-sim/test/gtest_vendor/src/gtest_main.cc
83: [==========] Running 8 tests from 1 test suite.
83: [----------] Global test environment set-up.
83: [----------] 8 tests from ModelCommandAPI
83: [ RUN      ] ModelCommandAPI.NoServerRunning
83: Running command [/tmp/ws/install_isolated/gz-tools2/bin/gz model --list ]
83: [       OK ] ModelCommandAPI.NoServerRunning (5166 ms)
83: [ RUN      ] ModelCommandAPI.Commands
83: (2025-05-27 19:39:20.153) [error] [Physics.cc:845] Failed to find plugin [gz-physics-dartsim-plugin]. Have you checked the GZ_SIM_PHYSICS_ENGINE_PATH environment variable?
83: Running command [/tmp/ws/install_isolated/gz-tools2/bin/gz model --list]
83: Running command [/tmp/ws/install_isolated/gz-tools2/bin/gz model -m vehicle_blue]
83: Running command [/tmp/ws/install_isolated/gz-tools2/bin/gz model -m vehicle_blue --pose ]
83: Running command [/tmp/ws/install_isolated/gz-tools2/bin/gz model -m vehicle_blue --link]
83: Running command [/tmp/ws/install_isolated/gz-tools2/bin/gz model -m vehicle_blue --link caster]
83: Running command [/tmp/ws/install_isolated/gz-tools2/bin/gz model -m vehicle_blue --joint]
83: Running command [/tmp/ws/install_isolated/gz-tools2/bin/gz model -m vehicle_blue --joint caster_wheel]
83: [       OK ] ModelCommandAPI.Commands (6267 ms)
83: [ RUN      ] ModelCommandAPI.AirPressureSensor
83: Running command [/tmp/ws/install_isolated/gz-tools2/bin/gz model -m air_pressure_model -l link -s air_pressure_sensor]
83: [       OK ] ModelCommandAPI.AirPressureSensor (595 ms)
83: [ RUN      ] ModelCommandAPI.AltimeterSensor
83: (2025-05-27 19:39:26.848) [error] [Physics.cc:845] Failed to find plugin [gz-physics-dartsim-plugin]. Have you checked the GZ_SIM_PHYSICS_ENGINE_PATH environment variable?
83: Running command [/tmp/ws/install_isolated/gz-tools2/bin/gz model -m altimeter_model -l link -s altimeter_sensor]
83: [       OK ] ModelCommandAPI.AltimeterSensor (706 ms)
83: [ RUN      ] ModelCommandAPI.GpuLidarSensor
83: (2025-05-27 19:39:27.560) [error] [Physics.cc:845] Failed to find plugin [gz-physics-dartsim-plugin]. Have you checked the GZ_SIM_PHYSICS_ENGINE_PATH environment variable?
83: Running command [/tmp/ws/install_isolated/gz-tools2/bin/gz model -m gpu_lidar -l gpu_lidar_link -s gpu_lidar]
83: [       OK ] ModelCommandAPI.GpuLidarSensor (583 ms)
83: [ RUN      ] ModelCommandAPI.MagnetometerSensor
83: (2025-05-27 19:39:28.138) [error] [Physics.cc:845] Failed to find plugin [gz-physics-dartsim-plugin]. Have you checked the GZ_SIM_PHYSICS_ENGINE_PATH environment variable?
83: Running command [/tmp/ws/install_isolated/gz-tools2/bin/gz model -m magnetometer_model -l link -s magnetometer_sensor]
83: [       OK ] ModelCommandAPI.MagnetometerSensor (874 ms)
83: [ RUN      ] ModelCommandAPI.RgbdCameraSensor
83: (2025-05-27 19:39:29.016) [error] [Physics.cc:845] Failed to find plugin [gz-physics-dartsim-plugin]. Have you checked the GZ_SIM_PHYSICS_ENGINE_PATH environment variable?
83: Running command [/tmp/ws/install_isolated/gz-tools2/bin/gz model -m rgbd_camera -l rgbd_camera_link -s rgbd_camera]
83: [       OK ] ModelCommandAPI.RgbdCameraSensor (1129 ms)
83: [ RUN      ] ModelCommandAPI.ModelHelpVsCompletionFlags
83: Running command [/tmp/ws/install_isolated/gz-tools2/bin/gz model  --help]
83: Running command [bash -c ". /tmp/ws/src/gz-sim/src/cmd/model.bash_completion.sh; _gz_model_flags"]
83: [       OK ] ModelCommandAPI.ModelHelpVsCompletionFlags (166 ms)
83: [----------] 8 tests from ModelCommandAPI (15490 ms total)
83: 
83: [----------] Global test environment tear-down
83: [==========] 8 tests from 1 test suite ran. (15490 ms total)
83: [  PASSED  ] 8 tests.
 83/328 Test  #83: UNIT_ModelCommandAPI_TEST ...............................   Passed   15.53 sec
~~~

</details>

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
