### PR TITLE
Disable Quick Start Dialog on Windows

### DIFF
--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -258,6 +258,13 @@ std::string launchQuickStart(int &_argc, char **_argv,
 
   gzdbg << "Reading Quick start menu config." << std::endl;
   auto showDialog = dialog->ReadConfigAttribute(_configInUse, "show_again");
+  // Quick start menu is not supported on Windows at the moment, see
+  // https://github.com/gazebosim/gz-sim/issues/3106
+  #ifdef _WIN32
+  gzdbg << "Hardcoding Quick start menu config to "
+        << "false as we are on Windows." << std::endl;
+  showDialog = "false";
+  #endif
   if (showDialog == "false")
   {
     gzmsg << "Not showing Quick start menu." << std::endl;


### PR DESCRIPTION
# 🦟 Bug fix

Workaround for https://github.com/gazebosim/gz-sim/issues/3106 .
Fix https://github.com/gazebosim/gz-sim/issues/2393 .

## Summary

Until https://github.com/gazebosim/gz-sim/issues/3106  is fixed, I think it make sense to disable the Quick Start Dialog on Windows.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

