### PR TITLE
Fix no-GUI Tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,10 +164,13 @@ if (MSVC)
   set_source_files_properties(${sources} ${gtest_sources} COMPILE_FLAGS "/wd4251 /wd4146")
 endif()
 
+
 # Executable target that runs the GUI without ruby for debugging purposes.
-add_executable(runGui cmd/runGui_main.cc)
-target_link_libraries(runGui PRIVATE ${gz_lib_target} gz-gui gz)
-install(TARGETS runGui DESTINATION ${CMAKE_INSTALL_PREFIX}/libexec)
+if(ENABLE_GUI)
+  add_executable(runGui cmd/runGui_main.cc)
+  target_link_libraries(runGui PRIVATE ${gz_lib_target} gz-gui gz)
+  install(TARGETS runGui DESTINATION ${CMAKE_INSTALL_PREFIX}/libexec)
+endif()
 
 # Create the library target
 gz_create_core_library(SOURCES ${sources} CXX_STANDARD 17)


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary

PR #2667 breaks the new no-gui tests. I was a numpty and enabled auto-merge on it. This PR tries to fix the no-gui tests.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

