### PR TITLE
Disable failing test on macOS in EntityComponentManager_TEST

### DIFF
--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -1937,7 +1937,7 @@ TEST_P(EntityComponentManagerFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(State))
 
 /////////////////////////////////////////////////
 TEST_P(EntityComponentManagerFixture,
-       GZ_UTILS_TEST_DISABLED_ON_WIN32(ChangedStateComponents))
+       GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ChangedStateComponents))
 {
   // Entity and component
   Entity e1{1};
@@ -3336,7 +3336,7 @@ TEST_P(EntityComponentManagerFixture, ResetToWithAddedEntity)
 
 //////////////////////////////////////////////////
 TEST_P(EntityComponentManagerFixture,
-    GZ_UTILS_TEST_DISABLED_ON_WIN32(AddRemoveAddComponentsStateMap))
+    GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(AddRemoveAddComponentsStateMap))
 {
   Entity e1 = manager.CreateEntity();
   EXPECT_EQ(1u, manager.EntityCount());


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-sim/issues/3089

## Summary
This tests have been failing on macOS consistently. I have been able to reproduce the failures locally, but I have not been able to understand why they are failing. Let's disable them for now to unblock other PRs.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
