### PR TITLE
Set default camera angle in cart_pole example

### DIFF
--- a/examples/scripts/reinforcement_learning/simple_cart_pole/cart_pole.sdf
+++ b/examples/scripts/reinforcement_learning/simple_cart_pole/cart_pole.sdf
@@ -23,6 +23,22 @@
       name="gz::sim::systems::SceneBroadcaster">
     </plugin>
 
+    <gui fullscreen="0">
+      <plugin filename="MinimalScene" name="3D View">
+        <gz-gui>
+          <title>3D View</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="string" key="state">docked</property>
+        </gz-gui>
+        <engine>ogre2</engine>
+        <scene>scene</scene>
+        <ambient_light>0.4 0.4 0.4</ambient_light>
+        <background_color>0.8 0.8 0.8</background_color>
+        <!-- set default user camera pose -->
+        <camera_pose>0 6 3 0 0 -1.57</camera_pose>
+      </plugin>
+    </gui>
+
     <light type="directional" name="sun">
       <cast_shadows>true</cast_shadows>
       <pose>0 0 10 0 0 0</pose>


### PR DESCRIPTION
# 🦟 Bug fix

Improve default camera angle for cart pole reinforcement learning example

## Summary

The default camera angle looks directly along the path of travel

<img width="769" height="942" alt="Screenshot 2025-10-28 at 2 34 13 PM" src="https://github.com/user-attachments/assets/63eba4f5-5cfb-4b14-87d0-6568063b069c" />

This pull request changes the angle to look perpendicular to the path of travel, which makes it easier to see the pole swing angle

<img width="769" height="943" alt="Screenshot 2025-10-28 at 2 35 04 PM" src="https://github.com/user-attachments/assets/0b1aaecd-46fe-4874-a458-6f0f4534253e" />



<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
