### PR TITLE
Remove AUTOMOC from non-GUI targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,13 +134,6 @@ if(ENABLE_GUI)
       QuickControls2
     REQUIRED
     PKGCONFIG "Qt${QT_MAJOR_VERSION}Core Qt${QT_MAJOR_VERSION}Quick Qt${QT_MAJOR_VERSION}QuickControls2")
-
-  set(CMAKE_AUTOMOC TRUE)
-  set(CMAKE_AUTOUIC TRUE)
-  set(CMAKE_AUTORCC TRUE)
-  if(POLICY CMP0100)
-    cmake_policy(SET CMP0100 NEW)
-  endif()
 endif()
 
 #--------------------------------------


### PR DESCRIPTION
# 🦟 Bug fix
@traversaro brought this up in [#Gazebo PMC (Restricted posting) > automoc on all files of gz-sim?](https://openrobotics.zulipchat.com/#narrow/channel/526046-Gazebo-PMC-.28Restricted-posting.29/topic/automoc.20on.20all.20files.20of.20gz-sim.3F/with/543961378)

The CMake code for setting AUTOMOC is already in src/gui/CMakeLists.txt

https://github.com/gazebosim/gz-sim/blob/615fbd51efd4b4b5f3eab464cb00e370ec2f5d81/src/gui/CMakeLists.txt#L19-L23

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
