### PR TITLE
Add support for loading physics engine plugins from static plugin registry

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -674,6 +674,7 @@ gz_sim_system_libraries(
         "@gz-sensors",
         "@gz-sensors//:dvl",
         "@gz-transport",
+        "@gz-utils//:ImplPtr",
     ],
 )
 

--- a/include/gz/sim/Util.hh
+++ b/include/gz/sim/Util.hh
@@ -342,6 +342,15 @@ namespace gz
     GZ_SIM_VISIBLE std::optional<math::AxisAlignedBox> meshAxisAlignedBox(
       const sdf::Mesh &_sdfMesh);
 
+    /// \brief Get the static plugin prefix
+    /// \return The static plugin prefix
+    GZ_SIM_VISIBLE const std::string &staticPluginPrefixStr();
+
+    /// \brief Check if input filename of a library is a static plugin or not.
+    /// \param _filename_ Library filename to check
+    /// \return True if input filename has a static plugin string format.
+    GZ_SIM_VISIBLE bool isStaticPlugin(const std::string &_filename);
+
     /// \brief Environment variable holding resource paths.
     const std::string kResourcePathEnv{"GZ_SIM_RESOURCE_PATH"};
 
@@ -355,6 +364,9 @@ namespace gz
     /// \brief Environment variable holding paths to custom rendering engine
     /// plugins.
     const std::string kRenderPluginPathEnv{"GZ_SIM_RENDER_ENGINE_PATH"};
+
+    /// \brief Static plugin filename prefix string.
+    const std::string kStaticPluginFilenamePrefix{"static://"};
     }
   }
 }

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -1022,6 +1022,17 @@ math::AxisAlignedBox transformAxisAlignedBox(
   );
 }
 
+const std::string &staticPluginPrefixStr()
+{
+  return kStaticPluginFilenamePrefix;
+}
+
+bool isStaticPlugin(const std::string &_filename)
+{
+  return _filename.substr(0, staticPluginPrefixStr().size()) ==
+        staticPluginPrefixStr();
+}
+
 }
 }
 }

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -925,9 +925,6 @@ void Physics::Configure(const Entity &_entity,
         continue;
       }
 
-      //this->dataPtr->engine =
-      //    this->dataPtr->RequestPhysicsEngineFromPlugin(plugin);
-
       this->dataPtr->engine = physics::RequestEngine<
         physics::FeaturePolicy3d,
         PhysicsPrivate::MinimumFeatureList>::From(plugin);

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -358,14 +358,6 @@ class gz::sim::systems::PhysicsPrivate
   /// \param[in] _ecm The entity component manager.
   public: void UpdateModelsBoundingBoxes(EntityComponentManager &_ecm);
 
-  /// \brief Get physics engine from plugin and verify it has all
-  /// requested features.
-  /// \param[in] _plugin Physics engine plugin to check
-  /// \return The physics engine pointer or null if the plugin
-  /// does not contain a physics engine that has the requested features.
-  // public: EngineTypePtr RequestPhysicsEngineFromPlugin(
-  //     const plugin::PluginPtr &_plugin);
-
   /// \brief Cache the top-level model for each entity.
   /// The key is an entity and the value is its top level model.
   public: std::unordered_map<Entity, Entity> topLevelModelMap;
@@ -867,7 +859,6 @@ void Physics::Configure(const Entity &_entity,
     const std::string pluginToInstantiate =
         pluginLib.substr(prefixLen);
     auto plugin = pluginLoader.Instantiate(pluginToInstantiate);
-    //this->dataPtr->engine = this->RequestPhysicsEngineFromPlugin(plugin);
 
     this->dataPtr->engine = physics::RequestEngine<
       physics::FeaturePolicy3d,
@@ -879,7 +870,6 @@ void Physics::Configure(const Entity &_entity,
       gzerr << "Failed to load physics engine plugin: "
             << "(Reason: static plugin registry does not contain the requested "
                "plugin)\n"
-            // << "- Requested plugin name: [" << _sdfPlugin.Name() << "]\n"
             << "- Requested plugin name: [" << pluginLib << "]\n";
       return;
     }
@@ -906,7 +896,6 @@ void Physics::Configure(const Entity &_entity,
     }
 
     // Load engine plugin
-    // plugin::Loader pluginLoader;
     auto plugins = pluginLoader.LoadLib(pathToLib);
     if (plugins.empty())
     {
@@ -4504,40 +4493,6 @@ void PhysicsPrivate::UpdateModelsBoundingBoxes(EntityComponentManager &_ecm)
       return true;
     });
 }
