### PR TITLE
Fix sporadic crash when launching GUI client on windows

### DIFF
--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -332,11 +332,19 @@ std::unique_ptr<gz::gui::Application> createGui(
   gzmsg << "Gazebo Sim GUI    v" << GZ_SIM_VERSION_FULL
          << std::endl;
 
-  gzdbg << "Qt Prefix:" << QLibraryInfo::path(QLibraryInfo::PrefixPath).toStdString() << "\n";
-  gzdbg << "Qt libs:" << QLibraryInfo::path(QLibraryInfo::LibrariesPath).toStdString() << "\n";
-  gzdbg << "Qt data:" << QLibraryInfo::path(QLibraryInfo::DataPath).toStdString() << " arch:" << QLibraryInfo::path(QLibraryInfo::ArchDataPath).toStdString() << "\n";
-  gzdbg << "Qt plugins:" << QLibraryInfo::path(QLibraryInfo::PluginsPath).toStdString() << "\n";
-  gzdbg << "Qt imports:" << QLibraryInfo::path(QLibraryInfo::QmlImportsPath).toStdString() << "\n";
+  gzdbg << "Qt Prefix:"
+        << QLibraryInfo::path(QLibraryInfo::PrefixPath).toStdString() << "\n";
+  gzdbg << "Qt libs:"
+        << QLibraryInfo::path(QLibraryInfo::LibrariesPath).toStdString()
+        << "\n";
+  gzdbg << "Qt data:"
+        << QLibraryInfo::path(QLibraryInfo::DataPath).toStdString() << " arch:"
+        << QLibraryInfo::path(QLibraryInfo::ArchDataPath).toStdString() << "\n";
+  gzdbg << "Qt plugins:"
+        << QLibraryInfo::path(QLibraryInfo::PluginsPath).toStdString() << "\n";
+  gzdbg << "Qt imports:"
+        << QLibraryInfo::path(QLibraryInfo::QmlImportsPath).toStdString()
+        << "\n";
 
   // Set auto scaling factor for HiDPI displays
   if (QString::fromLocal8Bit(qgetenv("QT_AUTO_SCREEN_SCALE_FACTOR")).isEmpty())

--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -332,6 +332,12 @@ std::unique_ptr<gz::gui::Application> createGui(
   gzmsg << "Gazebo Sim GUI    v" << GZ_SIM_VERSION_FULL
          << std::endl;
 
+  gzdbg << "Qt Prefix:" << QLibraryInfo::path(QLibraryInfo::PrefixPath).toStdString() << "\n";
+  gzdbg << "Qt libs:" << QLibraryInfo::path(QLibraryInfo::LibrariesPath).toStdString() << "\n";
+  gzdbg << "Qt data:" << QLibraryInfo::path(QLibraryInfo::DataPath).toStdString() << " arch:" << QLibraryInfo::path(QLibraryInfo::ArchDataPath).toStdString() << "\n";
+  gzdbg << "Qt plugins:" << QLibraryInfo::path(QLibraryInfo::PluginsPath).toStdString() << "\n";
+  gzdbg << "Qt imports:" << QLibraryInfo::path(QLibraryInfo::QmlImportsPath).toStdString() << "\n";
+
   // Set auto scaling factor for HiDPI displays
   if (QString::fromLocal8Bit(qgetenv("QT_AUTO_SCREEN_SCALE_FACTOR")).isEmpty())
   {


### PR DESCRIPTION
# 🦟 Bug fix

Toward: https://github.com/gazebosim/gz-sim/issues/2945

## Summary

The issues seems to stem form using iterators created on temporary std::string objects. Calling `std::ostringstream::str` creates a new string each time, so the `begin` and `end` calls are getting two different copies of the string. This PR instead just uses a single `std::string` object to construct the command line. This also wraps arguments with extra quotes if necessary. Lastly, it adds debug messages to help with QT6 library paths.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
