### PR TITLE
Add missing dependencies to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>cmake</buildtool_depend>
 
   <depend>benchmark</depend>
+  <depend>binutils</depend>
   <depend>glut</depend>
   <depend>gz-cmake</depend>
   <depend>gz-common</depend>
@@ -25,8 +26,11 @@
   <depend>gz-tools2</depend>
   <depend>gz-transport</depend>
   <depend>gz-utils</depend>
+  <depend>libdw-dev</depend>
+  <depend>libdwarf-dev</depend>
   <depend>libfreeimage-dev</depend>
   <depend>libglew-dev</depend>
+  <depend>libwebsockets-dev</depend>
   <depend>libxi-dev</depend>
   <depend>libxmu-dev</depend>
   <depend>protobuf-dev</depend>


### PR DESCRIPTION
# 🦟 Bug fix


## Summary

I believe these are all optional dependencies, so the vendor packages have been building successfully without them, but we should add them to the package.xml to ensure feature parity with the non-vendored gz-sim.

This was caught while running a test build on https://build.osrfoundation.org/view/ci/job/ci__colcon_any-manual_ubuntu_noble_amd64/57/. 

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.