### PR TITLE
Fix crash when setting debug visualization mode while `gi` is disabled

### DIFF
--- a/src/gui/plugins/global_illumination_vct/GlobalIlluminationVct.cc
+++ b/src/gui/plugins/global_illumination_vct/GlobalIlluminationVct.cc
@@ -499,9 +499,21 @@ bool GlobalIlluminationVct::eventFilter(QObject *_obj, QEvent *_event)
       }
       else if (this->dataPtr->debugVisualizationDirty)
       {
-        this->dataPtr->gi->SetDebugVisualization(
+        if (this->dataPtr->enabled && this->dataPtr->gi->Enabled())
+        {
+          this->dataPtr->gi->SetDebugVisualization(
           static_cast<rendering::GlobalIlluminationVct::DebugVisualizationMode>(
-            this->dataPtr->debugVisMode));
+          this->dataPtr->debugVisMode));
+        }
+        else
+        {
+          gzerr << "Trying to set debug visualization mode while GI is "
+                << "disabled. Please enable GI first."
+                << std::endl;
+          // Always set to none when disabled to avoid crash
+          this->dataPtr->gi->SetDebugVisualization(
+            rendering::GlobalIlluminationVct::DVM_None);
+        }
         this->dataPtr->debugVisualizationDirty = false;
       }
     }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #3058 

## Summary
When attempting to set the debug visualization mode, the code now checks if `gi`is enabled. If `gi` is disabled, it logs an error and always sets the debug visualization mode to `None` to avoid a crash.
Setting a debug visualization mode while `gi` is disabled can cause a crash due to invalid or released resources. This change ensures safety by forcing the mode to None when `gi` is not active.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
