### PR TITLE
Display version from the gz-physics plugin

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,11 @@
 
 1. **Baseline:** this includes all changes from 9.3.0 and earlier.
 
+1. Update `PhysicsEnginePlugin` component to display physics engine version
+    * Adds `GetEngineInfo` feature to physics engine to retrieve name and version separately
+    * Updates `PhysicsEnginePlugin` component to store "name-version" format (e.g., "dartsim-6.13.0")
+    * Engine version displayed in Component Inspector for world entity
+
 1. Don't install vendored backward files
     * [Pull request #3088](https://github.com/gazebosim/gz-sim/pull/3088)
 

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -913,7 +913,7 @@ void Physics::Configure(const Entity &_entity,
 
     // Update the PhysicsEnginePlugin component to include version
     std::string engineName = this->dataPtr->engine->GetName();
-    std::string engineVersion = this->dataPtr->engine->GetVersion();
+    std::string engineVersion = this->dataPtr->engine->GetVersion().Version();
     std::string engineNameWithVersion = engineName;
     if (!engineVersion.empty())
     {
@@ -990,7 +990,7 @@ void Physics::Configure(const Entity &_entity,
 
         // Update the PhysicsEnginePlugin component to include version
         std::string engineName = this->dataPtr->engine->GetName();
-        std::string engineVersion = this->dataPtr->engine->GetVersion();
+        std::string engineVersion = this->dataPtr->engine->GetVersion().Version();
         std::string engineNameWithVersion = engineName;
         if (!engineVersion.empty())
         {

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -919,11 +919,13 @@ void Physics::Configure(const Entity &_entity,
     {
       engineNameWithVersion += "-" + engineVersion;
     }
-    auto enginePluginComp = _ecm.Component<components::PhysicsEnginePlugin>(_entity);
+    auto enginePluginComp =
+        _ecm.Component<components::PhysicsEnginePlugin>(_entity);
     if (enginePluginComp)
     {
       enginePluginComp->SetData(engineNameWithVersion,
-          [](const std::string &_a, const std::string &_b){return _a == _b;});
+          [](const std::string &_a, const std::string &_b)
+              {return _a == _b;});
     }
   }
   else
@@ -994,11 +996,13 @@ void Physics::Configure(const Entity &_entity,
         {
           engineNameWithVersion += "-" + engineVersion;
         }
-        auto enginePluginComp = _ecm.Component<components::PhysicsEnginePlugin>(_entity);
+        auto enginePluginComp =
+            _ecm.Component<components::PhysicsEnginePlugin>(_entity);
         if (enginePluginComp)
         {
           enginePluginComp->SetData(engineNameWithVersion,
-              [](const std::string &_a, const std::string &_b){return _a == _b;});
+              [](const std::string &_a, const std::string &_b)
+                  {return _a == _b;});
         }
         break;
       }

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -179,7 +179,8 @@ class gz::sim::systems::PhysicsPrivate
           physics::sdf::ConstructSdfModel,
           physics::sdf::ConstructSdfWorld,
           physics::GetLinkFromModel,
-          physics::GetShapeFromLink
+          physics::GetShapeFromLink,
+          physics::GetEngineInfo
           >{};
 
   /// \brief Engine type with just the minimum features.
@@ -863,6 +864,9 @@ void Physics::Configure(const Entity &_entity,
         [](const std::string &_a, const std::string &_b){return _a == _b;});
   }
 
+  // Store the engine version/name after the engine is loaded
+  // This will be populated later in the Configure function
+
   // Check if entity names should be populated in contact points.
   auto contactsElement = _sdf->FindElement("contacts");
   if (contactsElement)
@@ -906,6 +910,21 @@ void Physics::Configure(const Entity &_entity,
     }
     gzdbg << "Loaded [" << pluginLib <<"] from the static plugin registry"
           << std::endl;
+
+    // Update the PhysicsEnginePlugin component to include version
+    std::string engineName = this->dataPtr->engine->GetName();
+    std::string engineVersion = this->dataPtr->engine->GetVersion();
+    std::string engineNameWithVersion = engineName;
+    if (!engineVersion.empty())
+    {
+      engineNameWithVersion += "-" + engineVersion;
+    }
+    auto enginePluginComp = _ecm.Component<components::PhysicsEnginePlugin>(_entity);
+    if (enginePluginComp)
+    {
+      enginePluginComp->SetData(engineNameWithVersion,
+          [](const std::string &_a, const std::string &_b){return _a == _b;});
+    }
   }
   else
   {
@@ -966,6 +985,21 @@ void Physics::Configure(const Entity &_entity,
       {
         gzdbg << "Loaded [" << className << "] from library ["
                << pathToLib << "]" << std::endl;
+
+        // Update the PhysicsEnginePlugin component to include version
+        std::string engineName = this->dataPtr->engine->GetName();
+        std::string engineVersion = this->dataPtr->engine->GetVersion();
+        std::string engineNameWithVersion = engineName;
+        if (!engineVersion.empty())
+        {
+          engineNameWithVersion += "-" + engineVersion;
+        }
+        auto enginePluginComp = _ecm.Component<components::PhysicsEnginePlugin>(_entity);
+        if (enginePluginComp)
+        {
+          enginePluginComp->SetData(engineNameWithVersion,
+              [](const std::string &_a, const std::string &_b){return _a == _b;});
+        }
         break;
       }
 


### PR DESCRIPTION
## Summary

This PR updates gz-sim to display physics engine version information in the Component Inspector by extending the `PhysicsEnginePlugin` component to use the new `GetEngineVersion()` API from gz-physics. 

**Dependencies:**
- Requires gz-physics PR that adds `GetEngineVersion()` API https://github.com/gazebosim/gz-physics/pull/821

**Changes:**
- Updated `PhysicsEnginePlugin` component to store engine name with version in "name-version" format
- Physics engine version now dynamically retrieved and displayed (e.g., "dartsim-6.13.0", "bullet-3.24", "tpe-1.0")
- Removed need for separate version component by extending existing `PhysicsEnginePlugin`

**User-visible changes:**
- Component Inspector now shows physics engine with version when selecting world entity
- Example: `PhysicsEnginePlugin: "dartsim-6.13.0"` (previously showed library path or hardcoded name)

**Implementation details:**
- Calls `engine->GetName()` and `engine->GetVersion()` from gz-physics API
- Concatenates name and version with hyphen separator when version is non-empty
- Updates component data in both static and dynamic plugin loading paths

## Test it

Build from source the gz-physics PR and this branch. Launch any world and see the GUI:

<img width="860" height="804" alt="image" src="https://github.com/user-attachments/assets/328eba02-1cef-4105-a64f-8100525a937c" />
   
   Expected output in Component Inspector:
   - bullet: "bullet-3.24"
   - bullet-featherstone: "bullet-featherstone-3.24"
   - dartsim: "dartsim-6.13.0" (or current DART version)
   - tpe: "tpe-1.0"

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed) - Added changelog entry
- [ ] Updated migration guide (as needed) - Non-breaking change
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-with: GitHub Copilot (Claude Sonnet 4.5)