### PR TITLE
Add getters for joint velocity, effort, and position limits

### DIFF
--- a/include/gz/sim/Joint.hh
+++ b/include/gz/sim/Joint.hh
@@ -276,14 +276,15 @@ namespace gz
           const EntityComponentManager &_ecm) const;
 
       /// \brief Get joint velocity limits.
-      /// \details For each axis, returns the maximum absolute velocity limit. 
-      /// The size of the returned vector corresponds to the joint's degrees of freedom.
-      /// For multi-axis joints, limits are returned for each axis in order (for
-      /// example, including both JointAxis and JointAxis2 when applicable).
+      /// \details For each axis, returns the maximum absolute velocity limit.
+      /// The size of the returned vector corresponds to the joint's degrees
+      /// of freedom. For multi-axis joints, limits are returned for each axis 
+      /// in order (for example, including both JointAxis and JointAxis2 
+      /// when applicable).
       /// \param[in] _ecm Entity component manager.
       /// \return Velocity limits if available.
-      public: std::optional<std::vector<double>>
-      MaxVelocityLimits(const EntityComponentManager &_ecm) const;
+      public: std::optional<std::vector<double>> MaxVelocityLimits(
+          const EntityComponentManager &_ecm) const;
 
       /// \brief Private data pointer.
       GZ_UTILS_IMPL_PTR(dataPtr)

--- a/include/gz/sim/Joint.hh
+++ b/include/gz/sim/Joint.hh
@@ -276,14 +276,14 @@ namespace gz
           const EntityComponentManager &_ecm) const;
 
       /// \brief Get joint velocity limits.
-      /// \details For each axis, returns the maximum velocity limit. The size of
-      /// the returned vector corresponds to the joint's degrees of freedom. For
-      /// multi-axis joints, limits are returned for each axis in order (for
+      /// \details For each axis, returns the maximum absolute velocity limit. 
+      /// The size of the returned vector corresponds to the joint's degrees of freedom.
+      /// For multi-axis joints, limits are returned for each axis in order (for
       /// example, including both JointAxis and JointAxis2 when applicable).
       /// \param[in] _ecm Entity component manager.
       /// \return Velocity limits if available.
       public: std::optional<std::vector<double>>
-      VelocityLimits(const EntityComponentManager &_ecm) const;
+      MaxVelocityLimits(const EntityComponentManager &_ecm) const;
 
       /// \brief Private data pointer.
       GZ_UTILS_IMPL_PTR(dataPtr)

--- a/include/gz/sim/Joint.hh
+++ b/include/gz/sim/Joint.hh
@@ -275,6 +275,18 @@ namespace gz
       public: std::optional<Model> ParentModel(
           const EntityComponentManager &_ecm) const;
 
+      /// \brief Get joint velocity limits.
+      /// \details For each axis, the X() component of the gz::math::Vector2d
+      /// specifies the minimum velocity limit, and the Y() component specifies
+      /// the maximum velocity limit. The size of the returned vector corresponds
+      /// to the joint's degrees of freedom. For multi-axis joints, limits are
+      /// returned for each axis in order (for example, including both JointAxis
+      /// and JointAxis2 when applicable).
+      /// \param[in] _ecm Entity component manager.
+      /// \return Velocity limits if available.
+      public: std::optional<std::vector<gz::math::Vector2d>>
+      VelocityLimits(const EntityComponentManager &_ecm) const;
+
       /// \brief Private data pointer.
       GZ_UTILS_IMPL_PTR(dataPtr)
     };

--- a/include/gz/sim/Joint.hh
+++ b/include/gz/sim/Joint.hh
@@ -278,8 +278,8 @@ namespace gz
       /// \brief Get joint velocity limits.
       /// \details For each axis, returns the maximum absolute velocity limit.
       /// The size of the returned vector corresponds to the joint's degrees
-      /// of freedom. For multi-axis joints, limits are returned for each axis 
-      /// in order (for example, including both JointAxis and JointAxis2 
+      /// of freedom. For multi-axis joints, limits are returned for each axis
+      /// in order (for example, including both JointAxis and JointAxis2
       /// when applicable).
       /// \param[in] _ecm Entity component manager.
       /// \return Velocity limits if available.

