### PR TITLE
Avoid model recreation when adding child entities in Component Inspector Editor

### DIFF
--- a/src/gui/plugins/component_inspector_editor/ModelEditor.cc
+++ b/src/gui/plugins/component_inspector_editor/ModelEditor.cc
@@ -43,12 +43,10 @@
 #include "gz/sim/components/Model.hh"
 #include "gz/sim/components/Name.hh"
 #include "gz/sim/components/ParentEntity.hh"
-#include "gz/sim/components/Recreate.hh"
 #include "gz/sim/EntityComponentManager.hh"
 #include "gz/sim/SdfEntityCreator.hh"
 
 #include "gz/sim/gui/GuiEvents.hh"
-#include "gz/sim/Util.hh"
 
 #include "ModelEditor.hh"
 
@@ -182,9 +180,6 @@ void ModelEditor::Update(const UpdateInfo &,
       {
         Entity entity = this->dataPtr->entityCreator->CreateEntities(&(*link));
         this->dataPtr->entityCreator->SetParent(entity, eta.parentEntity);
-        // Make sure to mark the parent as needing recreation. This will
-        // tell the server to rebuild the model with the new link.
-        _ecm.CreateComponent(eta.parentEntity, components::Recreate());
         entities.push_back(entity);
       }
     }
@@ -197,10 +192,6 @@ void ModelEditor::Update(const UpdateInfo &,
         Entity entity = this->dataPtr->entityCreator->CreateEntities(
             &(*sensor));
         this->dataPtr->entityCreator->SetParent(entity, eta.parentEntity);
-        // Make sure to mark the parent as needing recreation. This will
-        // tell the server to rebuild the model with the new link.
-        _ecm.CreateComponent(topLevelModel(eta.parentEntity, _ecm),
-                             components::Recreate());
         entities.push_back(entity);
       }
     }
@@ -212,9 +203,6 @@ void ModelEditor::Update(const UpdateInfo &,
         Entity entity = this->dataPtr->entityCreator->CreateEntities(
             &(*joint), true);
         this->dataPtr->entityCreator->SetParent(entity, eta.parentEntity);
-        // Make sure to mark the parent as needing recreation. This will
-        // tell the server to rebuild the model with the new link.
-        _ecm.CreateComponent(eta.parentEntity, components::Recreate());
         entities.push_back(entity);
       }
     }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #3318 

## Summary
Adding a Link via the Component Inspector caused the parent Model to disappear. `ModelEditor::Update()` was marking the parent with `components::Recreate`, triggering a model teardown and rebuild from stale SDF that didn't include the new entity.

This change removes the three Recreate markings in the link, sensor, and joint add paths. Runtime additions now rely on the existing physics-side entity construction flow in `Physics.cc` (`ConstructSdfLinkFeatureList` / related runtime creation), avoiding model teardown.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.