### PR TITLE
Fix Python test PYTHONPATH: use ENVIRONMENT_MODIFICATION instead of ENVIRONMENT

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -105,10 +105,7 @@ if (BUILD_TESTING)
         "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/python/test/${test}.py")
     endif()
 
-    set(_env_vars)
-    list(APPEND _env_vars "PYTHONPATH=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/python/:$ENV{PYTHONPATH}")
-    list(APPEND _env_vars "LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}:$ENV{LD_LIBRARY_PATH}")
     set_tests_properties(${test} PROPERTIES
-      ENVIRONMENT "${_env_vars}")
+      ENVIRONMENT_MODIFICATION "PYTHONPATH=path_list_prepend:${CMAKE_BINARY_DIR}/lib;LD_LIBRARY_PATH=path_list_prepend:${CMAKE_BINARY_DIR}/lib")
   endforeach()
 endif()


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The Python test environment setup in `python/CMakeLists.txt` uses `set_tests_properties(... ENVIRONMENT "PYTHONPATH=...")` which has two problems:

1. **Overwrites shell PYTHONPATH** — `ENVIRONMENT` replaces the entire variable rather than prepending to it, so any `PYTHONPATH` set by the test runner or build system is lost.
2. **Bakes `CMAKE_INSTALL_PREFIX` paths** — These paths don't exist at test time (before `make install`), making the PYTHONPATH entry a no-op.

This PR replaces `ENVIRONMENT` with `ENVIRONMENT_MODIFICATION` using `path_list_prepend` (available since CMake 3.22, which gz-cmake already requires). This prepends `CMAKE_BINARY_DIR/lib` to both `PYTHONPATH` and \`LD_LIBRARY_PATH\` at test-execution time, preserving any paths already set in the environment.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] \`codecheck\` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add \"Generated-by\" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Code

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining \`Signed-off-by\` and \`Generated-by\` messages.