### PR TITLE
Fix saving world through GUI

### DIFF
--- a/src/gui/resources/GazeboDrawer.qml
+++ b/src/gui/resources/GazeboDrawer.qml
@@ -137,7 +137,7 @@ Rectangle {
     fileMode: FileDialog.OpenFile
     nameFilters: [ "SDF files (*.sdf)" ]
     onAccepted: {
-      saveWorldFileText.text = fileUrl;
+      saveWorldFileText.text = selectedFile;
     }
   }
 


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix



## Summary

Similar to the changes in https://github.com/gazebosim/gz-gui/pull/711. This was missed during the Qt5 -> Qt6 migration. The `fileUrl` var has changed to `selectedFile`

To test:

Run `gz sim -v 4` with any world, go to the top left hand corner menu in the GUI  and select `Save world` (not `Save world as..`), select the world and save. Without this change, you'll see a QML warning complaining about the unknown var `fileUrl`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

