### PR TITLE
Fix crash caused by moving ground_plane

### DIFF
--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -3143,10 +3143,10 @@ std::map<Entity, physics::FrameData3d> PhysicsPrivate::ChangedLinks(
 }
 
 //////////////////////////////////////////////////
-bool PhysicsPrivate::ModelContainsPlaneCollision(const Entity &modelEntity,
+bool PhysicsPrivate::ModelContainsPlaneCollision(const Entity &_modelEntity,
     EntityComponentManager &_ecm) const
 {
-  sim::Model model(modelEntity);
+  sim::Model model(_modelEntity);
   for (const auto &linkEntity : model.Links(_ecm))
   {
     sim::Link link(linkEntity);

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -2448,7 +2448,15 @@ void PhysicsPrivate::UpdatePhysics(EntityComponentManager &_ecm)
                  << std::endl;
           return true;
         }
-
+        // Check if the model is ground_plane
+        // If so, we refuse to set the pose
+        auto nameComp = _ecm.Component<components::Name>(_entity);
+        if ((nameComp && nameComp->Data() == "ground_plane"))
+        {
+          gzerr << "Refusing to set pose for ground_plane entity: "
+                << (nameComp ? nameComp->Data() : "") << std::endl;
+          return true;
+        }
         // TODO(addisu) Store the free group instead of searching for it at
         // every iteration
         auto freeGroup = modelPtrPhys->FindFreeGroup();

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -285,7 +285,7 @@ class gz::sim::systems::PhysicsPrivate
   /// \param[in] modelEntity The entity of the model to check.
   /// \param[in] _ecm The entity component manager.
   /// \return True if any collision geometry is a plane.
-  public: bool ModelContainsPlaneCollision(const Entity &modelEntity,
+  public: bool ModelContainsPlaneCollision(const Entity &_modelEntity,
               EntityComponentManager &_ecm) const;
 
   /// \brief Helper function to update the pose of a model.


### PR DESCRIPTION

# 🦟 Bug fix

Fixes #2605 

## Summary
This crash occurs due to an attempt to move the groud_plane, and according to @azeey commented on this [issue](https://github.com/gazebosim/gz-sim/issues/2605), we need to detect if the moving object is ground_plane, and if so, prohibit it.



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
