### PR TITLE
Fix generating gz-sim8 doxygen files on Jammy

### DIFF
--- a/include/gz/sim/components/SemanticDescription.hh
+++ b/include/gz/sim/components/SemanticDescription.hh
@@ -33,8 +33,7 @@ namespace gz
 namespace sim
 {
 // Inline bracket to help doxygen filtering.
-inline namespace GZ_SIM_VERSION_NAMESPACE
-{
+inline namespace GZ_SIM_VERSION_NAMESPACE {
 namespace serializers
 {
 class SemanticDescriptionSerializer

--- a/include/gz/sim/components/SemanticTags.hh
+++ b/include/gz/sim/components/SemanticTags.hh
@@ -33,8 +33,7 @@ namespace gz
 namespace sim
 {
 // Inline bracket to help doxygen filtering.
-inline namespace GZ_SIM_VERSION_NAMESPACE
-{
+inline namespace GZ_SIM_VERSION_NAMESPACE {
 namespace serializers
 {
 class SemanticTagsSerializer

--- a/src/systems/entity_semantics/EntitySemantics.hh
+++ b/src/systems/entity_semantics/EntitySemantics.hh
@@ -25,8 +25,7 @@ namespace gz
 namespace sim
 {
 // Inline bracket to help doxygen filtering.
-inline namespace GZ_SIM_VERSION_NAMESPACE
-{
+inline namespace GZ_SIM_VERSION_NAMESPACE {
 namespace systems
 {
 // Forward declaration


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

The [doc nightly builds](https://github.com/gazebosim/docs/actions/workflows/nightly-upload.yml) are failing to deploy due to a segfault in Harmonic doc builds. I was able to reproduce this locally on Jammy and the changes in this PR should fix the doxygen build.

I vaguely remember that we had to put the `{` bracket in the same line for inline namespaces but forgot the exact reason. This only affects Jammy. I tested building gz-sim8 doc on Noble and it ran fine without the changes in this PR.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
