### PR TITLE
Prevent publishing empty messages in pose publisher

### DIFF
--- a/src/systems/pose_publisher/PosePublisher.cc
+++ b/src/systems/pose_publisher/PosePublisher.cc
@@ -527,6 +527,9 @@ void PosePublisherPrivate::PublishPoses(
 {
   GZ_PROFILE("PosePublisher::PublishPoses");
 
+  if (_poses.empty())
+    return;
+
   // publish poses
   msgs::Pose *msg = nullptr;
   if (this->usePoseV)


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

Add a check to make sure we don't publish pose messages if it's empty, otherwise you get a bunch of empty msgs.


To test:

Add the pose publisher system to your favorite static model., e.g. edit `shapes.df` and add the following system to the `ground_plane` model:

```xml
      <plugin filename="libgz-sim-pose-publisher-system.so"
        name="gz::sim::systems::PosePublisher">
        <publish_link_pose>true</publish_link_pose>
        <publish_sensor_pose>false</publish_sensor_pose>
        <publish_collision_pose>false</publish_collision_pose>
        <publish_visual_pose>false</publish_visual_pose>
        <publish_nested_model_pose>true</publish_nested_model_pose>
        <publish_model_pose>true</publish_model_pose>
        <use_pose_vector_msg>true</use_pose_vector_msg>
        <static_publisher>true</static_publisher>
        <static_update_frequency>1</static_update_frequency>
      </plugin>
```

Run sim:

```sh
gz sim -v 4 -r shapes.sdf
```

Now echo the `/model/ground_plane/pose` topic to see that no messages should be published. Before this fix, there'll be a lot of empty messages (empty lines)

```
gz topic -e -t /model/ground_plane/pose
```

Echo the `pose_static` topic to make sure data are published:


```
/model/ground_plane/pose_static
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

