### PR TITLE
Auto-load SceneBroadcaster when missing from world plugins

### DIFF
--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -98,8 +98,31 @@ struct MaybeGilScopedRelease
     MaybeGilScopedRelease(){}
   };
 #endif
-}
 
+// Constants for identifying the SceneBroadcaster system
+constexpr const char *kSceneBroadcasterSystemFilename =
+  "gz-sim-scene-broadcaster-system";
+constexpr const char *kSceneBroadcasterSystemName =
+  "gz::sim::systems::SceneBroadcaster";
+
+//////////////////////////////////////////////////
+/// \brief Checks if the SceneBroadcaster system is loaded in the
+/// given list of systems.
+/// \param _systems Vector of SystemInternal objects to search.
+/// \return True if a SceneBroadcaster system is found, false otherwise.
+bool HasSceneBroadcaster(const std::vector<SystemInternal> &_systems)
+{
+  return std::any_of(_systems.begin(), _systems.end(),
+      [](const SystemInternal &_system)
+      {
+        return _system.fname == kSceneBroadcasterSystemFilename ||
+               _system.fname.find("scene-broadcaster-system") !=
+                   std::string::npos ||
+               _system.name == kSceneBroadcasterSystemName ||
+               _system.name.find("SceneBroadcaster") != std::string::npos;
+      });
+}
+}
 
 //////////////////////////////////////////////////
 SimulationRunner::SimulationRunner(const sdf::World &_world,
@@ -1637,6 +1660,19 @@ void SimulationRunner::CreateEntities(const sdf::World &_world)
     auto plugins = gz::sim::loadPluginInfo(isPlayback);
     this->LoadServerPlugins(plugins);
   }
+
+  auto worldSystems = this->systemMgr->TotalByEntity(worldEntity);
+  if (!HasSceneBroadcaster(worldSystems))
+  {
+    gzwarn << "World [" << this->worldName
+           << "] has no SceneBroadcaster system loaded. "
+           << "Auto-loading [" << kSceneBroadcasterSystemName
+           << "] to publish scene updates to the GUI." << std::endl;
+    sdf::Plugin sceneBroadcasterPlugin(kSceneBroadcasterSystemFilename,
+        kSceneBroadcasterSystemName, "");
+    this->LoadPlugin(worldEntity, sceneBroadcasterPlugin);
+  }
+
   // Load logging plugins after all server plugins so that necessary
   // plugins such as SceneBroadcaster are loaded first. This might be
   // a bug or an assumption made in the logging plugins.

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -56,6 +56,7 @@
 #include "gz/sim/components/ParentLinkName.hh"
 #include "gz/sim/components/Pose.hh"
 #include "gz/sim/components/Sensor.hh"
+#include "gz/sim/components/SystemPluginInfo.hh"
 #include "gz/sim/components/Visual.hh"
 #include "gz/sim/components/Wind.hh"
 #include "gz/sim/components/World.hh"
@@ -1303,7 +1304,35 @@ TEST_P(SimulationRunnerTest,
   SimulationRunner runner(*rootWithout.WorldByIndex(0), systemLoader,
       serverConfig);
 
-  ASSERT_EQ(2u, runner.SystemCount());
+  ASSERT_EQ(3u, runner.SystemCount());
+
+  bool foundWorld{false};
+  bool hasSceneBroadcaster{false};
+  runner.EntityCompMgr().Each<World, components::SystemPluginInfo>(
+      [&](const Entity &,
+          const World *,
+          const components::SystemPluginInfo *_pluginInfo) -> bool
+      {
+        foundWorld = true;
+        EXPECT_NE(nullptr, _pluginInfo);
+        if (!_pluginInfo)
+          return true;
+
+        for (int i = 0; i < _pluginInfo->Data().plugins_size(); ++i)
+        {
+          const auto &plugin = _pluginInfo->Data().plugins(i);
+          if (plugin.filename() == "gz-sim-scene-broadcaster-system" ||
+              plugin.name() == "gz::sim::systems::SceneBroadcaster")
+          {
+            hasSceneBroadcaster = true;
+            break;
+          }
+        }
+        return true;
+      });
+
+  EXPECT_TRUE(foundWorld);
+  EXPECT_TRUE(hasSceneBroadcaster);
 }
 
 /////////////////////////////////////////////////
@@ -1531,15 +1560,15 @@ TEST_P(SimulationRunnerTest,
       serverConfig);
 
   // 1 model plugin from SDF and 1 world plugin from config
-  // and 1 model plugin from theconfig
-  EXPECT_EQ(3u, runner.SystemCount());
+  // and 1 model plugin from the config, plus auto-injected SceneBroadcaster.
+  EXPECT_EQ(4u, runner.SystemCount());
   runner.SetPaused(false);
   runner.Run(1);
 
-  // Remove the model. Only 1 world plugin should remain.
+  // Remove the model. The configured world plugin and SceneBroadcaster remain.
   EXPECT_TRUE(runner.RequestRemoveEntity("box"));
   runner.Run(2);
-  EXPECT_EQ(1u, runner.SystemCount());
+  EXPECT_EQ(2u, runner.SystemCount());
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2962

## Summary
Auto-load SceneBroadcaster when missing from world plugins
Adds automatic detection and injection of the SceneBroadcaster system in CreateEntities() when it is not explicitly present in the world's plugin list. A gzwarn is emitted when auto-injection occurs. If already loaded, it is skipped. Tests updated to reflect the additional system count and verify presence via ECS query.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.