### PR TITLE
Auto-load missing SceneBroadcaster and seed scene graph for late-load…

### DIFF
--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -25,6 +25,8 @@
 
 #include <QScreen>
 
+#include <memory>
+#include <mutex>
 #include <unordered_set>
 
 #include <gz/common/Console.hh>
@@ -249,42 +251,59 @@ std::unique_ptr<gz::gui::Application> createGui(
 
   transport::Node node;
 
-  std::unordered_set<std::string> injectedWorlds;
+  auto injectedWorlds = std::make_shared<std::unordered_set<std::string>>();
+  auto checkingWorlds = std::make_shared<std::unordered_set<std::string>>();
+  auto injectedWorldsMutex = std::make_shared<std::mutex>();
   auto ensureSceneBroadcaster = [&](const std::string &worldName)
   {
-    const unsigned int timeout = 5000;
-    bool sceneBroadcasterFound = false;
-    bool sceneResult = false;
-    msgs::Empty sceneReq;
-    msgs::Scene sceneRes;
-    auto sceneService = transport::TopicUtils::AsValidTopic(
-      "/world/" + worldName + "/scene/info");
-    for (int attempt = 0; attempt < 2 && !sceneBroadcasterFound; ++attempt)
     {
-        if (!sceneService.empty() &&
-          node.Request(sceneService, sceneReq, timeout, sceneRes,
-            sceneResult) &&
-          sceneResult)
-      {
-        sceneBroadcasterFound = true;
-        break;
-      }
+      std::lock_guard<std::mutex> lock(*injectedWorldsMutex);
+      if (injectedWorlds->count(worldName) > 0 ||
+          checkingWorlds->count(worldName) > 0)
+        return;
 
-      if (attempt == 0)
-      {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-      }
+      checkingWorlds->insert(worldName);
     }
 
-    if (!sceneBroadcasterFound)
+    std::thread([worldName, injectedWorlds, checkingWorlds,
+        injectedWorldsMutex]()
     {
-      if (injectedWorlds.count(worldName) > 0)
-        return;
+      transport::Node threadNode;
+      msgs::Empty sceneReq;
+      msgs::Scene sceneRes;
+      bool sceneResult = false;
+      auto sceneService = transport::TopicUtils::AsValidTopic(
+        "/world/" + worldName + "/scene/info");
+      for (int attempt = 0; attempt < 10; ++attempt)
+      {
+        bool sceneRequestOk = false;
+        if (!sceneService.empty())
+        {
+          sceneRequestOk = threadNode.Request(sceneService, sceneReq, 100u,
+              sceneRes, sceneResult);
+        }
+
+        if (sceneRequestOk && sceneResult)
+        {
+          std::lock_guard<std::mutex> lock(*injectedWorldsMutex);
+          checkingWorlds->erase(worldName);
+          return;
+        }
+
+        if (attempt < 9)
+        {
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+      }
 
       gzwarn << "SceneBroadcaster is missing. Attempting to load it so the "
              << "scene can be visualized." << std::endl;
 
-      injectedWorlds.insert(worldName);
+      {
+        std::lock_guard<std::mutex> lock(*injectedWorldsMutex);
+        checkingWorlds->erase(worldName);
+        injectedWorlds->insert(worldName);
+      }
 
       msgs::EntityPlugin_V addReq;
       addReq.mutable_entity()->set_id(0u);
@@ -300,7 +319,7 @@ std::unique_ptr<gz::gui::Application> createGui(
         "/world/" + worldName + "/entity/system/add");
       if (!addService.empty())
       {
-        addRequestOk = node.Request(addService, addReq, timeout,
+        addRequestOk = threadNode.Request(addService, addReq, 5000u,
             addRes, addResult);
       }
 
@@ -309,11 +328,7 @@ std::unique_ptr<gz::gui::Application> createGui(
         gzerr << "Failed to load SceneBroadcaster for world [" << worldName
                << "]" << std::endl;
       }
-      else
-      {
-        node.Request(sceneService, sceneReq, timeout, sceneRes, sceneResult);
-      }
-    }
+    }).detach();
   };
 
   // Quick start dialog if no specific SDF file was passed and it's not playback


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2962 

## Summary
This PR improves robustness when a world is loaded without the `SceneBroadcaster` system by automatically injecting it from the GUI if it is missing and seeding the scene graph when it is loaded after world creation, ensuring that existing entities are immediately visualized and preventing blank or non-responsive GUI behavior.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.