### PR TITLE
Prevent crash in ApplyForceTorque plugin

### DIFF
--- a/src/gui/plugins/apply_force_torque/ApplyForceTorque.cc
+++ b/src/gui/plugins/apply_force_torque/ApplyForceTorque.cc
@@ -212,11 +212,23 @@ ApplyForceTorque::ApplyForceTorque()
 /////////////////////////////////////////////////
 ApplyForceTorque::~ApplyForceTorque()
 {
+  // Remove event filter to prevent events from being sent to a destroyed object
+  auto mainWindow = gz::gui::App()->findChild<gz::gui::MainWindow *>();
+  if (mainWindow)
+    mainWindow->removeEventFilter(this);
+
   if (!this->dataPtr->scene)
     return;
+  // Destroy rendering nodes to release resources
   this->dataPtr->scene->DestroyNode(this->dataPtr->forceVisual, true);
   this->dataPtr->scene->DestroyNode(this->dataPtr->torqueVisual, true);
   this->dataPtr->scene->DestroyNode(this->dataPtr->gizmoVisual, true);
+
+  // Set pointers to nullptr to avoid dangling references
+  this->dataPtr->forceVisual = nullptr;
+  this->dataPtr->torqueVisual = nullptr;
+  this->dataPtr->gizmoVisual = nullptr;
+  this->dataPtr->scene = nullptr;
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #2983 

## Summary
This PR fixes a potential crash when frequently opening and closing the "Apply force and torque" panel in Gazebo.
The root cause was that Qt events could be sent to a destroyed plugin object, and rendering resources might be accessed after being released.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
