### PR TITLE
Introduce relative topic names to DiffDrive

### DIFF
--- a/src/systems/diff_drive/DiffDrive.cc
+++ b/src/systems/diff_drive/DiffDrive.cc
@@ -336,7 +336,12 @@ void DiffDrive::Configure(const Entity &_entity,
   std::vector<std::string> topics;
   if (_sdf->HasElement("topic"))
   {
-    topics.push_back(_sdf->Get<std::string>("topic"));
+    std::string topic = _sdf->Get<std::string>("topic");
+    if (topic.front() != '/')
+    {
+      topic = "/" + this->dataPtr->model.Name(_ecm) + "/" + topic;
+    }
+    topics.push_back(topic);
   }
   topics.push_back("/model/" + this->dataPtr->model.Name(_ecm) + "/cmd_vel");
   auto topic = validTopic(topics);

--- a/src/systems/diff_drive/DiffDrive.cc
+++ b/src/systems/diff_drive/DiffDrive.cc
@@ -336,12 +336,12 @@ void DiffDrive::Configure(const Entity &_entity,
   std::vector<std::string> topics;
   if (_sdf->HasElement("topic"))
   {
-    std::string topic = _sdf->Get<std::string>("topic");
-    if (topic.front() != '/')
+    std::string topicName = _sdf->Get<std::string>("topic");
+    if (!topicName.empty() && topicName.front() != '/')
     {
-      topic = "/" + this->dataPtr->model.Name(_ecm) + "/" + topic;
+      topicName = "/" + this->dataPtr->model.Name(_ecm) + "/" + topicName;
     }
-    topics.push_back(topic);
+    topics.push_back(topicName);
   }
   topics.push_back("/model/" + this->dataPtr->model.Name(_ecm) + "/cmd_vel");
   auto topic = validTopic(topics);
@@ -365,7 +365,12 @@ void DiffDrive::Configure(const Entity &_entity,
   std::vector<std::string> odomTopics;
   if (_sdf->HasElement("odom_topic"))
   {
-    odomTopics.push_back(_sdf->Get<std::string>("odom_topic"));
+    std::string odomTopicName = _sdf->Get<std::string>("odom_topic");
+    if (!odomTopicName.empty() && odomTopicName.front() != '/')
+    {
+      odomTopicName = "/" + this->dataPtr->model.Name(_ecm) + "/" + odomTopicName;
+    }
+    odomTopics.push_back(odomTopicName);
   }
   odomTopics.push_back("/model/" + this->dataPtr->model.Name(_ecm) +
       "/odometry");
@@ -377,7 +382,13 @@ void DiffDrive::Configure(const Entity &_entity,
   std::string tfTopic{"/model/" + this->dataPtr->model.Name(_ecm) +
     "/tf"};
   if (_sdf->HasElement("tf_topic"))
+  {
     tfTopic = _sdf->Get<std::string>("tf_topic");
+    if (!tfTopic.empty() && tfTopic.front() != '/')
+    {
+      tfTopic = "/" + this->dataPtr->model.Name(_ecm) + "/" + tfTopic;
+    }
+  }
   this->dataPtr->tfPub = this->dataPtr->node.Advertise<msgs::Pose_V>(
       tfTopic);
 

--- a/src/systems/diff_drive/DiffDrive.cc
+++ b/src/systems/diff_drive/DiffDrive.cc
@@ -368,7 +368,8 @@ void DiffDrive::Configure(const Entity &_entity,
     std::string odomTopicName = _sdf->Get<std::string>("odom_topic");
     if (!odomTopicName.empty() && odomTopicName.front() != '/')
     {
-      odomTopicName = "/" + this->dataPtr->model.Name(_ecm) + "/" + odomTopicName;
+      odomTopicName =
+        "/" + this->dataPtr->model.Name(_ecm) + "/" + odomTopicName;
     }
     odomTopics.push_back(odomTopicName);
   }

--- a/test/integration/diff_drive_system.cc
+++ b/test/integration/diff_drive_system.cc
@@ -235,7 +235,8 @@ class DiffDriveTest : public InternalFixture<::testing::TestWithParam<int>>
 
     unsigned int odomPosesCount = 0;
     std::function<void(const msgs::Odometry &)> odomCb =
-      [&odomPosesCount, &_expectedFrameId, &_expectedChildFrameId](const msgs::Odometry &_msg)
+      [&odomPosesCount, &_expectedFrameId, &_expectedChildFrameId]
+      (const msgs::Odometry &_msg)
       {
         ASSERT_TRUE(_msg.has_header());
         ASSERT_TRUE(_msg.header().has_stamp());
@@ -300,7 +301,8 @@ class DiffDriveTest : public InternalFixture<::testing::TestWithParam<int>>
 
     unsigned int tfPosesCount = 0;
     std::function<void(const msgs::Pose_V &)> pose_VCb =
-      [&tfPosesCount, &_expectedFrameId, &_expectedChildFrameId](const msgs::Pose_V &_msg)
+      [&tfPosesCount, &_expectedFrameId, &_expectedChildFrameId]
+      (const msgs::Pose_V &_msg)
       {
         ASSERT_GT(_msg.pose_size(), 0);
         ASSERT_TRUE(_msg.pose(0).has_header());
@@ -650,7 +652,8 @@ TEST_P(DiffDriveTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Pose_VCustomTfTopic))
 }
 
 /////////////////////////////////////////////////
-TEST_P(DiffDriveTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Pose_VCustomRelativeTfTopic))
+TEST_P(DiffDriveTest,
+  GZ_UTILS_TEST_DISABLED_ON_WIN32(Pose_VCustomRelativeTfTopic))
 {
   TestTfTopic(
       std::string(PROJECT_SOURCE_PATH) +

--- a/test/integration/diff_drive_system.cc
+++ b/test/integration/diff_drive_system.cc
@@ -213,6 +213,138 @@ class DiffDriveTest : public InternalFixture<::testing::TestWithParam<int>>
   testCmdVel(true /*test forward movement*/);
   testCmdVel(false /*test backward movement*/);
   }
+
+  /// \param[in] _sdfFile SDF file to load.
+  /// \param[in] _odomTopic Odometry topic to subscribe.
+  /// \param[in] _expectedFrameId Expected frame_id in Pose_V header.
+  /// \param[in] _expectedChildFrameId Expected child_frame_id in Pose_V header.
+  protected: void TestOdomTopic(const std::string &_sdfFile,
+                              const std::string &_odomTopic,
+                              const std::string &_expectedFrameId,
+                              const std::string &_expectedChildFrameId)
+  {
+    // Start server
+    ServerConfig serverConfig;
+    serverConfig.SetSdfFile(_sdfFile);
+
+    Server server(serverConfig);
+    EXPECT_FALSE(server.Running());
+    EXPECT_FALSE(*server.Running(0));
+
+    server.SetUpdatePeriod(0ns);
+
+    unsigned int odomPosesCount = 0;
+    std::function<void(const msgs::Odometry &)> odomCb =
+      [&odomPosesCount, &_expectedFrameId, &_expectedChildFrameId](const msgs::Odometry &_msg)
+      {
+        ASSERT_TRUE(_msg.has_header());
+        ASSERT_TRUE(_msg.header().has_stamp());
+
+        ASSERT_GT(_msg.header().data_size(), 1);
+
+        EXPECT_STREQ(_msg.header().data(0).key().c_str(), "frame_id");
+        EXPECT_STREQ(
+              _msg.header().data(0).value().Get(0).c_str(),
+              _expectedFrameId.c_str());
+
+        EXPECT_STREQ(_msg.header().data(1).key().c_str(), "child_frame_id");
+        EXPECT_STREQ(
+              _msg.header().data(1).value().Get(0).c_str(),
+              _expectedChildFrameId.c_str());
+
+        odomPosesCount++;
+      };
+
+    transport::Node node;
+    auto pub = node.Advertise<msgs::Twist>("/model/vehicle/cmd_vel");
+    node.Subscribe(_odomTopic, odomCb);
+
+    msgs::Twist msg;
+    msgs::Set(msg.mutable_linear(), math::Vector3d(0.5, 0, 0));
+    msgs::Set(msg.mutable_angular(), math::Vector3d(0.0, 0, 0.2));
+
+    pub.Publish(msg);
+
+    server.Run(true, 100, false);
+
+    int sleep = 0;
+    int maxSleep = 30;
+    // cppcheck-suppress knownConditionTrueFalse
+    for (; odomPosesCount < 5 && sleep < maxSleep; ++sleep) // NOLINT
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    ASSERT_NE(maxSleep, sleep);
+
+    EXPECT_EQ(5u, odomPosesCount);
+  }
+
+  /// \param[in] _sdfFile SDF file to load.
+  /// \param[in] _tfTopic TF topic to subscribe.
+  /// \param[in] _expectedFrameId Expected frame_id in Pose_V header.
+  /// \param[in] _expectedChildFrameId Expected child_frame_id in Pose_V header.
+  protected: void TestTfTopic(const std::string &_sdfFile,
+                              const std::string &_tfTopic,
+                              const std::string &_expectedFrameId,
+                              const std::string &_expectedChildFrameId)
+  {
+    // Start server
+    ServerConfig serverConfig;
+    serverConfig.SetSdfFile(_sdfFile);
+
+    Server server(serverConfig);
+    EXPECT_FALSE(server.Running());
+    EXPECT_FALSE(*server.Running(0));
+
+    server.SetUpdatePeriod(0ns);
+
+    unsigned int tfPosesCount = 0;
+    std::function<void(const msgs::Pose_V &)> pose_VCb =
+      [&tfPosesCount, &_expectedFrameId, &_expectedChildFrameId](const msgs::Pose_V &_msg)
+      {
+        ASSERT_GT(_msg.pose_size(), 0);
+        ASSERT_TRUE(_msg.pose(0).has_header());
+        ASSERT_TRUE(_msg.pose(0).header().has_stamp());
+
+        ASSERT_GT(_msg.pose(0).header().data_size(), 1);
+
+        EXPECT_STREQ(_msg.pose(0).header().data(0).key().c_str(), "frame_id");
+        EXPECT_STREQ(
+            _msg.pose(0).header().data(0).value().Get(0).c_str(),
+            _expectedFrameId.c_str());
+
+        EXPECT_STREQ(
+            _msg.pose(0).header().data(1).key().c_str(), "child_frame_id");
+        EXPECT_STREQ(
+            _msg.pose(0).header().data(1).value().Get(0).c_str(),
+            _expectedChildFrameId.c_str());
+
+        tfPosesCount++;
+      };
+
+    transport::Node node;
+    auto pub = node.Advertise<msgs::Twist>("/model/vehicle/cmd_vel");
+    node.Subscribe(_tfTopic, pose_VCb);
+
+    msgs::Twist msg;
+    msgs::Set(msg.mutable_linear(), math::Vector3d(0.5, 0, 0));
+    msgs::Set(msg.mutable_angular(), math::Vector3d(0.0, 0, 0.2));
+
+    pub.Publish(msg);
+
+    server.Run(true, 100, false);
+
+    int sleep = 0;
+    int maxSleep = 30;
+    // cppcheck-suppress knownConditionTrueFalse
+    for (; tfPosesCount < 5 && sleep < maxSleep; ++sleep)
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    ASSERT_NE(maxSleep, sleep);
+
+    EXPECT_EQ(5u, tfPosesCount);
+  }
 };
 
 /////////////////////////////////////////////////
@@ -234,6 +366,16 @@ TEST_P(DiffDriveTest,
       std::string(PROJECT_SOURCE_PATH) +
       "/test/worlds/diff_drive_custom_topics.sdf",
       "/model/foo/cmdvel", "/model/bar/odom");
+}
+
+/////////////////////////////////////////////////
+TEST_P(DiffDriveTest,
+       GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(PublishCmdCustomRelativeTopics))
+{
+  TestPublishCmd(
+      std::string(PROJECT_SOURCE_PATH) +
+      "/test/worlds/diff_drive_custom_relative_topics.sdf",
+      "/vehicle/cmdvel", "/vehicle/odom");
 }
 
 /////////////////////////////////////////////////
@@ -465,297 +607,55 @@ TEST_P(DiffDriveTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(EnableDisableCmd))
 /////////////////////////////////////////////////
 TEST_P(DiffDriveTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(OdomFrameId))
 {
-  // Start server
-  ServerConfig serverConfig;
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/diff_drive.sdf");
-
-  Server server(serverConfig);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-
-  server.SetUpdatePeriod(0ns);
-
-  unsigned int odomPosesCount = 0;
-  std::function<void(const msgs::Odometry &)> odomCb =
-    [&odomPosesCount](const msgs::Odometry &_msg)
-    {
-      ASSERT_TRUE(_msg.has_header());
-      ASSERT_TRUE(_msg.header().has_stamp());
-
-      ASSERT_GT(_msg.header().data_size(), 1);
-
-      EXPECT_STREQ(_msg.header().data(0).key().c_str(), "frame_id");
-      EXPECT_STREQ(
-            _msg.header().data(0).value().Get(0).c_str(), "vehicle/odom");
-
-      EXPECT_STREQ(_msg.header().data(1).key().c_str(), "child_frame_id");
-      EXPECT_STREQ(
-            _msg.header().data(1).value().Get(0).c_str(), "vehicle/chassis");
-
-      odomPosesCount++;
-    };
-
-  transport::Node node;
-  auto pub = node.Advertise<msgs::Twist>("/model/vehicle/cmd_vel");
-  node.Subscribe("/model/vehicle/odometry", odomCb);
-
-  msgs::Twist msg;
-  msgs::Set(msg.mutable_linear(), math::Vector3d(0.5, 0, 0));
-  msgs::Set(msg.mutable_angular(), math::Vector3d(0.0, 0, 0.2));
-
-  pub.Publish(msg);
-
-  server.Run(true, 100, false);
-
-  int sleep = 0;
-  int maxSleep = 30;
-  // cppcheck-suppress knownConditionTrueFalse
-  for (; odomPosesCount < 5 && sleep < maxSleep; ++sleep) // NOLINT
-  {
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  }
-  ASSERT_NE(maxSleep, sleep);
-
-  EXPECT_EQ(5u, odomPosesCount);
+  TestOdomTopic(
+      std::string(PROJECT_SOURCE_PATH) +
+      "/test/worlds/diff_drive.sdf",
+      "/model/vehicle/odometry", "vehicle/odom", "vehicle/chassis");
 }
 
 /////////////////////////////////////////////////
 TEST_P(DiffDriveTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(OdomCustomFrameId))
 {
-  // Start server
-  ServerConfig serverConfig;
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/diff_drive_custom_frame_id.sdf");
-
-  Server server(serverConfig);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-
-  server.SetUpdatePeriod(0ns);
-
-  unsigned int odomPosesCount = 0;
-  std::function<void(const msgs::Odometry &)> odomCb =
-    [&odomPosesCount](const msgs::Odometry &_msg)
-    {
-      ASSERT_TRUE(_msg.has_header());
-      ASSERT_TRUE(_msg.header().has_stamp());
-
-      ASSERT_GT(_msg.header().data_size(), 1);
-
-      EXPECT_STREQ(_msg.header().data(0).key().c_str(), "frame_id");
-      EXPECT_STREQ(_msg.header().data(0).value().Get(0).c_str(), "odom");
-
-      EXPECT_STREQ(_msg.header().data(1).key().c_str(), "child_frame_id");
-      EXPECT_STREQ(
-            _msg.header().data(1).value().Get(0).c_str(), "base_footprint");
-
-      odomPosesCount++;
-    };
-
-  transport::Node node;
-  auto pub = node.Advertise<msgs::Twist>("/model/vehicle/cmd_vel");
-  node.Subscribe("/model/vehicle/odometry", odomCb);
-
-  msgs::Twist msg;
-  msgs::Set(msg.mutable_linear(), math::Vector3d(0.5, 0, 0));
-  msgs::Set(msg.mutable_angular(), math::Vector3d(0.0, 0, 0.2));
-
-  pub.Publish(msg);
-
-  server.Run(true, 100, false);
-
-  int sleep = 0;
-  int maxSleep = 30;
-  // cppcheck-suppress knownConditionTrueFalse
-  for (; odomPosesCount < 5 && sleep < maxSleep; ++sleep)
-  {
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  }
-  ASSERT_NE(maxSleep, sleep);
-
-  EXPECT_EQ(5u, odomPosesCount);
+  TestOdomTopic(
+      std::string(PROJECT_SOURCE_PATH) +
+      "/test/worlds/diff_drive_custom_frame_id.sdf",
+      "/model/vehicle/odometry", "odom", "base_footprint");
 }
 
 /////////////////////////////////////////////////
 TEST_P(DiffDriveTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Pose_VFrameId))
 {
-  // Start server
-  ServerConfig serverConfig;
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/diff_drive.sdf");
-
-  Server server(serverConfig);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-
-  server.SetUpdatePeriod(0ns);
-
-  unsigned int odomPosesCount = 0;
-  std::function<void(const msgs::Pose_V &)> pose_VCb =
-    [&odomPosesCount](const msgs::Pose_V &_msg)
-    {
-      ASSERT_TRUE(_msg.pose(0).has_header());
-      ASSERT_TRUE(_msg.pose(0).header().has_stamp());
-
-      ASSERT_GT(_msg.pose(0).header().data_size(), 1);
-
-      EXPECT_STREQ(_msg.pose(0).header().data(0).key().c_str(),
-                   "frame_id");
-      EXPECT_STREQ(_msg.pose(0).header().data(0).value().Get(0).c_str(),
-                   "vehicle/odom");
-
-      EXPECT_STREQ(_msg.pose(0).header().data(1).key().c_str(),
-                   "child_frame_id");
-      EXPECT_STREQ(_msg.pose(0).header().data(1).value().Get(0).c_str(),
-                   "vehicle/chassis");
-
-      odomPosesCount++;
-    };
-
-  transport::Node node;
-  auto pub = node.Advertise<msgs::Twist>("/model/vehicle/cmd_vel");
-  node.Subscribe("/model/vehicle/tf", pose_VCb);
-
-  msgs::Twist msg;
-  msgs::Set(msg.mutable_linear(), math::Vector3d(0.5, 0, 0));
-  msgs::Set(msg.mutable_angular(), math::Vector3d(0.0, 0, 0.2));
-
-  pub.Publish(msg);
-
-  server.Run(true, 100, false);
-
-  int sleep = 0;
-  int maxSleep = 30;
-  // cppcheck-suppress knownConditionTrueFalse
-  for (; odomPosesCount < 5 && sleep < maxSleep; ++sleep)
-  {
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  }
-  ASSERT_NE(maxSleep, sleep);
-
-  EXPECT_EQ(5u, odomPosesCount);
+  TestTfTopic(
+      std::string(PROJECT_SOURCE_PATH) +
+      "/test/worlds/diff_drive.sdf",
+      "/model/vehicle/tf", "vehicle/odom", "vehicle/chassis");
 }
 
 /////////////////////////////////////////////////
 TEST_P(DiffDriveTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Pose_VCustomFrameId))
 {
-  // Start server
-  ServerConfig serverConfig;
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/diff_drive_custom_frame_id.sdf");
-
-  Server server(serverConfig);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-
-  server.SetUpdatePeriod(0ns);
-
-  unsigned int odomPosesCount = 0;
-  std::function<void(const msgs::Pose_V &)> Pose_VCb =
-    [&odomPosesCount](const msgs::Pose_V &_msg)
-    {
-      ASSERT_TRUE(_msg.pose(0).has_header());
-      ASSERT_TRUE(_msg.pose(0).header().has_stamp());
-
-      ASSERT_GT(_msg.pose(0).header().data_size(), 1);
-
-      EXPECT_STREQ(_msg.pose(0).header().data(0).key().c_str(),
-                   "frame_id");
-      EXPECT_STREQ(_msg.pose(0).header().data(0).value().Get(0).c_str(),
-                   "odom");
-
-      EXPECT_STREQ(_msg.pose(0).header().data(1).key().c_str(),
-                   "child_frame_id");
-      EXPECT_STREQ(_msg.pose(0).header().data(1).value().Get(0).c_str(),
-            "base_footprint");
-
-      odomPosesCount++;
-    };
-
-  transport::Node node;
-  auto pub = node.Advertise<msgs::Twist>("/model/vehicle/cmd_vel");
-  node.Subscribe("/model/vehicle/tf", Pose_VCb);
-
-  msgs::Twist msg;
-  msgs::Set(msg.mutable_linear(), math::Vector3d(0.5, 0, 0));
-  msgs::Set(msg.mutable_angular(), math::Vector3d(0.0, 0, 0.2));
-
-  pub.Publish(msg);
-
-  server.Run(true, 100, false);
-
-  int sleep = 0;
-  int maxSleep = 30;
-  // cppcheck-suppress knownConditionTrueFalse
-  for (; odomPosesCount < 5 && sleep < maxSleep; ++sleep)
-  {
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  }
-  ASSERT_NE(maxSleep, sleep);
-
-  EXPECT_EQ(5u, odomPosesCount);
+  TestTfTopic(
+      std::string(PROJECT_SOURCE_PATH) +
+      "/test/worlds/diff_drive_custom_frame_id.sdf",
+      "/model/vehicle/tf", "odom", "base_footprint");
 }
 
 /////////////////////////////////////////////////
 TEST_P(DiffDriveTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Pose_VCustomTfTopic))
 {
-  // Start server
-  ServerConfig serverConfig;
-  serverConfig.SetSdfFile(std::string(PROJECT_SOURCE_PATH) +
-      "/test/worlds/diff_drive_custom_tf_topic.sdf");
+  TestTfTopic(
+      std::string(PROJECT_SOURCE_PATH) +
+      "/test/worlds/diff_drive_custom_tf_topic.sdf",
+      "/tf_foo", "vehicle/odom", "vehicle/chassis");
+}
 
