### PR TITLE
[bazel] Add support for Systems

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,10 @@
 load("@gz-msgs//tools:gz_msgs_generate.bzl", "gz_proto_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@rules_gazebo//gazebo:headers.bzl", "gz_configure_header", "gz_export_header")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//bazel:gz_sim_system_libraries.bzl", "gz_sim_system_libraries")
 
 package(
     default_applicable_licenses = [":license"],
@@ -80,6 +83,7 @@ public_headers_no_gen = glob(
         "include/gz/sim/comms/*.hh",
         "include/gz/sim/components/*.hh",
         "include/gz/sim/detail/*.hh",
+        "include/gz/sim/physics/*.hh",
         "include/gz/sim/rendering/*.hh",
     ],
 )
@@ -136,6 +140,7 @@ cc_library(
         ":RenderingExport",
         ":gzsim_cc_proto",
         "@com_google_protobuf//:protobuf_lite",
+        "@eigen",
         "@gz-common",
         "@gz-common//events",
         "@gz-common//geospatial",
@@ -146,9 +151,9 @@ cc_library(
         "@gz-math",
         "@gz-msgs",
         "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-physics",
         "@gz-plugin//:core",
         "@gz-plugin//:loader",
-        "@gz-plugin//:register",
         "@gz-rendering",
         "@gz-transport",
         "@gz-transport//parameters",
@@ -162,17 +167,67 @@ cc_library(
 test_sources = glob(
     include = ["src/*_TEST.cc"],
     exclude = [
-        # These tests currently fail in bazel build, either due to missing
-        # System plugin dependencies or due to incorrect resolved output paths.
-        "src/AddedMass_TEST.cc",
+        # - Requires a missing export for transport/log/sql/0.1.0.sql in
+        #   gz-transport
+        # - Uses versioned System plugin library names which are not supported
+        #   in Bazel build.
+        # - Expects test cwd to be different from PROJECT_SOURCE_PATH, which is
+        #   false in Bazel build.
         "src/Server_TEST.cc",
-        "src/ServerConfig_TEST.cc",
+        # Uses rendering engine which is not yet available in Bazel build.
         "src/Server_Rendering_TEST.cc",
+        # Some test cases fail in Bazel build.
         "src/SimulationRunner_TEST.cc",
+        # Uses versioned System plugin library names which are not supported in
+        # Bazel build.
         "src/SystemLoader_TEST.cc",
-        "src/SdfGenerator_TEST.cc",
-        "src/Util_TEST.cc",
     ],
+)
+
+# Genrule to copy the default server config to the test execroot.
+genrule(
+    name = "install_server_config",
+    testonly = True,
+    srcs = ["include/gz/sim/server.config"],
+    outs = ["server.config"],
+    cmd = "cp $(SRCS) $(OUTS)",
+)
+
+# Test systems are expected to be found under $(execroot)/lib
+# See test/helpers/EnvTestFixture.hh
+genrule(
+    name = "install_test_systems",
+    testonly = True,
+    srcs = [
+        "//test:MockSystem.so",
+        "//test:TestModelSystem.so",
+        "//test:TestSensorSystem.so",
+        "//test:TestVisualSystem.so",
+        "//test:TestWorldSystem.so",
+    ],
+    outs = [
+        "lib/libMockSystem.so",
+        "lib/libTestModelSystem.so",
+        "lib/libTestSensorSystem.so",
+        "lib/libTestVisualSystem.so",
+        "lib/libTestWorldSystem.so",
+    ],
+    cmd = """
+        source_files=($(SRCS));
+        destination_paths=($(OUTS));
+        for ((i=0; i < $${#source_files[@]}; i++)); do
+            cp "$${source_files[i]}" "$${destination_paths[i]}"
+        done
+    """,
+)
+
+# Install physics engine for tests at a known location.
+genrule(
+    name = "install_physics_engine",
+    testonly = True,
+    srcs = ["@gz-physics//dartsim:libgz-physics-dartsim-plugin.so"],
+    outs = ["physics_engine/libgz-physics-dartsim-plugin.so"],
+    cmd = "cp $(SRCS) $(OUTS)",
 )
 
 [cc_test(
@@ -181,10 +236,28 @@ test_sources = glob(
     # Some tests need private headers.
     copts = ["-Wno-private-header"],
     data = [
+        "include/gz/sim/playback_server.config",
+        "include/gz/sim/server.config",
+        "physics_engine/libgz-physics-dartsim-plugin.so",
+        ":gz-sim-air-pressure-system.so",
+        ":gz-sim-log-system.so",
+        ":gz-sim-physics-system.so",
+        ":gz-sim-scene-broadcaster-system.so",
+        ":gz-sim-user-commands-system.so",
+        ":gz-sim-velocity-control-system.so",
+        ":lib/libMockSystem.so",
+        ":lib/libTestModelSystem.so",
+        ":lib/libTestSensorSystem.so",
+        ":lib/libTestVisualSystem.so",
+        ":lib/libTestWorldSystem.so",
+        ":server.config",
+        "//test:media",
         "//test:worlds",
     ],
     env = {
         "GZ_BAZEL": "1",
+        "GZ_SIM_PHYSICS_ENGINE_PATH": "physics_engine",
+        "GZ_SIM_RESOURCE_PATH": "test/worlds",
     },
     deps = [
         ":gz-sim",
@@ -207,3 +280,1507 @@ test_sources = glob(
         "@tinyxml2",
     ],
 ) for src in test_sources]
+
+# Following systems are not yet supported in the Bazel BUILD:
+# - src/systems/camera_video_recorder (av sub-package in gz-common is not yet available in Bazel build)
+# - src/systems/dvl (av sub-package in gz-common is not yet available in Bazel build)
+# - src/systems/elevator (doesn't build)
+# - src/systems/python_system_loader (missing pybind11 dep)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/ackermann_steering/**/*.cc",
+            "src/systems/ackermann_steering/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-ackermann-steering-system.so",
+    static_lib_name = "gz-sim-ackermann-steering-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/acoustic_comms/**/*.cc",
+            "src/systems/acoustic_comms/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-acoustic-comms-system.so",
+    static_lib_name = "gz-sim-acoustic-comms-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-plugin//:register",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/advanced_lift_drag/**/*.cc",
+            "src/systems/advanced_lift_drag/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-advanced-lift-drag-system.so",
+    static_lib_name = "gz-sim-advanced-lift-drag-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-physics",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/air_pressure/**/*.cc",
+            "src/systems/air_pressure/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-air-pressure-system.so",
+    static_lib_name = "gz-sim-air-pressure-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-sensors",
+        "@gz-sensors//:air_pressure",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/air_speed/**/*.cc",
+            "src/systems/air_speed/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-air-speed-system.so",
+    static_lib_name = "gz-sim-air-speed-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-sensors",
+        "@gz-sensors//:air_speed",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/altimeter/**/*.cc",
+            "src/systems/altimeter/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-altimeter-system.so",
+    static_lib_name = "gz-sim-altimeter-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-sensors",
+        "@gz-sensors//:altimeter",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/apply_joint_force/**/*.cc",
+            "src/systems/apply_joint_force/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-apply-joint-force-system.so",
+    static_lib_name = "gz-sim-apply-joint-force-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/apply_link_wrench/**/*.cc",
+            "src/systems/apply_link_wrench/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-apply-link-wrench-system.so",
+    static_lib_name = "gz-sim-apply-link-wrench-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/battery_plugin/**/*.cc",
+            "src/systems/battery_plugin/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-linearbatteryplugin-system.so",
+    static_lib_name = "gz-sim-linearbatteryplugin-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common",
+        "@gz-common//profiler",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/breadcrumbs/**/*.cc",
+            "src/systems/breadcrumbs/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-breadcrumbs-system.so",
+    static_lib_name = "gz-sim-breadcrumbs-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/buoyancy/**/*.cc",
+            "src/systems/buoyancy/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-buoyancy-system.so",
+    static_lib_name = "gz-sim-buoyancy-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//graphics",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/buoyancy_engine/**/*.cc",
+            "src/systems/buoyancy_engine/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-buoyancy-engine-system.so",
+    static_lib_name = "gz-sim-buoyancy-engine-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/collada_world_exporter/**/*.cc",
+            "src/systems/collada_world_exporter/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-collada-world-exporter-system.so",
+    static_lib_name = "gz-sim-collada-world-exporter-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//graphics",
+        "@gz-math",
+        "@gz-plugin//:register",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/comms_endpoint/**/*.cc",
+            "src/systems/comms_endpoint/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-comms-endpoint-system.so",
+    static_lib_name = "gz-sim-comms-endpoint-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@gz-utils//:ImplPtr",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/contact/**/*.cc",
+            "src/systems/contact/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-contact-system.so",
+    static_lib_name = "gz-sim-contact-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/detachable_joint/**/*.cc",
+            "src/systems/detachable_joint/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-detachable-joint-system.so",
+    static_lib_name = "gz-sim-detachable-joint-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/diff_drive/**/*.cc",
+            "src/systems/diff_drive/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-diff-drive-system.so",
+    static_lib_name = "gz-sim-diff-drive-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/drive_to_pose_controller/**/*.cc",
+            "src/systems/drive_to_pose_controller/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-drive-to-pose-controller-system.so",
+    static_lib_name = "gz-sim-drive-to-pose-controller-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+# Doesn't build
+# gz_sim_system_libraries(
+#     srcs = glob(
+#         [
+#             "src/systems/elevator/**/*.cc",
+#             "src/systems/elevator/**/*.hh",
+#             "src/systems/elevator/**/*.hpp",
+#         ],
+#     ),
+#     includes = [
+#         "src/systems/elevator/utils",
+#         "src/systems/elevator/vender/afsm/include",
+#         "src/systems/elevator/vender/metapushkin/include",
+#     ],
+#     so_lib_name = "gz-sim-elevator-system.so",
+#     static_lib_name = "gz-sim-elevator-system-static",
+#     visibility = ["//visibility:public"],
+#     deps = [
+#         ":gz-sim",
+#         "@gz-plugin//:register",
+#     ],
+# )
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/environmental_sensor_system/**/*.cc",
+            "src/systems/environmental_sensor_system/**/*.hh",
+        ],
+        exclude = ["src/systems/environmental_sensor_system/*_TEST.cc"],
+    ),
+    so_lib_name = "gz-sim-environmental-sensor-system.so",
+    static_lib_name = "gz-sim-environmental-sensor-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common",
+        "@gz-math",
+        "@gz-plugin//:register",
+        "@gz-sensors",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+environmental_sensor_system_test_sources = glob([
+    "src/systems/environmental_sensor_system/*_TEST.cc",
+])
+
+[cc_test(
+    name = src.replace("/", "_").replace(".cc", "").replace("src_", ""),
+    srcs = [src],
+    # Some tests need private headers.
+    copts = ["-Wno-private-header"],
+    deps = [
+        ":gz-sim-environmental-sensor-system-static",
+        "//test:Helpers",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@gz-utils//:ExtraTestMacros",
+    ],
+) for src in environmental_sensor_system_test_sources]
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/environment_preload/**/*.cc",
+            "src/systems/environment_preload/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-environment-preload-system.so",
+    static_lib_name = "gz-sim-environment-preload-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common",
+        "@gz-common//io",
+        "@gz-msgs",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/follow_actor/**/*.cc",
+            "src/systems/follow_actor/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-follow-actor-system.so",
+    static_lib_name = "gz-sim-follow-actor-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-plugin//:register",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/force_torque/**/*.cc",
+            "src/systems/force_torque/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-forcetorque-system.so",
+    static_lib_name = "gz-sim-forcetorque-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common",
+        "@gz-common//profiler",
+        "@gz-plugin//:register",
+        "@gz-sensors",
+        "@gz-sensors//:force_torque",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/hydrodynamics/**/*.cc",
+            "src/systems/hydrodynamics/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-hydrodynamics-system.so",
+    static_lib_name = "gz-sim-hydrodynamics-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@eigen",
+        "@gz-msgs",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/imu/**/*.cc",
+            "src/systems/imu/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-imu-system.so",
+    static_lib_name = "gz-sim-imu-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-plugin//:register",
+        "@gz-sensors",
+        "@gz-sensors//:imu",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/joint_controller/**/*.cc",
+            "src/systems/joint_controller/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-joint-controller-system.so",
+    static_lib_name = "gz-sim-joint-controller-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/joint_position_controller/**/*.cc",
+            "src/systems/joint_position_controller/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-joint-position-controller-system.so",
+    static_lib_name = "gz-sim-joint-position-controller-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@gz-transport//parameters",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/joint_state_publisher/**/*.cc",
+            "src/systems/joint_state_publisher/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-joint-state-publisher-system.so",
+    static_lib_name = "gz-sim-joint-state-publisher-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/joint_traj_control/**/*.cc",
+            "src/systems/joint_traj_control/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-joint-trajectory-controller-system.so",
+    static_lib_name = "gz-sim-joint-trajectory-controller-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/kinetic_energy_monitor/**/*.cc",
+            "src/systems/kinetic_energy_monitor/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-kinetic-energy-monitor-system.so",
+    static_lib_name = "gz-sim-kinetic-energy-monitor-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@com_google_protobuf//:protobuf",
+        "@gz-common//profiler",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/label/**/*.cc",
+            "src/systems/label/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-label-system.so",
+    static_lib_name = "gz-sim-label-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-plugin//:register",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/lens_flare/**/*.cc",
+            "src/systems/lens_flare/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-lens-flare-system.so",
+    static_lib_name = "gz-sim-lens-flare-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-plugin//:register",
+        "@gz-rendering",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/lift_drag/**/*.cc",
+            "src/systems/lift_drag/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-lift-drag-system.so",
+    static_lib_name = "gz-sim-lift-drag-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/lighter_than_air_dynamics/**/*.cc",
+            "src/systems/lighter_than_air_dynamics/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-lighter-than-air-dynamics-system.so",
+    static_lib_name = "gz-sim-lighter-than-air-dynamics-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@eigen",
+        "@gz-math",
+        "@gz-msgs",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/log/**/*.cc",
+            "src/systems/log/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-log-system.so",
+    static_lib_name = "gz-sim-log-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common",
+        "@gz-common//profiler",
+        "@gz-fuel-tools",
+        "@gz-math",
+        "@gz-msgs",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@gz-transport//log",
+        "@sdformat",
+    ],
+)
+
+gz_export_header(
+    name = "LogicalAudioSensorSystemExport",
+    out = "include/gz/sim/logicalaudiosensorplugin-system/Export.hh",
+    export_base = "GZ_SIM_LOGICALAUDIOSENSORPLUGIN_SYSTEM",
+    lib_name = "gz-sim-logicalaudiosensorplugin-system",
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/logical_audio_sensor_plugin/**/*.cc",
+            "src/systems/logical_audio_sensor_plugin/**/*.hh",
+        ],
+        exclude = ["src/systems/logical_audio_sensor_plugin/**/*_TEST.cc"],
+    ) + ["include/gz/sim/logicalaudiosensorplugin-system/Export.hh"],
+    so_lib_name = "gz-sim-logicalaudiosensorplugin-system.so",
+    static_lib_name = "gz-sim-logicalaudiosensorplugin-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+logical_audio_sensor_plugin_test_sources = glob([
+    "src/systems/logical_audio_sensor_plugin/**/*_TEST.cc",
+])
+
+[cc_test(
+    name = src.replace("/", "_").replace(".cc", "").replace("src_", ""),
+    srcs = [src],
+    # Some tests need private headers.
+    copts = ["-Wno-private-header"],
+    deps = [
+        ":gz-sim-logicalaudiosensorplugin-system-static",
+        "//test:Helpers",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@gz-utils//:ExtraTestMacros",
+    ],
+) for src in logical_audio_sensor_plugin_test_sources]
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/logical_camera/**/*.cc",
+            "src/systems/logical_camera/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-logical-camera-system.so",
+    static_lib_name = "gz-sim-logical-camera-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-sensors",
+        "@gz-sensors//:logical_camera",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/log_video_recorder/**/*.cc",
+            "src/systems/log_video_recorder/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-log-video-recorder-system.so",
+    static_lib_name = "gz-sim-log-video-recorder-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/magnetometer/**/*.cc",
+            "src/systems/magnetometer/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-magnetometer-system.so",
+    static_lib_name = "gz-sim-magnetometer-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-plugin//:register",
+        "@gz-sensors",
+        "@gz-sensors//:magnetometer",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/mecanum_drive/**/*.cc",
+            "src/systems/mecanum_drive/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-mecanum-drive-system.so",
+    static_lib_name = "gz-sim-mecanum-drive-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/model_photo_shoot/**/*.cc",
+            "src/systems/model_photo_shoot/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-model-photo-shoot-system.so",
+    static_lib_name = "gz-sim-model-photo-shoot-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common",
+        "@gz-common//graphics",
+        "@gz-plugin//:register",
+        "@gz-rendering",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/multicopter_control/**/*.cc",
+            "src/systems/multicopter_control/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-multicopter-control-system.so",
+    static_lib_name = "gz-sim-multicopter-control-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@eigen",
+        "@gz-common",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-math//eigen3",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/multicopter_motor_model/**/*.cc",
+            "src/systems/multicopter_motor_model/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-multicopter-motor-model-system.so",
+    static_lib_name = "gz-sim-multicopter-motor-model-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/navsat/**/*.cc",
+            "src/systems/navsat/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-navsat-system.so",
+    static_lib_name = "gz-sim-navsat-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-sensors",
+        "@gz-sensors//:navsat",
+        "@gz-transport",
+        "@gz-utils//:ImplPtr",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/odometry_publisher/**/*.cc",
+            "src/systems/odometry_publisher/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-odometry-publisher-system.so",
+    static_lib_name = "gz-sim-odometry-publisher-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/optical_tactile_plugin/**/*.cc",
+            "src/systems/optical_tactile_plugin/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-opticaltactileplugin-system.so",
+    static_lib_name = "gz-sim-opticaltactileplugin-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/particle_emitter/**/*.cc",
+            "src/systems/particle_emitter/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-particle-emitter-system.so",
+    static_lib_name = "gz-sim-particle-emitter-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-msgs",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/perfect_comms/**/*.cc",
+            "src/systems/perfect_comms/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-perfect-comms-system.so",
+    static_lib_name = "gz-sim-perfect-comms-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-plugin//:register",
+        "@gz-utils//:ImplPtr",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/performer_detector/**/*.cc",
+            "src/systems/performer_detector/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-performer-detector-system.so",
+    static_lib_name = "gz-sim-performer-detector-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+# Targets including this under `deps` (for static linking) or under `data` (for
+# external library) should also include data deps on the physics engine
+# libraries that need to be supported. e.g.
+# cc_library(
+#     name = "my_gz_sim_server_with_bullet_featherstone_physics",
+#     srcs = my_sources_list,
+#     data = [
+#         "@gz-physics//bullet-featherstone:libgz-physics-bullet-featherstone-plugin.so",
+#     ],
+#     deps = [
+#         "@gz-sim",
+#         "@gz-sim//:gz-sim-physics-system-static",
+#     ]
+# )
+#
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/physics/**/*.cc",
+            "src/systems/physics/**/*.hh",
+        ],
+        exclude = ["src/systems/physics/**/*TEST.cc"],
+    ),
+    so_lib_name = "gz-sim-physics-system.so",
+    static_lib_name = "gz-sim-physics-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common",
+        "@gz-common//geospatial",
+        "@gz-common//graphics",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-math//eigen3",
+        "@gz-msgs",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-physics",
+        "@gz-physics//:heightmap",
+        "@gz-physics//:mesh",
+        "@gz-physics//:sdf",
+        "@gz-plugin//:core",
+        "@gz-plugin//:loader",
+        "@gz-plugin//:register",
+        "@sdformat",
+    ],
+)
+
+physics_test_sources = glob(["src/systems/physics/**/*TEST.cc"])
+
+[cc_test(
+    name = src.replace("/", "_").replace(".cc", "").replace("src_", ""),
+    srcs = [src],
+    # Some tests need private headers.
+    copts = ["-Wno-private-header"],
+    data = ["physics_engine/libgz-physics-dartsim-plugin.so"],
+    env = {
+        "GZ_BAZEL": "1",
+        "GZ_PLUGIN_PATH": "physics_engine",
+    },
+    deps = [
+        ":gz-sim",
+        ":gz-sim-physics-system-static",
+        "//test:Helpers",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@gz-physics",
+        "@gz-plugin//:loader",
+        "@gz-utils//:ExtraTestMacros",
+    ],
+) for src in physics_test_sources]
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/pose_publisher/**/*.cc",
+            "src/systems/pose_publisher/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-pose-publisher-system.so",
+    static_lib_name = "gz-sim-pose-publisher-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/rf_comms/**/*.cc",
+            "src/systems/rf_comms/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-rf-comms-system.so",
+    static_lib_name = "gz-sim-rf-comms-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-utils//:ImplPtr",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/scene_broadcaster/**/*.cc",
+            "src/systems/scene_broadcaster/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-scene-broadcaster-system.so",
+    static_lib_name = "gz-sim-scene-broadcaster-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/sensors/**/*.cc",
+            "src/systems/sensors/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-sensors-system.so",
+    static_lib_name = "gz-sim-sensors-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-plugin//:register",
+        "@gz-rendering",
+        "@gz-sensors",
+        "@gz-sensors//:boundingbox_camera",
+        "@gz-sensors//:camera",
+        "@gz-sensors//:depth_camera",
+        "@gz-sensors//:gpu_lidar",
+        "@gz-sensors//:rendering",
+        "@gz-sensors//:rgbd_camera",
+        "@gz-sensors//:segmentation_camera",
+        "@gz-sensors//:thermal_camera",
+        "@gz-sensors//:wide_angle_camera",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/shader_param/**/*.cc",
+            "src/systems/shader_param/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-shader-param-system.so",
+    static_lib_name = "gz-sim-shader-param-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-plugin//:register",
+        "@gz-rendering",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/spacecraft_thruster_model/**/*.cc",
+            "src/systems/spacecraft_thruster_model/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-spacecraft-thruster-model-system.so",
+    static_lib_name = "gz-sim-spacecraft-thruster-model-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = [
+        "src/systems/thermal/Thermal.cc",
+        "src/systems/thermal/Thermal.hh",
+    ],
+    so_lib_name = "gz-sim-thermal-system.so",
+    static_lib_name = "gz-sim-thermal-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common",
+        "@gz-plugin//:register",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = [
+        "src/systems/thermal/ThermalSensor.cc",
+        "src/systems/thermal/ThermalSensor.hh",
+    ],
+    so_lib_name = "gz-sim-thermal-sensor-system.so",
+    static_lib_name = "gz-sim-thermal-sensor-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common",
+        "@gz-plugin//:register",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/thruster/**/*.cc",
+            "src/systems/thruster/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-thruster-system.so",
+    static_lib_name = "gz-sim-thruster-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/touch_plugin/**/*.cc",
+            "src/systems/touch_plugin/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-touchplugin-system.so",
+    static_lib_name = "gz-sim-touchplugin-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/track_controller/**/*.cc",
+            "src/systems/track_controller/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-track-controller-system.so",
+    static_lib_name = "gz-sim-track-controller-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-math",
+        "@gz-math//eigen3",
+        "@gz-msgs",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/tracked_vehicle/**/*.cc",
+            "src/systems/tracked_vehicle/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-tracked-vehicle-system.so",
+    static_lib_name = "gz-sim-tracked-vehicle-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/trajectory_follower/**/*.cc",
+            "src/systems/trajectory_follower/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-trajectory-follower-system.so",
+    static_lib_name = "gz-sim-trajectory-follower-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/triggered_publisher/**/*.cc",
+            "src/systems/triggered_publisher/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-triggered-publisher-system.so",
+    static_lib_name = "gz-sim-triggered-publisher-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@com_google_protobuf//:differencer",
+        "@com_google_protobuf//:protobuf",
+        "@gz-common",
+        "@gz-common//profiler",
+        "@gz-msgs",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/user_commands/**/*.cc",
+            "src/systems/user_commands/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-user-commands-system.so",
+    static_lib_name = "gz-sim-user-commands-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@com_google_protobuf//:protobuf",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/velocity_control/**/*.cc",
+            "src/systems/velocity_control/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-velocity-control-system.so",
+    static_lib_name = "gz-sim-velocity-control-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/wheel_slip/**/*.cc",
+            "src/systems/wheel_slip/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-wheel-slip-system.so",
+    static_lib_name = "gz-sim-wheel-slip-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/wind_effects/**/*.cc",
+            "src/systems/wind_effects/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-wind-effects-system.so",
+    static_lib_name = "gz-sim-wind-effects-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@com_google_protobuf//:protobuf",
+        "@gz-common//profiler",
+        "@gz-math",
+        "@gz-msgs",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-sensors",
+        "@gz-transport",
+        "@sdformat",
+    ],
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -283,7 +283,6 @@ genrule(
 
 # Following systems are not yet supported in the Bazel BUILD:
 # - src/systems/camera_video_recorder (av sub-package in gz-common is not yet available in Bazel build)
-# - src/systems/dvl (av sub-package in gz-common is not yet available in Bazel build)
 # - src/systems/elevator (doesn't build)
 # - src/systems/python_system_loader (missing pybind11 dep)
 
@@ -654,6 +653,27 @@ gz_sim_system_libraries(
         "@gz-plugin//:register",
         "@gz-transport",
         "@sdformat",
+    ],
+)
+
+gz_sim_system_libraries(
+    srcs = glob(
+        [
+            "src/systems/dvl/**/*.cc",
+            "src/systems/dvl/**/*.hh",
+        ],
+    ),
+    so_lib_name = "gz-sim-dvl-system.so",
+    static_lib_name = "gz-sim-dvl-system-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gz-sim",
+        "@gz-common//profiler",
+        "@gz-plugin//:register",
+        "@gz-rendering",
+        "@gz-sensors",
+        "@gz-sensors//:dvl",
+        "@gz-transport",
     ],
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,9 +102,12 @@ gz_find_package(gz-common6
     graphics
     io
     profiler
+    testing
   REQUIRED
 )
 set(GZ_COMMON_VER ${gz-common6_VERSION_MAJOR})