--- a/include/gz/sim/Joint.hh
+++ b/include/gz/sim/Joint.hh
@@ -276,15 +276,13 @@ namespace gz
           const EntityComponentManager &_ecm) const;
 
       /// \brief Get joint velocity limits.
-      /// \details For each axis, the X() component of the gz::math::Vector2d
-      /// specifies the minimum velocity limit, and the Y() component specifies
-      /// the maximum velocity limit. The size of the returned vector corresponds
-      /// to the joint's degrees of freedom. For multi-axis joints, limits are
-      /// returned for each axis in order (for example, including both JointAxis
-      /// and JointAxis2 when applicable).
+      /// \details For each axis, returns the maximum velocity limit. The size of
+      /// the returned vector corresponds to the joint's degrees of freedom. For
+      /// multi-axis joints, limits are returned for each axis in order (for
+      /// example, including both JointAxis and JointAxis2 when applicable).
       /// \param[in] _ecm Entity component manager.
       /// \return Velocity limits if available.
-      public: std::optional<std::vector<gz::math::Vector2d>>
+      public: std::optional<std::vector<double>>
       VelocityLimits(const EntityComponentManager &_ecm) const;
 
       /// \brief Private data pointer.

--- a/include/gz/sim/Joint.hh
+++ b/include/gz/sim/Joint.hh
@@ -275,6 +275,28 @@ namespace gz
       public: std::optional<Model> ParentModel(
           const EntityComponentManager &_ecm) const;
 
+      /// \brief Get joint effort limits.
+      /// \details For each axis, returns the maximum absolute effort limit.
+      /// The size of the returned vector corresponds to the joint's degrees
+      /// of freedom. For multi-axis joints, limits are returned for each axis
+      /// in order (for example, including both JointAxis and JointAxis2 when
+      /// applicable).
+      /// \param[in] _ecm Entity component manager.
+      /// \return Effort limits if available.
+      public: std::optional<std::vector<double>> EffortLimits(
+          const EntityComponentManager &_ecm) const;
+
+      /// \brief Get joint position limits.
+      /// \details For each axis, returns min / max position limits. The size
+      /// of the returned vector corresponds to the joint's degrees of freedom.
+      /// For multi-axis joints, limits are returned for each axis in order
+      /// (for example, including both JointAxis and JointAxis2 when
+      /// applicable).
+      /// \param[in] _ecm Entity component manager.
+      /// \return Position limits if available.
+      public: std::optional<std::vector<math::Vector2d>> PositionLimits(
+          const EntityComponentManager &_ecm) const;
+
       /// \brief Get joint velocity limits.
       /// \details For each axis, returns the maximum absolute velocity limit.
       /// The size of the returned vector corresponds to the joint's degrees

--- a/python/src/gz/sim/Joint.cc
+++ b/python/src/gz/sim/Joint.cc
@@ -93,6 +93,12 @@ void defineSimJoint(py::object module)
   .def("max_velocity_limits", &gz::sim::Joint::MaxVelocityLimits,
       py::arg("ecm"),
       "Get the maximum velocity limit for each joint axis.")
+  .def("effort_limits", &gz::sim::Joint::EffortLimits,
+      py::arg("ecm"),
+      "Get the maximum effort limit for each joint axis.")
+  .def("position_limits", &gz::sim::Joint::PositionLimits,
+      py::arg("ecm"),
+      "Get the position limits for each joint axis.")
   .def("set_effort_limits", &gz::sim::Joint::SetEffortLimits,
       py::arg("ecm"),
       py::arg("limits"),

--- a/python/src/gz/sim/Joint.cc
+++ b/python/src/gz/sim/Joint.cc
@@ -90,6 +90,9 @@ void defineSimJoint(py::object module)
       py::arg("ecm"),
       py::arg("limits"),
       "Set the velocity limits on a joint axis.")
+  .def("max_velocity_limits", &gz::sim::Joint::MaxVelocityLimits,
+      py::arg("ecm"),
+      "Get the maximum velocity limit for each joint axis.")
   .def("set_effort_limits", &gz::sim::Joint::SetEffortLimits,
       py::arg("ecm"),
       py::arg("limits"),

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -386,23 +386,21 @@ std::optional<Model> Joint::ParentModel(const EntityComponentManager &_ecm)
 }
 
 //////////////////////////////////////////////////
