### PR TITLE
JointController: allow braking to be disabled in force mode

### DIFF
--- a/src/systems/joint_controller/JointController.cc
+++ b/src/systems/joint_controller/JointController.cc
@@ -77,6 +77,9 @@ class gz::sim::systems::JointControllerPrivate
   /// velocity.
   public: bool useForceCommands{false};
 
+  /// \brief True if braking is disabled.
+  public: bool disableBraking{false};
+
   /// \brief Velocity PID controller.
   public: math::PID velPid;
 };
@@ -146,6 +149,11 @@ void JointController::Configure(const Entity &_entity,
 
     this->dataPtr->velPid.Init(p, i, d, iMax, iMin, cmdMax, cmdMin, cmdOffset);
 
+    if (_sdf->HasElement("disable_braking"))
+    {
+      this->dataPtr->disableBraking = _sdf->Get<bool>("disable_braking");
+    }
+
     gzdbg << "[JointController] Force mode with parameters:" << std::endl;
     gzdbg << "p_gain: ["     << p         << "]"             << std::endl;
     gzdbg << "i_gain: ["     << i         << "]"             << std::endl;
@@ -155,6 +163,8 @@ void JointController::Configure(const Entity &_entity,
     gzdbg << "cmd_max: ["    << cmdMax    << "]"             << std::endl;
     gzdbg << "cmd_min: ["    << cmdMin    << "]"             << std::endl;
     gzdbg << "cmd_offset: [" << cmdOffset << "]"             << std::endl;
+    gzdbg << "disable_braking: [" << this->dataPtr->disableBraking
+          << "]" << std::endl;
   }
   else
   {
@@ -316,9 +326,19 @@ void JointController::PreUpdate(const UpdateInfo &_info,
 
   double error = jointVelComp->Data().at(0) - targetVel;
 
+  // If braking is disabled only apply force if the actual velocity is below
+  // the target - i.e. allow joint to freewheel.
+  bool applyForce = true;
+  if (this->dataPtr->disableBraking)
+  {
+      double sgn = math::signum(targetVel);
+      applyForce = sgn && sgn * error <= 0.0;
+  }
+
   // Force mode.
   if ((this->dataPtr->useForceCommands) &&
-      (!jointVelComp->Data().empty()))
+      (!jointVelComp->Data().empty()) &&
+      (applyForce))
   {
     for (Entity joint : this->dataPtr->jointEntities)
     {

--- a/src/systems/joint_controller/JointController.hh
+++ b/src/systems/joint_controller/JointController.hh
@@ -92,6 +92,11 @@ namespace systems
   ///
   /// - `<cmd_offset>` Command offset (feed-forward) of the PID.
   /// The default value is 0.
+  ///
+  /// - `<disable_braking>` Disable braking. Allows the joint to freewheel
+  /// if the commanded velocity is below the actual velocity.
+  /// The default value is 0.
+  ///
   class JointController
       : public System,
         public ISystemConfigure,


### PR DESCRIPTION
# 🎉 New feature

## Summary

Allow braking to be disabled when operating the joint controller in force mode. What this means is that a force will only be applied to bring up a joint to it's target velocity (accounting for sign). If a joint is rotating at a velocity higher than the commanded velocity the joint will freewheel and spin down subject to damping and friction only.

The optional parameter <disable_braking> is set to true to enable the feature. The default is to use force braking (current behaviour).

## Test it

Edit the `joint_controller_demo_2` model in the example `joint_controller.sdf` adding damping to the joint and the `<disable_braking>` element:

```xml
      <joint name="j1" type="revolute">
        <pose>0 0 -0.5 0 0 0</pose>
        <parent>base_link</parent>
        <child>rotor2</child>
        <axis>
          <xyz>0 0 1</xyz>
          <dynamics>
            <damping>0.0001</damping>
          </dynamics>
        </axis>
      </joint>

      <!-- Force mode -->
      <plugin
        filename="gz-sim-joint-controller-system"
        name="gz::sim::systems::JointController">
        <joint_name>j1</joint_name>
        <use_force_commands>true</use_force_commands>
        <disable_braking>true</disable_braking>
        <p_gain>0.2</p_gain>
        <i_gain>0.01</i_gain>
      </plugin>
```

Spin up the joint

```bash
gz topic -t "/model/joint_controller_demo_2/joint/j1/cmd_vel" -m gz.msgs.Double -p "data: 10.0"
```

then lower the velocity set point to >= 0.0:

```bash
gz topic -t "/model/joint_controller_demo_2/joint/j1/cmd_vel" -m gz.msgs.Double -p "data: 0.0" 
```

The joint will not stop abruptly, but freewheel with damping.




## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.