### PR TITLE
Support for user-defined topic in PosePublisher

### DIFF
--- a/src/systems/pose_publisher/PosePublisher.cc
+++ b/src/systems/pose_publisher/PosePublisher.cc
@@ -254,12 +254,23 @@ void PosePublisher::Configure(const Entity &_entity,
   this->dataPtr->usePoseV =
     _sdf->Get<bool>("use_pose_vector_msg", this->dataPtr->usePoseV).first;
 
-  std::string poseTopic = topicFromScopedName(_entity, _ecm, true) + "/pose";
+  std::string poseTopic;
+  if (_sdf->HasElement("topic"))
+  {
+    if (transport::TopicUtils::IsValidTopic(_sdf->Get<std::string>("topic")))
+    {
+      poseTopic = _sdf->Get<std::string>("topic");
+    }
+  }
+  if (poseTopic.empty())
+  {
+    poseTopic = topicFromScopedName(_entity, _ecm, true) + "/pose";
+  }
   if (poseTopic.empty())
   {
     poseTopic = "/pose";
     gzerr << "Empty pose topic generated for pose_publisher system. "
-           << "Setting to " << poseTopic << std::endl;
+             "Setting to " << poseTopic << std::endl;
   }
   std::string staticPoseTopic = poseTopic + "_static";
 

--- a/src/systems/pose_publisher/PosePublisher.cc
+++ b/src/systems/pose_publisher/PosePublisher.cc
@@ -261,6 +261,11 @@ void PosePublisher::Configure(const Entity &_entity,
     {
       poseTopic = _sdf->Get<std::string>("topic");
     }
+    else
+    {
+      gzerr << "Provided topic: " << _sdf->Get<std::string>("topic")
+            << " is not a valid topic." << std::endl;
+    }
   }
   if (poseTopic.empty())
   {

--- a/src/systems/pose_publisher/PosePublisher.hh
+++ b/src/systems/pose_publisher/PosePublisher.hh
@@ -58,6 +58,7 @@ namespace systems
   /// - `<static_update_frequency>`: Frequency of static pose publications in
   ///   Hz. A negative frequency publishes as fast as possible (i.e, at the
   ///   rate of the simulation step).
+  /// - `<topic>`: Set a custom topic instead of default value
   class PosePublisher
       : public System,
         public ISystemConfigure,

--- a/test/helpers/Subscription.hh
+++ b/test/helpers/Subscription.hh
@@ -99,7 +99,7 @@ class Subscription
   public: MessageT GetMessageByIndex(int _index)
   {
     std::lock_guard<std::mutex> lock(this->mutex);
-    return this->messageHistory[_index];
+    return this->messageHistory.at(_index);
   }
 
   /// \brief Reset the messageHistory container by clearing

--- a/test/helpers/TestFixture.hh
+++ b/test/helpers/TestFixture.hh
@@ -127,8 +127,9 @@ class TestFixture
       const double stepSize =
           std::chrono::duration<double>(deadline - this->info.simTime).count();
       uint64_t previous_iterations = this->Iterations();
-      simulator->Run(
-          blocking, std::ceil(stepSize / this->maxStepSize), this->paused);
+      simulator->Run(blocking,
+          static_cast<uint64_t>(std::ceil(stepSize / this->maxStepSize)),
+          this->paused);
       iterations += this->Iterations() - previous_iterations;
     } while (this->info.simTime < deadline);
     return iterations;

--- a/test/integration/pose_publisher_system.cc
+++ b/test/integration/pose_publisher_system.cc
@@ -16,6 +16,7 @@
 */
 
 #include <gtest/gtest.h>
+#include <chrono>
 #include <list>
 #include <mutex>
 
@@ -23,6 +24,7 @@
 #include <gz/msgs/pose_v.pb.h>
 
 #include <gz/common/Console.hh>
+#include <gz/common/Filesystem.hh>
 #include <gz/common/Util.hh>
 #include <gz/math/Pose3.hh>
 #include <gz/transport/Node.hh>
@@ -39,9 +41,12 @@
 
 #include "../helpers/Relay.hh"
 #include "../helpers/EnvTestFixture.hh"
+#include "../helpers/Subscription.hh"
+#include "../helpers/TestFixture.hh"
 
 using namespace gz;
 using namespace sim;
+using namespace std::literals::chrono_literals;
 
 /// \brief Test PosePublisher system
 class PosePublisherTest : public InternalFixture<::testing::TestWithParam<int>>
@@ -803,38 +808,16 @@ TEST_F(PosePublisherTest,
 TEST_F(PosePublisherTest,
        GZ_UTILS_TEST_DISABLED_ON_WIN32(UserDefinedTopic))
 {
-  ServerConfig serverConfig;
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/pose_publisher.sdf");
+  const auto worldFile = common::joinPaths(
+    std::string(PROJECT_SOURCE_PATH), "test", "worlds", "pose_publisher.sdf");
 
-  Server server(serverConfig);
-  ASSERT_FALSE(server.Running());
-  ASSERT_FALSE(*server.Running(0));
+  ::TestFixture fixture(worldFile);
 
-  {
-    const std::lock_guard<std::mutex> lock(mutex);
-    poseMsgs.clear();
-  }
-
-  // expect messages will be published to a custom topic
   transport::Node node;
-  node.Subscribe(std::string("/my/little/topic"), &poseCb);
+  Subscription<msgs::Pose> poseSubscription;
+  poseSubscription.Subscribe(node, "/my/little/topic", 1);
 
-  // Run server
-  unsigned int iters = 100u;
-  server.Run(true, iters, false);
+  fixture.Step(50ms);
 
-  bool received = false;
-  for (int sleep = 0; sleep < 30; ++sleep)
-  {
-    {
-      std::lock_guard<std::mutex> lock(mutex);
-      received = !poseMsgs.empty();
-    }
-
-    if (received)
-      break;
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  }
-  ASSERT_TRUE(received);
+  ASSERT_TRUE(poseSubscription.WaitForMessages(1, 100ms));
 }

--- a/test/worlds/pose_publisher.sdf
+++ b/test/worlds/pose_publisher.sdf
@@ -529,5 +529,19 @@
       </plugin>
     </model>
 
+    <model name="test_publish_custom_topic">
+      <pose>5 5 5 0 0 0</pose>
+      <link name="link1"/>
+      <plugin
+         filename="gz-sim-pose-publisher-system"
+         name="gz::sim::systems::PosePublisher">
+        <publish_link_pose>true</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
+        <topic>/my/little/topic</topic>
+      </plugin>
+    </model>
   </world>
 </sdf>

--- a/test/worlds/pose_publisher.sdf
+++ b/test/worlds/pose_publisher.sdf
@@ -529,7 +529,7 @@
       </plugin>
     </model>
 
-    <model name="test_publish_custom_topic">
+    <model name="test_user_defined_topic">
       <pose>5 5 5 0 0 0</pose>
       <link name="link1"/>
       <plugin


### PR DESCRIPTION
# 🎉 New feature

Closes #<NUMBER>

## Summary
This patch should add feature to specify a `topic` for a Pose Publisher System.

* It became consistent with other systems (user won't be confused)
* Simpler for users to generate SDFs by their scripts (can assign topic, not calculate it)
* Also small cleanup for test (RAII, avoid copying, do not sleep if not needed, seems after spinning server it's quite small probability that msgs are not received yet)

It could be very nice if we can have port of it in a current LTS release

## Test it

* Integration test
* Can run `test/worlds/pose_publisher.sdf` and check list of topics. `/my/little/topic` should be there

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.