### PR TITLE
Added missing gz::sim system aliases.

### DIFF
--- a/src/systems/buoyancy_engine/BuoyancyEngine.cc
+++ b/src/systems/buoyancy_engine/BuoyancyEngine.cc
@@ -281,4 +281,8 @@ IGNITION_ADD_PLUGIN(
   BuoyancyEnginePlugin::ISystemPreUpdate)
 
 IGNITION_ADD_PLUGIN_ALIAS(BuoyancyEnginePlugin,
+                          "gz::sim::systems::BuoyancyEngine")
+
+// TODO(CH3): Deprecated, remove on version 8
+IGNITION_ADD_PLUGIN_ALIAS(BuoyancyEnginePlugin,
                           "ignition::gazebo::systems::BuoyancyEngine")

--- a/src/systems/comms_endpoint/CommsEndpoint.cc
+++ b/src/systems/comms_endpoint/CommsEndpoint.cc
@@ -190,4 +190,8 @@ IGNITION_ADD_PLUGIN(CommsEndpoint,
                     CommsEndpoint::ISystemPreUpdate)
 
 IGNITION_ADD_PLUGIN_ALIAS(CommsEndpoint,
+                          "gz::sim::systems::CommsEndpoint")
+
+// TODO(CH3): Deprecated, remove on version 8
+IGNITION_ADD_PLUGIN_ALIAS(CommsEndpoint,
                           "ignition::gazebo::systems::CommsEndpoint")

--- a/src/systems/follow_actor/FollowActor.cc
+++ b/src/systems/follow_actor/FollowActor.cc
@@ -291,4 +291,7 @@ IGNITION_ADD_PLUGIN(FollowActor, System,
   FollowActor::ISystemPreUpdate
 )
 
+IGNITION_ADD_PLUGIN_ALIAS(FollowActor, "gz::sim::systems::FollowActor")
+
+// TODO(CH3): Deprecated, remove on version 8
 IGNITION_ADD_PLUGIN_ALIAS(FollowActor, "ignition::gazebo::systems::FollowActor")

--- a/src/systems/force_torque/ForceTorque.cc
+++ b/src/systems/force_torque/ForceTorque.cc
@@ -367,4 +367,7 @@ IGNITION_ADD_PLUGIN(ForceTorque, System,
   ForceTorque::ISystemPostUpdate
 )
 
+IGNITION_ADD_PLUGIN_ALIAS(ForceTorque, "gz::sim::systems::ForceTorque")
+
+// TODO(CH3): Deprecated, remove on version 8
 IGNITION_ADD_PLUGIN_ALIAS(ForceTorque, "ignition::gazebo::systems::ForceTorque")

