### PR TITLE
Fix FileDialog when saving world

### DIFF
--- a/src/gui/resources/GazeboDrawer.qml
+++ b/src/gui/resources/GazeboDrawer.qml
@@ -134,7 +134,7 @@ Rectangle {
     id: saveWorldDialog
     title: "Save world"
     currentFolder: StandardPaths.writableLocation(StandardPaths.HomeLocation)
-    fileMode: FileDialog.OpenFile
+    fileMode: FileDialog.SaveFile
     nameFilters: [ "SDF files (*.sdf)" ]
     onAccepted: {
       saveWorldFileText.text = fileUrl;


### PR DESCRIPTION

# 🦟 Bug fix

Fixes #3109

## Summary

Currently with the `FileDialog.OpenFile` file mode, users can only save the world sdf to an existing file. This PR changes the file mode  to `FileDilaog.SaveFile` so that users can create a new file to save. 

This textfield for naming a new file should now be available in the file dialog. On ubuntu, this will appear at the top of the dialog:

<img width="1198" height="236" alt="Screenshot 2025-10-14 at 9 59 20 AM" src="https://github.com/user-attachments/assets/ad6fade1-b510-418b-a5cb-6c300a697e3e" />



## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

