### PR TITLE
Update our usage of workerpools

### DIFF
--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -198,16 +198,22 @@ bool ServerPrivate::Run(const uint64_t _iterations,
   }
   else
   {
+    if (!this->workerPool.has_value())
+    {
+      // Initialize the workerpool if we do have multiple simulation runners and
+      // it hasn't been initialized before
+      this->workerPool.emplace(2);
+    }
     for (std::unique_ptr<SimulationRunner> &runner : this->simRunners)
     {
-      this->workerPool.AddWork([&runner, &_iterations] ()
+      this->workerPool->AddWork([&runner, &_iterations] ()
         {
           runner->Run(_iterations);
         });
     }
 
     // Wait for the runner to complete.
-    result = this->workerPool.WaitForResults();
+    result = this->workerPool->WaitForResults();
   }
 
   // See comments ServerPrivate::Stop() for why we lock this mutex here.

--- a/src/ServerPrivate.hh
+++ b/src/ServerPrivate.hh
@@ -154,7 +154,10 @@ namespace gz
         const gz::msgs::ServerControl &_req, msgs::Boolean &_res);
 
       /// \brief A pool of worker threads.
-      public: common::WorkerPool workerPool{2};
+      /// \note We use optional here since most of the time, there will be a
+      /// single simulation runner and a workerpool is not needed. We will
+      /// initialize the workerpool as necessary later on.
+      public: std::optional<common::WorkerPool> workerPool;
 
       /// \brief All the simulation runners.
       public: std::vector<std::unique_ptr<SimulationRunner>> simRunners;

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -41,7 +41,6 @@
 #include <sdf/World.hh>
 
 #include <gz/common/Event.hh>
-#include <gz/common/WorkerPool.hh>
 #include <gz/math/Stopwatch.hh>
 #include <gz/transport/Node.hh>
 
@@ -432,9 +431,6 @@ namespace gz
 
       /// \brief Manager of distributing/receiving network work.
       private: std::unique_ptr<NetworkManager> networkMgr{nullptr};
-
-      /// \brief A pool of worker threads.
-      private: common::WorkerPool workerPool{2};
 
       /// \brief Wall time of the previous update.
       private: std::chrono::steady_clock::time_point prevUpdateRealTime;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
In `SimulationRunner`, we initialize a worker pool but we never actually use it so it's pure overhead. In `ServerPrivate` we only use the worker pool if there are multiple simulation runners, so we can optimize for the most common use case of one runner.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.