### PR TITLE
Prepare for 6.17.1 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-gazebo6 VERSION 6.17.0)
+project(ignition-gazebo6 VERSION 6.17.1)
 set (GZ_DISTRIBUTION "Fortress")
 
 #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,64 @@
 ## Ignition Gazebo 6.x
 
+### Gazebo Sim 6.17.1 (2026-02-12)
+
+1. Improve RTF Stability and Precision
+    * [Pull request #3269](https://github.com/gazebosim/gz-sim/pull/3269)
+
+1. Fix deprecation warning in `benchmark`
+    * [Pull request #3296](https://github.com/gazebosim/gz-sim/pull/3296)
+
+1. Fortress: disable Ubuntu Focal CI
+    * [Pull request #3294](https://github.com/gazebosim/gz-sim/pull/3294)
+
+1. Fix illegal anchor warnings
+    * [Pull request #2741](https://github.com/gazebosim/gz-sim/pull/2741)
+
+1. Add benchmark to list packages to be installed
+    * [Pull request #1733](https://github.com/gazebosim/gz-sim/pull/1733)
+
+1. Fix CMake warning in example
+    * [Pull request #2145](https://github.com/gazebosim/gz-sim/pull/2145)
+
+1. Update our usage of workerpools
+    * [Pull request #2995](https://github.com/gazebosim/gz-sim/pull/2995)
+
+1. Suppress child link warning in DetachableJoint
+    * [Pull request #3231](https://github.com/gazebosim/gz-sim/pull/3231)
+
+1. Suppress particle emitter deprecation warnings on homebrew-arm64
+    * [Pull request #3183](https://github.com/gazebosim/gz-sim/pull/3183)
+
+1. Use latest 1.14 google-test in gtest_setup
+    * [Pull request #3205](https://github.com/gazebosim/gz-sim/pull/3205)
+
+1. Clean up temporary home directory to make tests more robust
+    * [Pull request #3146](https://github.com/gazebosim/gz-sim/pull/3146)
+
+1. Disable failing test on macOS in EntityComponentManager_TEST
+    * [Pull request #3113](https://github.com/gazebosim/gz-sim/pull/3113)
+
+1. Fix compatibility with protobuf v30
+    * [Pull request #3034](https://github.com/gazebosim/gz-sim/pull/3034)
+
+1. Add missing algorithm include
+    * [Pull request #3022](https://github.com/gazebosim/gz-sim/pull/3022)
+
+1. Assign new gz-sim maintainer
+    * [Pull request #3008](https://github.com/gazebosim/gz-sim/pull/3008)
+
+1. Set IGN_IP=127.0.0.1 in cmd tests
+    * [Pull request #2959](https://github.com/gazebosim/gz-sim/pull/2959)
+
+1. Also handle SIGTERM gracefully
+    * [Pull request #2747](https://github.com/gazebosim/gz-sim/pull/2747)
+
+1. Reduce/Eliminate `sdf::Model` and `sdf::World` serialization warnings
+    * [Pull request #2742](https://github.com/gazebosim/gz-sim/pull/2742)
+
+1. Fix mesh import filters not displaying correctly on KDE
+    * [Pull request #2732](https://github.com/gazebosim/gz-sim/pull/2732)
+
 ### Gazebo Sim 6.17.0 (2025-01-10)
 
 1. Add parameter for adjust current sign in battery plugin


### PR DESCRIPTION
# 🎈 Release

Preparation for 6.17.1 release.

Comparison to 6.17.0: https://github.com/gazebosim/gz-sim/compare/ignition-gazebo6_6.17.0...ign-gazebo6

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.