### PR TITLE
Fix \TODO to \todo in systems plugins for Doxygen compliance

### DIFF
--- a/src/systems/ackermann_steering/AckermannSteering.cc
+++ b/src/systems/ackermann_steering/AckermannSteering.cc
@@ -504,7 +504,7 @@ void AckermannSteering::PreUpdate(const UpdateInfo &_info,
 {
   GZ_PROFILE("AckermannSteering::PreUpdate");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/advanced_lift_drag/AdvancedLiftDrag.cc
+++ b/src/systems/advanced_lift_drag/AdvancedLiftDrag.cc
@@ -798,7 +798,7 @@ void AdvancedLiftDrag::PreUpdate(const UpdateInfo &_info,
 {
   GZ_PROFILE("AdvancedLiftDrag::PreUpdate");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/air_pressure/AirPressure.cc
+++ b/src/systems/air_pressure/AirPressure.cc
@@ -128,7 +128,7 @@ void AirPressure::PostUpdate(const UpdateInfo &_info,
   // Only update and publish if not paused.
   GZ_PROFILE("AirPressure::PostUpdate");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/air_speed/AirSpeed.cc
+++ b/src/systems/air_speed/AirSpeed.cc
@@ -148,7 +148,7 @@ void AirSpeed::PostUpdate(const UpdateInfo &_info,
   // Only update and publish if not paused.
   GZ_PROFILE("AirSpeed::PostUpdate");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/altimeter/Altimeter.cc
+++ b/src/systems/altimeter/Altimeter.cc
@@ -128,7 +128,7 @@ void Altimeter::PostUpdate(const UpdateInfo &_info,
 {
   GZ_PROFILE("Altimeter::PostUpdate");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/apply_joint_force/ApplyJointForce.cc
+++ b/src/systems/apply_joint_force/ApplyJointForce.cc
@@ -130,7 +130,7 @@ void ApplyJointForce::PreUpdate(const UpdateInfo &_info,
 {
   GZ_PROFILE("ApplyJointForce::PreUpdate");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/battery_plugin/LinearBatteryPlugin.cc
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.cc
@@ -135,11 +135,11 @@ class gz::sim::systems::LinearBatteryPluginPrivate
   /// \brief Initial power load set through config
   public: double initialPowerLoad{0.0};
 
-  /// \TODO(caguero) Remove in Gazebo Dome.
+  /// \todo(caguero) Remove in Gazebo Dome.
   /// \brief Battery current for a historic time window
   public: std::deque<double> iList;
 
-  /// \TODO(caguero) Remove in Gazebo Dome.
+  /// \todo(caguero) Remove in Gazebo Dome.
   /// \brief Time interval for a historic time window
   public: std::deque<double> dtList;
 
@@ -178,7 +178,7 @@ class gz::sim::systems::LinearBatteryPluginPrivate
   /// \brief Flag to invert the current sign
   public: bool invertCurrentSign{false};
 
-  /// \TODO(caguero) Remove this flag in Gazebo Dome.
+  /// \todo(caguero) Remove this flag in Gazebo Dome.
   /// \brief Flag to enable some battery fixes.
   public: bool fixIssue225{false};
 };
@@ -559,7 +559,7 @@ void LinearBatteryPlugin::Update(const UpdateInfo &_info,
   if (!this->dataPtr->battery)
     return;
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/buoyancy/Buoyancy.cc
+++ b/src/systems/buoyancy/Buoyancy.cc
@@ -138,7 +138,7 @@ class gz::sim::systems::BuoyancyPrivate
   /// \brief List of points from where the forces act.
   /// This holds values refent to the current link being processed and must be
   /// cleared between links.
-  /// \TODO(chapulina) It's dangerous to keep link-specific values in a member
+  /// \todo(chapulina) It's dangerous to keep link-specific values in a member
   /// variable. We should consider reducing the scope of this variable and pass
   /// it across functions as needed.
   public: std::vector<BuoyancyActionPoint> buoyancyForces;

--- a/src/systems/contact/Contact.cc
+++ b/src/systems/contact/Contact.cc
@@ -272,7 +272,7 @@ void Contact::PostUpdate(const UpdateInfo &_info,
 {
   GZ_PROFILE("Contact::PostUpdate");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/diff_drive/DiffDrive.cc
+++ b/src/systems/diff_drive/DiffDrive.cc
@@ -392,7 +392,7 @@ void DiffDrive::PreUpdate(const UpdateInfo &_info,
 {
   GZ_PROFILE("DiffDrive::PreUpdate");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/force_torque/ForceTorque.cc
+++ b/src/systems/force_torque/ForceTorque.cc
@@ -171,7 +171,7 @@ void ForceTorque::Update(const UpdateInfo &_info,
 {
   GZ_PROFILE("ForceTorque::Update");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/imu/Imu.cc
+++ b/src/systems/imu/Imu.cc
@@ -132,7 +132,7 @@ void Imu::PostUpdate(const UpdateInfo &_info,
 {
   GZ_PROFILE("Imu::PostUpdate");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/joint_controller/JointController.cc
+++ b/src/systems/joint_controller/JointController.cc
@@ -275,7 +275,7 @@ void JointController::PreUpdate(const UpdateInfo &_info,
 {
   GZ_PROFILE("JointController::PreUpdate");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/joint_position_controller/JointPositionController.cc
+++ b/src/systems/joint_position_controller/JointPositionController.cc
@@ -522,7 +522,7 @@ void JointPositionController::PreUpdate(
 {
   GZ_PROFILE("JointPositionController::PreUpdate");
 
-  // \TODO(anyone) This is a temporary fix for
+  // \todo(anyone) This is a temporary fix for
   // gazebosim/gz-sim#2165 until gazebosim/gz-sim#2217 is resolved.
   if (kNullEntity == this->dataPtr->model.Entity())
   {
@@ -537,7 +537,7 @@ void JointPositionController::PreUpdate(
     return;
   }
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/lift_drag/LiftDrag.cc
+++ b/src/systems/lift_drag/LiftDrag.cc
@@ -553,7 +553,7 @@ void LiftDrag::PreUpdate(const UpdateInfo &_info, EntityComponentManager &_ecm)
 {
   GZ_PROFILE("LiftDrag::PreUpdate");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/log/LogRecord.cc
+++ b/src/systems/log/LogRecord.cc
@@ -665,7 +665,7 @@ void LogRecord::PostUpdate(const UpdateInfo &_info,
   if (!this->dataPtr->instStarted)
     return;
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/logical_camera/LogicalCamera.cc
+++ b/src/systems/logical_camera/LogicalCamera.cc
@@ -130,7 +130,7 @@ void LogicalCamera::PostUpdate(const UpdateInfo &_info,
 {
   GZ_PROFILE("LogicalCamera::PostUpdate");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/magnetometer/Magnetometer.cc
+++ b/src/systems/magnetometer/Magnetometer.cc
@@ -299,7 +299,7 @@ void Magnetometer::PostUpdate(const UpdateInfo &_info,
 {
   GZ_PROFILE("Magnetometer::PostUpdate");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/mecanum_drive/MecanumDrive.cc
+++ b/src/systems/mecanum_drive/MecanumDrive.cc
@@ -341,7 +341,7 @@ void MecanumDrive::PreUpdate(const UpdateInfo &_info,
 {
   GZ_PROFILE("MecanumDrive::PreUpdate");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/multicopter_control/MulticopterVelocityControl.cc
+++ b/src/systems/multicopter_control/MulticopterVelocityControl.cc
@@ -345,7 +345,7 @@ void MulticopterVelocityControl::PreUpdate(
     return;
   }
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
+++ b/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
@@ -395,7 +395,7 @@ void MulticopterMotorModel::PreUpdate(const UpdateInfo &_info,
 {
   GZ_PROFILE("MulticopterMotorModel::PreUpdate");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/navsat/NavSat.cc
+++ b/src/systems/navsat/NavSat.cc
@@ -124,7 +124,7 @@ void NavSat::PostUpdate(const UpdateInfo &_info,
 {
   GZ_PROFILE("NavSat::PostUpdate");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/odometry_publisher/OdometryPublisher.cc
+++ b/src/systems/odometry_publisher/OdometryPublisher.cc
@@ -303,7 +303,7 @@ void OdometryPublisher::PreUpdate(const gz::sim::UpdateInfo &_info,
 {
   GZ_PROFILE("OdometryPublisher::PreUpdate");
 
-  // \TODO(anyone) This is a temporary fix for
+  // \todo(anyone) This is a temporary fix for
   // gazebosim/gz-sim#2165 until gazebosim/gz-sim#2217 is resolved.
   if (kNullEntity == this->dataPtr->model.Entity())
   {
@@ -318,7 +318,7 @@ void OdometryPublisher::PreUpdate(const gz::sim::UpdateInfo &_info,
     return;
   }
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["
@@ -333,7 +333,7 @@ void OdometryPublisher::PostUpdate(const UpdateInfo &_info,
 {
   GZ_PROFILE("OdometryPublisher::PostUpdate");
 
-  // \TODO(anyone) This is a temporary fix for
+  // \todo(anyone) This is a temporary fix for
   // gazebosim/gz-sim#2165 until gazebosim/gz-sim#2217 is resolved.
   if (kNullEntity == this->dataPtr->model.Entity())
   {

--- a/src/systems/pose_publisher/PosePublisher.cc
+++ b/src/systems/pose_publisher/PosePublisher.cc
@@ -310,7 +310,7 @@ void PosePublisher::PostUpdate(const UpdateInfo &_info,
 {
   GZ_PROFILE("PosePublisher::PostUpdate");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/spacecraft_thruster_model/SpacecraftThrusterModel.cc
+++ b/src/systems/spacecraft_thruster_model/SpacecraftThrusterModel.cc
@@ -263,7 +263,7 @@ void SpacecraftThrusterModel::PreUpdate(const UpdateInfo &_info,
     EntityComponentManager &_ecm)
 {
   GZ_PROFILE("SpacecraftThrusterModel::PreUpdate");
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/touch_plugin/TouchPlugin.cc
+++ b/src/systems/touch_plugin/TouchPlugin.cc
@@ -314,7 +314,7 @@ void TouchPluginPrivate::Update(const UpdateInfo &_info,
 {
   GZ_PROFILE("TouchPluginPrivate::Update");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -502,7 +502,7 @@ class gz::sim::systems::UserCommandsPrivate
   public: std::mutex pendingMutex;
 
   /// \brief Global timeout settings for services.
-  /// \TODO(azeey) Consider making this configurable.
+  /// \todo(azeey) Consider making this configurable.
   public: const unsigned int kServiceHandlerTimeoutMs{5000};
 };
 

--- a/src/systems/velocity_control/VelocityControl.cc
+++ b/src/systems/velocity_control/VelocityControl.cc
@@ -184,7 +184,7 @@ void VelocityControl::PreUpdate(const UpdateInfo &_info,
 {
   GZ_PROFILE("VelocityControl::PreUpdate");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["

--- a/src/systems/wind_effects/WindEffects.cc
+++ b/src/systems/wind_effects/WindEffects.cc
@@ -729,7 +729,7 @@ void WindEffects::PreUpdate(const UpdateInfo &_info,
 {
   GZ_PROFILE("WindEffects::PreUpdate");
 
-  // \TODO(anyone) Support rewind
+  // \todo(anyone) Support rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
   {
     gzwarn << "Detected jump back in time ["


### PR DESCRIPTION
## Summary

Replace `\TODO` with `\todo` across 29 files in `src/systems/`. 

Doxygen recognizes `\todo` (lowercase) as a valid tag and includes it 
in the generated TODO list in the documentation. The uppercase `\TODO` 
is not a recognized Doxygen tag and is silently ignored, meaning these 
notes have never appeared in the official documentation.

This fix affects 35 instances across plugins including imu, diff_drive, 
contact, navsat, apply_joint_force, logical_camera, velocity_control, 
magnetometer, and others.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests