### PR TITLE
Fix crash and synchronize gui when disabling `gi` with active debug visualization mode

### DIFF
--- a/src/gui/plugins/global_illumination_vct/GlobalIlluminationVct.cc
+++ b/src/gui/plugins/global_illumination_vct/GlobalIlluminationVct.cc
@@ -549,9 +549,23 @@ void GlobalIlluminationVct::UpdateOctantCount(int _axis, uint32_t _count)
 //////////////////////////////////////////////////
 void GlobalIlluminationVct::SetEnabled(const bool _enabled)
 {
-  std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
-  this->dataPtr->enabled = _enabled;
-  this->dataPtr->visualDirty = true;
+  bool needEmitDebugVisChanged = false;
+  {
+    std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
+    if (this->dataPtr->enabled && !_enabled)
+    {
+      // When disabling GI, force debugVisMode to None for safety
+      this->dataPtr->debugVisMode = rendering::GlobalIlluminationVct::DVM_None;
+      this->dataPtr->debugVisualizationDirty = true;
+      needEmitDebugVisChanged = true;
+    }
+    this->dataPtr->enabled = _enabled;
+    this->dataPtr->visualDirty = true;
+  }
+  if (needEmitDebugVisChanged)
+  {
+    this->DebugVisualizationModeChanged();
+  }
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #3060 

## Summary
When `gi` is being disabled (`Enabled` changes from `true` to `false`), the code sets the debug visualization mode to `None`, marks it as dirty, and sets a flag. After releasing the mutex lock, if the `flag` is set, it emits the `DebugVisualizationModeChanged` signal to notify the GUI to update.

This ensures internal state consistency and prevents crashes by forcing the debug visualization mode to `None` when `gi` is off. Emitting the signal outside the lock avoids deadlocks and keeps the GUI synchronized with the internal state.



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers