### PR TITLE
Remove obsolete tag from sdf

### DIFF
--- a/examples/worlds/gpu_lidar_sensor.sdf
+++ b/examples/worlds/gpu_lidar_sensor.sdf
@@ -162,7 +162,6 @@
               <resolution>0.01</resolution>
             </range>
           </lidar>
-          <alwaysOn>1</alwaysOn>
           <visualize>true</visualize>
         </sensor>
       </link>

--- a/examples/worlds/logical_camera_sensor.sdf
+++ b/examples/worlds/logical_camera_sensor.sdf
@@ -138,7 +138,6 @@
             <horizontal_fov>1.04719755</horizontal_fov>
             <aspect_ratio>1.778</aspect_ratio>
           </logical_camera>
-          <alwaysOn>1</alwaysOn>
           <visualize>true</visualize>
           <topic>logical_camera</topic>
           <enable_metrics>true</enable_metrics>

--- a/examples/worlds/visualize_frustum.sdf
+++ b/examples/worlds/visualize_frustum.sdf
@@ -433,7 +433,6 @@
             <horizontal_fov>1.04719755</horizontal_fov>
             <aspect_ratio>1.778</aspect_ratio>
           </logical_camera>
-          <alwaysOn>1</alwaysOn>
           <visualize>true</visualize>
           <topic>logical_camera</topic>
           <enable_metrics>true</enable_metrics>

--- a/test/worlds/gpu_lidar_sensor.sdf
+++ b/test/worlds/gpu_lidar_sensor.sdf
@@ -146,7 +146,6 @@
               <resolution>0.01</resolution>
             </range>
           </ray>
-          <alwaysOn>1</alwaysOn>
           <visualize>true</visualize>
         </sensor>
       </link>

--- a/test/worlds/logical_camera_sensor.sdf
+++ b/test/worlds/logical_camera_sensor.sdf
@@ -124,7 +124,6 @@
             <horizontal_fov>1.04719755</horizontal_fov>
             <aspect_ratio>1.778</aspect_ratio>
           </logical_camera>
-          <alwaysOn>1</alwaysOn>
           <visualize>true</visualize>
         </sensor>
       </link>
@@ -156,7 +155,6 @@
             <horizontal_fov>1.04719755</horizontal_fov>
             <aspect_ratio>1.778</aspect_ratio>
           </logical_camera>
-          <alwaysOn>1</alwaysOn>
           <visualize>true</visualize>
         </sensor>
       </link>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gazebo_test_cases/issues/2176

## Summary
PR removes obsolete <alwaysOn> tag that was producing warning messages in terminal, while running with Gazebo Jetty.

## Checklist
- [ x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
