### PR TITLE
Fix crash when selecting static models without links by adding empty check

### DIFF
--- a/src/gui/plugins/apply_force_torque/ApplyForceTorque.cc
+++ b/src/gui/plugins/apply_force_torque/ApplyForceTorque.cc
@@ -448,6 +448,10 @@ void ApplyForceTorque::Update(const UpdateInfo &/*_info*/,
 
     if (this->dataPtr->selectedEntity.has_value())
     {
+      if (this->dataPtr->linkNameList.empty())
+      {
+        return;
+      }
       auto parentModel = Link(*this->dataPtr->selectedEntity).ParentModel(_ecm);
       std::string linkName =
         this->dataPtr->linkNameList[this->dataPtr->linkIndex].toStdString();


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #3077 

## Summary
The crash is triggered by loading a static model without any `link`, then opening the `ApplyForceTorque` plugin and toggling the selected object from normal to static  The plugin attempts to access an empty `linkNameList` , leading to an illegal memory access and segmentation fault. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
