### PR TITLE
Use high resolution timer on Windows

### DIFF
--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -185,11 +185,6 @@ SimulationRunner::SimulationRunner(const sdf::World &_world,
 
 #ifdef _WIN32
   winPrecisionTimer = CreateWaitableTimerExA(NULL, NULL, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
-  if (winPrecisionTimer == NULL)
-  {
-    gzerr << "Could not initialize Windows precision timer" << std::endl;
-    return;
-  }
 #endif
 
   // World control
@@ -942,17 +937,24 @@ bool SimulationRunner::Run(const uint64_t _iterations)
 #ifndef _WIN32
           std::this_thread::sleep_until(sleepTarget);
 #else
-          auto sleepTargetDuration = std::chrono::duration_cast<std::chrono::microseconds>(sleepTarget - now);
-          LARGE_INTEGER due_time;
-          memset(&due_time, 0, sizeof(due_time));
-          due_time.QuadPart = -sleepTargetDuration.count() * 10;
-          if (SetWaitableTimer(winPrecisionTimer, &due_time, 0, NULL, NULL, FALSE) != TRUE)
+          if (winPrecisionTimer != NULL)
           {
-            gzerr << "Could not SetWaitableTimer" << std::endl;
+            auto sleepTargetDuration = std::chrono::duration_cast<std::chrono::microseconds>(sleepTarget - now);
+            LARGE_INTEGER due_time;
+            memset(&due_time, 0, sizeof(due_time));
+            due_time.QuadPart = -sleepTargetDuration.count() * 10;
+            if (SetWaitableTimer(winPrecisionTimer, &due_time, 0, NULL, NULL, FALSE) != TRUE)
+            {
+              gzerr << "Could not SetWaitableTimer" << std::endl;
+            }
+            else
+            {
+              WaitForSingleObject(winPrecisionTimer, INFINITE);
+            }
           }
           else
           {
-            WaitForSingleObject(winPrecisionTimer, INFINITE);
+            std::this_thread::sleep_until(sleepTarget);
           }
 #endif
         }

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -67,6 +67,16 @@
 #include "LevelManager.hh"
 #include "SdfGenerator.hh"
 
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#endif
+
 using namespace gz;
 using namespace sim;
 
@@ -104,6 +114,31 @@ struct MaybeGilScopedRelease
 
 }
 
