### PR TITLE
Fix flaky test by lowering resolution

### DIFF
--- a/src/Util_TEST.cc
+++ b/src/Util_TEST.cc
@@ -1041,7 +1041,7 @@ TEST_F(UtilTest, LoadMesh)
   EXPECT_TRUE(meshSdf.SetOptimization("convex_decomposition"));
   sdf::ConvexDecomposition convexDecomp;
   convexDecomp.SetMaxConvexHulls(16u);
-  convexDecomp.SetResolution(50000u);
+  convexDecomp.SetVoxelResolution(50000u);
   meshSdf.SetConvexDecomposition(convexDecomp);
   auto *optimizedMesh = loadMesh(meshSdf);
   EXPECT_NE(nullptr, optimizedMesh);


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #3239 

## Summary
`UNIT_Util_TEST`(coverage mode)
```
[ RUN      ] UtilTest.LoadMesh
(2025-12-23 16:42:35.991) [warning] [Util.cc:885] Failed to load mesh [].
(2025-12-23 16:42:35.991) [warning] [Util.cc:885] Failed to load mesh [invalid_uri].
(2025-12-23 16:48:06.727) [warning] [MeshManager.cc:1704] Convex decomposition timed out. Process took more than 300 seconds. 
(2025-12-23 16:48:06.727) [warning] [MeshManager.cc:1714] No convex hulls are generated from /home/momo/gz_jetty/src/gz-sim/test/media/duck.dae_merged_submesh(2025-12-23 16:48:06.727) [debug] [Util.cc:967] Optimizing mesh (convex_decomposition): /home/momo/gz_jetty/src/gz-sim/test/media/duck.dae
(2025-12-23 16:48:06.727) [error] [Util.cc:983] Convex decomposition generated zero meshes: /home/momo/gz_jetty/src/gz-sim/test/media/duck.dae
(2025-12-23 16:48:06.727) [warning] [Util.cc:896] Failed to optimize Mesh /home/momo/gz_jetty/src/gz-sim/test/media/duck.dae
/home/momo/gz_jetty/src/gz-sim/src/Util_TEST.cc:1049: Failure
Expected equality of these values:
  16u
    Which is: 16
  optimizedMesh->SubMeshCount()
    Which is: 1
[  FAILED  ] UtilTest.LoadMesh (330747 ms)
```
In coverage mode, the performance overhead from instrumentation and lack of optimization cause algorithm to exceed the 300-second timeout（set in `MeshManager.cc` ）
```auto timeout = std::chrono::seconds(300); ```

And `voxelResolution` in set to `200000u` in `Util.cc`
```  std::size_t voxelResolution = 200000u; ``` 

To solve this flaky test , I think we can adjust `voxelResolution` from the default 200k to 50k in the unit test. This keeps the test's intent (verifying convex decomposition results) while ensuring stability in instrumented environments (like Coverage/Debug) where the 300s timeout is frequently triggered.  ` convexDecomp.SetVoxelResolution(50000u); `
after adjusting and runing, the output as belows
```
[ RUN      ] UtilTest.LoadMesh
(2025-12-23 17:21:54.278) [warning] [Util.cc:885] Failed to load mesh [].
(2025-12-23 17:21:54.278) [warning] [Util.cc:885] Failed to load mesh [invalid_uri].
(2025-12-23 17:24:20.721) [debug] [Util.cc:967] Optimizing mesh (convex_decomposition): /home/momo/gz_jetty/src/gz-sim/test/media/duck.dae
[       OK ] UtilTest.LoadMesh (146449 ms)
```



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
