### PR TITLE
Fix a link in the underwater vehicle tutorial

### DIFF
--- a/tutorials/underwater_vehicles.md
+++ b/tutorials/underwater_vehicles.md
@@ -231,7 +231,7 @@ control. Fortunately, Gazebo already has a version of the LiftDrag plugin. In
 this tutorial, we will simply add two liftdrag plugins to the rudder and
 elevator of MBARI's LRAUV. For more info about the liftdrag plugin including
 what the parameters mean, you may look
-at [this gazebo classic tutorial](http://gazebosim.org/tutorials?tut=aerodynamics&cat=physics).
+at [this gazebo classic tutorial](http://classic.gazebosim.org/tutorials?tut=aerodynamics&cat=physics).
 Essentially when we tilt the fins, we should experience a lift force which
 will cause the vehicle to experience a torque and the vehicle should start
 turning when we move.


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

Link was broken. This fixes it to correctly point to the gazebo-classic tutorial


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
