### PR TITLE
Prevent sdf double parsing

### DIFF
--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -782,23 +782,11 @@ void ServerPrivate::DownloadAssets(const ServerConfig &_config)
     // Fetch queued assets
     this->FetchQueuedAssets();
 
-    // Reload the SDF root, which will cause the models to download.
-    sdf::Root localRoot;
-    sdf::Errors localErrors = this->LoadSdfRootHelper(_config,
-        localRoot, true);
-
-    // Output any errors.
-    if (!localErrors.empty())
-    {
-      for (auto &err : localErrors)
-        gzerr << err << "\n";
-    }
-
     // Add the models back into the worlds.
     for (auto &runner : this->simRunners)
     {
       // Get a pointer to the SDF world
-      sdf::World *world = localRoot.WorldByName(runner->WorldSdf().Name());
+      sdf::World *world = this->sdfRoot.WorldByName(runner->WorldSdf().Name());
       if (!world)
       {
         gzerr << "Unable to find world with name["


### PR DESCRIPTION

# 🎉 New feature

## Summary

This is part of an effort to analyze and improve performance. The SDF file was being parsed twice at load time. The second parsing was used to download simulation assets. Instead, we can use the queued assets map.

I tested with the jetty demo world: `time gz-sim-server -r --iterations 1 jetty.sdf`

### Before
real  0m5.713s
user  0m2.857s
sys   0m4.271s

### After
real  0m3.453s
user  0m1.833s
sys   0m2.960s


## Test it

Tests should pass, and running simulation should behave as normal.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)