### PR TITLE
ParticleEmitter: do not use header for topic

### DIFF
--- a/src/systems/particle_emitter/ParticleEmitter.cc
+++ b/src/systems/particle_emitter/ParticleEmitter.cc
@@ -21,7 +21,6 @@
 #include <map>
 #include <mutex>
 #include <string>
-#include <vector>
 
 #include <gz/common/Profiler.hh>
 #include <gz/msgs/Utility.hh>
@@ -154,19 +153,6 @@ void ParticleEmitter::PreUpdate(const gz::sim::UpdateInfo &_info,
         {
           std::string topic = _emitter->Data().topic().data();
 
-          // Get the topic information from the header, which is currently a
-          // hack to avoid breaking the particle_emitter.proto message.
-          if (topic.empty() && _emitter->Data().has_header())
-          {
-            for (const auto & data : _emitter->Data().header().data())
-            {
-              if (data.key() == "topic" && !data.value().empty())
-              {
-                topic = data.value(0);
-              }
-            }
-          }
-
           // If a topic has not been specified, then generate topic based
           // on the scoped name.
           if (topic.empty())
@@ -196,14 +182,6 @@ void ParticleEmitter::PreUpdate(const gz::sim::UpdateInfo &_info,
             this->dataPtr->serviceMsg.add_particle_emitter();
           emitterMsg->CopyFrom(_emitter->Data());
           msgs::Set(emitterMsg->mutable_pose(), _pose->Data());
-
-          // Set the topic information if it was not set via SDF.
-          if (!emitterMsg->has_header())
-          {
-            auto headerData = emitterMsg->mutable_header()->add_data();
-            headerData->set_key("topic");
-            headerData->add_value(topic);
-          }
 
           // Set the particle emitter frame
           auto frameData = emitterMsg->mutable_header()->add_data();


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
As was discussed in https://github.com/gazebosim/gz-sim/pull/3244, we can remove reading and setting topic in a header of the message. Related to initial PR https://github.com/gazebosim/gz-sim/pull/2461


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.