### PR TITLE
sim_main: Print clear error in case gz-sim process returns with non-zero return value

### DIFF
--- a/src/cmd/sim_main.cc
+++ b/src/cmd/sim_main.cc
@@ -493,7 +493,11 @@ int main(int argc, char** argv)
           utils::setenv(
               std::string("GZ_SIM_WAIT_GUI"),
               std::to_string(opt->waitGui));
-          launchProcess(std::string(GZ_SIM_GUI_EXE), createGuiCommand(opt));
+          int gzSimGuiReturnValue = launchProcess(std::string(GZ_SIM_GUI_EXE), createGuiCommand(opt));
+          if (gzSimGuiReturnValue != 0)
+          {
+            gzerr << "Process for gz-sim GUI launched with command " << std::string(GZ_SIM_GUI_EXE) << " returned non-zero return value " << processRetValue << std::endl;
+          }
         }
         catch (const std::exception &e)
         {
@@ -576,7 +580,11 @@ int main(int argc, char** argv)
     else if(opt->launchGui)
     {
       #ifdef WITH_GUI
-      launchProcess(std::string(GZ_SIM_GUI_EXE), createGuiCommand(opt));
+      int gzSimGuiReturnValue = launchProcess(std::string(GZ_SIM_GUI_EXE), createGuiCommand(opt));
+      if (gzSimGuiReturnValue != 0)
+      {
+        gzerr << "Process for gz-sim GUI launched with command " << std::string(GZ_SIM_GUI_EXE) << " returned non-zero return value " << processRetValue << std::endl;
+      }
       #else
       std::cerr << "This version of Gazebo does not support GUI" << std::endl;
       #endif


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Without this fix, if for any reason the invocation of the `gz-sim-gui-client` fails, the `gz-sim-main` process (or the parent process `gz`) silently exits, that may be confusing for users.

See https://github.com/conda-forge/gz-sim-feedstock/issues/110 .

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

