### PR TITLE
Update GUI Runner initial state request timing

### DIFF
--- a/src/gui/GuiRunner.cc
+++ b/src/gui/GuiRunner.cc
@@ -74,7 +74,7 @@ class gz::sim::GuiRunner::Implementation
   public: std::thread updateThread;
 
   /// \brief True if the initial state has been received and processed.
-  public: bool receivedInitialState{false};
+  public: std::atomic<bool> receivedInitialState{false};
 
   /// \brief Name of WorldControl service
   public: std::string controlService;
@@ -264,7 +264,6 @@ void GuiRunner::OnStateAsyncService(const msgs::SerializedStepMap &_res)
   // variables.
   QMetaObject::invokeMethod(this, "OnStateQt", Qt::QueuedConnection,
                             Q_ARG(gz::msgs::SerializedStepMap, _res));
-  this->dataPtr->receivedInitialState = true;
 
   // todo(anyone) store reqSrv string in a member variable and use it here
   // and in RequestState()
@@ -302,6 +301,8 @@ void GuiRunner::OnStateQt(const msgs::SerializedStepMap &_msg)
   // Update all plugins
   this->dataPtr->updateInfo = convert<UpdateInfo>(_msg.stats());
   this->UpdatePlugins();
+
+  this->dataPtr->receivedInitialState = true;
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

Related issue: https://github.com/gazebosim/jetty_demo/issues/3

## Summary

While testing the [Jetty demo](https://github.com/gazebosim/jetty_demo/) world, it was found that Gazebo took a while to load because there is a large number of entities in the world. The slow down is mainly on the GUI side. One cause of the long load time was found to be that the GuiRunner setting its ECM initial state twice: Once from the [async state request](https://github.com/gazebosim/gz-sim/blob/7267e3648a9c9a0406dfd59ad55819947986f06d/src/gui/GuiRunner.cc#L255) and the other from the [state topic subscription callback](https://github.com/gazebosim/gz-sim/blob/7267e3648a9c9a0406dfd59ad55819947986f06d/src/gui/GuiRunner.cc#L251) (sync version). 

More info:

There was a PR (https://github.com/gazebosim/gz-sim/pull/1073) to only start the processing the states from topic subscription callback (sync version) only after the async version is done, which is tracked using the `this->dataPtr->receivedInitialState` bool variable. That worked fine until this [merge forward change](https://github.com/gazebosim/gz-sim/commit/63d4983790a4c177c101250eac678b4e7fcb10c9#diff-6ce9681832237a23588ca3966cc842bba8f76e2283d06f020de3136e9b442408L174) that changed the processing of the state request in the aysnc callback to a `QueuedConnection`. As the result, the state is not processed immediately but `this->dataPtr->receivedInitialState` is incorrectly marked as `true`. This causes the sync version to start processing states right away.

The fix is to properly set `this->dataPtr->receivedInitialState` to `true` in the state callback function after the states are actually processed.

This patch reduces the load time by ~15 seconds (from ~1min 10sec to ~55 sec) on my machine.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

