### PR TITLE
Fix compatibility with protobuf v30

### DIFF
--- a/src/systems/log/LogRecord.cc
+++ b/src/systems/log/LogRecord.cc
@@ -298,7 +298,7 @@ bool LogRecordPrivate::Start(const std::string &_logPath,
   if (!validSdfTopic.empty())
   {
     this->sdfPub = this->node.Advertise(validSdfTopic,
-        this->sdfMsg.GetTypeName());
+        std::string(this->sdfMsg.GetTypeName()));
   }
   else
   {

--- a/src/systems/triggered_publisher/TriggeredPublisher.cc
+++ b/src/systems/triggered_publisher/TriggeredPublisher.cc
@@ -574,8 +574,8 @@ void TriggeredPublisher::Configure(const Entity &,
       info.msgData = msgs::Factory::New(info.msgType, msgStr);
       if (nullptr != info.msgData)
       {
-        info.pub =
-            this->node.Advertise(info.topic, info.msgData->GetTypeName());
+        info.pub = this->node.Advertise(info.topic,
+            std::string(info.msgData->GetTypeName()));
         if (info.pub.Valid())
         {
           this->outputInfo.push_back(std::move(info));


### PR DESCRIPTION
# 🦟 Bug fix

Fixes build with protobuf 30, partial backport of fixes from #2966.

## Summary

Similar to https://github.com/gazebosim/gz-msgs/pull/499.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
