### PR TITLE
Disable Quick Start Dialog on Windows

### DIFF
--- a/src/cmd/sim_main.cc
+++ b/src/cmd/sim_main.cc
@@ -483,7 +483,13 @@ int main(int argc, char** argv)
     bool blocking = true;
 
     #ifdef WITH_GUI
+    // quick start dialog is not currently supported on Windows,
+    // see https://github.com/gazebosim/gz-sim/issues/3106
+    #ifndef _WIN32
     opt->waitGui = 1;
+    #else
+    opt->waitGui = 0;
+    #endif
     blocking = false;
 
     // Launch the GUI in a separate thread


### PR DESCRIPTION
# 🦟 Bug fix

Workaround for https://github.com/gazebosim/gz-sim/issues/3106 .
Fix https://github.com/gazebosim/gz-sim/issues/2393 .

## Summary

Until https://github.com/gazebosim/gz-sim/issues/3106  is fixed, I think it make sense to disable the Quick Start Dialog on Windows.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
