### PR TITLE
Fix: Fix Windows offstream build error in sim_main.cc

### DIFF
--- a/src/cmd/sim_main.cc
+++ b/src/cmd/sim_main.cc
@@ -161,7 +161,7 @@ int launchProcess(
                       NULL, NULL, &si, &pi))
     {
       gzerr << "Failure in creating process for command "
-            << command << std::endl;
+            << command.str() << std::endl;
       return -1;
     }
 


### PR DESCRIPTION
Build failed in buildfarm due to backport from gz10 to main to add gzerror, but command isn't the same in both

# 🦟 Bug fix

## Summary
Without this fix, if for any reason the invocation of the gz-sim-gui-client fails on Windows, the gz-sim-main process (or the parent process gz) silently exits, that may be confusing for users.

After [Backport](https://github.com/gazebosim/gz-sim/pull/3161) buildfarm in main branch started to fail cause `command` in `src/cmd/sim_main.cc` have another type so I changed

```diff
-      gzerr << "Failure in creating process for command "
-            << command << std::endl;
+      gzerr << "Failure in creating process for command "
+            << command.str() << std::endl;
```

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

CC: @Crola1702 