### PR TITLE
Make Model::Name return std::optional and update call sites

### DIFF
--- a/include/gz/sim/Model.hh
+++ b/include/gz/sim/Model.hh
@@ -18,6 +18,7 @@
 #define GZ_SIM_MODEL_HH_
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -54,7 +55,7 @@ namespace gz
     /// a simpler function call:
     ///
     ///    Model model(entity);
-    ///    std::string name = model.Name(ecm);
+    ///    std::string name = model.Name(ecm).value_or("");
     ///
     /// \todo(louise) Store the ecm instead of passing it at every API call.
     class GZ_SIM_VISIBLE Model {
@@ -95,8 +96,9 @@ namespace gz
 
       /// \brief Get the model's unscoped name.
       /// \param[in] _ecm Entity-component manager.
-      /// \return Model's name.
-      public: std::string Name(const EntityComponentManager &_ecm) const;
+      /// \return Model's name or nullopt if the entity does not have a
+      /// components::Name component.
+      public: std::optional<std::string> Name(const EntityComponentManager &_ecm) const;
 
       /// \brief Get whether this model is static.
       /// \param[in] _ecm Entity-component manager.

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -79,13 +79,13 @@ bool Model::Valid(const EntityComponentManager &_ecm) const
 }
 
 //////////////////////////////////////////////////
-std::string Model::Name(const EntityComponentManager &_ecm) const
+std::optional<std::string> Model::Name(const EntityComponentManager &_ecm) const
 {
   auto comp = _ecm.Component<components::Name>(this->dataPtr->id);
   if (comp)
     return comp->Data();
 
-  return "";
+  return std::nullopt;
 }
 
 //////////////////////////////////////////////////

--- a/src/gui/plugins/apply_force_torque/ApplyForceTorque.cc
+++ b/src/gui/plugins/apply_force_torque/ApplyForceTorque.cc
@@ -422,7 +422,8 @@ void ApplyForceTorque::Update(const UpdateInfo &/*_info*/,
       }
 
       this->dataPtr->modelName = QString::fromStdString(
-        parentModel.Name(_ecm));
+        parentModel.Name(_ecm)
+          .value_or(std::to_string(parentModel.Entity())));
       this->dataPtr->selectedEntity = selectedLink.Entity();
 
       // Put all of the model's links into the list