+#ifdef _WIN32
+namespace gz
+{
+namespace sim
+{
+inline namespace GZ_SIM_VERSION_NAMESPACE {
+class SimulationRunnerWinHandleStorage
+{
+  private: HANDLE handle_storage{NULL};
+
+  public: HANDLE handle() { return handle_storage; }
+
+  public: SimulationRunnerWinHandleStorage(HANDLE h) : handle_storage(h) {}
+
+  public: ~SimulationRunnerWinHandleStorage() {
+    if (handle_storage != NULL)
+    {
+      CloseHandle(handle_storage);
+    }
+  }
+};
+}
+}
+}
+#endif
 
 //////////////////////////////////////////////////
 SimulationRunner::SimulationRunner(const sdf::World &_world,
@@ -184,7 +219,11 @@ SimulationRunner::SimulationRunner(const sdf::World &_world,
   this->currentInfo.simTime = this->simTimeEpoch;
 
 #ifdef _WIN32
-  winPrecisionTimer = CreateWaitableTimerExA(NULL, NULL, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
+  HANDLE winPrecisionTimer_handle = CreateWaitableTimerExA(NULL, NULL, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
+  if (winPrecisionTimer_handle != NULL)
+  {
+    winPrecisionTimer = std::make_unique<SimulationRunnerWinHandleStorage>(winPrecisionTimer_handle);
+  }
 #endif
 
   // World control
@@ -328,13 +367,6 @@ SimulationRunner::SimulationRunner(const sdf::World &_world,
 SimulationRunner::~SimulationRunner()
 {
   this->StopWorkerThreads();
-#ifdef _WIN32
-  if (winPrecisionTimer != NULL)
-  {
-    CloseHandle(winPrecisionTimer);
-    winPrecisionTimer = NULL;
-  }
-#endif
 }
 
 /////////////////////////////////////////////////
@@ -937,19 +969,19 @@ bool SimulationRunner::Run(const uint64_t _iterations)
 #ifndef _WIN32
           std::this_thread::sleep_until(sleepTarget);
 #else
-          if (winPrecisionTimer != NULL)
+          if (winPrecisionTimer)
           {
             auto sleepTargetDuration = std::chrono::duration_cast<std::chrono::microseconds>(sleepTarget - now);
             LARGE_INTEGER due_time;
             memset(&due_time, 0, sizeof(due_time));
             due_time.QuadPart = -sleepTargetDuration.count() * 10;
-            if (SetWaitableTimer(winPrecisionTimer, &due_time, 0, NULL, NULL, FALSE) != TRUE)
+            if (SetWaitableTimer(winPrecisionTimer->handle(), &due_time, 0, NULL, NULL, FALSE) != TRUE)
             {
               gzerr << "Could not SetWaitableTimer" << std::endl;
             }
             else
             {
-              WaitForSingleObject(winPrecisionTimer, INFINITE);
+              WaitForSingleObject(winPrecisionTimer->handle(), INFINITE);
             }
           }
           else

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -183,6 +183,15 @@ SimulationRunner::SimulationRunner(const sdf::World &_world,
   );
   this->currentInfo.simTime = this->simTimeEpoch;
 
+#ifdef _WIN32
+  winPrecisionTimer = CreateWaitableTimerExA(NULL, NULL, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
+  if (winPrecisionTimer == NULL)
+  {
+    gzerr << "Could not initialize Windows precision timer" << std::endl;
+    return;
+  }
+#endif
+
   // World control
   transport::NodeOptions opts;
   std::string ns{"/world/" + this->worldName};
@@ -324,6 +333,13 @@ SimulationRunner::SimulationRunner(const sdf::World &_world,
 SimulationRunner::~SimulationRunner()
 {
   this->StopWorkerThreads();
+#ifdef _WIN32
+  if (winPrecisionTimer != NULL)
+  {
+    CloseHandle(winPrecisionTimer);
+    winPrecisionTimer = NULL;
+  }
+#endif
 }
 
 /////////////////////////////////////////////////
@@ -914,14 +930,31 @@ bool SimulationRunner::Run(const uint64_t _iterations)
       // larger than the typical OS + CPU C-state latency.
       constexpr auto kSpinThreshold = 200us;
 
+      auto now = std::chrono::steady_clock::now();
+
       // If the scheduled update time is in the future...
-      if (nextUpdateTime > std::chrono::steady_clock::now())
+      if (nextUpdateTime > now)
       {
         // ...sleep until we are close to the target time.
         auto sleepTarget = nextUpdateTime - kSpinThreshold;
-        if (sleepTarget > std::chrono::steady_clock::now())
+        if (sleepTarget > now)
         {
+#ifndef _WIN32
           std::this_thread::sleep_until(sleepTarget);
+#else
+          auto sleepTargetDuration = std::chrono::duration_cast<std::chrono::microseconds>(sleepTarget - now);
+          LARGE_INTEGER due_time;
+          memset(&due_time, 0, sizeof(due_time));
+          due_time.QuadPart = -sleepTargetDuration.count() * 10;
+          if (SetWaitableTimer(winPrecisionTimer, &due_time, 0, NULL, NULL, FALSE) != TRUE)
+          {
+            gzerr << "Could not SetWaitableTimer" << std::endl;
+          }
+          else
+          {
+            WaitForSingleObject(winPrecisionTimer, INFINITE);
+          }
+#endif
         }
 
         // ...then busy-wait for the final moments for precision.
@@ -932,7 +965,7 @@ bool SimulationRunner::Run(const uint64_t _iterations)
       }
 
       // Schedule the next update time.
-      auto now = std::chrono::steady_clock::now();
+      now = std::chrono::steady_clock::now();
       nextUpdateTime += this->updatePeriod;
       if (nextUpdateTime < now)
       {

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -222,10 +222,12 @@ SimulationRunner::SimulationRunner(const sdf::World &_world,
   this->currentInfo.simTime = this->simTimeEpoch;
 
 #ifdef _WIN32
-  HANDLE winPrecisionTimerHandle = CreateWaitableTimerExA(NULL, NULL, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
+  HANDLE winPrecisionTimerHandle = CreateWaitableTimerExA(NULL, NULL,
+    CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
   if (winPrecisionTimerHandle != NULL)
   {
-    winPrecisionTimer = std::make_unique<SimulationRunnerWinHandleStorage>(winPrecisionTimerHandle);
+    winPrecisionTimer = std::make_unique<SimulationRunnerWinHandleStorage>(
+      winPrecisionTimerHandle);
   }
 #endif
 
@@ -974,13 +976,18 @@ bool SimulationRunner::Run(const uint64_t _iterations)
 #else
           if (winPrecisionTimer)
           {
-            auto sleepTargetDuration = std::chrono::duration_cast<std::chrono::microseconds>(sleepTarget - now);
+            auto sleepTargetDuration =
+              std::chrono::duration_cast<std::chrono::microseconds>(
+              sleepTarget - now);
             LARGE_INTEGER due_time;
             memset(&due_time, 0, sizeof(due_time));
-            // Positive durations are absolute, while negative durations are relative in 10 us intervals
-            // The absolute time uses the non-precision system clock so we need to use relative time
+            // Positive durations are absolute, while negative durations
+            // are relative in 10 us intervals.
+            // The absolute time uses the non-precision system clock so we
+            // need to use relative time.
             due_time.QuadPart = -sleepTargetDuration.count() * 10;
-            if (SetWaitableTimer(winPrecisionTimer->handle(), &due_time, 0, NULL, NULL, FALSE) != TRUE)
+            if (SetWaitableTimer(winPrecisionTimer->handle(), &due_time, 0,
+              NULL, NULL, FALSE) != TRUE)
             {
               gzerr << "Could not SetWaitableTimer" << std::endl;
             }

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -120,18 +120,21 @@ namespace gz
 namespace sim
 {
 inline namespace GZ_SIM_VERSION_NAMESPACE {
+// Utility class to store the windows HANDLE variable and close
+// the handle using RAII. This class also hides the HANDLE
+// type from the global header files.
 class SimulationRunnerWinHandleStorage
 {
-  private: HANDLE handle_storage{NULL};
+  private: HANDLE handleStorage{NULL};
 
-  public: HANDLE handle() { return handle_storage; }
+  public: HANDLE handle() { return handleStorage; }
 
-  public: SimulationRunnerWinHandleStorage(HANDLE h) : handle_storage(h) {}
+  public: SimulationRunnerWinHandleStorage(HANDLE h) : handleStorage(h) {}
 
   public: ~SimulationRunnerWinHandleStorage() {
-    if (handle_storage != NULL)
+    if (handleStorage != NULL)
     {
-      CloseHandle(handle_storage);
+      CloseHandle(handleStorage);
     }
   }
 };
@@ -219,10 +222,10 @@ SimulationRunner::SimulationRunner(const sdf::World &_world,
   this->currentInfo.simTime = this->simTimeEpoch;
 
 #ifdef _WIN32
-  HANDLE winPrecisionTimer_handle = CreateWaitableTimerExA(NULL, NULL, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
-  if (winPrecisionTimer_handle != NULL)
+  HANDLE winPrecisionTimerHandle = CreateWaitableTimerExA(NULL, NULL, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
+  if (winPrecisionTimerHandle != NULL)
   {
-    winPrecisionTimer = std::make_unique<SimulationRunnerWinHandleStorage>(winPrecisionTimer_handle);
+    winPrecisionTimer = std::make_unique<SimulationRunnerWinHandleStorage>(winPrecisionTimerHandle);
   }
 #endif
 
@@ -974,6 +977,8 @@ bool SimulationRunner::Run(const uint64_t _iterations)
             auto sleepTargetDuration = std::chrono::duration_cast<std::chrono::microseconds>(sleepTarget - now);
             LARGE_INTEGER due_time;
             memset(&due_time, 0, sizeof(due_time));
+            // Positive durations are absolute, while negative durations are relative in 10 us intervals
+            // The absolute time uses the non-precision system clock so we need to use relative time
             due_time.QuadPart = -sleepTargetDuration.count() * 10;
             if (SetWaitableTimer(winPrecisionTimer->handle(), &due_time, 0, NULL, NULL, FALSE) != TRUE)
             {

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -593,7 +593,8 @@ namespace gz
       /// `SetExitedWithErrors()`.
       private: bool exitedWithErrors{false};
 #ifdef _WIN32
-      private: std::unique_ptr<SimulationRunnerWinHandleStorage> winPrecisionTimer;
+      private: std::unique_ptr<SimulationRunnerWinHandleStorage>
+        winPrecisionTimer;
 #endif
 
       friend class LevelManager;

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -590,7 +590,7 @@ namespace gz
       /// `SetExitedWithErrors()`.
       private: bool exitedWithErrors{false};
 #ifdef _WIN32
-      private: HANDLE winPrecisionTimer;
+      private: HANDLE winPrecisionTimer{NULL};
 #endif
 
       friend class LevelManager;

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -69,6 +69,9 @@ namespace gz
     inline namespace GZ_SIM_VERSION_NAMESPACE {
     // Forward declarations.
     class SimulationRunnerPrivate;
+#ifdef _WIN32
+    class SimulationRunnerWinHandleStorage;
+#endif
 
     class GZ_SIM_VISIBLE SimulationRunner
     {
@@ -590,7 +593,7 @@ namespace gz
       /// `SetExitedWithErrors()`.
       private: bool exitedWithErrors{false};
 #ifdef _WIN32
-      private: HANDLE winPrecisionTimer{NULL};
+      private: std::unique_ptr<SimulationRunnerWinHandleStorage> winPrecisionTimer;
 #endif
 
       friend class LevelManager;

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -589,6 +589,9 @@ namespace gz
       /// initialization and should exit immediately. See
       /// `SetExitedWithErrors()`.
       private: bool exitedWithErrors{false};
+#ifdef _WIN32
+      private: HANDLE winPrecisionTimer;
+#endif
 
       friend class LevelManager;
     };


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This PR fixes timing issues on Windows. Simulation ratios have been observed as low as 6.5% on Windows with an empty scene, and simulation rates often hover around 80% with busier scenes. The problem was caused by the loop rate stabilization strategy. By default the Windows kernel timing resolution is 15.6 ms, meaning that a normal sleep command can not wake before 15.6 ms. On older version of Windows, a system-wide command was used to modify the system timing resolution, meaning that if any process requested a higher timing resolution all timers would also have this resolution. Newer Windows updates have changed this behavior, and each high resolution timer must now use the `CREATE_WAITABLE_TIMER_HIGH_RESOLUTION` with the Win32 API function `CreateWaitableTimerEx()` to create a timer that has the higher resolution capability.

This PR modifies the `SimulationRunner` class to use a high resolution timer instead of `std::this_thread::sleep_until()` when on Windows.

We ran into a similar problem in the Robot Raconteur project: https://github.com/robotraconteur/robotraconteur/pull/239

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.



**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

@traversaro 