### PR TITLE
Update Qt6 deps in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -31,16 +31,17 @@
   <depend>libxmu-dev</depend>
   <depend>protobuf-dev</depend>
   <depend>pybind11-dev</depend>
-  <depend>qml-module-qt-labs-folderlistmodel</depend>
-  <depend>qml-module-qt-labs-settings</depend>
-  <depend>qml-module-qtgraphicaleffects</depend>
-  <depend>qml-module-qtquick-controls2</depend>
-  <depend>qml-module-qtquick-controls</depend>
-  <depend>qml-module-qtquick-dialogs</depend>
-  <depend>qml-module-qtquick-layouts</depend>
-  <depend>qml-module-qtquick2</depend>
-  <depend>qtbase5-dev</depend>
-  <depend>qtdeclarative5-dev</depend>
+  <depend>qml6-module-qt-labs-folderlistmodel</depend>
+  <depend>qml6-module-qt-labs-settings</depend>
+  <depend>qml6-module-qt5compat-graphicaleffects</depend>
+  <depend>qml6-module-qtquick-controls</depend>
+  <depend>qml6-module-qtquick-dialogs</depend>
+  <depend>qml6-module-qtquick-layouts</depend>
+  <depend>qml6-module-qtquick</depend>
+  <depend>qt6-5compat-dev</depend>
+  <depend>qt6-base-dev</depend>
+  <depend>qt6-base-private-dev</depend>
+  <depend>qt6-declarative-dev</depend>
   <depend>sdformat</depend>
   <depend>tinyxml2</depend>
   <depend>uuid</depend>


### PR DESCRIPTION

# 🦟 Bug fix


## Summary

Fixes https://github.com/gazebosim/gz-sim/issues/2993

Depends on:

* https://github.com/ros/rosdistro/pull/47214
* https://github.com/ros/rosdistro/pull/47215

Updated to use Qt6 deps.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

