### PR TITLE
Add missing virtual destructors

### DIFF
--- a/include/gz/sim/System.hh
+++ b/include/gz/sim/System.hh
@@ -135,6 +135,8 @@ namespace gz
     /// and components are loaded from the corresponding SDF world, and before
     /// simulation begins execution.
     class ISystemConfigure {
+      public: virtual ~ISystemConfigure() = default;
+
       /// \brief Configure the system
       /// \param[in] _entity The entity this plugin is attached to.
       /// \param[in] _sdf The SDF Element associated with this system plugin.
@@ -157,6 +159,8 @@ namespace gz
     /// override System::kDefaultPriority. It can still be overridden by the
     /// XML priority element.
     class ISystemConfigurePriority {
+      public: virtual ~ISystemConfigurePriority() = default;
+
       /// \brief Configure the default priority of the system, which can still
       /// be overridden by the XML priority element.
       /// \return The default priority for the system.
@@ -169,6 +173,8 @@ namespace gz
     /// ISystemConfigureParameters::ConfigureParameters is called after
     /// ISystemConfigure::Configure.
     class ISystemConfigureParameters {
+      public: virtual ~ISystemConfigureParameters() = default;
+
       /// \brief Configure the parameters of the system.
       /// \param[in] _registry The parameter registry.
       public: virtual void ConfigureParameters(
@@ -178,6 +184,7 @@ namespace gz
 
 
     class ISystemReset {
+      public: virtual ~ISystemReset() = default;
       public: virtual void Reset(const UpdateInfo &_info,
                                  EntityComponentManager &_ecm) = 0;
     };
@@ -185,6 +192,7 @@ namespace gz
     /// \class ISystemPreUpdate ISystem.hh gz/sim/System.hh
     /// \brief Interface for a system that uses the PreUpdate phase
     class ISystemPreUpdate {
+      public: virtual ~ISystemPreUpdate() = default;
       public: virtual void PreUpdate(const UpdateInfo &_info,
                                      EntityComponentManager &_ecm) = 0;
     };
@@ -192,6 +200,7 @@ namespace gz
     /// \class ISystemUpdate ISystem.hh gz/sim/System.hh
     /// \brief Interface for a system that uses the Update phase
     class ISystemUpdate {
+      public: virtual ~ISystemUpdate() = default;
       public: virtual void Update(const UpdateInfo &_info,
                                   EntityComponentManager &_ecm) = 0;
     };
@@ -199,6 +208,7 @@ namespace gz
     /// \class ISystemPostUpdate ISystem.hh gz/sim/System.hh
     /// \brief Interface for a system that uses the PostUpdate phase
     class ISystemPostUpdate{
+      public: virtual ~ISystemPostUpdate() = default;
       public: virtual void PostUpdate(const UpdateInfo &_info,
                                       const EntityComponentManager &_ecm) = 0;
     };

--- a/src/rendering/MaterialParser/ConfigLoader.hh
+++ b/src/rendering/MaterialParser/ConfigLoader.hh
@@ -40,7 +40,7 @@ public:
 
   ConfigLoader();
 
-  ~ConfigLoader();
+  virtual ~ConfigLoader();
 
   // For a line like
   // entity animals/dog


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2829

## Summary
Add missing virtual destructors so that "-Wnon-virtual-dtor" in combination with "-Werror" does not cause any issues. 

## Checklist
- [] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
