### PR TITLE
fix @param mismatches or stray @param doxygen warnings

### DIFF
--- a/src/gui/plugins/component_inspector/ComponentInspector.hh
+++ b/src/gui/plugins/component_inspector/ComponentInspector.hh
@@ -37,7 +37,9 @@
 
 #include <gz/msgs/light.pb.h>
 
+/// \cond
 Q_DECLARE_METATYPE(gz::sim::ComponentTypeId)
+/// \endcond
 
 namespace gz
 {
@@ -274,8 +276,10 @@ namespace sim
       double _falloff, double _intensity, int _type, bool _isLightOn,
       bool _visualizeVisual);
 
-    /// \brief Callback in Qt thread when gravity change.
-    /// \param[in] _gravity vector
+    /// \brief Callback in Qt thread when gravity changes.
+    /// \param[in] _x Gravity X component.
+    /// \param[in] _y Gravity Y component.
+    /// \param[in] _z Gravity Z component.
     public: Q_INVOKABLE void OnGravity(double _x, double _y, double _z);
 
     /// \brief Callback in Qt thread when physics' properties change.
@@ -350,7 +354,7 @@ namespace sim
 
     /// \brief Set the type of entity currently inspected.
     /// \param[in] _type Type, such as 'world' or 'model'.
-    public: Q_INVOKABLE void SetType(const QString &_entity);
+    public: Q_INVOKABLE void SetType(const QString &_type);
 
     /// \brief Notify that entity type has changed
     signals: void TypeChanged();
@@ -393,7 +397,7 @@ namespace sim
     public: Q_INVOKABLE QStringList SystemNameList() const;
 
     /// \brief Set the system plugin display name list
-    /// \param[in] _systempFilenameList A list of system plugin display names
+    /// \param[in] _systemNameList A list of system plugin display names
     public: Q_INVOKABLE void SetSystemNameList(
         const QStringList &_systemNameList);
 

--- a/src/gui/plugins/component_inspector_editor/ComponentInspectorEditor.hh
+++ b/src/gui/plugins/component_inspector_editor/ComponentInspectorEditor.hh
@@ -36,7 +36,9 @@
 #include <gz/msgs/light.pb.h>
 
 #include "Types.hh"
+/// \cond
 Q_DECLARE_METATYPE(gz::sim::ComponentTypeId)
+/// \endcond
 
 namespace gz
 {
@@ -334,7 +336,7 @@ namespace sim
 
     /// \brief Set the type of entity currently inspected.
     /// \param[in] _type Type, such as 'world' or 'model'.
-    public: Q_INVOKABLE void SetType(const QString &_entity);
+    public: Q_INVOKABLE void SetType(const QString &_type);
 
     /// \brief Notify that entity type has changed
     signals: void TypeChanged();


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Part of #3371

## Summary
This PR removes the remaining live Doxygen warnings from the `@param mismatch or stray @param` category by hiding the remaining `Q_DECLARE_METATYPE(ComponentTypeId)` declarations from Doxygen parsing and fixing the real parameter-name mismatches exposed once that spillover is removed.

### Warnings removed

| Warning category | Before | After | Files / area |
| --- | ---: | ---: | --- |
| `@param` mismatch or stray `@param` | 131 | 0 | `build/gz-doxygen.warn`, `src/gui/plugins/component_inspector/ComponentInspector.hh`, `src/gui/plugins/component_inspector_editor/ComponentInspectorEditor.hh` |

### What changed

| File | Change | Why it fixes the warning |
| --- | --- | --- |
| `src/gui/plugins/component_inspector/ComponentInspector.hh` | Wrapped `Q_DECLARE_METATYPE(gz::sim::ComponentTypeId)` with `\cond` / `\endcond`; fixed `OnGravity(...)` docs to `_x`, `_y`, `_z`; corrected `SetType(...)` declaration arg name to `_type`; corrected `SetSystemNameList(...)` doc parameter name to `_systemNameList` | Stops Doxygen from binding nearby `\param` docs to the Qt metatype macro and fixes the real mismatches that remain once the macro spillover is removed |
| `src/gui/plugins/component_inspector_editor/ComponentInspectorEditor.hh` | Wrapped `Q_DECLARE_METATYPE(gz::sim::ComponentTypeId)` with `\cond` / `\endcond` and corrected `SetType(...)` declaration arg name to `_type` | Eliminates the remaining `ComponentTypeId` spillover in the editor header and aligns the declaration with its documentation |

### Reproduction and verification

After this PR:
1. Run `cmake -S . -B build`
2. Run `cmake --build build --target cpplint`
3. Run `cmake --build build --target doc`
4. Inspect `build/gz-doxygen.warn`

The targeted warnings above no longer appear in the regenerated warning log:
- the total `@param mismatch or stray @param` count drops from `131` to `0`
- no `<Q_DECLARE_METATYPE>:1` warnings remain in the regenerated warning log
- a direct scan of `build/gz-doxygen.warn` finds no remaining lines containing `@param` or `not documented`

### Scope

This PR intentionally fixes only the remaining `@param mismatch or stray @param` warnings.

It does not address:
- the `310` recursive `gz::physics` relation warnings
- unsupported XML / HTML tag warnings in tutorials and headers
- unresolved `\ref` warnings
- obsolete Doxygen configuration-tag warnings printed during doc generation

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: GitHub Copilot (GPT-5.4)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.