-
-/*
-//////////////////////////////////////////////////
-EnginePtrType PhysicsPrivate::RequestPhysicsEngineFromPlugin(
-    const plugin::PluginPtr &_plugin)
-{
-  EnginePtrType enginePtr = physics::RequestEngine<
-    physics::FeaturePolicy3d,
-    PhysicsPrivate::MinimumFeatureList>::From(_plugin);
-
-  if (nullptr != enginePtr)
-  {
-    gzdbg << "Loaded [" << className << "] from library ["
-           << pathToLib << "]" << std::endl;
-    return enginePtr;
-  }
-
-  auto missingFeatures = physics::RequestEngine<
-      physics::FeaturePolicy3d,
-      PhysicsPrivate::MinimumFeatureList>::MissingFeatureNames(plugin);
-
-  std::stringstream msg;
-  msg << "Plugin [" << className << "] misses required features:"
-      << std::endl;
-  for (auto feature : missingFeatures)
-  {
-    msg << "- " << feature << std::endl;
-  }
-  gzwarn << msg.str();
-  return nullptr;
-}
-*/
-
-
 
 GZ_ADD_PLUGIN(Physics,
                     System,

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -163,6 +163,22 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "INTEGRATION_load_physics_system_static_registry",
+    srcs = ["integration/load_physics_system_static_registry.cc"],
+    env = {"GZ_BAZEL": "1"},
+    deps = [
+        ":Helpers",
+        ":MockSystem",
+        "//:gz-sim-physics-system-static",
+        "//:gz-sim",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@gz-common",
+        "@gz-physics//dartsim:libgz-physics-dartsim-plugin-static",
+    ],
+)
+
 filegroup(
     name = "worlds",
     srcs = glob(["worlds/**"]),

--- a/test/integration/load_physics_system_static_registry.cc
+++ b/test/integration/load_physics_system_static_registry.cc
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <gz/common/Util.hh>
+
+#include "../helpers/EnvTestFixture.hh"
+#include "gz/sim/Server.hh"
+#include "gz/sim/Util.hh"
+#include "gz/sim/components/PhysicsEnginePlugin.hh"
+#include "plugins/MockSystem.hh"
+
+using namespace gz;
+using namespace sim;
+
+/// \brief Test loading physics system and physics plugin from static
+/// plugin registry
+class LoadPhysicsSystemStaticRegistryTest
+    : public InternalFixture<::testing::Test> {};
+
+TEST_F(LoadPhysicsSystemStaticRegistryTest, LoadDartsim)
+{
+  // Start server
+  ServerConfig serverConfig;
+  serverConfig.SetSdfString(R"(
+    <?xml version="1.0"?>
+    <sdf version="1.12">
+      <world name="default">
+        <plugin
+          filename="static://gz::sim::systems::Physics"
+          name="gz::sim::systems::Physics">
+          <engine>
+            <filename>static://gz::physics::dartsim::Plugin</filename>
+          </engine>
+        </plugin>
+      </world>
+    </sdf>)");
+
+  Server server(serverConfig);
+
+  // Verify that server was initialized correctly
+  auto iterationCount = server.IterationCount();
+  ASSERT_NE(iterationCount, std::nullopt);
+  ASSERT_EQ(*iterationCount, 0);
+
+  // Verify that the physics system is loading the static dartsim plugin.
+  auto mockSystem = std::make_shared<MockSystem>();
+  mockSystem->postUpdateCallback =
+      [](const sim::UpdateInfo &,
+         const sim::EntityComponentManager &_ecm)
+      {
+        auto plugin = _ecm.ComponentData<components::PhysicsEnginePlugin>(
+            worldEntity(_ecm));
+        ASSERT_TRUE(plugin.has_value());
+        EXPECT_EQ("static://gz::physics::dartsim::Plugin", plugin.value());
+      };
+  ASSERT_TRUE(server.AddSystem(mockSystem));
+  server.RunOnce();
+  EXPECT_EQ(1, mockSystem->postUpdateCallCount);
+}


### PR DESCRIPTION


# 🎉 New feature

Depends on https://github.com/gazebosim/gz-physics/pull/761

## Summary

https://github.com/gazebosim/gz-physics/pull/761 added support for registering physics engine plugins in the static plugin registry. This PR extends the physics system to load these physics engine plugins from the static plugin registry. 

To indicate that a physics engine plugin is from the static plugin registry, specify the filename with the prefix `static://`, e.g.

```xml
        <plugin
          filename="static://gz::sim::systems::Physics"
          name="gz::sim::systems::Physics">
          <engine>
            <filename>static://gz::physics::dartsim::Plugin</filename>
          </engine>
        </plugin>
```

This follows the same convention for loading static gz-sim systems introduced in https://github.com/gazebosim/gz-sim/pull/2950

## Test it

Note: to run the test below, you'll need https://github.com/gazebosim/gz-physics/pull/761. 

A `INTEGRATION_load_physics_system_static_registry` test is added in the bazel build. To run the test, update your `MODULE.bazel` to use a local copy of gz-physics with the changes in https://github.com/gazebosim/gz-physics/pull/761, e.g.

```diff
+local_path_override(
     module_name = "gz-physics",
-    strip_prefix = "gz-physics-gz-physics8",
-    urls = ["https://github.com/gazebosim/gz-physics/archive/refs/heads/gz-physics8.tar.gz"],
+    path = "<path_to_your_bzl_workspace>/gz-physics",
 )
 
```

then run the test:

```sh
bazel test -c opt //test:INTEGRATION_load_physics_system_static_registry --action_env=CC=/usr/bin/clang-19  --dynamic_mode=off --test_output=streamed --cache_test_results=no
```