### PR TITLE
Prevent crash in OpticalTactilePlugin by checking contact data validity after world reset

### DIFF
--- a/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
+++ b/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
@@ -386,6 +386,9 @@ void OpticalTactilePlugin::PreUpdate(const UpdateInfo &_info,
     // We assume there's only one object being touched
     auto csd = _ecm.Component<components::ContactSensorData>(
       this->dataPtr->sensorCollisionEntity);
+    // Check the validity of contact data to avoid crashes
+    if(!csd || csd->Data().contact_size() == 0)
+      return;
     for (const auto &contact : csd->Data().contact())
     {
       this->dataPtr->objectCollisionEntity =


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2600 

## Summary
The plugin does not check the component pointer and data validity, and the invalid protobuf repeated field is accessed after emulation reset.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

