### PR TITLE
reset_sensors.cc: fix variable name in Stop

### DIFF
--- a/test/integration/reset_sensors.cc
+++ b/test/integration/reset_sensors.cc
@@ -93,7 +93,7 @@ struct MsgReceiver
   }
 
   void Stop() {
-    this->node.Unsubscribe(this->_topic);
+    this->node.Unsubscribe(this->topic);
   }
 
   void Callback(const T &_msg) {


### PR DESCRIPTION
# 🦟 Bug fix

Fixes a variable name error in a templated test function

## Summary

While building from source, I noticed a build error:

~~~
test/integration/reset_sensors.cc:96:34: error: no member named '_topic' in 'MsgReceiver<T>'; did you mean 'topic'?
   96 |     this->node.Unsubscribe(this->_topic);
      |                                  ^~~~~~
      |                                  topic
/Users/scpeters/ws/jetty/src/gz-sim/test/integration/reset_sensors.cc:81:15: note: 'topic' declared here
   81 |   std::string topic;
      |               ^
~~~

I think this method is ignored since it is not called directly in this test. We could also consider removing the unused function or changing the test to use it.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