--- a/src/systems/hydrodynamics/Hydrodynamics.cc
+++ b/src/systems/hydrodynamics/Hydrodynamics.cc
@@ -426,4 +426,9 @@ IGNITION_ADD_PLUGIN(
 
 IGNITION_ADD_PLUGIN_ALIAS(
   Hydrodynamics,
+  "gz::sim::systems::Hydrodynamics")
+
+// TODO(CH3): Deprecated, remove on version 8
+IGNITION_ADD_PLUGIN_ALIAS(
+  Hydrodynamics,
   "ignition::gazebo::systems::Hydrodynamics")

--- a/src/systems/joint_traj_control/JointTrajectoryController.cc
+++ b/src/systems/joint_traj_control/JointTrajectoryController.cc
@@ -1064,4 +1064,9 @@ IGNITION_ADD_PLUGIN(JointTrajectoryController,
                     JointTrajectoryController::ISystemPreUpdate)
 IGNITION_ADD_PLUGIN_ALIAS(
     JointTrajectoryController,
+    "gz::sim::systems::JointTrajectoryController")
+
+// TODO(CH3): Deprecated, remove on version 8
+IGNITION_ADD_PLUGIN_ALIAS(
+    JointTrajectoryController,
     "ignition::gazebo::systems::JointTrajectoryController")

--- a/src/systems/label/Label.cc
+++ b/src/systems/label/Label.cc
@@ -103,4 +103,6 @@ void Label::Configure(const Entity &_entity,
 }
 
 IGNITION_ADD_PLUGIN(Label, System, Label::ISystemConfigure)
+IGNITION_ADD_PLUGIN_ALIAS(Label, "gz::sim::systems::Label")
+// TODO(CH3): Deprecated, remove on version 8
 IGNITION_ADD_PLUGIN_ALIAS(Label, "ignition::gazebo::systems::Label")

--- a/src/systems/mecanum_drive/MecanumDrive.cc
+++ b/src/systems/mecanum_drive/MecanumDrive.cc
@@ -566,4 +566,8 @@ IGNITION_ADD_PLUGIN(MecanumDrive,
                     MecanumDrive::ISystemPostUpdate)
 
 IGNITION_ADD_PLUGIN_ALIAS(MecanumDrive,
+                          "gz::sim::systems::MecanumDrive")
+
+// TODO(CH3): Deprecated, remove on version 8
+IGNITION_ADD_PLUGIN_ALIAS(MecanumDrive,
                           "ignition::gazebo::systems::MecanumDrive")

--- a/src/systems/model_photo_shoot/ModelPhotoShoot.cc
+++ b/src/systems/model_photo_shoot/ModelPhotoShoot.cc
@@ -311,4 +311,8 @@ IGNITION_ADD_PLUGIN(ModelPhotoShoot, ignition::gazebo::System,
                     ModelPhotoShoot::ISystemPreUpdate)
 
 IGNITION_ADD_PLUGIN_ALIAS(ModelPhotoShoot,
+                          "gz::sim::systems::ModelPhotoShoot")
+
+// TODO(CH3): Deprecated, remove on version 8
+IGNITION_ADD_PLUGIN_ALIAS(ModelPhotoShoot,
                           "ignition::gazebo::systems::ModelPhotoShoot")

--- a/src/systems/navsat/NavSat.cc
+++ b/src/systems/navsat/NavSat.cc
@@ -299,4 +299,7 @@ IGNITION_ADD_PLUGIN(NavSat, System,
   NavSat::ISystemPostUpdate
 )
 
+IGNITION_ADD_PLUGIN_ALIAS(NavSat, "gz::sim::systems::NavSat")
+
+// TODO(CH3): Deprecated, remove on version 8
 IGNITION_ADD_PLUGIN_ALIAS(NavSat, "ignition::gazebo::systems::NavSat")

--- a/src/systems/odometry_publisher/OdometryPublisher.cc
+++ b/src/systems/odometry_publisher/OdometryPublisher.cc
@@ -525,4 +525,8 @@ IGNITION_ADD_PLUGIN(OdometryPublisher,
                     OdometryPublisher::ISystemPostUpdate)
 
 IGNITION_ADD_PLUGIN_ALIAS(OdometryPublisher,
+                          "gz::sim::systems::OdometryPublisher")
+
+// TODO(CH3): Deprecated, remove on version 8
+IGNITION_ADD_PLUGIN_ALIAS(OdometryPublisher,
                           "ignition::gazebo::systems::OdometryPublisher")

--- a/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
+++ b/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
@@ -841,4 +841,8 @@ IGNITION_ADD_PLUGIN(OpticalTactilePlugin,
   OpticalTactilePlugin::ISystemPostUpdate)
 
 IGNITION_ADD_PLUGIN_ALIAS(OpticalTactilePlugin,
+  "gz::sim::systems::OpticalTactilePlugin")
+
+// TODO(CH3): Deprecated, remove on version 8
+IGNITION_ADD_PLUGIN_ALIAS(OpticalTactilePlugin,
   "ignition::gazebo::systems::OpticalTactilePlugin")

--- a/src/systems/particle_emitter/ParticleEmitter.cc
+++ b/src/systems/particle_emitter/ParticleEmitter.cc
@@ -352,4 +352,8 @@ IGNITION_ADD_PLUGIN(ParticleEmitter,
                     ParticleEmitter::ISystemPreUpdate)
 
 IGNITION_ADD_PLUGIN_ALIAS(ParticleEmitter,
+                          "gz::sim::systems::ParticleEmitter")
+
+// TODO(CH3): Deprecated, remove on version 8
+IGNITION_ADD_PLUGIN_ALIAS(ParticleEmitter,
                           "ignition::gazebo::systems::ParticleEmitter")

--- a/src/systems/particle_emitter2/ParticleEmitter2.cc
+++ b/src/systems/particle_emitter2/ParticleEmitter2.cc
@@ -252,4 +252,8 @@ IGNITION_ADD_PLUGIN(ParticleEmitter2,
                     ParticleEmitter2::ISystemPreUpdate)
 
 IGNITION_ADD_PLUGIN_ALIAS(ParticleEmitter2,
+                          "gz::sim::systems::ParticleEmitter2")
+
+// TODO(CH3): Deprecated, remove on version 8
+IGNITION_ADD_PLUGIN_ALIAS(ParticleEmitter2,
                           "ignition::gazebo::systems::ParticleEmitter2")

--- a/src/systems/perfect_comms/PerfectComms.cc
+++ b/src/systems/perfect_comms/PerfectComms.cc
@@ -112,4 +112,8 @@ IGNITION_ADD_PLUGIN(PerfectComms,
                     comms::ICommsModel::ISystemPreUpdate)
 
 IGNITION_ADD_PLUGIN_ALIAS(PerfectComms,
+                          "gz::sim::systems::PerfectComms")
+
+// TODO(CH3): Deprecated, remove on version 8
+IGNITION_ADD_PLUGIN_ALIAS(PerfectComms,
                           "ignition::gazebo::systems::PerfectComms")

--- a/src/systems/rf_comms/RFComms.cc
+++ b/src/systems/rf_comms/RFComms.cc
@@ -478,4 +478,8 @@ IGNITION_ADD_PLUGIN(RFComms,
                     comms::ICommsModel::ISystemPreUpdate)
 
 IGNITION_ADD_PLUGIN_ALIAS(RFComms,
+                          "gz::sim::systems::RFComms")
+
+// TODO(CH3): Deprecated, remove on version 8
+IGNITION_ADD_PLUGIN_ALIAS(RFComms,
                           "ignition::gazebo::systems::RFComms")

--- a/src/systems/shader_param/ShaderParam.cc
+++ b/src/systems/shader_param/ShaderParam.cc
@@ -503,4 +503,8 @@ IGNITION_ADD_PLUGIN(ShaderParam,
                     ShaderParam::ISystemPreUpdate)
 
 IGNITION_ADD_PLUGIN_ALIAS(ShaderParam,
+  "gz::sim::systems::ShaderParam")
+
+// TODO(CH3): Deprecated, remove on version 8
+IGNITION_ADD_PLUGIN_ALIAS(ShaderParam,
   "ignition::gazebo::systems::ShaderParam")

--- a/src/systems/thermal/ThermalSensor.cc
+++ b/src/systems/thermal/ThermalSensor.cc
@@ -90,4 +90,8 @@ IGNITION_ADD_PLUGIN(ThermalSensor, System,
 )
 
 IGNITION_ADD_PLUGIN_ALIAS(ThermalSensor,
+    "gz::sim::systems::ThermalSensor")
+
+// TODO(CH3): Deprecated, remove on version 8
+IGNITION_ADD_PLUGIN_ALIAS(ThermalSensor,
     "ignition::gazebo::systems::ThermalSensor")

--- a/src/systems/thruster/Thruster.cc
+++ b/src/systems/thruster/Thruster.cc
@@ -595,5 +595,7 @@ IGNITION_ADD_PLUGIN(
   Thruster::ISystemPreUpdate,
   Thruster::ISystemPostUpdate)
 
-IGNITION_ADD_PLUGIN_ALIAS(Thruster, "ignition::gazebo::systems::Thruster")
+IGNITION_ADD_PLUGIN_ALIAS(Thruster, "gz::sim::systems::Thruster")
 
+// TODO(CH3): Deprecated, remove on version 8
+IGNITION_ADD_PLUGIN_ALIAS(Thruster, "ignition::gazebo::systems::Thruster")

--- a/src/systems/trajectory_follower/TrajectoryFollower.cc
+++ b/src/systems/trajectory_follower/TrajectoryFollower.cc
@@ -429,4 +429,8 @@ IGNITION_ADD_PLUGIN(TrajectoryFollower,
                     TrajectoryFollower::ISystemPreUpdate)
 
 IGNITION_ADD_PLUGIN_ALIAS(TrajectoryFollower,
+                          "gz::sim::systems::TrajectoryFollower")
+
+// TODO(CH3): Deprecated, remove on version 8
+IGNITION_ADD_PLUGIN_ALIAS(TrajectoryFollower,
                           "ignition::gazebo::systems::TrajectoryFollower")


### PR DESCRIPTION
## Summary

Some systems were missing the "ignition::gazebo" -> "gz::sim" alias which makes migration more complicated. I added (hopefully all of) them.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.