-std::optional<std::vector<gz::math::Vector2d>>
+std::optional<std::vector<double>>
 Joint::VelocityLimits(const EntityComponentManager &_ecm) const
 {
-  std::vector<gz::math::Vector2d> limits;
+  std::vector<double> limits;
 
   auto axis1 = _ecm.Component<components::JointAxis>(this->dataPtr->id);
   if (!axis1)
     return std::nullopt;
 
-  const double maxVel1 = axis1->Data().MaxVelocity();
-  limits.emplace_back(-maxVel1, maxVel1);
+  limits.push_back(axis1->Data().MaxVelocity());
 
   auto axis2 = _ecm.Component<components::JointAxis2>(this->dataPtr->id);
   if (axis2)
   {
-    const double maxVel2 = axis2->Data().MaxVelocity();
-    limits.emplace_back(-maxVel2, maxVel2);
+    limits.push_back(axis2->Data().MaxVelocity());
   }
 
   return limits;

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -387,7 +387,7 @@ std::optional<Model> Joint::ParentModel(const EntityComponentManager &_ecm)
 
 //////////////////////////////////////////////////
 std::optional<std::vector<double>>
-Joint::VelocityLimits(const EntityComponentManager &_ecm) const
+Joint::MaxVelocityLimits(const EntityComponentManager &_ecm) const
 {
   std::vector<double> limits;
 

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -384,3 +384,26 @@ std::optional<Model> Joint::ParentModel(const EntityComponentManager &_ecm)
 
   return std::optional<Model>(parent->Data());
 }
+
+//////////////////////////////////////////////////
+std::optional<std::vector<gz::math::Vector2d>>
+Joint::VelocityLimits(const EntityComponentManager &_ecm) const
+{
+  std::vector<gz::math::Vector2d> limits;
+
+  auto axis1 = _ecm.Component<components::JointAxis>(this->dataPtr->id);
+  if (!axis1)
+    return std::nullopt;
+
+  const double maxVel1 = axis1->Data().MaxVelocity();
+  limits.emplace_back(-maxVel1, maxVel1);
+
+  auto axis2 = _ecm.Component<components::JointAxis2>(this->dataPtr->id);
+  if (axis2)
+  {
+    const double maxVel2 = axis2->Data().MaxVelocity();
+    limits.emplace_back(-maxVel2, maxVel2);
+  }
+
+  return limits;
+}

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -405,3 +405,45 @@ Joint::MaxVelocityLimits(const EntityComponentManager &_ecm) const
 
   return limits;
 }
+
+//////////////////////////////////////////////////
+std::optional<std::vector<double>>
+Joint::EffortLimits(const EntityComponentManager &_ecm) const
+{
+  std::vector<double> limits;
+
+  auto axis1 = _ecm.Component<components::JointAxis>(this->dataPtr->id);
+  if (!axis1)
+    return std::nullopt;
+
+  limits.push_back(std::abs(axis1->Data().Effort()));
+
+  auto axis2 = _ecm.Component<components::JointAxis2>(this->dataPtr->id);
+  if (axis2)
+  {
+    limits.push_back(std::abs(axis2->Data().Effort()));
+  }
+
+  return limits;
+}
+
+//////////////////////////////////////////////////
+std::optional<std::vector<math::Vector2d>>
+Joint::PositionLimits(const EntityComponentManager &_ecm) const
+{
+  std::vector<math::Vector2d> limits;
+
+  auto axis1 = _ecm.Component<components::JointAxis>(this->dataPtr->id);
+  if (!axis1)
+    return std::nullopt;
+
+  limits.emplace_back(axis1->Data().Lower(), axis1->Data().Upper());
+
+  auto axis2 = _ecm.Component<components::JointAxis2>(this->dataPtr->id);
+  if (axis2)
+  {
+    limits.emplace_back(axis2->Data().Lower(), axis2->Data().Upper());
+  }
+
+  return limits;
+}

--- a/src/Joint_TEST.cc
+++ b/src/Joint_TEST.cc
@@ -22,6 +22,7 @@
 #include "gz/sim/EntityComponentManager.hh"
 #include "gz/sim/Joint.hh"
 #include "gz/sim/components/Joint.hh"
+#include "gz/sim/components/JointAxis.hh"
 #include "gz/sim/components/Name.hh"
 #include "gz/sim/components/ParentEntity.hh"
 #include "gz/sim/components/Sensor.hh"

