### PR TITLE
Disable `UtilTest.ResolveSdfWorldFile` on macOS

### DIFF
--- a/src/Util_TEST.cc
+++ b/src/Util_TEST.cc
@@ -981,7 +981,8 @@ TEST_F(UtilTest, EntityFromMsg)
 }
 
 /////////////////////////////////////////////////
-TEST_F(UtilTest, ResolveSdfWorldFile)
+// This test appears to be flaky on macOS (see https://github.com/gazebosim/gz-sim/issues/3031)
+TEST_F(UtilTest, GZ_UTILS_TEST_DISABLED_ON_MAC(ResolveSdfWorldFile))
 {
   // Test resolving a Fuel URI
   fuel_tools::ClientConfig config;

--- a/src/Util_TEST.cc
+++ b/src/Util_TEST.cc
@@ -26,6 +26,7 @@
 #include <sdf/Types.hh>
 
 #include <gz/fuel_tools/ClientConfig.hh>
+#include <gz/utils/ExtraTestMacros.hh>
 
 #include "gz/sim/components/Actor.hh"
 #include "gz/sim/components/Collision.hh"


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
This test appears to be flaky on macOS (see https://github.com/gazebosim/gz-sim/issues/3031)

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
