### PR TITLE
Fix crash when calling setPose service on static and nolink entity

### DIFF
--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -2453,6 +2453,13 @@ void PhysicsPrivate::UpdatePhysics(EntityComponentManager &_ecm)
                 << std::endl;
           return true;
         }
+        sim::Model model(_entity);
+        if (model.Links(_ecm).empty())
+        {
+            gzerr << "SetPose is not supported for models without any link. "
+                  << "Entity [" << _entity << "]. Request ignored." << std::endl;
+            return true;
+        }
         auto modelPtrPhys = this->entityModelMap.Get(_entity);
         if (nullptr == modelPtrPhys)
           return true;

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -2456,8 +2456,9 @@ void PhysicsPrivate::UpdatePhysics(EntityComponentManager &_ecm)
         sim::Model model(_entity);
         if (model.Links(_ecm).empty())
         {
-            gzerr << "SetPose is not supported for models without any link. "
-                  << "Entity [" << _entity << "]. Request ignored." << std::endl;
+            gzerr << "SetPose is not supported for models without any link."
+                  << "Entity [" << _entity << "]."
+                  << "Request ignored" << std::endl;
             return true;
         }
         auto modelPtrPhys = this->entityModelMap.Get(_entity);


### PR DESCRIPTION


# 🦟 Bug fix

Fixes #2981 

## Summary
Gazebo allows loading static models without any links. However, if a `/world/<world>/set_pose` service call is made targeting such a model, the physics system crashes ,  because the underlying physics code assumes every model has at least one link. 
After Fix : Before executing set_pose, the code now checks whether the target model contains at least one link.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
