### PR TITLE
Fix relocatability of gz-sim-main executable

### DIFF
--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -72,7 +72,7 @@ if(ENABLE_GUI)
   target_compile_definitions(${sim_executable} PRIVATE WITH_GUI)
   target_compile_definitions(${sim_executable}
     PRIVATE
-      "GZ_SIM_GUI_EXE=\"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBEXECDIR}/gz/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}/$<TARGET_FILE_NAME:${gui_executable}>\""
+      "GZ_SIM_GUI_EXE_RELATIVE_PATH=\"${CMAKE_INSTALL_LIBEXECDIR}/gz/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}/$<TARGET_FILE_NAME:${gui_executable}>\""
   )
 endif()
 

--- a/src/cmd/sim_main.cc
+++ b/src/cmd/sim_main.cc
@@ -31,6 +31,7 @@
 #include <gz/utils/Subprocess.hh>
 
 #include "gz/sim/config.hh"
+#include "gz/sim/InstallationDirectories.hh"
 #include "gz/sim/Server.hh"
 #include "gz/sim/ServerConfig.hh"
 #include "gz.hh"
@@ -493,7 +494,10 @@ int main(int argc, char** argv)
           utils::setenv(
               std::string("GZ_SIM_WAIT_GUI"),
               std::to_string(opt->waitGui));
-          launchProcess(std::string(GZ_SIM_GUI_EXE), createGuiCommand(opt));
+          std::string gz_sim_gui_exe = gz::common::joinPaths(
+              sim::getInstallPrefix(),
+              GZ_SIM_GUI_EXE_RELATIVE_PATH);
+          launchProcess(gz_sim_gui_exe, createGuiCommand(opt));
         }
         catch (const std::exception &e)
         {
@@ -576,7 +580,10 @@ int main(int argc, char** argv)
     else if(opt->launchGui)
     {
       #ifdef WITH_GUI
-      launchProcess(std::string(GZ_SIM_GUI_EXE), createGuiCommand(opt));
+      std::string gz_sim_gui_exe = gz::common::joinPaths(
+          sim::getInstallPrefix(),
+          GZ_SIM_GUI_EXE_RELATIVE_PATH);
+      launchProcess(gz_sim_gui_exe, createGuiCommand(opt));
       #else
       std::cerr << "This version of Gazebo does not support GUI" << std::endl;
       #endif


### PR DESCRIPTION
# 🦟 Bug fix

Fixes part of of https://github.com/gazebosim/gz-sim/issues/626 .

## Summary

The `gz-sim-main` contained the location of gui executable as an absolute location, that breaks in case `gz-sim` is compiled with the option `GZ_ENABLE_RELOCATABLE_INSTALL` and the install is moved after the installation.

See related PR https://github.com/gazebosim/gz-sim/pull/1968 .

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
