### PR TITLE
Expose APIs for clearing the ECMs internal state tracking addition and removal

### DIFF
--- a/include/gz/sim/EntityComponentManager.hh
+++ b/include/gz/sim/EntityComponentManager.hh
@@ -684,21 +684,19 @@ namespace gz
                   const std::string &_name) const;
 
       /// \brief Clear the list of newly added entities so that a call to
-      /// EachAdded after this will have no entities to iterate. This function
-      /// is protected to facilitate testing.
-      protected: void ClearNewlyCreatedEntities();
+      /// EachAdded after this will have no entities to iterate.
+      public: void ClearNewlyCreatedEntities();
 
       /// \brief Clear the list of removed components so that a call to
       /// RemoveComponent doesn't make the list grow indefinitely.
-      protected: void ClearRemovedComponents();
+      public: void ClearRemovedComponents();
 
       /// \brief Process all entity remove requests. This will remove
-      /// entities and their components. This function is protected to
-      /// facilitate testing.
-      protected: void ProcessRemoveEntityRequests();
+      /// entities and their components.
+      public: void ProcessRemoveEntityRequests();
 
       /// \brief Mark all components as not changed.
-      protected: void SetAllComponentsUnchanged();
+      public: void SetAllComponentsUnchanged();
 
       /// Compute the diff between this EntityComponentManager and _other at the
       /// entity level. This does not compute the diff between components of an


### PR DESCRIPTION
# 🎉 New feature


## Summary
This is necessary for use with the `SetState` API. This API is commonly used to create a local version of the servers ECM that is periodically synchronized. However, without exposing this function into our public API additions and removals of entities or components are not reflected in the local ECM.

Currently, we use `friend` relationships for the `GuiRunner` class to allow it to run these functions, but this is not feasible for external code that wants to use `SetState`.

https://github.com/gazebosim/gz-sim/blob/5ce62a8826b930078fae940288ac9677aae9ec7b/include/gz/sim/EntityComponentManager.hh#L833-L838

https://github.com/gazebosim/gz-sim/blob/5ce62a8826b930078fae940288ac9677aae9ec7b/src/gui/GuiRunner.cc#L316-L318

This is needed for https://github.com/gazebosim/ros_gz/pull/790 to be able to get the updated state of the world, for example, when requested for the list of entities in the world after an entity has been removed.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.