--- a/src/systems/apply_joint_force/ApplyJointForce.cc
+++ b/src/systems/apply_joint_force/ApplyJointForce.cc
@@ -105,8 +105,10 @@ void ApplyJointForce::Configure(const Entity &_entity,
 
   // Subscribe to commands
   //! [cmdTopic]
+  const auto modelName = this->dataPtr->model.Name(_ecm)
+      .value_or(std::to_string(this->dataPtr->model.Entity()));
   auto topic = transport::TopicUtils::AsValidTopic("/model/" +
-      this->dataPtr->model.Name(_ecm) + "/joint/" + this->dataPtr->jointName +
+      modelName + "/joint/" + this->dataPtr->jointName +
       "/cmd_force");
   //! [cmdTopic]
   if (topic.empty())

--- a/src/systems/battery_plugin/LinearBatteryPlugin.cc
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.cc
@@ -224,7 +224,8 @@ void LinearBatteryPlugin::Configure(const Entity &_entity,
     return;
   }
   this->dataPtr->model = model;
-  this->dataPtr->modelName = model.Name(_ecm);
+  this->dataPtr->modelName = model.Name(_ecm)
+      .value_or(std::to_string(model.Entity()));
 
   if (_sdf->HasElement("open_circuit_voltage_constant_coef"))
     this->dataPtr->e0 = _sdf->Get<double>("open_circuit_voltage_constant_coef");
@@ -418,7 +419,7 @@ void LinearBatteryPlugin::Configure(const Entity &_entity,
       components::BatterySoC(this->dataPtr->soc));
 
   // Setup battery state topic
-  std::string stateTopic{"/model/" + this->dataPtr->model.Name(_ecm) +
+  std::string stateTopic{"/model/" + this->dataPtr->modelName +
     "/battery/" + this->dataPtr->battery->Name() + "/state"};
 
   auto validStateTopic = transport::TopicUtils::AsValidTopic(stateTopic);

--- a/src/systems/breadcrumbs/Breadcrumbs.cc
+++ b/src/systems/breadcrumbs/Breadcrumbs.cc
@@ -138,8 +138,10 @@ void Breadcrumbs::Configure(const Entity &_entity,
   {
     topics.push_back(_sdf->Get<std::string>("topic"));
   }
+  const auto modelName = this->model.Name(_ecm)
+      .value_or(std::to_string(this->model.Entity()));
   topics.push_back("/model/" +
-      this->model.Name(_ecm) + "/breadcrumbs/" +
+      modelName + "/breadcrumbs/" +
       this->modelRoot.Model()->Name() + "/deploy");
   this->topic = validTopic(topics);
 

--- a/src/systems/buoyancy_engine/BuoyancyEngine.cc
+++ b/src/systems/buoyancy_engine/BuoyancyEngine.cc
@@ -140,8 +140,10 @@ void BuoyancyEnginePlugin::Configure(
     model.LinkByName(_ecm, _sdf->Get<std::string>("link_name"));
   if (this->dataPtr->linkEntity == kNullEntity)
   {
+    const auto modelName = model.Name(_ecm)
+        .value_or(std::to_string(model.Entity()));
     gzerr << "Link [" << _sdf->Get<std::string>("link_name")
-      << "] was not found in model [" << model.Name(_ecm) << "]" << std::endl;
+      << "] was not found in model [" << modelName << "]" << std::endl;
     return;
   }
 

--- a/src/systems/comms_endpoint/CommsEndpoint.cc
+++ b/src/systems/comms_endpoint/CommsEndpoint.cc
@@ -154,7 +154,9 @@ void CommsEndpoint::Configure(const Entity &_entity,
 
   // Prepare the bind parameters.
   this->dataPtr->bindReq.add_data(this->dataPtr->address);
-  this->dataPtr->bindReq.add_data(this->dataPtr->model.Name(_ecm));
+  this->dataPtr->bindReq.add_data(
+      this->dataPtr->model.Name(_ecm)
+          .value_or(std::to_string(this->dataPtr->model.Entity())));
   this->dataPtr->bindReq.add_data(this->dataPtr->topic);
 
   // Prepare the unbind parameters.

--- a/src/systems/detachable_joint/DetachableJoint.cc
+++ b/src/systems/detachable_joint/DetachableJoint.cc
@@ -53,6 +53,9 @@ void DetachableJoint::Configure(const Entity &_entity,
     return;
   }
 
+  const auto modelName = this->model.Name(_ecm)
+      .value_or(std::to_string(this->model.Entity()));
+
   if (_sdf->HasElement("parent_link"))
   {
     auto parentLinkName = _sdf->Get<std::string>("parent_link");
@@ -60,7 +63,7 @@ void DetachableJoint::Configure(const Entity &_entity,
     if (kNullEntity == this->parentLinkEntity)
     {
       gzerr << "Link with name " << parentLinkName
-             << " not found in model " << this->model.Name(_ecm)
+             << " not found in model " << modelName
              << ". Make sure the parameter 'parent_link' has the "
              << "correct value. Failed to initialize.\n";
       return;
@@ -101,7 +104,7 @@ void DetachableJoint::Configure(const Entity &_entity,
   {
     detachTopics.push_back(_sdf->Get<std::string>("detach_topic"));
   }
-  detachTopics.push_back("/model/" + this->model.Name(_ecm) +
+  detachTopics.push_back("/model/" + modelName +
       "/detachable_joint/detach");
 
   if (_sdf->HasElement("topic"))
@@ -149,7 +152,7 @@ void DetachableJoint::Configure(const Entity &_entity,
   {
     attachTopics.push_back(_sdf->Get<std::string>("attach_topic"));
   }
-  attachTopics.push_back("/model/" + this->model.Name(_ecm) +
+  attachTopics.push_back("/model/" + modelName +
       "/detachable_joint/attach");
   this->attachTopic = validTopic(attachTopics);
   if (this->attachTopic.empty())

--- a/src/systems/drive_to_pose_controller/DriveToPoseController.cc
+++ b/src/systems/drive_to_pose_controller/DriveToPoseController.cc
@@ -139,7 +139,9 @@ void DriveToPoseController::Configure(
   }
 
   // Topic namespace for publish and subscribe
-  std::string topicNamespace = "/model/" + this->dataPtr->model.Name(_ecm);
+  const auto modelName = this->dataPtr->model.Name(_ecm)
+      .value_or(std::to_string(this->dataPtr->model.Entity()));
+  std::string topicNamespace = "/model/" + modelName;
 
   // Subscribe to odometry pose publisher
   this->dataPtr->node.Subscribe(

--- a/src/systems/elevator/Elevator.cc
+++ b/src/systems/elevator/Elevator.cc
@@ -192,7 +192,9 @@ void Elevator::Configure(const Entity &_entity,
   std::string cabinJointName =
       _sdf->Get<std::string>("cabin_joint", "lift").first;
 
-  std::string topicPrefix = "/model/" + this->dataPtr->model.Name(_ecm);
+  const auto modelName = this->dataPtr->model.Name(_ecm)
+      .value_or(std::to_string(this->dataPtr->model.Entity()));
+  std::string topicPrefix = "/model/" + modelName;
 
   if (!this->dataPtr->InitCabin(cabinJointName, floorLinkPrefix, topicPrefix,
                                 _ecm))
@@ -230,7 +232,7 @@ void Elevator::Configure(const Entity &_entity,
       _sdf->Get<std::string>("cmd_topic", topicPrefix + "/cmd").first;
   this->dataPtr->node.Subscribe(cmdTopicName, &ElevatorPrivate::OnCmdMsg,
                                 this->dataPtr.get());
-  gzmsg << "System " << this->dataPtr->model.Name(_ecm) << " subscribed to "
+  gzmsg << "System " << modelName << " subscribed to "
          << cmdTopicName << " for command messages" << std::endl;
 }
 

--- a/src/systems/joint_controller/JointController.cc
+++ b/src/systems/joint_controller/JointController.cc
@@ -193,11 +193,13 @@ void JointController::Configure(const Entity &_entity,
 
   // Subscribe to commands
   std::string topic;
+  const auto modelName = this->dataPtr->model.Name(_ecm)
+      .value_or(std::to_string(this->dataPtr->model.Entity()));
   if ((!_sdf->HasElement("sub_topic")) && (!_sdf->HasElement("topic"))
     && (!this->dataPtr->useActuatorMsg))
   {
     topic = transport::TopicUtils::AsValidTopic("/model/" +
-        this->dataPtr->model.Name(_ecm) + "/joint/" +
+        modelName + "/joint/" +
         this->dataPtr->jointNames[0] + "/cmd_vel");
     if (topic.empty())
     {
@@ -222,13 +224,13 @@ void JointController::Configure(const Entity &_entity,
   if (_sdf->HasElement("sub_topic"))
   {
     topic = transport::TopicUtils::AsValidTopic("/model/" +
-      this->dataPtr->model.Name(_ecm) + "/" +
+      modelName + "/" +
         _sdf->Get<std::string>("sub_topic"));
 
     if (topic.empty())
     {
       gzerr << "Failed to create topic from sub_topic [/model/"
-             << this->dataPtr->model.Name(_ecm) << "/"
+             << modelName << "/"
              << _sdf->Get<std::string>("sub_topic")
              << "]" << " for joint [" << this->dataPtr->jointNames[0]
              << "]" << std::endl;

--- a/src/systems/joint_position_controller/JointPositionController.cc
+++ b/src/systems/joint_position_controller/JointPositionController.cc
@@ -341,11 +341,13 @@ void JointPositionController::Configure(const Entity &_entity,
 
   // Subscribe to commands
   std::string topic;
+  const auto modelName = this->dataPtr->model.Name(_ecm)
+      .value_or(std::to_string(this->dataPtr->model.Entity()));
   if ((!_sdf->HasElement("sub_topic")) && (!_sdf->HasElement("topic"))
     && (!this->dataPtr->useActuatorMsg))
   {
     topic = transport::TopicUtils::AsValidTopic("/model/" +
-        this->dataPtr->model.Name(_ecm) + "/joint/" +
+        modelName + "/joint/" +
         this->dataPtr->jointNames[0] + "/" +
         std::to_string(this->dataPtr->jointIndex) + "/cmd_pos");
     if (topic.empty())
@@ -371,13 +373,13 @@ void JointPositionController::Configure(const Entity &_entity,
   if (_sdf->HasElement("sub_topic"))
   {
     topic = transport::TopicUtils::AsValidTopic("/model/" +
-      this->dataPtr->model.Name(_ecm) + "/" +
+      modelName + "/" +
         _sdf->Get<std::string>("sub_topic"));
 
     if (topic.empty())
     {
       gzerr << "Failed to create topic from sub_topic [/model/"
-             << this->dataPtr->model.Name(_ecm) << "/"
+             << modelName << "/"
              << _sdf->Get<std::string>("sub_topic")
              << "]" << " for joint [" << this->dataPtr->jointNames[0]
              << "]" << std::endl;

--- a/src/systems/joint_state_publisher/JointStatePublisher.cc
+++ b/src/systems/joint_state_publisher/JointStatePublisher.cc
@@ -188,7 +188,8 @@ void JointStatePublisher::PostUpdate(const UpdateInfo &_info,
       convert<msgs::Time>(_info.simTime));
 
   // Set the name and ID.
-  msg.set_name(this->model.Name(_ecm));
+  msg.set_name(this->model.Name(_ecm)
+      .value_or(std::to_string(this->model.Entity())));
   msg.set_id(this->model.Entity());
 
   // Set the model pose

--- a/src/systems/joint_traj_control/JointTrajectoryController.cc
+++ b/src/systems/joint_traj_control/JointTrajectoryController.cc
@@ -324,16 +324,18 @@ void JointTrajectoryController::Configure(
 {
   // Make sure the controller is attached to a valid model
   const auto model = Model(_entity);
+  const auto modelName = model.Name(_ecm)
+      .value_or(std::to_string(model.Entity()));
   if (!model.Valid(_ecm))
   {
     gzerr << "[JointTrajectoryController] Failed to initialize because ["
-           << model.Name(_ecm) << "(Entity=" << _entity
+           << modelName << "(Entity=" << _entity
            << ")] is not a model. Please make sure that"
               " JointTrajectoryController is attached to a valid model.\n";
     return;
   }
   gzmsg << "[JointTrajectoryController] Setting up controller for ["
-         << model.Name(_ecm) << "(Entity=" << _entity << ")].\n";
+         << modelName << "(Entity=" << _entity << ")].\n";
 
   // Get list of enabled joints
   const auto enabledJoints = this->dataPtr->GetEnabledJoints(_entity,
@@ -358,7 +360,7 @@ void JointTrajectoryController::Configure(
   if (this->dataPtr->actuatedJoints.empty())
   {
     gzerr << "[JointTrajectoryController] Failed to initialize because ["
-           << model.Name(_ecm) << "(Entity=" << _entity
+          << modelName << "(Entity=" << _entity
            << ")] has no supported joints.\n";
     return;
   }
@@ -379,7 +381,7 @@ void JointTrajectoryController::Configure(
   if (trajectoryTopic.empty())
   {
     // If not specified, use the default topic based on model name
-    trajectoryTopic = "/model/" + model.Name(_ecm) + "/joint_trajectory";
+    trajectoryTopic = "/model/" + modelName + "/joint_trajectory";
   }
   // Make sure the topic is valid
   const auto validTrajectoryTopic = transport::TopicUtils::AsValidTopic(

--- a/src/systems/kinetic_energy_monitor/KineticEnergyMonitor.cc
+++ b/src/systems/kinetic_energy_monitor/KineticEnergyMonitor.cc
@@ -99,7 +99,8 @@ void KineticEnergyMonitor::Configure(const Entity &_entity,
     return;
   }
 
-  this->dataPtr->modelName = this->dataPtr->model.Name(_ecm);
+  this->dataPtr->modelName = this->dataPtr->model.Name(_ecm)
+      .value_or(std::to_string(this->dataPtr->model.Entity()));
 
   auto sdfClone = _sdf->Clone();
   std::string linkName;

--- a/src/systems/lookup_wheel_slip/LookupWheelSlip.cc
+++ b/src/systems/lookup_wheel_slip/LookupWheelSlip.cc
@@ -273,8 +273,10 @@ void LookupWheelSlip::Configure(const Entity &_entity,
     auto link = Link(this->dataPtr->model.LinkByName(_ecm, linkName));
     if (!link.Valid(_ecm))
     {
+      const auto modelName = this->dataPtr->model.Name(_ecm)
+          .value_or(std::to_string(this->dataPtr->model.Entity()));
       gzerr << "Could not find link named [" << linkName
-            << "] in model [" << this->dataPtr->model.Name(_ecm) << "]"
+            << "] in model [" << modelName << "]"
             << std::endl;
       continue;
     }

--- a/src/systems/model_photo_shoot/ModelPhotoShoot.cc
+++ b/src/systems/model_photo_shoot/ModelPhotoShoot.cc
@@ -112,7 +112,8 @@ void ModelPhotoShoot::Configure(const gz::sim::Entity &_entity,
           this->dataPtr.get()));
 
   this->dataPtr->model = std::make_shared<gz::sim::Model>(_entity);
-  this->dataPtr->modelName = this->dataPtr->model->Name(_ecm);
+  this->dataPtr->modelName = this->dataPtr->model->Name(_ecm)
+      .value_or(std::to_string(this->dataPtr->model->Entity()));
   // Get the pose of the model
   this->dataPtr->modelPose3D =
       gz::sim::worldPose(this->dataPtr->model->Entity(), _ecm);

--- a/src/systems/multicopter_control/Common.cc
+++ b/src/systems/multicopter_control/Common.cc
@@ -51,6 +51,8 @@ RotorConfiguration loadRotorConfiguration(const EntityComponentManager &_ecm,
 {
   RotorConfiguration out;
   std::size_t count = 0;
+  const auto modelName = _model.Name(_ecm)
+      .value_or(std::to_string(_model.Entity()));
   for (sdf::ElementPtr elem = _sdf->GetFirstElement(); elem;
         elem = elem->GetNextElement("rotor"), ++count)
   {
@@ -68,8 +70,8 @@ RotorConfiguration loadRotorConfiguration(const EntityComponentManager &_ecm,
     if (kNullEntity == joint)
     {
       gzerr << "Joint with name " << jointName << " could not be found in "
-              << "model " << _model.Name(_ecm) << " while processing rotor "
-              << "index " << count << std::endl;
+            << "model " << modelName << " while processing rotor "
+            << "index " << count << std::endl;
       continue;
     }
 
@@ -89,7 +91,7 @@ RotorConfiguration loadRotorConfiguration(const EntityComponentManager &_ecm,
     {
       gzerr << "Child link of joint " << jointName << " with name "
               << childLinkName << " could not be found in  model "
-              << _model.Name(_ecm) << " while processing rotor index " << count
+            << modelName << " while processing rotor index " << count
               << std::endl;
       continue;
     }

--- a/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
+++ b/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
@@ -255,7 +255,8 @@ void MulticopterMotorModel::Configure(const Entity &_entity,
   else
   {
     gzwarn << "No robotNamespace set using entity name.\n";
-    this->dataPtr->robotNamespace = this->dataPtr->model.Name(_ecm);
+    this->dataPtr->robotNamespace = this->dataPtr->model.Name(_ecm)
+        .value_or(std::to_string(this->dataPtr->model.Entity()));
   }
 
   // Get params from SDF

--- a/src/systems/odometry_publisher/OdometryPublisher.cc
+++ b/src/systems/odometry_publisher/OdometryPublisher.cc
@@ -154,7 +154,9 @@ void OdometryPublisher::Configure(const Entity &_entity,
     return;
   }
 
-  this->dataPtr->odomFrame = this->dataPtr->model.Name(_ecm) + "/" + "odom";
+  const auto modelName = this->dataPtr->model.Name(_ecm)
+      .value_or(std::to_string(this->dataPtr->model.Entity()));
+  this->dataPtr->odomFrame = modelName + "/" + "odom";
   if (!_sdf->HasElement("odom_frame"))
   {
     gzdbg << "OdometryPublisher system plugin missing <odom_frame>, "
@@ -183,8 +185,7 @@ void OdometryPublisher::Configure(const Entity &_entity,
     this->dataPtr->gaussianNoise = _sdf->Get<double>("gaussian_noise");
   }
 
-  this->dataPtr->robotBaseFrame = this->dataPtr->model.Name(_ecm)
-    + "/" + "base_footprint";
+  this->dataPtr->robotBaseFrame = modelName + "/" + "base_footprint";
   if (!_sdf->HasElement("robot_base_frame"))
   {
     gzdbg << "OdometryPublisher system plugin missing <robot_base_frame>, "
@@ -222,10 +223,8 @@ void OdometryPublisher::Configure(const Entity &_entity,
   }
 
   // Setup odometry
-  std::string odomTopic{"/model/" + this->dataPtr->model.Name(_ecm) +
-    "/odometry"};
-  std::string odomCovTopic{"/model/" + this->dataPtr->model.Name(_ecm) +
-    "/odometry_with_covariance"};
+  std::string odomTopic{"/model/" + modelName + "/odometry"};
+  std::string odomCovTopic{"/model/" + modelName + "/odometry_with_covariance"};
 
   if (_sdf->HasElement("odom_topic"))
     odomTopic = _sdf->Get<std::string>("odom_topic");
@@ -263,7 +262,7 @@ void OdometryPublisher::Configure(const Entity &_entity,
            << odomCovTopicValid << "]" << std::endl;
   }
 
-  std::string tfTopic{"/model/" + this->dataPtr->model.Name(_ecm) + "/pose"};
+  std::string tfTopic{"/model/" + modelName + "/pose"};
   if (_sdf->HasElement("tf_topic"))
     tfTopic = _sdf->Get<std::string>("tf_topic");
   std::string tfTopicValid {transport::TopicUtils::AsValidTopic(tfTopic)};

--- a/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
+++ b/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
@@ -505,7 +505,8 @@ void OpticalTactilePluginPrivate::Load(const EntityComponentManager &_ecm)
     {
       this->sensorCollisionEntity = colEntity;
 
-      this->modelName = this->model.Name(_ecm);
+      this->modelName = this->model.Name(_ecm)
+          .value_or(std::to_string(this->model.Entity()));
 
       // Get the size of the collision element
       const auto geometry =

--- a/src/systems/performer_detector/PerformerDetector.cc
+++ b/src/systems/performer_detector/PerformerDetector.cc
@@ -55,7 +55,8 @@ void PerformerDetector::Configure(const Entity &_entity,
     return;
   }
 
-  this->detectorName = this->model.Name(_ecm);
+  this->detectorName = this->model.Name(_ecm)
+      .value_or(std::to_string(this->model.Entity()));
 
   auto sdfClone = _sdf->Clone();
   bool hasGeometry{false};
@@ -116,7 +117,7 @@ void PerformerDetector::Configure(const Entity &_entity,
     }
   }
 
-  std::string defaultTopic{"/model/" + this->model.Name(_ecm) +
+  std::string defaultTopic{"/model/" + this->detectorName +
                              "/performer_detector/status"};
   auto topic = _sdf->Get<std::string>("topic", defaultTopic).first;
 

--- a/src/systems/spacecraft_thruster_model/SpacecraftThrusterModel.cc
+++ b/src/systems/spacecraft_thruster_model/SpacecraftThrusterModel.cc
@@ -145,7 +145,8 @@ void SpacecraftThrusterModel::Configure(const Entity &_entity,
   else
   {
     gzwarn << "No topic set using entity name.\n";
-    this->dataPtr->topic = this->dataPtr->model.Name(_ecm);
+    this->dataPtr->topic = this->dataPtr->model.Name(_ecm)
+        .value_or(std::to_string(this->dataPtr->model.Entity()));
   }
 
   if (sdfClone->HasElement("link_name"))

--- a/src/systems/thruster/Thruster.cc
+++ b/src/systems/thruster/Thruster.cc
@@ -223,7 +223,8 @@ void Thruster::Configure(
   // Create model object, to access convenient functions
   this->dataPtr->modelEntity = _entity;
   auto model = Model(_entity);
-  auto modelName = model.Name(_ecm);
+  const auto modelName = model.Name(_ecm)
+      .value_or(std::to_string(model.Entity()));
 
   // Get namespace
   std::string ns = modelName;

--- a/src/systems/touch_plugin/TouchPlugin.cc
+++ b/src/systems/touch_plugin/TouchPlugin.cc
@@ -264,6 +264,9 @@ void TouchPluginPrivate::Update(const UpdateInfo &_info,
   if (_info.paused)
     return;
 
+  const auto modelName = this->model.Name(_ecm)
+      .value_or(std::to_string(this->model.Entity()));
+
   bool touching{false};
   // Iterate through all the target entities and check if there is a contact
   // between the target entity and this model
@@ -294,7 +297,7 @@ void TouchPluginPrivate::Update(const UpdateInfo &_info,
     std::lock_guard<std::mutex> lock(this->serviceMutex);
     if (this->touchStart != DurationType::zero())
     {
-      gzdbg << "Model [" << this->model.Name(_ecm)
+      gzdbg << "Model [" << modelName
              << "] not touching anything at [" << _info.simTime.count()
              << "]" << std::endl;
     }
@@ -310,7 +313,7 @@ void TouchPluginPrivate::Update(const UpdateInfo &_info,
       this->touchStart =
         std::chrono::duration_cast<DurationType>(_info.simTime);
 
-      gzdbg << "Model [" << this->model.Name(_ecm) << "] started touching ["
+      gzdbg << "Model [" << modelName << "] started touching ["
         << this->targetName << "] at " << this->touchStart.count() << " s"
         << std::endl;
     }
@@ -324,7 +327,7 @@ void TouchPluginPrivate::Update(const UpdateInfo &_info,
   // and stop updating
   if (completed)
   {
-    gzdbg << "Model [" << this->model.Name(_ecm) << "] touched ["
+    gzdbg << "Model [" << modelName << "] touched ["
       << this->targetName << "] exclusively for "
       << this->targetTime.count() << " s" << std::endl;
 

--- a/src/systems/track_controller/TrackController.cc
+++ b/src/systems/track_controller/TrackController.cc
@@ -249,7 +249,9 @@ void TrackController::Configure(const Entity &_entity,
     }
   );
 
-  const auto topicPrefix = "/model/" + this->dataPtr->model.Name(_ecm) +
+  const auto modelName = this->dataPtr->model.Name(_ecm)
+      .value_or(std::to_string(this->dataPtr->model.Entity()));
+  const auto topicPrefix = "/model/" + modelName +
     "/link/" + this->dataPtr->linkName;
 
   const auto kDefaultVelTopic = topicPrefix + "/track_cmd_vel";

--- a/src/systems/trajectory_follower/TrajectoryFollower.cc
+++ b/src/systems/trajectory_follower/TrajectoryFollower.cc
@@ -258,7 +258,9 @@ void TrajectoryFollowerPrivate::Load(const EntityComponentManager &_ecm,
     this->forceZeroAngVel = _sdf->Get<bool>("zero_vel_on_bearing_reached");
 
   // Parse the optional <topic> element.
-  this->topic = "/model/" + this->model.Name(_ecm) +
+  const auto modelName = this->model.Name(_ecm)
+      .value_or(std::to_string(this->model.Entity()));
+  this->topic = "/model/" + modelName +
     "/trajectory_follower/pause";
 
   if (_sdf->HasElement("topic"))
@@ -269,7 +271,7 @@ void TrajectoryFollowerPrivate::Load(const EntityComponentManager &_ecm,
   this->node.Subscribe(topic, &TrajectoryFollowerPrivate::OnPause, this);
 
   gzmsg << "TrajectoryFollower["
-      << this->model.Name(_ecm) << "] subscribed "
+      << modelName << "] subscribed "
       << "to pause messages on topic[" << this->topic << "]\n";
 
   // If we have waypoints to visit, read the first one.

--- a/src/systems/velocity_control/VelocityControl.cc
+++ b/src/systems/velocity_control/VelocityControl.cc
@@ -145,8 +145,10 @@ void VelocityControl::Configure(const Entity &_entity,
   {
     modelTopics.push_back(_sdf->Get<std::string>("topic"));
   }
+  const auto modelName = this->dataPtr->model.Name(_ecm)
+      .value_or(std::to_string(this->dataPtr->model.Entity()));
   modelTopics.push_back(
-    "/model/" + this->dataPtr->model.Name(_ecm) + "/cmd_vel");
+    "/model/" + modelName + "/cmd_vel");
   auto modelTopic = validTopic(modelTopics);
   this->dataPtr->node.Subscribe(
     modelTopic, &VelocityControlPrivate::OnCmdVel, this->dataPtr.get());
@@ -167,7 +169,7 @@ void VelocityControl::Configure(const Entity &_entity,
   // Subscribe to link commands
   for (const auto &linkName : this->dataPtr->linkNames)
   {
-    std::string linkTopic{"/model/" + this->dataPtr->model.Name(_ecm) +
+    std::string linkTopic{"/model/" + modelName +
                              "/link/" + linkName + "/cmd_vel"};
     linkTopic = transport::TopicUtils::AsValidTopic(linkTopic);
     this->dataPtr->node.Subscribe(
@@ -206,7 +208,8 @@ void VelocityControl::PreUpdate(const UpdateInfo &_info,
 
   // If there are links, create link components
   // If the link hasn't been identified yet, look for it
-  auto modelName = this->dataPtr->model.Name(_ecm);
+  const auto modelName = this->dataPtr->model.Name(_ecm)
+      .value_or(std::to_string(this->dataPtr->model.Entity()));
 
   if (this->dataPtr->linkNames.empty())
     return;

--- a/src/systems/wheel_slip/WheelSlip.cc
+++ b/src/systems/wheel_slip/WheelSlip.cc
@@ -178,7 +178,8 @@ class gz::sim::systems::WheelSlipPrivate
 bool WheelSlipPrivate::Load(EntityComponentManager &_ecm,
                             sdf::ElementPtr _sdf)
 {
-  const std::string modelName = this->model.Name(_ecm);
+  const auto modelName = this->model.Name(_ecm)
+      .value_or(std::to_string(this->model.Entity()));
 
   if (!_sdf->HasElement("wheel"))
   {

--- a/test/integration/model.cc
+++ b/test/integration/model.cc
@@ -83,11 +83,11 @@ TEST_F(ModelIntegrationTest, Name)
   Model model(id);
 
   // No name
-  EXPECT_TRUE(model.Name(ecm).empty());
+  EXPECT_FALSE(model.Name(ecm).has_value());
 
   // Add name
   ecm.CreateComponent<components::Name>(id, components::Name("model_name"));
-  EXPECT_EQ("model_name", model.Name(ecm));
+  EXPECT_EQ("model_name", model.Name(ecm).value());
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #987 

## Summary
This updates gz::sim::Model::Name to return std::optional<std::string>,
making it consistent with World and Link APIs.

All call sites have been updated to safely handle the optional return,
using entity ID fallbacks where a stable identifier is required.

## Local validation:
- Built and tested on Ubuntu 24.04 (Docker)
- All unit and GUI tests passed (GUI tests via xvfb)

## Checklist
- [x] Signed all commits for DCO