### PR TITLE
Fix C4530 warning in backward-cpp by enabling /EHsc on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,13 @@ endif()
 set(BACKWARD_TESTS OFF)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vendor/backward-cpp)
 
+# Fix C4530 warning on MSVC: backward-cpp uses exceptions but /EHsc is not
+# set by default. Applied here instead of in vendor/ to survive updates.
+if(MSVC)
+  target_compile_options(backward_object PRIVATE /EHsc)
+  target_compile_options(backward PRIVATE /EHsc)
+endif()
+
 # Using other CMake interfaces from backwards won't work here since
 # CMake would not resolve them into gz-cmake (uses EXTRA_TEST_LIB_DEPS)
 # using backward_object set the object file path.

--- a/vendor/backward-cpp/CMakeLists.txt
+++ b/vendor/backward-cpp/CMakeLists.txt
@@ -98,9 +98,6 @@ add_library(Backward::Interface ALIAS backward_interface)
 add_library(backward_object OBJECT backward.cpp)
 set_target_properties(backward_object PROPERTIES EXPORT_NAME Object)
 target_link_libraries(backward_object PUBLIC Backward::Interface)
-if(MSVC)
-    target_compile_options(backward_object PRIVATE /EHsc)
-endif()
 add_library(Backward::Object ALIAS backward_object)
 
 ###############################################################################
@@ -116,9 +113,6 @@ endif()
 add_library(backward ${libtype} backward.cpp)
 set_target_properties(backward PROPERTIES EXPORT_NAME Backward)
 target_link_libraries(backward PUBLIC Backward::Interface)
-if(MSVC)
-    target_compile_options(backward PRIVATE /EHsc)
-endif()
 add_library(Backward::Backward ALIAS backward)
 
 ###############################################################################


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-launch/issues/312

## Summary

Add  the suggested EHsc flag to solve the compiler warning on MSVC.

Tested  [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_launch-pr-cnlwin&build=25)](https://build.osrfoundation.org/job/gz_launch-pr-cnlwin/25/) 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Opus 4.6