### PR TITLE
[bazel/infra] Future-proof branch filtering

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,9 +1,10 @@
 name: Bazel CI
 on:
-  push:
-    branches: [gz-sim9, main]
   pull_request:
-    branches: [gz-sim9, main]
+  push:
+    branches:
+      - 'gz-sim[1-9]?[0-9]'
+      - 'main'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
# Internal tooling

Update branch filtering to always run on pull requests and conditionally on `main` and `gz-sim[1-9]?[0-9]` (same as cmake CI). This was already done on the Jetty branch: https://github.com/gazebosim/gz-sim/pull/3041/files

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.