### PR TITLE
Fix EventManager RTTI failures across shared-library boundaries

### DIFF
--- a/include/gz/sim/EventManager.hh
+++ b/include/gz/sim/EventManager.hh
@@ -17,6 +17,7 @@
 #ifndef GZ_SIM_EVENTMANAGER_HH_
 #define GZ_SIM_EVENTMANAGER_HH_
 
+#include <cstring>
 #include <functional>
 #include <memory>
 #include <typeinfo>
@@ -75,19 +76,13 @@ namespace gz
                   this->events[typeid(E)] = std::make_unique<E>();
                 }
 
-                E *eventPtr = dynamic_cast<E *>(this->events[typeid(E)].get());
-                // All values in the map should be derived from Event,
-                // so this shouldn't be an issue, but it doesn't hurt to check.
-                if (eventPtr != nullptr)
-                {
-                  return eventPtr->Connect(_subscriber);
-                }
-                else
-                {
-                  gzerr << "Failed to connect event: "
-                    << typeid(E).name() << std::endl;
-                  return nullptr;
-                }
+                // static_cast is used instead of dynamic_cast because
+                // dynamic_cast fails across shared-library boundaries when
+                // plugins are loaded with RTLD_LOCAL and hidden visibility
+                // (the RTTI type_info pointers differ per dylib on macOS).
+                // The map key guarantees the correct type by construction.
+                E *eventPtr = static_cast<E *>(this->events[typeid(E)].get());
+                return eventPtr->Connect(_subscriber);
               }
 
       /// \brief Emit an event signal to connected subscribers.
@@ -107,18 +102,9 @@ namespace gz
                   return;
                 }
 
-                E *eventPtr = dynamic_cast<E *>(this->events[typeid(E)].get());
-                // All values in the map should be derived from Event,
-                // so this shouldn't be an issue, but it doesn't hurt to check.
-                if (eventPtr != nullptr)
-                {
-                  eventPtr->Signal(std::forward<Args>(_args) ...);
-                }
-                else
-                {
-                  gzerr << "Failed to signal event: "
-                    << typeid(E).name() << std::endl;
-                }
+                // static_cast: see Connect() comment on RTTI across dylibs.
+                E *eventPtr = static_cast<E *>(this->events[typeid(E)].get());
+                eventPtr->Signal(std::forward<Args>(_args) ...);
               }
 
       /// \brief Get connection count for a particular event
@@ -132,30 +118,23 @@ namespace gz
                   return 0u;
                 }
 
-                E *eventPtr = dynamic_cast<E *>(this->events[typeid(E)].get());
-                // All values in the map should be derived from Event,
-                // so this shouldn't be an issue, but it doesn't hurt to check.
-                if (eventPtr != nullptr)
-                {
-                  return eventPtr->ConnectionCount();
-                }
-                else
-                {
-                  gzerr << "Failed to get connection count for event: "
-                    << typeid(E).name() << std::endl;
-                  return 0u;
-                }
+                // static_cast: see Connect() comment on RTTI across dylibs.
+                E *eventPtr = static_cast<E *>(this->events[typeid(E)].get());
+                return eventPtr->ConnectionCount();
               }
 
       /// \brief Convenience type for storing typeinfo references.
       private: using TypeInfoRef = std::reference_wrapper<const std::type_info>;
 
       /// \brief Hash functor for TypeInfoRef
+      /// \details Uses name-based hashing so that the same type loaded
+      /// across shared-library boundaries (RTLD_LOCAL) hashes to the same
+      /// bucket on macOS where typeid() pointer identity differs per dylib.
       private: struct Hasher
                {
                  std::size_t operator()(TypeInfoRef _code) const
                  {
-                   return _code.get().hash_code();
+                   return std::hash<std::string>{}(_code.get().name());
                  }
                };
 
@@ -164,7 +143,9 @@ namespace gz
                {
                  bool operator()(TypeInfoRef _lhs, TypeInfoRef _rhs) const
                  {
-                   return _lhs.get() == _rhs.get();
+                   return _lhs.get() == _rhs.get() ||
+                          std::strcmp(_lhs.get().name(),
+                                     _rhs.get().name()) == 0;
                  }
                };
 

--- a/include/gz/sim/EventManager.hh
+++ b/include/gz/sim/EventManager.hh
@@ -20,6 +20,7 @@
 #include <cstring>
 #include <functional>
 #include <memory>
+#include <string>
 #include <typeinfo>
 #include <unordered_map>
 #include <utility>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #1992

## Summary

When plugins are loaded with `RTLD_LOCAL` and built with hidden visibility (the default via gz-cmake), each dylib gets its own copy of the RTTI `type_info` for the same C++ type. This causes `dynamic_cast` to return `nullptr` in `EventManager::Connect`, `Emit`, and `ConnectionCount` even though the object really is the requested type. It also causes `typeid(E).hash_code()` and `operator==` on `type_info` references to disagree across dylib boundaries, creating duplicate map entries.

This is the root cause of the issues described in #1992.

### Changes

- Replace `dynamic_cast` with `static_cast` in `Connect()`, `Emit()`, and `ConnectionCount()`. The map key already guarantees the correct type by construction.
- Switch `Hasher` to name-based hashing via `std::hash<std::string>(typeid::name())`.
- Add a name-based fallback in `EqualTo` so that the same type loaded from different shared libraries compares equal.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Code

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.