### PR TITLE
LiftDrag: allow reversible airfoils

### DIFF
--- a/src/systems/lift_drag/LiftDrag.cc
+++ b/src/systems/lift_drag/LiftDrag.cc
@@ -104,6 +104,11 @@ class gz::sim::systems::LiftDragPrivate
   /// angle of attack.
   public: bool radialSymmetry = false;
 
+  /// \brief if the shape is aerodynamically symmetric when the inflow
+  /// determined by the forward direction is reversed. Defaults to false.
+  /// The main application is to reversible propellers.
+  public: bool reversible = false;
+
   /// \brief effective planeform surface area
   public: double area = 1.0;
 
@@ -164,6 +169,7 @@ void LiftDragPrivate::Load(const EntityComponentManager &_ecm,
   this->rho = _sdf->Get<double>("air_density", this->rho).first;
   this->radialSymmetry = _sdf->Get<bool>("radial_symmetry",
       this->radialSymmetry).first;
+  this->reversible = _sdf->Get<bool>("reversible", this->reversible).first;
   this->area = _sdf->Get<double>("area", this->area).first;
   this->alpha0 = _sdf->Get<double>("a0", this->alpha0).first;
   this->cp = _sdf->Get<math::Vector3d>("cp", this->cp).first;
@@ -309,9 +315,10 @@ void LiftDragPrivate::Update(EntityComponentManager &_ecm)
   // rotate forward and upward vectors into world frame
   const auto forwardI = pose.Rot().RotateVector(this->forward);
 
-  if (forwardI.Dot(vel) <= 0.0){
-    // Only calculate lift or drag if the wind relative velocity
-    // is in the same direction
+  if (!this->reversible && forwardI.Dot(vel) <= 0.0)
+  {
+    // For non-reversible airfoils, only calculate lift or drag if the
+    // wind relative velocity is in the same direction
     return;
   }
 

--- a/src/systems/lift_drag/LiftDrag.hh
+++ b/src/systems/lift_drag/LiftDrag.hh
@@ -44,6 +44,8 @@ namespace systems
   /// - `<air_density>`: Density of the fluid this model is suspended in.
   /// - `<radial_symmetry>`: True if the shape is aerodynamically radially
   ///    symmetric about the forward direction.
+  /// - `<reversible>`: True if the airfoil is symmetric when the inflow is
+  ///   reversed (for example reversible propellers)
   /// - `<area>`: Surface area of the link.
   /// - `<a0>`: The initial "alpha" or initial angle of attack. a0 is also
   ///   the y-intercept of the alpha-lift coefficient curve.

--- a/src/systems/lift_drag/LiftDrag.hh
+++ b/src/systems/lift_drag/LiftDrag.hh
@@ -42,6 +42,8 @@ namespace systems
   ///   nested models. \sa entitiesFromScopedName to learn more
   ///   about scoped names.
   /// - `<air_density>`: Density of the fluid this model is suspended in.
+  /// - `<radial_symmetry>`: True if the shape is aerodynamically radially
+  ///    symmetric about the forward direction.
   /// - `<area>`: Surface area of the link.
   /// - `<a0>`: The initial "alpha" or initial angle of attack. a0 is also
   ///   the y-intercept of the alpha-lift coefficient curve.
@@ -49,6 +51,8 @@ namespace systems
   ///   stall. Slope of the first portion of the alpha-lift
   ///   coefficient curve.
   /// - `<cda>`: The ratio of the coefficient of drag and alpha slope before
+  ///   stall.
+  /// - `<cma>`: The ratio of the coefficient of moment and alpha slope before
   ///   stall.
   /// - `<cp>`: Center of pressure. The forces due to lift and drag will be
   ///   applied here.
@@ -62,10 +66,14 @@ namespace systems
   ///   coefficient curve.
   /// - `<cda_stall>`: The ratio of coefficient of drag and alpha slope after
   ///   stall.
+  /// - `<cda_stall>`: The ratio of coefficient of moment and alpha slope after
+  ///   stall.
   /// - `<control_joint_name>`: Name of joint that actuates a control surface
   ///   for this lifting body (Optional)
   /// - `<cm_delta>`: How much Cm changes with a change in control
   ///   surface deflection angle
+  /// - `<control_joint_rad_to_cl>`: How much to change CL per radian of
+  ///   control joint surface angle.
   class LiftDrag
       : public System,
         public ISystemConfigure,


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2476

## Summary

Add a `<reversible>` parameter as suggested here: https://github.com/gazebosim/gz-sim/issues/2476#issuecomment-2229895066.

Setting `<reversible>1</reversible>` recovers the behaviour prior to https://github.com/gazebosim/gz-sim/pull/2189.

Document the remaining parameters in the header file.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.