-  Server server(serverConfig);
-  EXPECT_FALSE(server.Running());
-  EXPECT_FALSE(*server.Running(0));
-
-  server.SetUpdatePeriod(0ns);
-
-  unsigned int odomPosesCount = 0;
-  std::function<void(const msgs::Pose_V &)> pose_VCb =
-    [&odomPosesCount](const msgs::Pose_V &_msg)
-    {
-      ASSERT_TRUE(_msg.pose(0).has_header());
-      ASSERT_TRUE(_msg.pose(0).header().has_stamp());
-
-      ASSERT_GT(_msg.pose(0).header().data_size(), 1);
-
-      EXPECT_STREQ(_msg.pose(0).header().data(0).key().c_str(), "frame_id");
-      EXPECT_STREQ(
-            _msg.pose(0).header().data(0).value().Get(0).c_str(),
-            "vehicle/odom");
-
-      EXPECT_STREQ(
-            _msg.pose(0).header().data(1).key().c_str(), "child_frame_id");
-      EXPECT_STREQ(
-            _msg.pose(0).header().data(1).value().Get(0).c_str(),
-            "vehicle/chassis");
-
-      odomPosesCount++;
-    };
-
-  transport::Node node;
-  auto pub = node.Advertise<msgs::Twist>("/model/vehicle/cmd_vel");
-  node.Subscribe("/tf_foo", pose_VCb);
-
-  msgs::Twist msg;
-  msgs::Set(msg.mutable_linear(), math::Vector3d(0.5, 0, 0));
-  msgs::Set(msg.mutable_angular(), math::Vector3d(0.0, 0, 0.2));
-
-  pub.Publish(msg);
-
-  server.Run(true, 100, false);
-
-  int sleep = 0;
-  int maxSleep = 30;
-  // cppcheck-suppress knownConditionTrueFalse
-  for (; odomPosesCount < 5 && sleep < maxSleep; ++sleep)
-  {
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  }
-  ASSERT_NE(maxSleep, sleep);
-
-  EXPECT_EQ(5u, odomPosesCount);
+/////////////////////////////////////////////////
+TEST_P(DiffDriveTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Pose_VCustomRelativeTfTopic))
+{
+  TestTfTopic(
+      std::string(PROJECT_SOURCE_PATH) +
+      "/test/worlds/diff_drive_custom_relative_tf_topic.sdf",
+      "/vehicle/tf_foo", "vehicle/odom", "vehicle/chassis");
 }
 
 // Run multiple times

