### PR TITLE
Fix deprecation warning in `benchmark`

### DIFF
--- a/test/benchmark/CMakeLists.txt
+++ b/test/benchmark/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_TYPE "BENCHMARK")
+find_package(benchmark)
 include(GzBenchmark OPTIONAL RESULT_VARIABLE GzBenchmark_FOUND)
 
 if (GzBenchmark_FOUND)
@@ -8,4 +9,9 @@ if (GzBenchmark_FOUND)
   )
 
   gz_add_benchmarks(SOURCES ${tests})
+
+  if (benchmark_VERSION VERSION_LESS "1.9.5")
+    add_compile_definitions(BENCHMARK_INTERNAL)
+  endif()
+
 endif()

--- a/test/benchmark/each.cc
+++ b/test/benchmark/each.cc
@@ -30,6 +30,11 @@
 #include "gz/sim/components/Pose.hh"
 #include "gz/sim/components/World.hh"
 
+#ifdef BENCHMARK_INTERNAL
+using Benchmark = ::benchmark::internal::Benchmark;
+#else
+using Benchmark = ::benchmark::Benchmark;
+#endif
 
 using namespace gz;
 using namespace sim;
@@ -361,7 +366,7 @@ BENCHMARK_DEFINE_F(ManyComponentFixture, Each10ComponentNoCache)
 
 /// Method to generate test argument combinations.  google/benchmark does
 /// powers of 2 by default, which looks kind of ugly.
-static void EachTestArgs(benchmark::internal::Benchmark *_b)
+static void EachTestArgs(Benchmark *_b)
 {
   int maxEntityCount = 1000;
   int step = maxEntityCount/5;


### PR DESCRIPTION
# 🦟 Bug fix


## Summary

`benchmark::internal::Benchmark` was deprecated in https://github.com/google/benchmark/pull/2101 which was released as 1.9.5


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
