### PR TITLE
Assign new gz-sim maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,8 @@
 # More info:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-*                     @mjcarroll
+*                     @arjo129
 */rendering/*         @iche033
-examples/*            @mabelzhang
 src/systems/physics/* @azeey
 src/systems/sensors/* @iche033
 */gui/*               @jennuine
-tutorials/*           @mabelzhang

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gazebo Sim : A Robotic Simulator
 
-**Maintainer:** michael AT openrobotics DOT org
+**Maintainer:** arjoc AT intrinsic DOT ai
 
 [![GitHub open issues](https://img.shields.io/github/issues-raw/gazebosim/gz-sim.svg)](https://github.com/gazebosim/gz-sim/issues)
 [![GitHub open pull requests](https://img.shields.io/github/issues-pr-raw/gazebosim/gz-sim.svg)](https://github.com/gazebosim/gz-sim/pulls)


### PR DESCRIPTION
Per our discussion in the July 28th PMC meeting, @arjo129 will take over as maintainer of gz-sim.

I've also removed Mabel from the codeowners list since she's no longer active on this project.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.