--- a/test/worlds/diff_drive_custom_relative_tf_topic.sdf
+++ b/test/worlds/diff_drive_custom_relative_tf_topic.sdf
@@ -228,7 +228,7 @@
         <wheel_radius>0.3</wheel_radius>
         <max_acceleration>1</max_acceleration>
         <max_velocity>0.5</max_velocity>
-        <tf_topic>/tf_foo</tf_topic>
+        <tf_topic>tf_foo</tf_topic>
         <!-- no odom_publisher_frequency defaults to 50 Hz -->
       </plugin>
 

--- a/test/worlds/diff_drive_custom_relative_topics.sdf
+++ b/test/worlds/diff_drive_custom_relative_topics.sdf
@@ -32,6 +32,7 @@
           <geometry>
             <plane>
               <normal>0 0 1</normal>
+              <size>100 100</size>
             </plane>
           </geometry>
         </collision>
@@ -226,15 +227,17 @@
         <right_joint>right_wheel_joint</right_joint>
         <wheel_separation>1.25</wheel_separation>
         <wheel_radius>0.3</wheel_radius>
-        <max_acceleration>1</max_acceleration>
-        <max_velocity>0.5</max_velocity>
-        <tf_topic>/tf_foo</tf_topic>
+        <topic>cmdvel</topic>
+        <odom_topic>odom</odom_topic>
+        <max_linear_acceleration>1</max_linear_acceleration>
+        <min_linear_acceleration>-1</min_linear_acceleration>
+        <max_angular_acceleration>2</max_angular_acceleration>
+        <min_angular_acceleration>-2</min_angular_acceleration>
+        <max_linear_velocity>0.5</max_linear_velocity>
+        <min_linear_velocity>-0.5</min_linear_velocity>
+        <max_angular_velocity>1</max_angular_velocity>
+        <min_angular_velocity>-1</min_angular_velocity>
         <!-- no odom_publisher_frequency defaults to 50 Hz -->
-      </plugin>
-
-      <plugin
-        filename="gz-sim-joint-state-publisher-system"
-        name="gz::sim::systems::JointStatePublisher">
       </plugin>
 
     </model>


### PR DESCRIPTION
# 🎉 New feature

Related to  #3420 

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->
This PR introduces support for relative topic names in the `DiffDrive` system.
* Topics starting with `/` are treated as absolute
* Otherwise, topics are treated as relative and automatically prefixed with the model name
```
/<model_name>/<topic>
```
This behavior is applied to: `cmd_vel`, `odometry`, and `tf`.

New tests are added, and existing tests are refactored to reduce duplication by extracting common logic.

## Test it
```
ctest -R diff
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)