--- a/src/Joint_TEST.cc
+++ b/src/Joint_TEST.cc
@@ -136,3 +136,32 @@ TEST(JointTest, Sensors)
   gz::sim::Joint jointC(jointCEntity);
   EXPECT_EQ(0u, jointC.Sensors(ecm).size());
 }
+
+/////////////////////////////////////////////////
+TEST(JointTest, VelocityLimitsMultiAxis)
+{
+  gz::sim::EntityComponentManager ecm;
+
+  auto jointEntity = ecm.CreateEntity();
+  ecm.CreateComponent(jointEntity, gz::sim::components::Joint());
+
+  gz::sim::components::JointAxis axis1;
+  axis1.Data().SetMaxVelocity(5.0);
+  ecm.CreateComponent(jointEntity, axis1);
+
+  gz::sim::components::JointAxis2 axis2;
+  axis2.Data().SetMaxVelocity(2.0);
+  ecm.CreateComponent(jointEntity, axis2);
+
+  gz::sim::Joint joint(jointEntity);
+
+  auto limits = joint.VelocityLimits(ecm);
+
+  ASSERT_TRUE(limits.has_value());
+  ASSERT_EQ(limits->size(), 2u);
+
+  EXPECT_DOUBLE_EQ((*limits)[0].X(), -5.0);
+  EXPECT_DOUBLE_EQ((*limits)[0].Y(),  5.0);
+  EXPECT_DOUBLE_EQ((*limits)[1].X(), -2.0);
+  EXPECT_DOUBLE_EQ((*limits)[1].Y(),  2.0);
+}

--- a/src/Joint_TEST.cc
+++ b/src/Joint_TEST.cc
@@ -160,10 +160,8 @@ TEST(JointTest, VelocityLimitsMultiAxis)
   ASSERT_TRUE(limits.has_value());
   ASSERT_EQ(limits->size(), 2u);
 
-  EXPECT_DOUBLE_EQ((*limits)[0].X(), -5.0);
-  EXPECT_DOUBLE_EQ((*limits)[0].Y(),  5.0);
-  EXPECT_DOUBLE_EQ((*limits)[1].X(), -2.0);
-  EXPECT_DOUBLE_EQ((*limits)[1].Y(),  2.0);
+  EXPECT_DOUBLE_EQ((*limits)[0], 5.0);
+  EXPECT_DOUBLE_EQ((*limits)[1], 2.0);
 }
 
 /////////////////////////////////////////////////
@@ -184,8 +182,7 @@ TEST(JointTest, VelocityLimitsSingleAxis)
 
   ASSERT_TRUE(limits.has_value());
   ASSERT_EQ(limits->size(), 1u);
-  EXPECT_DOUBLE_EQ((*limits)[0].X(), -3.0);
-  EXPECT_DOUBLE_EQ((*limits)[0].Y(),  3.0);
+  EXPECT_DOUBLE_EQ((*limits)[0],  3.0);
 }
 
 /////////////////////////////////////////////////

--- a/src/Joint_TEST.cc
+++ b/src/Joint_TEST.cc
@@ -200,3 +200,135 @@ TEST(JointTest, MaxVelocityLimitsNoAxis)
 
   EXPECT_FALSE(limits.has_value());
 }
