### PR TITLE
Add global guard in SelectEntities eventFilter to avoid null pointer crash on render engine failure

### DIFF
--- a/src/gui/plugins/select_entities/SelectEntities.cc
+++ b/src/gui/plugins/select_entities/SelectEntities.cc
@@ -598,4 +598,3 @@ bool SelectEntities::eventFilter(QObject *_obj, QEvent *_event)
 // Register this plugin
 GZ_ADD_PLUGIN(gz::sim::gui::SelectEntities,
                     gz::gui::Plugin)
-


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2954 

## Summary
The plugin could crash when the render engine fails to load and scene is not initialized.
This commit adds a guard to ensure only Render events are processed before scene is ready.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added test
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

