### PR TITLE
Use common::findFile when searching for slip map in LookupWheelSlip system

### DIFF
--- a/src/systems/lookup_wheel_slip/LookupWheelSlip.cc
+++ b/src/systems/lookup_wheel_slip/LookupWheelSlip.cc
@@ -36,6 +36,7 @@
 #include <sdf/Geometry.hh>
 #include <sdf/Heightmap.hh>
 
+#include "gz/sim/components/SourceFilePath.hh"
 #include "gz/sim/components/Geometry.hh"
 #include "gz/sim/components/World.hh"
 #include "gz/sim/Link.hh"
@@ -213,8 +214,10 @@ void LookupWheelSlip::Configure(const Entity &_entity,
   }
 
   // find the slip map file
+  auto modelPath =
+    _ecm.ComponentData<components::SourceFilePath>(_entity);
   std::string filePath = common::findFile(asFullPath(
-      this->dataPtr->slipMapFilename, _sdf->FilePath()), false);
+      this->dataPtr->slipMapFilename, modelPath.value()), false);
   if (filePath.empty())
   {
     auto *component =

--- a/src/systems/lookup_wheel_slip/LookupWheelSlip.cc
+++ b/src/systems/lookup_wheel_slip/LookupWheelSlip.cc
@@ -212,22 +212,17 @@ void LookupWheelSlip::Configure(const Entity &_entity,
     return;
   }
 
-  // transformation matrix from world to image coordinates
-  std::string filePath;
-  if (common::isFile(this->dataPtr->slipMapFilename))
-  {
-    filePath = this->dataPtr->slipMapFilename;
-  }
-  else if (common::isRelativePath(this->dataPtr->slipMapFilename))
+  // file the slip map file
+  std::string filePath = common::findFile(asFullPath(
+      this->dataPtr->slipMapFilename, _sdf->FilePath()), false);
+  if (filePath.empty())
   {
     auto *component =
         _ecm.Component<components::WorldSdf>(worldEntity(_ecm));
     const std::string rootPath =
         common::parentPath(component->Data().Element()->FilePath());
-    std::string path = common::joinPaths(rootPath,
-        this->dataPtr->slipMapFilename);
-    if (common::isFile(path))
-      filePath = path;
+    filePath = common::findFile(asFullPath(this->dataPtr->slipMapFilename,
+        component->Data().Element()->FilePath()), false);
   }
   if (filePath.empty())
   {
@@ -237,6 +232,7 @@ void LookupWheelSlip::Configure(const Entity &_entity,
     return;
   }
   gzdbg << "Using slip_map: " << filePath << std::endl;
+  // transformation matrix from world to image coordinates
   this->dataPtr->slipMapImg.Load(filePath);
   this->dataPtr->slipMapRgb = this->dataPtr->slipMapImg.RGBData();
   this->dataPtr->worldToImgTransform(0, 0) =

--- a/src/systems/lookup_wheel_slip/LookupWheelSlip.cc
+++ b/src/systems/lookup_wheel_slip/LookupWheelSlip.cc
@@ -212,7 +212,7 @@ void LookupWheelSlip::Configure(const Entity &_entity,
     return;
   }
 
-  // file the slip map file
+  // find the slip map file
   std::string filePath = common::findFile(asFullPath(
       this->dataPtr->slipMapFilename, _sdf->FilePath()), false);
   if (filePath.empty())


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The lookup wheel slip system currently only searches the slip map file by checking path relative to the world file. This PR updates the file search logic to use `common::findFile` which is more reliable. It now searches for paths relative to the model sdf file (if plugin is added to a model in model.sdf) and world file, as well as URIs pointing to Fuel.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