+
+/////////////////////////////////////////////////
+TEST(JointTest, EffortLimitsMultiAxis)
+{
+  gz::sim::EntityComponentManager ecm;
+
+  auto jointEntity = ecm.CreateEntity();
+  ecm.CreateComponent(jointEntity, gz::sim::components::Joint());
+
+  gz::sim::components::JointAxis axis1;
+  axis1.Data().SetEffort(5.0);
+  ecm.CreateComponent(jointEntity, axis1);
+
+  gz::sim::components::JointAxis2 axis2;
+  axis2.Data().SetEffort(2.0);
+  ecm.CreateComponent(jointEntity, axis2);
+
+  gz::sim::Joint joint(jointEntity);
+
+  auto limits = joint.EffortLimits(ecm);
+
+  ASSERT_TRUE(limits.has_value());
+  ASSERT_EQ(limits->size(), 2u);
+
+  EXPECT_DOUBLE_EQ((*limits)[0], 5.0);
+  EXPECT_DOUBLE_EQ((*limits)[1], 2.0);
+}
+
+/////////////////////////////////////////////////
+TEST(JointTest, EffortLimitsSingleAxis)
+{
+  gz::sim::EntityComponentManager ecm;
+
+  auto jointEntity = ecm.CreateEntity();
+  ecm.CreateComponent(jointEntity, gz::sim::components::Joint());
+
+  gz::sim::components::JointAxis axis;
+  axis.Data().SetEffort(3.0);
+  ecm.CreateComponent(jointEntity, axis);
+
+  gz::sim::Joint joint(jointEntity);
+
+  auto limits = joint.EffortLimits(ecm);
+
+  ASSERT_TRUE(limits.has_value());
+  ASSERT_EQ(limits->size(), 1u);
+  EXPECT_DOUBLE_EQ((*limits)[0], 3.0);
+}
+
+/////////////////////////////////////////////////
+TEST(JointTest, EffortLimitsNoAxis)
+{
+  gz::sim::EntityComponentManager ecm;
+
+  auto jointEntity = ecm.CreateEntity();
+  ecm.CreateComponent(jointEntity, gz::sim::components::Joint());
+
+  gz::sim::Joint joint(jointEntity);
+
+  auto limits = joint.EffortLimits(ecm);
+
+  EXPECT_FALSE(limits.has_value());
+}
+
+/////////////////////////////////////////////////
+TEST(JointTest, PositionLimitsMultiAxis)
+{
+  gz::sim::EntityComponentManager ecm;
+
+  auto jointEntity = ecm.CreateEntity();
+  ecm.CreateComponent(jointEntity, gz::sim::components::Joint());
+
+  gz::sim::components::JointAxis axis1;
+  axis1.Data().SetLower(-1.0);
+  axis1.Data().SetUpper(2.0);
+  ecm.CreateComponent(jointEntity, axis1);
+
+  gz::sim::components::JointAxis2 axis2;
+  axis2.Data().SetLower(-3.0);
+  axis2.Data().SetUpper(4.0);
+  ecm.CreateComponent(jointEntity, axis2);
+
+  gz::sim::Joint joint(jointEntity);
+
+  auto limits = joint.PositionLimits(ecm);
+
+  ASSERT_TRUE(limits.has_value());
+  ASSERT_EQ(limits->size(), 2u);
+
+  EXPECT_DOUBLE_EQ((*limits)[0].X(), -1.0);
+  EXPECT_DOUBLE_EQ((*limits)[0].Y(), 2.0);
+  EXPECT_DOUBLE_EQ((*limits)[1].X(), -3.0);
+  EXPECT_DOUBLE_EQ((*limits)[1].Y(), 4.0);
+}
+
+/////////////////////////////////////////////////
+TEST(JointTest, PositionLimitsSingleAxis)
+{
+  gz::sim::EntityComponentManager ecm;
+
+  auto jointEntity = ecm.CreateEntity();
+  ecm.CreateComponent(jointEntity, gz::sim::components::Joint());
+
+  gz::sim::components::JointAxis axis;
+  axis.Data().SetLower(-0.5);
+  axis.Data().SetUpper(0.7);
+  ecm.CreateComponent(jointEntity, axis);
+
+  gz::sim::Joint joint(jointEntity);
+
+  auto limits = joint.PositionLimits(ecm);
+
+  ASSERT_TRUE(limits.has_value());
+  ASSERT_EQ(limits->size(), 1u);
+  EXPECT_DOUBLE_EQ((*limits)[0].X(), -0.5);
+  EXPECT_DOUBLE_EQ((*limits)[0].Y(), 0.7);
+}
+
+/////////////////////////////////////////////////
+TEST(JointTest, PositionLimitsNoAxis)
+{
+  gz::sim::EntityComponentManager ecm;
+
+  auto jointEntity = ecm.CreateEntity();
+  ecm.CreateComponent(jointEntity, gz::sim::components::Joint());
+
+  gz::sim::Joint joint(jointEntity);
+
+  auto limits = joint.PositionLimits(ecm);
+
+  EXPECT_FALSE(limits.has_value());
+}

--- a/src/Joint_TEST.cc
+++ b/src/Joint_TEST.cc
@@ -165,3 +165,40 @@ TEST(JointTest, VelocityLimitsMultiAxis)
   EXPECT_DOUBLE_EQ((*limits)[1].X(), -2.0);
   EXPECT_DOUBLE_EQ((*limits)[1].Y(),  2.0);
 }
