### PR TITLE
Fix compatibility with protobuf v30

### DIFF
--- a/src/systems/websocket_server/WebsocketServer.cc
+++ b/src/systems/websocket_server/WebsocketServer.cc
@@ -66,7 +66,7 @@ using namespace systems;
 /// \param[in] _type The message type string.
 /// \return A string that is the frame header.
 #define BUILD_HEADER(_op, _topic, _type) \
-    ((_op)+","+(_topic)+","+(_type)+",")
+    ((_op)+","+(_topic)+","+(std::string(_type))+",")
 
 /// \brief Construction a complete websocket frame.
 /// \param[in] _op The operation string.


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

Ports the fix from https://github.com/gazebosim/gz-launch/pull/295


This should fix the recent homebrew build failures:

```sh
/Users/jenkins/jenkins-agent/workspace/gz_sim-ci-pr_any-homebrew-amd64/gz-sim/src/systems/websocket_server/WebsocketServer.cc:1053:24: error: invalid operands to binary expression ('basic_string<char, char_traits<char>, allocator<char>>' and 'absl::string_view' (aka 'basic_string_view<char>'))
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
