### PR TITLE
Skip Model SDF serialization

### DIFF
--- a/include/gz/sim/components/Model.hh
+++ b/include/gz/sim/components/Model.hh
@@ -41,7 +41,7 @@ namespace serializers
     /// \param[in] _time Model to stream
     /// \return The stream.
     public: static std::ostream &Serialize(std::ostream &_out,
-                const sdf::Model &_model)
+                const sdf::Model &)
     {
       // Skip serialization of model sdf
       // \todo(iche033) It was found that deserialization is
@@ -60,25 +60,11 @@ namespace serializers
     /// \param[out] _model Model to populate
     /// \return The stream.
     public: static std::istream &Deserialize(std::istream &_in,
-                sdf::Model &_model)
+                sdf::Model &)
     {
-      std::string sdf(std::istreambuf_iterator<char>(_in), {});
-      if (sdf.empty())
-      {
-        return _in;
-      }
-
-      // Its super expensive to create an SDFElement for some reason
+      // Its super expensive to create an SDFElement for some reason.
+      // So seriazliation / deserialization of model sdf is skipped
       // https://github.com/gazebosim/sdformat/issues/1478
-      sdf::Root root;
-      sdf::Errors errors = root.LoadSdfString(sdf);
-      if (!root.Model())
-      {
-        gzwarn << "Unable to deserialize sdf::Model " << sdf<< std::endl;
-        return _in;
-      }
-
-      _model = *root.Model();
       return _in;
     }
   };

--- a/include/gz/sim/components/Model.hh
+++ b/include/gz/sim/components/Model.hh
@@ -43,50 +43,15 @@ namespace serializers
     public: static std::ostream &Serialize(std::ostream &_out,
                 const sdf::Model &_model)
     {
-      sdf::ElementPtr modelElem = _model.Element();
-      if (!modelElem)
-      {
-        gzwarn << "Unable to serialize sdf::Model" << std::endl;
-        return _out;
-      }
-
-      bool skip = false;
-      if (modelElem->HasElement("pose"))
-      {
-        sdf::ElementPtr poseElem = modelElem->GetElement("pose");
-        if (poseElem->GetAttribute("relative_to")->GetSet())
-        {
-          // Skip serializing models with //pose/@relative_to attribute
-          // since deserialization will fail. This could be a nested model.
-          // see https://github.com/gazebosim/gz-sim/issues/1071
-          // Once https://github.com/gazebosim/sdformat/issues/820 is
-          // resolved, there should be an API that returns sdf::Errors objects
-          // instead of printing console msgs so it would be easier to ignore
-          // specific errors in Deserialize.
-          static bool warned = false;
-          if (!warned)
-          {
-            gzwarn << "Skipping serialization / deserialization for models "
-                    << "with //pose/@relative_to attribute."
-                    << std::endl;
-            warned = true;
-          }
-          skip = true;
-        }
-      }
-
-      if (!skip)
-      {
-        _out << "<?xml version=\"1.0\" ?>"
-              << "<sdf version='" << SDF_PROTOCOL_VERSION << "'>"
-              << modelElem->ToString("")
-              << "</sdf>";
-
-      }
-      else
-      {
-        _out << "";
-      }
+      // Skip serialization of model sdf
+      // \todo(iche033) It was found that deserialization is
+      // very expensive, which impacts initial load time of a world with many
+      // entities. Currently only the server consumes ModelSdf components
+      // so let's skip serialization until either the deserialization
+      // performance is improved or when the GUI needs the to use Model SDF
+      // components.
+      // see, https://github.com/gazebosim/sdformat/issues/1478
+      _out << "";
       return _out;
     }
 
@@ -104,6 +69,7 @@ namespace serializers
       }
 
       // Its super expensive to create an SDFElement for some reason
+      // https://github.com/gazebosim/sdformat/issues/1478
       sdf::Root root;
       sdf::Errors errors = root.LoadSdfString(sdf);
       if (!root.Model())

--- a/test/integration/components.cc
+++ b/test/integration/components.cc
@@ -1276,8 +1276,10 @@ TEST_F(ComponentsTest, ModelSdf)
   std::istringstream istr(ostr.str());
   comp2.Deserialize(istr);
 
-  EXPECT_EQ("my_model", comp2.Data().Name());
-  EXPECT_EQ(1u, comp2.Data().LinkCount());
+  // Model sdf serialization / deserialization is disabled due to perf issue
+  // https://github.com/gazebosim/sdformat/issues/1478
+  // EXPECT_EQ("my_model", comp2.Data().Name());
+  // EXPECT_EQ(1u, comp2.Data().LinkCount());
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION


# 🦟 Bug fix

Related https://github.com/gazebosim/sdformat/issues/1478

## Summary

Skip model sdf serialization. The main problem is actually in the perf of deserialization (`root.LoadSdfString`), see https://github.com/gazebosim/sdformat/issues/1478. This change returns an empty string in the `Serialize` function which will cause the `Deserialize` function to just skip trying to load the sdf string. 

Testing with the Jetty demo world, the reduced load time from 55s to 42s and resuming from paused state (ie hit Play button) is now  almost instantaneous.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

