### PR TITLE
[RFC] Example of using custom component instead of entity map

### DIFF
--- a/examples/plugin/custom_sensor_system/OdometerSystem.hh
+++ b/examples/plugin/custom_sensor_system/OdometerSystem.hh
@@ -23,6 +23,14 @@
 
 namespace custom
 {
+  // Create a custom component to store the sensor date
+  using OdometerComponent =
+      gz::sim::components::Component<std::shared_ptr<Odometer>, class OdometerComponentTag>;
+
+  // Use this macro to register a component. Give it a unique name across the
+  // entire simulation.
+  GZ_SIM_REGISTER_COMPONENT("custom::OdometerComponent", OdometerComponent)
+
   /// \brief Example showing how to tie a custom sensor, in this case an
   /// odometer, into simulation
   class OdometerSystem:
@@ -41,16 +49,6 @@ namespace custom
     // Also remove sensors that have been deleted.
     public: void PostUpdate(const gz::sim::UpdateInfo &_info,
         const gz::sim::EntityComponentManager &_ecm) final;
-
-    /// \brief Remove custom sensors if their entities have been removed from
-    /// simulation.
-    /// \param[in] _ecm Immutable reference to ECM.
-    private: void RemoveSensorEntities(
-        const gz::sim::EntityComponentManager &_ecm);
-
-    /// \brief A map of custom entities to their sensors
-    private: std::unordered_map<gz::sim::Entity,
-        std::shared_ptr<Odometer>> entitySensorMap;
   };
 }
 #endif


### PR DESCRIPTION
# 🎉 New feature

Example of alternative pattern proposed in #3319

## Summary
This PR removes the custom hash map we use to map each entity to a sensor that it contains:

```
std::unordered_map<gz::sim::Entity, std::shared_ptr<Odometer>> entitySensorMap;
```

Instead, it creates a custom component to wrap the data:

```
  using OdometerComponent =
      gz::sim::components::Component<std::shared_ptr<Odometer>, class OdometerComponentTag>;
```

This component is then added to the sensor entity.
This approach will remove the need to do manual updates of the hash map, and will instead leave that to the ECM, for example:

* Deleting all entities that use the sensor will destroy the sensor automatically, without the need for a custom function to do that.
* Copying entities will also copy the underlying component (see :warning:  below).
* We can now just iterate through an `Each` call over the component, rather than in a custom hash map.
* Potentially, since the component is stored in the ECM it would make it possible to make it public (i.e. if users want to access the sensor directly they could).

## (minor) :warning: Removed components

`EachRemoved` should trigger cleanup in two cases:

1) Removed entity when despawning (what the docs say is the purpose of the function).
2) The `components::CustomSensor` component is removed.

While I believe 99% of the cases are covered by 1), there is still the 1% where users might keep the entity, remove a component but be puzzled at why is the sensor still there.
We could solve this by keeping the `EachRemoved` function and have it remove the custom component, but I would argue that is not the best design since `EachRemoved` has some system ordering footguns as found out in #3319.
Instead, what I would propose is change the "root component" (i.e. [this](https://github.com/gazebosim/gz-sim/blob/2ea05c17777f7e72cfa4b0f2fb6101ca743d99f8/include/gz/sim/components/CustomSensor.hh#L37-L38)) to also encapsulate the sensor itself, something like:

```
class CustomSensor {
private:
  std::shared_ptr<gz:sensors::Sensor> sensor;
public:
  sdf::Plugin sdf;
}
```

So again removing the component will remove the sensor as well*.

* Depending on reference count, or not if it's a `unique_ptr` but see :warning:  Cloning :warning:  below

## :warning: Cloning :warning: 

Cloning the entity will automatically clone the component. In this case, this will share the underlying sensor since it's wrapped in a `shared_ptr`.
The main use I found is [copy pasting entities](https://github.com/gazebosim/gz-sim/issues/102). In this case I _think_ cloning the shared pointer to the sensor might mean that there is only one sensor and I suspect that might mean that, for example, cloning a camera and moving it around will end up with the same camera rather than two cameras with different viewpoints.
To be fully honest though, entity copy-paste + sensors is a bit confusing in general.
On one hand, we would like cloning to really clone everything about the sensor, on the other, if we do and clone all parameters we might end up in confusing cases where we also clone the "output data topic parameter" and end up in clashes like in the video below when cloning a camera, which might not be what users expect. 

https://github.com/user-attachments/assets/47c9bfd6-8b29-4858-ab59-5878fbefc46e

By contrast, there is also _component_ cloning, used for example to [reset the simulation to a known state](https://github.com/gazebosim/gz-sim/blob/2ea05c17777f7e72cfa4b0f2fb6101ca743d99f8/src/EntityComponentManager.cc#L2334). This could potentially be better in this implementation, since we wouldn't need to destroy + recreate the sensors but we would just copy ` shared_ptr`s around that would keep them alive while we restore the world state.
Now again this might need some thinking about how many references are alive, whether we cleanup properly, but note that _right now_ it doesn't really work. Specifically using the same camera example, notice how when I remove the camera and reset the simulation, the camera entity is restored but the camera sensor itself doesn't work:

https://github.com/user-attachments/assets/cdc2a032-aacf-42fd-9b73-bae368b9c4c3


## Then what?

There are several ways to go about this:

### Leave everything unchanged

The most straightforward change, close this PR, leave things as they are, require users to manually update their hash map and deal with the maintenance of it. Fix the various issues that come up (i.e. the videos above, the linked issue) with system ordering or ad-hoc fixes.

### Selectively disable cloning

We could have a type of component that is cloneable and one that is not. Components that cannot be cloned will either fail entity cloning or report a warning.

### Provide custom copy constructors

Something that could work is to still require components to be clone-able but change sensor interfaces so they need to provide a custom copy function, then we can leave it to the single sensors to figure out what their copy behavior should be (i.e. reuse vs create a new underlying sensor, remap vs reuse topics, etc).
This would probably be my recommended choice.