### PR TITLE
Do not use gz module numbers in the RL example

### DIFF
--- a/examples/scripts/reinforcement_learning/simple_cart_pole/cart_pole_env.py
+++ b/examples/scripts/reinforcement_learning/simple_cart_pole/cart_pole_env.py
@@ -3,9 +3,9 @@ import os
 import gymnasium as gym
 import numpy as np
 
-from gz.common6 import set_verbosity
+from gz.common import set_verbosity
 from gz.sim import TestFixture, World, world_entity, Model, Link, get_install_prefix
-from gz.math8 import Vector3d
+from gz.math import Vector3d
 
 from stable_baselines3 import PPO
 import time


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The RL script still used the previous notation of python modules using numbers. Remove them.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.