+
+list(APPEND EXTRA_TEST_LIB_DEPS gz-common${GZ_COMMON_VER}::testing)
 
 #--------------------------------------
 # Find gz-fuel_tools

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,8 +4,11 @@ module(
     repo_name = "org_gazebosim_gz-sim",
 )
 
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "eigen", version = "3.4.0.bcr.3")
 bazel_dep(name = "googletest", version = "1.15.2")
 bazel_dep(name = "protobuf", version = "29.4", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "tinyxml2", version = "10.0.0")
@@ -16,8 +19,10 @@ bazel_dep(name = "gz-common")
 bazel_dep(name = "gz-fuel-tools")
 bazel_dep(name = "gz-math")
 bazel_dep(name = "gz-msgs")
+bazel_dep(name = "gz-physics")
 bazel_dep(name = "gz-plugin")
 bazel_dep(name = "gz-rendering")
+bazel_dep(name = "gz-sensors")
 bazel_dep(name = "gz-transport")
 bazel_dep(name = "gz-utils")
 bazel_dep(name = "sdformat")
@@ -47,6 +52,12 @@ archive_override(
 )
 
 archive_override(
+    module_name = "gz-physics",
+    strip_prefix = "gz-physics-gz-physics8",
+    urls = ["https://github.com/gazebosim/gz-physics/archive/refs/heads/gz-physics8.tar.gz"],
+)
+
+archive_override(
     module_name = "gz-plugin",
     strip_prefix = "gz-plugin-gz-plugin3",
     urls = ["https://github.com/gazebosim/gz-plugin/archive/refs/heads/gz-plugin3.tar.gz"],
@@ -56,6 +67,12 @@ archive_override(
     module_name = "gz-rendering",
     strip_prefix = "gz-rendering-gz-rendering9",
     urls = ["https://github.com/gazebosim/gz-rendering/archive/refs/heads/gz-rendering9.tar.gz"],
+)
+
+archive_override(
+    module_name = "gz-sensors",
+    strip_prefix = "gz-sensors-gz-sensors9",
+    urls = ["https://github.com/gazebosim/gz-sensors/archive/refs/heads/gz-sensors9.tar.gz"],
 )
 
 archive_override(

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "rules",
+    srcs = ["gz_sim_system_libraries.bzl"],
+    visibility = ["//:__subpackages__"],
+)

--- a/bazel/gz_sim_system_libraries.bzl
+++ b/bazel/gz_sim_system_libraries.bzl
@@ -1,0 +1,110 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+visibility("public")
+
+def _generate_static_plugin_src_impl(ctx):
+    ctx.actions.expand_template(
+        template = ctx.file.plugin_cc,
+        output = ctx.outputs.out,
+        substitutions = {
+            # Macro substitutions:
+            "GZ_ADD_PLUGIN": "GZ_ADD_STATIC_PLUGIN",
+            "GZ_ADD_PLUGIN_ALIAS": "GZ_ADD_STATIC_PLUGIN_ALIAS",
+            # Header substitutions:
+            "plugin/Register.hh": "plugin/RegisterStatic.hh",
+            "plugin/RegisterMore.hh": "plugin/RegisterStatic.hh",
+        },
+    )
+
+# This rule performs a substitution to link the plugin class to the static
+# plugin registry instead of the plugin hook registry for dynamic loading.
+_generate_static_plugin_src = rule(
+    attrs = {
+        "plugin_cc": attr.label(allow_single_file = True, mandatory = True),
+        "out": attr.output(mandatory = True),
+    },
+    implementation = _generate_static_plugin_src_impl,
+)
+
+def gz_sim_system_libraries(static_lib_name, so_lib_name, srcs, includes = [], **kwargs):
+    """
+    Adds two library targets for the System plugin for static and dynamic loading respectively
+
+    Args:
+        static_lib_name: Name of the `cc_library` target with static linking.
+          Note that the plugin registration macro is substituted with
+          `GZ_ADD_STATIC_PLUGIN` in the source file for this target to register
+          the plugin with the static registry.
+          The `alwayslink` attribute of this target is set to True, so that
+          downstream linking preserves symbols which are not referenced
+          explicitly.
+        so_lib_name: Name of the `cc_binary` shared library target which can be
+          loaded at runtime. Set this to empty string if the shared library
+          target should not be added.
+        srcs: List of source files including private headers. For example, this
+          can be a globbed list of *.cc and *.hh files.
+          ```
+          srcs = glob(
+              [
+                  "src/systems/wheel_slip/**/*.cc",
+                  "src/systems/wheel_slip/**/*.hh",
+              ],
+          ),
+          ```
+          Any test files should be excluded and can be added to separate
+           `cc_test` targets.
+        includes: List of include dirs to be added to the `cc_library` and
+          `cc_binary` targets
+        **kwargs: Forwarded to both the `cc_library` and `cc_binary` targets.
+    """
+    if not static_lib_name:
+        fail("The static_lib_name field must be non-empty.")
+
+    supported_cc_extensions = ["cc", "cpp"]
+    cc_files = [f for f in srcs if f.split(".")[-1] in supported_cc_extensions]
+    non_cc_files = [f for f in srcs if f not in cc_files]
+
+    if not cc_files:
+        fail("Did not find any .cc files in the provided srcs for library with static_lib_name '", static_lib_name, "'.")
+
+    plugin_dir = "/".join(cc_files[0].split("/")[:-1])
+
+    # Run the _generate_static_plugin_src rule to generate modified source files
+    # suitable for registering the System plugin(s) with the static plugin
+    # registry. Ideally the rule only needs to be run on source files which
+    # register System plugins with the GZ_ADD_PLUGIN macro. However, in the
+    # bazel analysis phase, there is no way to determine whether a particular
+    # .cc file registers a System plugin or not. To circumvent this limitation,
+    # the _generate_static_plugin_src rule is simply run for all source files.
+    # This has a very small overhead of writing out the original file as is into
+    # a new source file for the input source files which do not register a
+    # System plugin.
+    static_cc_files = []
+    for cc_file in cc_files:
+        name_without_extension = ".".join(cc_file.split(".")[:-1])
+        static_plugin_src_gen_without_extension = name_without_extension + "_static_plugin"
+        static_plugin_src_gen = static_plugin_src_gen_without_extension + ".cc"
+        _generate_static_plugin_src(
+            name = static_plugin_src_gen_without_extension,
+            plugin_cc = cc_file,
+            out = static_plugin_src_gen,
+        )
+        static_cc_files.append(static_plugin_src_gen)
+
+    cc_library(
+        name = static_lib_name,
+        alwayslink = True,
+        includes = includes + [plugin_dir],
+        srcs = non_cc_files + static_cc_files,
+        **kwargs
+    )
+
+    if so_lib_name:
+        cc_binary(
+            name = so_lib_name,
+            linkshared = True,
+            includes = includes,
+            srcs = srcs,
+            **kwargs
+        )

--- a/src/SdfGenerator_TEST.cc
+++ b/src/SdfGenerator_TEST.cc
@@ -709,10 +709,11 @@ TEST_F(ElementUpdateFixture, WorldWithModelsIncludedWithInvalidUris)
 /////////////////////////////////////////////////
 TEST_F(ElementUpdateFixture, WorldWithModelsIncludedWithNonFuelUris)
 {
+  const auto sdfSourceFilePath = common::testing::TestFile("worlds", "models",
+      "sphere");
   const std::vector<std::string> includeUris = {
       "https://fuel.gazebosim.org/1.0/openroboticstest/models/backpack",
-      std::string("file://") + PROJECT_SOURCE_PATH +
-          "/test/worlds/models/sphere"};
+      std::string("file://") + sdfSourceFilePath};
 
   std::string worldSdf = R"(
 <?xml version="1.0" ?>
@@ -900,8 +901,9 @@ TEST_F(ElementUpdateFixture, WorldWithModelsExpandedWithOneIncluded)
 TEST_F(ElementUpdateFixture,
     GZ_UTILS_TEST_DISABLED_ON_WIN32(WorldWithModelsUsingRelativeResourceURIs))
 {
-  const auto includeUri = std::string("file://") + PROJECT_SOURCE_PATH +
-                          "/test/worlds/models/relative_resource_uri";
+  const auto sdfSourceFilePath = common::testing::TestFile("worlds", "models",
+      "relative_resource_uri");
+  const auto includeUri = std::string("file://") + sdfSourceFilePath;
 
   std::string worldSdf = R"(
 <?xml version="1.0" ?>

--- a/src/systems/dvl/DopplerVelocityLogSystem.cc
+++ b/src/systems/dvl/DopplerVelocityLogSystem.cc
@@ -24,7 +24,6 @@
 #include <vector>
 
 #include <gz/common/Profiler.hh>
-#include <gz/common/VideoEncoder.hh>
 
 #include <gz/sim/components/AngularVelocity.hh>
 #include <gz/sim/components/CustomSensor.hh>
@@ -42,7 +41,6 @@
 #include <gz/sim/rendering/Events.hh>
 
 #include <gz/plugin/Register.hh>
-#include <gz/transport/Node.hh>
 
 #include <gz/rendering/Camera.hh>
 #include <gz/rendering/RenderEngine.hh>

--- a/src/systems/environmental_sensor_system/TransformTypes.hh
+++ b/src/systems/environmental_sensor_system/TransformTypes.hh
@@ -45,7 +45,7 @@ enum TransformType {
 /// \brief Given a string return the type of transform
 /// \param[in] _str - input string
 /// \return std::nullopt if string invalid, else corresponding transform
-std::optional<TransformType> getTransformType(const std::string &_str)
+inline std::optional<TransformType> getTransformType(const std::string &_str)
 {
   if(_str == "ADD_VELOCITY_LOCAL")
     return TransformType::ADD_VELOCITY_LOCAL;
@@ -64,7 +64,7 @@ std::optional<TransformType> getTransformType(const std::string &_str)
 /// \param[in] _velocity - Velocity of current frame.
 /// \param[in] _reading - vector to be transformed.
 /// \return transformed vector.
-math::Vector3d transformFrame(
+inline math::Vector3d transformFrame(
   const TransformType _type, const math::Pose3d& _pose,
   const math::Vector3d& _velocity, const math::Vector3d& _reading)
 {

--- a/src/systems/joint_position_controller/JointPositionController.cc
+++ b/src/systems/joint_position_controller/JointPositionController.cc
@@ -35,7 +35,7 @@
 #include <gz/math/PID.hh>
 #include <gz/plugin/Register.hh>
 #include <gz/transport/Node.hh>
-#include <gz/transport/parameters.hh>
+#include <gz/transport/parameters/Registry.hh>
 
 #include "gz/sim/components/Actuators.hh"
 #include "gz/sim/components/Joint.hh"

--- a/src/systems/log/LogRecord.cc
+++ b/src/systems/log/LogRecord.cc
@@ -298,7 +298,7 @@ bool LogRecordPrivate::Start(const std::string &_logPath,
   if (!validSdfTopic.empty())
   {
     this->sdfPub = this->node.Advertise(validSdfTopic,
-        this->sdfMsg.GetTypeName());
+        std::string(this->sdfMsg.GetTypeName()));
   }
   else
   {

--- a/src/systems/optical_tactile_plugin/Visualization.hh
+++ b/src/systems/optical_tactile_plugin/Visualization.hh
@@ -24,6 +24,7 @@
 #include <gz/sim/config.hh>
 #include <gz/sim/System.hh>
 #include <gz/msgs/marker.pb.h>
+#include <gz/transport/Node.hh>
 
 #include "gz/sim/components/ContactSensorData.hh"
 

--- a/src/systems/triggered_publisher/TriggeredPublisher.cc
+++ b/src/systems/triggered_publisher/TriggeredPublisher.cc
@@ -574,8 +574,8 @@ void TriggeredPublisher::Configure(const Entity &,
       info.msgData = msgs::Factory::New(info.msgType, msgStr);
       if (nullptr != info.msgData)
       {
-        info.pub =
-            this->node.Advertise(info.topic, info.msgData->GetTypeName());
+        info.pub = this->node.Advertise(info.topic,
+            std::string(info.msgData->GetTypeName()));
         if (info.pub.Valid())
         {
           this->outputInfo.push_back(std::move(info));

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@rules_gazebo//gazebo:headers.bzl", "gz_configure_header")
 
 package(
@@ -33,6 +35,20 @@ cc_library(
     ],
 )
 
+cc_binary(
+    name = "MockSystem.so",
+    srcs = [
+        "plugins/MockSystem.cc",
+        "plugins/MockSystem.hh",
+    ],
+    linkshared = True,
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//:gz-sim",
+        "@gz-plugin//:register",
+    ],
+)
+
 cc_library(
     name = "Helpers",
     testonly = 1,
@@ -48,6 +64,7 @@ cc_library(
         "//:gz-sim",
         "@googletest//:gtest",
         "@gz-common",
+        "@gz-common//testing",
         "@gz-math",
         "@gz-transport",
     ],
@@ -69,9 +86,72 @@ cc_library(
     alwayslink = 1,
 )
 
+cc_binary(
+    name = "TestModelSystem.so",
+    srcs = [
+        "plugins/TestModelSystem.cc",
+        "plugins/TestModelSystem.hh",
+    ],
+    linkshared = True,
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//:gz-sim",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+cc_binary(
+    name = "TestSensorSystem.so",
+    srcs = [
+        "plugins/TestSensorSystem.cc",
+        "plugins/TestSensorSystem.hh",
+    ],
+    linkshared = True,
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//:gz-sim",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+cc_binary(
+    name = "TestVisualSystem.so",
+    srcs = [
+        "plugins/TestVisualSystem.cc",
+        "plugins/TestVisualSystem.hh",
+    ],
+    linkshared = True,
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//:gz-sim",
+        "@gz-msgs//:gzmsgs_cc_proto",
+        "@gz-plugin//:register",
+        "@gz-transport",
+    ],
+)
+
+cc_binary(
+    name = "TestWorldSystem.so",
+    srcs = [
+        "plugins/TestWorldSystem.cc",
+        "plugins/TestWorldSystem.hh",
+    ],
+    linkshared = True,
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//:gz-sim",
+        "@gz-plugin//:register",
+    ],
+)
+
 cc_test(
     name = "INTEGRATION_load_system_static_registry",
     srcs = ["integration/load_system_static_registry.cc"],
+    env = {"GZ_BAZEL": "1"},
     deps = [
         ":Helpers",
         ":MockSystem",
@@ -86,5 +166,11 @@ cc_test(
 filegroup(
     name = "worlds",
     srcs = glob(["worlds/**"]),
+    visibility = ["//:__subpackages__"],
+)
+
+filegroup(
+    name = "media",
+    srcs = glob(["media/**"]),
     visibility = ["//:__subpackages__"],
 )

--- a/test/helpers/EnvTestFixture.hh
+++ b/test/helpers/EnvTestFixture.hh
@@ -22,6 +22,7 @@
 #include <gz/common/Console.hh>
 #include <gz/common/Filesystem.hh>
 #include <gz/common/Util.hh>
+#include <gz/common/testing/TestPaths.hh>
 #include "test_config.hh"
 
 using namespace gz;
@@ -52,8 +53,8 @@ class InternalFixture : public TestType
   }
 
   /// \brief Directory to act as $HOME for tests
-  public: const std::string kFakeHome = common::joinPaths(PROJECT_BINARY_PATH,
-      "test", "fake_home");
+  public: const std::string kFakeHome = common::testing::TempPath("test",
+      "fake_home");
 
   /// \brief Store user's real $HOME to set it back at the end of tests.
   public: std::string realHome;


### PR DESCRIPTION
# 🎉 New feature

## Summary
Adds bazel targets for Systems under `src/systems` so that downstream bazel users can use System plugins in their binaries/ tests.

The following changes are required to support this feature:
1. Added headers under `include/gz/sim/physics` to the `gz-sim` library target since they are required for the `Physics` System.
2. Added a bazel macro `gz_sim_system_libraries` to generate 
    - a `cc_binary` shared library target for a given System plugin that can be loaded dynamically, and
    - a `cc_library` statically linked library target for the System plugin that can be loaded from the static plugin registry.
3. The macro requires new `bazel_dep`s for `rules_cc` and `bazel_skylib` in MODULE.bazel. I also updated BUILD.bazel and test/BUILD.bazel to use `cc_*` rules from `rules_cc` instead of native rules to be consistent (this is required anyway for bazel 9).
4. Added `gz_sim_system_libraries` targets for all Systems except `camera_video_recorder`, `dvl`, `elevator` and `python_system_loader`. These either have missing dependencies or fail to build with bazel.
    - Few missing headers had to be included to build with bazel.
    - Some uses of `protoMsg->GetTypeName()` had to be updated since the bazel build uses protobuf v30, which changed the return type for `GetTypeName()` to be `std::string_view` (see [related gz-msgs PR](https://github.com/gazebosim/gz-msgs/pull/521) for more details).
    - The methods defined in `src/systems/environmental_sensor_system/TransformTypes.hh` had to marked `inline` to avoid linker ODR issues in bazel.
5. Enabled some more unit tests in bazel, see exclusions under the `test_sources` list in BUILD.bazel for details.
    - Updated `test/helpers/EnvTestFixture.hh` to use `common::testing::TempPath` to set up a temp home dir in tests. The  `common::testing::*` methods are compatible with both cmake and bazel (with the `GZ_BAZEL` env variable added to test targets). This requires updating the cmake build as well so that test targets depend on `gz-common${GZ_COMMON_VER}::testing`.
    - Also updated some sdf file paths in `src/SdfGenerator_TEST.cc` to be generated using `common::testing::TestFile()` instead of using the `PROJECT_SOURCE_PATH` variable which works well for cmake but not for bazel (returns relative path instead of absolute path, which some tests are sensitive to).
    - Some tests and Systems expect to find runtime data such as plugins or server.config files at locations indicated by env variables. Unfortunately, this doesn't work well in bazel since (i) predefined make variables only provide paths to the actual data artifact whereas the methods in `common::SystemPaths` expect the directory containing the artifact to be set in the env var, and (ii) the canonical way of navigating the runfiles system is using the `rules_cc//runfiles` library, but this cannot be used in code that can be cross compiled with cmake. To circumvent this issue, I added the required data artifacts to well-known paths under test runfiles with a few copy `genrule`s. This allows us to set the path env vars to well-known paths for tests.

## Test it
```
$ bazel test ...
$ bazel build --action_env=CC=/usr/bin/clang  ...
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
