### PR TITLE
Set non-unique material to submesh when updating cast shadows property

### DIFF
--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -396,10 +396,10 @@ rendering::VisualPtr SceneManager::CreateVisual(Entity _id,
           // unlike setting transparency above, the parent submesh are not
           // notified about the the cast shadows changes. So we need to set
           // the material back to the submesh.
-          // \todo(anyone) find way to propate cast shadows changes tos submesh
+          // \todo(anyone) find way to propagate cast shadows changes to submesh
           // in gz-rendering
           submeshMat->SetCastShadows(_visual.CastShadows());
-          submesh->SetMaterial(submeshMat);
+          submesh->SetMaterial(submeshMat, false);
         }
       }
     }


### PR DESCRIPTION
# 🦟 Bug fix

Related issue: https://github.com/gazebosim/jetty_demo/issues/3
Requires https://github.com/gazebosim/gz-rendering/pull/1168

## Summary

When updating the cast shadows property of a visual, we set the material with the cast shadow value to all the submeshes in the visual. However, the `SetMaterial` call by default clones the input material before setting it to the submesh. The submesh's original material will also be destroyed during this process. The problem is that the material destruction process was found to be expensive and does not cleanup textures properly, see https://github.com/gazebosim/gz-rendering/issues/1167.  This PR updates the `SetMaterial` call to pass `false` in the second arg so the material is not cloned when being set, which prevents the original material from being destroyed.

When running the [Jetty demo world](https://github.com/gazebosim/jetty_demo), the load time reduced from 30s to 24s on my machine (tested with with https://github.com/gazebosim/gz-sim/pull/3070 and https://github.com/gazebosim/gz-common/pull/706)



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
