### PR TITLE
Add Null Check for Scene Initialization in `onRefreshCamerasImpl` to Prevent Crash

### DIFF
--- a/src/gui/plugins/global_illumination_civct/GlobalIlluminationCiVct.cc
+++ b/src/gui/plugins/global_illumination_civct/GlobalIlluminationCiVct.cc
@@ -716,7 +716,7 @@ void GlobalIlluminationCiVct::OnRefreshCamerasImpl()
   REQUIRES(this->dataPtr->serviceMutex)
 {
   auto scene = this->dataPtr->scene.get();
-  if(!scene)
+  if (!scene)
   {
     gzerr << "Scene is not initialized. "
           << "Cannot refresh camera list."

--- a/src/gui/plugins/global_illumination_civct/GlobalIlluminationCiVct.cc
+++ b/src/gui/plugins/global_illumination_civct/GlobalIlluminationCiVct.cc
@@ -719,7 +719,8 @@ void GlobalIlluminationCiVct::OnRefreshCamerasImpl()
   if(!scene)
   {
     gzerr << "Scene is not initialized. "
-          << "Cannot refresh camera list." << std::endl;
+          << "Cannot refresh camera list."
+          << std::endl;
     return;
   }
   const unsigned int sensorCount = scene->SensorCount();

--- a/src/gui/plugins/global_illumination_civct/GlobalIlluminationCiVct.cc
+++ b/src/gui/plugins/global_illumination_civct/GlobalIlluminationCiVct.cc
@@ -716,6 +716,12 @@ void GlobalIlluminationCiVct::OnRefreshCamerasImpl()
   REQUIRES(this->dataPtr->serviceMutex)
 {
   auto scene = this->dataPtr->scene.get();
+  if(!scene)
+  {
+    gzerr << "Scene is not initialized. "
+          << "Cannot refresh camera list." << std::endl;
+    return;
+  }
   const unsigned int sensorCount = scene->SensorCount();
   for (unsigned int i = 0u; i < sensorCount; ++i)
   {


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #3050 

## Summary
if `scene` is not initialized correctly, we should add a check and `return` directly.

## Reproduce
see in #3050 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers