### PR TITLE
Fix sim_main console error logging on Windows

### DIFF
--- a/src/cmd/sim_main.cc
+++ b/src/cmd/sim_main.cc
@@ -161,7 +161,7 @@ int launchProcess(
                       NULL, NULL, &si, &pi))
     {
       gzerr << "Failure in creating process for command "
-            << command << std::endl;
+            << command.str() << std::endl;
       return -1;
     }
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Windows build was broken by https://github.com/gazebosim/gz-sim/pull/3161

Error msg:

```
C:\J\workspace\gz_sim-pr-cnlwin\ws\src\gz-sim\src\cmd\sim_main.cc(163,7): error C2678: binary '<<': no operator found which takes a left-hand operand of type 'std::basic_ostream<char,std::char_traits<char>>' (or there is no acceptable conversion) [C:\J\workspace\gz_sim-pr-cnlwin\ws\build\gz-sim\src\cmd\gz-sim-main.vcxproj]
```

This PR fixes the build on windows

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