+
+/////////////////////////////////////////////////
+TEST(JointTest, VelocityLimitsSingleAxis)
+{
+  gz::sim::EntityComponentManager ecm;
+
+  auto jointEntity = ecm.CreateEntity();
+  ecm.CreateComponent(jointEntity, gz::sim::components::Joint());
+
+  gz::sim::components::JointAxis axis;
+  axis.Data().SetMaxVelocity(3.0);
+  ecm.CreateComponent(jointEntity, axis);
+
+  gz::sim::Joint joint(jointEntity);
+
+  auto limits = joint.VelocityLimits(ecm);
+
+  ASSERT_TRUE(limits.has_value());
+  ASSERT_EQ(limits->size(), 1u);
+  EXPECT_DOUBLE_EQ((*limits)[0].X(), -3.0);
+  EXPECT_DOUBLE_EQ((*limits)[0].Y(),  3.0);
+}
+
+/////////////////////////////////////////////////
+TEST(JointTest, VelocityLimitsNoAxis)
+{
+  gz::sim::EntityComponentManager ecm;
+
+  auto jointEntity = ecm.CreateEntity();
+  ecm.CreateComponent(jointEntity, gz::sim::components::Joint());
+
+  gz::sim::Joint joint(jointEntity);
+
+  auto limits = joint.VelocityLimits(ecm);
+
+  EXPECT_FALSE(limits.has_value());
+}

--- a/src/Joint_TEST.cc
+++ b/src/Joint_TEST.cc
@@ -138,7 +138,7 @@ TEST(JointTest, Sensors)
 }
 
 /////////////////////////////////////////////////
-TEST(JointTest, VelocityLimitsMultiAxis)
+TEST(JointTest, MaxVelocityLimitsMultiAxis)
 {
   gz::sim::EntityComponentManager ecm;
 
@@ -155,7 +155,7 @@ TEST(JointTest, VelocityLimitsMultiAxis)
 
   gz::sim::Joint joint(jointEntity);
 
-  auto limits = joint.VelocityLimits(ecm);
+  auto limits = joint.MaxVelocityLimits(ecm);
 
   ASSERT_TRUE(limits.has_value());
   ASSERT_EQ(limits->size(), 2u);
@@ -165,7 +165,7 @@ TEST(JointTest, VelocityLimitsMultiAxis)
 }
 
 /////////////////////////////////////////////////
-TEST(JointTest, VelocityLimitsSingleAxis)
+TEST(JointTest, MaxVelocityLimitsSingleAxis)
 {
   gz::sim::EntityComponentManager ecm;
 
@@ -178,7 +178,7 @@ TEST(JointTest, VelocityLimitsSingleAxis)
 
   gz::sim::Joint joint(jointEntity);
 
-  auto limits = joint.VelocityLimits(ecm);
+  auto limits = joint.MaxVelocityLimits(ecm);
 
   ASSERT_TRUE(limits.has_value());
   ASSERT_EQ(limits->size(), 1u);
@@ -186,7 +186,7 @@ TEST(JointTest, VelocityLimitsSingleAxis)
 }
 
 /////////////////////////////////////////////////
-TEST(JointTest, VelocityLimitsNoAxis)
+TEST(JointTest, MaxVelocityLimitsNoAxis)
 {
   gz::sim::EntityComponentManager ecm;
 
@@ -195,7 +195,7 @@ TEST(JointTest, VelocityLimitsNoAxis)
 
   gz::sim::Joint joint(jointEntity);
 
-  auto limits = joint.VelocityLimits(ecm);
+  auto limits = joint.MaxVelocityLimits(ecm);
 
   EXPECT_FALSE(limits.has_value());
 }


### PR DESCRIPTION
# 🎉 New feature

Closes #2664

## Summary
This PR adds getter APIs for retrieving joint velocity, effort, and position limits.

gz::sim::Joint already provides setter methods for velocity limits, but
no corresponding getter. This change adds Joint::VelocityLimits(), which
reads the limit from the existing components::JointAxis state
(sdf::JointAxis::MaxVelocity), including support for multi-axis joints.

In addition, this PR also introduces getter methods for effort and position
limits for completeness and API symmetry with the existing setters.

## Test it
ctest -R Joint_TEST

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
