### PR TITLE
Make component typeIds constexpr

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -95,6 +95,11 @@ release will remove the deprecated code.
     `/<model_name>/pose` to `/model/<model>/pose`. The new topic name is
     is consistent with the topic names for models that already exist in the
     world, i.e. models that are not spawned.
+  * Component's `typeId` is now `constexpr`. It is not allowed to change it
+    at runtime anymore. Furthermore component registration is now only allowed
+    through the `GZ_SIM_REGISTER_COMPONENT` macro and components must be
+    registered before they are instantiated, else a static assertion failure
+    will be triggered at compile time.
 
 ## Gazebo Sim 9.x to 10.0
 

--- a/include/gz/sim/components/Component.hh
+++ b/include/gz/sim/components/Component.hh
@@ -200,6 +200,16 @@ namespace serializers
 
 namespace components
 {
+  /// \brief Fallback function for ADL component registration.
+  /// This returns 0 for components that are not registered using the macro.
+  /// It is a template so it has lower priority than the non-template
+  /// overloads defined by the GZ_SIM_REGISTER_COMPONENT macro.
+  template <typename T>
+  constexpr ComponentTypeId componentTypeId(T*)
+  {
+    return 0;
+  }
+
   /// \brief Convenient type to be used by components that don't wrap any data.
   /// I.e. they act as tags and their presence is enough to infer something
   /// about the entity.
@@ -349,6 +359,25 @@ namespace components
     // Documentation inherited
     public: std::unique_ptr<BaseComponent> Clone() const override;
 
+    /// \brief Returns the unique ID for the component's type.
+    public: static constexpr ComponentTypeId typeIdStatic()
+    {
+      // This call triggers Argument Dependent Lookup (ADL) to find the
+      // `componentTypeId` function defined by the GZ_SIM_REGISTER_COMPONENT
+      // macro in the component's namespace.
+      //
+      // We pass a null pointer of the type `Component*` to trigger ADL. ADL
+      // searches the namespaces of the template arguments of `Component`,
+      // which includes the namespace where the tag type (and thus the
+      // component) is defined. This removes the constraint that all
+      // components must be defined in the `gz::sim::components` namespace.
+      //
+      // Passing `Component*` also ensures that components sharing the same
+      // tag type but having different data types generate unique function
+      // overloads, preventing ODR collisions.
+      return componentTypeId((Component*)nullptr);
+    }
+
     // Documentation inherited
     public: ComponentTypeId TypeId() const override;
 
@@ -383,7 +412,7 @@ namespace components
 
     /// \brief Unique ID for this component type. This is set through the
     /// Factory registration.
-    public: inline static ComponentTypeId typeId{0};
+    public: inline static ComponentTypeId typeId = typeIdStatic();
 
     /// \brief Unique name for this component type. This is set through the
     /// Factory registration.
@@ -401,6 +430,7 @@ namespace components
   template <typename Identifier, typename Serializer>
   class Component<NoData, Identifier, Serializer> : public BaseComponent
   {
+    public: using Type = NoData;
     /// \brief Components with no data are always equal to another instance of
     /// the same type.
     /// \param[in] _component Component to compare to
@@ -418,6 +448,25 @@ namespace components
     // Documentation inherited
     public: std::unique_ptr<BaseComponent> Clone() const override;
 
+    /// \brief Returns the unique ID for the component's type.
+    public: static constexpr ComponentTypeId typeIdStatic()
+    {
+      // This call triggers Argument Dependent Lookup (ADL) to find the
+      // `componentTypeId` function defined by the GZ_SIM_REGISTER_COMPONENT
+      // macro in the component's namespace.
+      //
+      // We pass a null pointer of the type `Component*` to trigger ADL. ADL
+      // searches the namespaces of the template arguments of `Component`,
+      // which includes the namespace where the tag type (and thus the
+      // component) is defined. This removes the constraint that all
+      // components must be defined in the `gz::sim::components` namespace.
+      //
+      // Passing `Component*` also ensures that components sharing the same
+      // tag type but having different data types generate unique function
+      // overloads, preventing ODR collisions.
+      return componentTypeId((Component*)nullptr);
+    }
+
     // Documentation inherited
     public: ComponentTypeId TypeId() const override;
 
@@ -429,7 +478,9 @@ namespace components
 
     /// \brief Unique ID for this component type. This is set through the
     /// Factory registration.
-    public: inline static ComponentTypeId typeId{0};
+    public:
+    // [[deprecated("Use TypeId() or TypeIdStatic() for constexpr context. Editing this variable at runtime is not supported.")]]
+    inline static ComponentTypeId typeId = typeIdStatic();
 
     /// \brief Unique name for this component type. This is set through the
     /// Factory registration.
@@ -514,7 +565,7 @@ namespace components
   template <typename DataType, typename Identifier, typename Serializer>
   ComponentTypeId Component<DataType, Identifier, Serializer>::TypeId() const
   {
-    return typeId;
+    return typeIdStatic();
   }
 
   //////////////////////////////////////////////////
@@ -545,7 +596,7 @@ namespace components
   template <typename Identifier, typename Serializer>
   ComponentTypeId Component<NoData, Identifier, Serializer>::TypeId() const
   {
-    return typeId;
+    return typeIdStatic();
   }
 
   //////////////////////////////////////////////////

--- a/include/gz/sim/components/Component.hh
+++ b/include/gz/sim/components/Component.hh
@@ -207,6 +207,8 @@ namespace components
   template <typename T>
   constexpr ComponentTypeId componentTypeId(T*)  // NOLINT(readability/casting)
   {
+    static_assert(false, "Type ID not set, did you register the component "
+                  "through the GZ_SIM_REGISTER_COMPONENT macro?");
     return 0;
   }
 

--- a/include/gz/sim/components/Component.hh
+++ b/include/gz/sim/components/Component.hh
@@ -359,25 +359,6 @@ namespace components
     // Documentation inherited
     public: std::unique_ptr<BaseComponent> Clone() const override;
 
-    /// \brief Returns the unique ID for the component's type.
-    public: static constexpr ComponentTypeId typeIdStatic()
-    {
-      // This call triggers Argument Dependent Lookup (ADL) to find the
-      // `componentTypeId` function defined by the GZ_SIM_REGISTER_COMPONENT
-      // macro in the component's namespace.
-      //
-      // We pass a null pointer of the type `Component*` to trigger ADL. ADL
-      // searches the namespaces of the template arguments of `Component`,
-      // which includes the namespace where the tag type (and thus the
-      // component) is defined. This removes the constraint that all
-      // components must be defined in the `gz::sim::components` namespace.
-      //
-      // Passing `Component*` also ensures that components sharing the same
-      // tag type but having different data types generate unique function
-      // overloads, preventing ODR collisions.
-      return componentTypeId((Component*)nullptr);
-    }
-
     // Documentation inherited
     public: ComponentTypeId TypeId() const override;
 
@@ -410,9 +391,21 @@ namespace components
     /// \brief Private data pointer.
     private: DataType data;
 
-    /// \brief Unique ID for this component type. This is set through the
-    /// Factory registration.
-    public: inline static ComponentTypeId typeId = typeIdStatic();
+    // This call triggers Argument Dependent Lookup (ADL) to find the
+    // `componentTypeId` function defined by the GZ_SIM_REGISTER_COMPONENT
+    // macro in the component's namespace.
+    //
+    // We pass a null pointer of the type `Component*` to trigger ADL. ADL
+    // searches the namespaces of the template arguments of `Component`,
+    // which includes the namespace where the tag type (and thus the
+    // component) is defined. This removes the constraint that all
+    // components must be defined in the `gz::sim::components` namespace.
+    //
+    // Passing `Component*` also ensures that components sharing the same
+    // tag type but having different data types generate unique function
+    // overloads, preventing ODR collisions.
+    public: inline static constexpr ComponentTypeId typeId =
+            componentTypeId(static_cast<Component*>(nullptr));
 
     /// \brief Unique name for this component type. This is set through the
     /// Factory registration.
@@ -448,25 +441,6 @@ namespace components
     // Documentation inherited
     public: std::unique_ptr<BaseComponent> Clone() const override;
 
-    /// \brief Returns the unique ID for the component's type.
-    public: static constexpr ComponentTypeId typeIdStatic()
-    {
-      // This call triggers Argument Dependent Lookup (ADL) to find the
-      // `componentTypeId` function defined by the GZ_SIM_REGISTER_COMPONENT
-      // macro in the component's namespace.
-      //
-      // We pass a null pointer of the type `Component*` to trigger ADL. ADL
-      // searches the namespaces of the template arguments of `Component`,
-      // which includes the namespace where the tag type (and thus the
-      // component) is defined. This removes the constraint that all
-      // components must be defined in the `gz::sim::components` namespace.
-      //
-      // Passing `Component*` also ensures that components sharing the same
-      // tag type but having different data types generate unique function
-      // overloads, preventing ODR collisions.
-      return componentTypeId((Component*)nullptr);
-    }
-
     // Documentation inherited
     public: ComponentTypeId TypeId() const override;
 
@@ -478,9 +452,21 @@ namespace components
 
     /// \brief Unique ID for this component type. This is set through the
     /// Factory registration.
-    public:
-    // [[deprecated("Use TypeId() or TypeIdStatic() for constexpr context. Editing this variable at runtime is not supported.")]]
-    inline static ComponentTypeId typeId = typeIdStatic();
+    // This call triggers Argument Dependent Lookup (ADL) to find the
+    // `componentTypeId` function defined by the GZ_SIM_REGISTER_COMPONENT
+    // macro in the component's namespace.
+    //
+    // We pass a null pointer of the type `Component*` to trigger ADL. ADL
+    // searches the namespaces of the template arguments of `Component`,
+    // which includes the namespace where the tag type (and thus the
+    // component) is defined. This removes the constraint that all
+    // components must be defined in the `gz::sim::components` namespace.
+    //
+    // Passing `Component*` also ensures that components sharing the same
+    // tag type but having different data types generate unique function
+    // overloads, preventing ODR collisions.
+    public: inline static constexpr ComponentTypeId typeId =
+            componentTypeId(static_cast<Component*>(nullptr));
 
     /// \brief Unique name for this component type. This is set through the
     /// Factory registration.
@@ -565,7 +551,7 @@ namespace components
   template <typename DataType, typename Identifier, typename Serializer>
   ComponentTypeId Component<DataType, Identifier, Serializer>::TypeId() const
   {
-    return typeIdStatic();
+    return typeId;
   }
 
   //////////////////////////////////////////////////
@@ -596,7 +582,7 @@ namespace components
   template <typename Identifier, typename Serializer>
   ComponentTypeId Component<NoData, Identifier, Serializer>::TypeId() const
   {
-    return typeIdStatic();
+    return typeId;
   }
 
   //////////////////////////////////////////////////

--- a/include/gz/sim/components/Component.hh
+++ b/include/gz/sim/components/Component.hh
@@ -205,7 +205,8 @@ namespace components
   /// It is a template so it has lower priority than the non-template
   /// overloads defined by the GZ_SIM_REGISTER_COMPONENT macro.
   template <typename T>
-  constexpr ComponentTypeId gzSimFactoryComponentTypeId(T*)  // NOLINT(readability/casting)
+  // NOLINTNEXTLINE(readability/casting)
+  constexpr ComponentTypeId gzSimFactoryComponentTypeId(T*)
   {
     static_assert(false, "Type ID not set, did you register the component "
                   "through the GZ_SIM_REGISTER_COMPONENT macro?");

--- a/include/gz/sim/components/Component.hh
+++ b/include/gz/sim/components/Component.hh
@@ -205,7 +205,7 @@ namespace components
   /// It is a template so it has lower priority than the non-template
   /// overloads defined by the GZ_SIM_REGISTER_COMPONENT macro.
   template <typename T>
-  constexpr ComponentTypeId componentTypeId(T*)
+  constexpr ComponentTypeId componentTypeId(T*)  // NOLINT(readability/casting)
   {
     return 0;
   }

--- a/include/gz/sim/components/Component.hh
+++ b/include/gz/sim/components/Component.hh
@@ -205,7 +205,7 @@ namespace components
   /// It is a template so it has lower priority than the non-template
   /// overloads defined by the GZ_SIM_REGISTER_COMPONENT macro.
   template <typename T>
-  constexpr ComponentTypeId componentTypeId(T*)  // NOLINT(readability/casting)
+  constexpr ComponentTypeId gzSimFactoryComponentTypeId(T*)  // NOLINT(readability/casting)
   {
     static_assert(false, "Type ID not set, did you register the component "
                   "through the GZ_SIM_REGISTER_COMPONENT macro?");
@@ -394,8 +394,8 @@ namespace components
     private: DataType data;
 
     // This call triggers Argument Dependent Lookup (ADL) to find the
-    // `componentTypeId` function defined by the GZ_SIM_REGISTER_COMPONENT
-    // macro in the component's namespace.
+    // `gzSimFactoryComponentTypeId` function defined by the
+    // GZ_SIM_REGISTER_COMPONENT macro in the component's namespace.
     //
     // We pass a null pointer of the type `Component*` to trigger ADL. ADL
     // searches the namespaces of the template arguments of `Component`,
@@ -407,7 +407,7 @@ namespace components
     // tag type but having different data types generate unique function
     // overloads, preventing ODR collisions.
     public: inline static constexpr ComponentTypeId typeId =
-            componentTypeId(static_cast<Component*>(nullptr));
+            gzSimFactoryComponentTypeId(static_cast<Component*>(nullptr));
 
     /// \brief Unique name for this component type. This is set through the
     /// Factory registration.
@@ -455,8 +455,8 @@ namespace components
     /// \brief Unique ID for this component type. This is set through the
     /// Factory registration.
     // This call triggers Argument Dependent Lookup (ADL) to find the
-    // `componentTypeId` function defined by the GZ_SIM_REGISTER_COMPONENT
-    // macro in the component's namespace.
+    // `gzSimFactoryComponentTypeId` function defined by the
+    // GZ_SIM_REGISTER_COMPONENT macro in the component's namespace.
     //
     // We pass a null pointer of the type `Component*` to trigger ADL. ADL
     // searches the namespaces of the template arguments of `Component`,
@@ -468,7 +468,7 @@ namespace components
     // tag type but having different data types generate unique function
     // overloads, preventing ODR collisions.
     public: inline static constexpr ComponentTypeId typeId =
-            componentTypeId(static_cast<Component*>(nullptr));
+            gzSimFactoryComponentTypeId(static_cast<Component*>(nullptr));
 
     /// \brief Unique name for this component type. This is set through the
     /// Factory registration.

--- a/include/gz/sim/components/Factory.hh
+++ b/include/gz/sim/components/Factory.hh
@@ -218,12 +218,11 @@ namespace components
     void Register(const char *_type, ComponentDescriptorBase *_compDesc,
                   RegistrationObjectId  _regObjId)
     {
-      auto typeHash = gz::common::hash64(_type);
+      const auto typeHash = ComponentTypeT::typeIdStatic();
 
       // Initialize static member variable - we need to set these
       // static members for every shared lib that uses the component, but we
       // only add them to the maps below once.
-      ComponentTypeT::typeId = typeHash;
       ComponentTypeT::typeName = _type;
 
       // Check if component has already been registered by another library
@@ -257,9 +256,9 @@ namespace components
       }
 
       // Keep track of all types
-      this->compsById[ComponentTypeT::typeId].Add(_regObjId, _compDesc);
-      namesById[ComponentTypeT::typeId] = ComponentTypeT::typeName;
-      runtimeNamesById[ComponentTypeT::typeId] = runtimeName;
+      this->compsById[typeHash].Add(_regObjId, _compDesc);
+      namesById[typeHash] = ComponentTypeT::typeName;
+      runtimeNamesById[typeHash] = runtimeName;
     }
 
     /// \brief Unregister a component so that the factory can't create instances
@@ -271,7 +270,7 @@ namespace components
     public: template<typename ComponentTypeT>
     void Unregister(RegistrationObjectId  _regObjId)
     {
-      this->Unregister(ComponentTypeT::typeId, _regObjId);
+      this->Unregister(ComponentTypeT::typeIdStatic(), _regObjId);
     }
 
     /// \brief Unregister a component so that the factory can't create instances
@@ -404,41 +403,54 @@ namespace components
     public: std::map<ComponentTypeId, std::string>
         runtimeNamesById;
   };
+}
+}
+}
+}
 
-  /// \brief Static component registration macro.
-  ///
-  /// Use this macro to register components.
-  ///
-  /// \details Each time a plugin which uses a component is loaded, it tries to
-  /// register the component again, so we prevent that.
-  /// \param[in] _compType Component type name.
-  /// \param[in] _classname Class name for component.
-  #define GZ_SIM_REGISTER_COMPONENT(_compType, _classname) \
-  class GzSimComponents##_classname \
+/// \brief Static component registration macro.
+///
+/// Use this macro to register components.
+///
+/// \details Each time a plugin which uses a component is loaded, it tries to
+/// register the component again, so we prevent that.
+/// \param[in] _compType Component type name.
+/// \param[in] _classname Class name for component.
+///
+/// This macro defines a non-member function `componentTypeId` in the current
+/// namespace. This function is used by the `Component` class template to
+/// discover the component's unique ID via Argument Dependent Lookup (ADL).
+/// This removes the constraint that all components must be defined inside the
+/// `gz::sim::components` namespace, enabling custom components to be defined
+/// in any namespace.
+///
+/// We take a pointer to `_classname` as the argument to avoid name collisions
+/// and support distinguishing components that share the same tag type but have
+/// different data types.
+#define GZ_SIM_REGISTER_COMPONENT(_compType, _classname) \
+inline constexpr ::gz::sim::ComponentTypeId componentTypeId(_classname*) \
+{ \
+  return ::gz::common::hash64(_compType); \
+} \
+class GzSimComponents##_classname \
+{ \
+  public: GzSimComponents##_classname() \
   { \
-    public: GzSimComponents##_classname() \
-    { \
-      using namespace gz;\
-      using Desc = sim::components::ComponentDescriptor<_classname>; \
-      sim::components::Factory::Instance()->Register<_classname>(\
-        _compType, new Desc(), sim::components::RegistrationObjectId(this));\
-    } \
-    public: GzSimComponents##_classname( \
-                const GzSimComponents##_classname&) = delete; \
-    public: GzSimComponents##_classname( \
-                GzSimComponents##_classname&) = delete; \
-    public: ~GzSimComponents##_classname() \
-    { \
-      using namespace gz; \
-      sim::components::Factory::Instance()->Unregister<_classname>( \
-          sim::components::RegistrationObjectId(this)); \
-    } \
-  }; \
-  static GzSimComponents##_classname\
-    GzSimComponentsInitializer##_classname;
-}
-}
-}
-}
+    using Desc = ::gz::sim::components::ComponentDescriptor<_classname>; \
+    ::gz::sim::components::Factory::Instance()->Register<_classname>(\
+      _compType, new Desc(), ::gz::sim::components::RegistrationObjectId(this));\
+  } \
+  public: GzSimComponents##_classname( \
+              const GzSimComponents##_classname&) = delete; \
+  public: GzSimComponents##_classname( \
+              GzSimComponents##_classname&) = delete; \
+  public: ~GzSimComponents##_classname() \
+  { \
+    ::gz::sim::components::Factory::Instance()->Unregister<_classname>( \
+        ::gz::sim::components::RegistrationObjectId(this)); \
+  } \
+}; \
+static GzSimComponents##_classname\
+  GzSimComponentsInitializer##_classname;
 
 #endif

--- a/include/gz/sim/components/Factory.hh
+++ b/include/gz/sim/components/Factory.hh
@@ -428,8 +428,9 @@ namespace components
 /// and support distinguishing components that share the same tag type but have
 /// different data types.
 #define GZ_SIM_REGISTER_COMPONENT(_compType, _classname) \
-inline constexpr ::gz::sim::ComponentTypeId componentTypeId(_classname*) \
+inline constexpr ::gz::sim::ComponentTypeId componentTypeId(_classname* ptr) \
 { \
+  (void)ptr; \
   return ::gz::common::hash64(_compType); \
 } \
 class GzSimComponents##_classname \
@@ -438,7 +439,8 @@ class GzSimComponents##_classname \
   { \
     using Desc = ::gz::sim::components::ComponentDescriptor<_classname>; \
     ::gz::sim::components::Factory::Instance()->Register<_classname>(\
-      _compType, new Desc(), ::gz::sim::components::RegistrationObjectId(this));\
+      _compType, new Desc(), \
+      ::gz::sim::components::RegistrationObjectId(this));\
   } \
   public: GzSimComponents##_classname( \
               const GzSimComponents##_classname&) = delete; \

--- a/include/gz/sim/components/Factory.hh
+++ b/include/gz/sim/components/Factory.hh
@@ -415,9 +415,10 @@ namespace components
 /// \param[in] _compType Component type name.
 /// \param[in] _classname Class name for component.
 ///
-/// This macro defines a non-member function `componentTypeId` in the current
-/// namespace. This function is used by the `Component` class template to
-/// discover the component's unique ID via Argument Dependent Lookup (ADL).
+/// This macro defines a non-member function `gzSimFactorycomponentTypeId`
+/// in the current namespace. This function is used by the `Component` class
+/// template to discover the component's unique ID via Argument Dependent
+/// Lookup (ADL).
 /// This removes the constraint that all components must be defined inside the
 /// `gz::sim::components` namespace, enabling custom components to be defined
 /// in any namespace.
@@ -426,7 +427,8 @@ namespace components
 /// and support distinguishing components that share the same tag type but have
 /// different data types.
 #define GZ_SIM_REGISTER_COMPONENT(_compType, _classname) \
-inline constexpr ::gz::sim::ComponentTypeId componentTypeId(_classname* ptr) \
+inline constexpr ::gz::sim::ComponentTypeId \
+  gzSimFactoryComponentTypeId(_classname* ptr) \
 { \
   (void)ptr; \
   return ::gz::common::hash64(_compType); \

--- a/include/gz/sim/components/Factory.hh
+++ b/include/gz/sim/components/Factory.hh
@@ -218,7 +218,7 @@ namespace components
     void Register(const char *_type, ComponentDescriptorBase *_compDesc,
                   RegistrationObjectId  _regObjId)
     {
-      const auto typeHash = ComponentTypeT::typeIdStatic();
+      const auto typeHash = ComponentTypeT::typeId;
 
       // Initialize static member variable - we need to set these
       // static members for every shared lib that uses the component, but we
@@ -270,7 +270,7 @@ namespace components
     public: template<typename ComponentTypeT>
     void Unregister(RegistrationObjectId  _regObjId)
     {
-      this->Unregister(ComponentTypeT::typeIdStatic(), _regObjId);
+      this->Unregister(ComponentTypeT::typeId, _regObjId);
     }
 
     /// \brief Unregister a component so that the factory can't create instances

--- a/include/gz/sim/components/Factory.hh
+++ b/include/gz/sim/components/Factory.hh
@@ -218,8 +218,6 @@ namespace components
     void Register(const char *_type, ComponentDescriptorBase *_compDesc,
                   RegistrationObjectId  _regObjId)
     {
-      const auto typeHash = ComponentTypeT::typeId;
-
       // Initialize static member variable - we need to set these
       // static members for every shared lib that uses the component, but we
       // only add them to the maps below once.
@@ -227,7 +225,7 @@ namespace components
 
       // Check if component has already been registered by another library
       auto runtimeName = typeid(ComponentTypeT).name();
-      auto runtimeNameIt = this->runtimeNamesById.find(typeHash);
+      auto runtimeNameIt = this->runtimeNamesById.find(ComponentTypeT::typeId);
       if (runtimeNameIt != this->runtimeNamesById.end())
       {
         // Warn user if type was previously registered with a different name.
@@ -256,9 +254,9 @@ namespace components
       }
 
       // Keep track of all types
-      this->compsById[typeHash].Add(_regObjId, _compDesc);
-      namesById[typeHash] = ComponentTypeT::typeName;
-      runtimeNamesById[typeHash] = runtimeName;
+      this->compsById[ComponentTypeT::typeId].Add(_regObjId, _compDesc);
+      namesById[ComponentTypeT::typeId] = ComponentTypeT::typeName;
+      runtimeNamesById[ComponentTypeT::typeId] = runtimeName;
     }
 
     /// \brief Unregister a component so that the factory can't create instances

--- a/src/ComponentFactory_TEST.cc
+++ b/src/ComponentFactory_TEST.cc
@@ -39,26 +39,22 @@ class ComponentFactoryTest : public InternalFixture<::testing::Test>
   }
 };
 
+// Registration behavior changed significantly in the following ways:
+// * Factory registration methods _don't_ set type IDs anymore since they are constexpr.
+//   We should consider making the APIs public and only expose the macro.
+// * Multiple registration of a component is a _compile_ error.
+// * Unfortunately for now, only the tag type is checked, duplicate string values are allowed, while duplicate component tags will be a compile error.
+//   We could consider removing deprecating the name altogether and only using the class itself.
+//   Entt has some C++ reflection that gets the class type tag as a string, we could do something similar.
+
+// Create a custom component.
+using MyCustom = components::Component<components::NoData, class MyCustomTag>;
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.MyCustom", MyCustom);
+
 /////////////////////////////////////////////////
 TEST_F(ComponentFactoryTest, Register)
 {
   auto factory = components::Factory::Instance();
-
-  // Create a custom component.
-  using MyCustom = components::Component<components::NoData, class MyCustomTag>;
-
-  // Check it has no type id yet
-  EXPECT_EQ(0u, MyCustom::typeId);
-  EXPECT_EQ(nullptr, MyCustom::typeName);
-  EXPECT_EQ("", factory->Name(MyCustom::typeId));
-
-  // Store number of registered component types
-  auto registeredCount = factory->TypeIds().size();
-
-  factory->Register<MyCustom>("gz_sim_components.MyCustom",
-                              new components::ComponentDescriptor<MyCustom>(),
-                              components::RegistrationObjectId(this));
-
   // Check now it has type id
   EXPECT_NE(0u, MyCustom::typeId);
   EXPECT_EQ("gz_sim_components.MyCustom", MyCustom::typeName);
@@ -67,31 +63,7 @@ TEST_F(ComponentFactoryTest, Register)
 
   // Check factory knows id
   auto ids = factory->TypeIds();
-  EXPECT_EQ(registeredCount + 1, ids.size());
   EXPECT_NE(ids.end(), std::find(ids.begin(), ids.end(), MyCustom::typeId));
-
-  // Registering the component twice doesn't change the number of type ids.
-  factory->Register<MyCustom>("gz_sim_components.MyCustom",
-                              new components::ComponentDescriptor<MyCustom>(),
-                              components::RegistrationObjectId(this));
-
-  EXPECT_EQ(registeredCount + 1, factory->TypeIds().size());
-
-  // Fail to register 2 components with same name
-  using Duplicate = components::Component<components::NoData,
-      class DuplicateTag>;
-
-  factory->Register<Duplicate>("gz_sim_components.MyCustom",
-                               new components::ComponentDescriptor<Duplicate>(),
-                               components::RegistrationObjectId(this));
-
-  EXPECT_EQ(registeredCount + 1, factory->TypeIds().size());
-
-  // Unregister
-  factory->Unregister<MyCustom>(components::RegistrationObjectId(this));
-
-  ids = factory->TypeIds();
-  EXPECT_EQ(registeredCount + 1, ids.size());
 }
 
 /////////////////////////////////////////////////

--- a/src/ComponentFactory_TEST.cc
+++ b/src/ComponentFactory_TEST.cc
@@ -39,14 +39,6 @@ class ComponentFactoryTest : public InternalFixture<::testing::Test>
   }
 };
 
-// Registration behavior changed significantly in the following ways:
-// * Factory registration methods _don't_ set type IDs anymore since they are constexpr.
-//   We should consider making the APIs public and only expose the macro.
-// * Multiple registration of a component is a _compile_ error.
-// * Unfortunately for now, only the tag type is checked, duplicate string values are allowed, while duplicate component tags will be a compile error.
-//   We could consider removing deprecating the name altogether and only using the class itself.
-//   Entt has some C++ reflection that gets the class type tag as a string, we could do something similar.
-
 // Create a custom component.
 using MyCustom = components::Component<components::NoData, class MyCustomTag>;
 GZ_SIM_REGISTER_COMPONENT("gz_sim_components.MyCustom", MyCustom);

--- a/src/Component_TEST.cc
+++ b/src/Component_TEST.cc
@@ -35,6 +35,48 @@
 using namespace gz;
 using namespace sim;
 
+// Class with externally defined stream operator
+struct SimpleOperator
+{
+  int data{100};
+};
+
+struct Simple {};
+
+using CustomComponent =
+      components::Component<std::shared_ptr<int>, class CustomComponentTag>;
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.MyCustom", CustomComponent)
+
+using CustomString = components::Component<std::string, class CustomTag>;
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomString", CustomString)
+
+using CustomSimple = components::Component<Simple, class CustomTag>;
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomSimple", CustomSimple)
+
+using CustomOperator = components::Component<SimpleOperator, class CustomTag>;
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomOperator", CustomOperator)
+
+using CustomInertial = components::Component<math::Inertiald, class CustomTag>;
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomInertial", CustomInertial)
+
+using CustomSharedInt = components::Component<std::shared_ptr<int>, class CustomTag>;
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomSharedInt", CustomSharedInt)
+
+using CustomSharedSimple = components::Component<std::shared_ptr<Simple>, class CustomTag>;
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomSharedSimple", CustomSharedSimple)
+
+using CustomSharedSimpleOperator = components::Component<std::shared_ptr<SimpleOperator>, class CustomTag>;
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomSharedSimpleOperator", CustomSharedSimpleOperator)
+
+using CustomSharedSdf = components::Component<std::shared_ptr<sdf::Element>, class CustomTag>;
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomSharedSdf", CustomSharedSdf)
+
+using CustomSharedInertial = components::Component<std::shared_ptr<math::Inertiald>, class CustomTag>;
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomSharedInertial", CustomSharedInertial)
+
+using CustomMsg = components::Component<msgs::Int32, class CustomTag, serializers::MsgSerializer>;
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomMsg", CustomMsg)
+
 //////////////////////////////////////////////////
 class ComponentTest : public InternalFixture<::testing::Test>
 {
@@ -65,17 +107,6 @@ TEST_F(ComponentTest, ComponentCanBeCopiedAfterDefaultCtor)
 // See https://github.com/gazebosim/gz-sim/issues/1175
 TEST_F(ComponentTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(DataByMove))
 {
-  auto factory = components::Factory::Instance();
-
-  // Create a custom component with shared_ptr data
-  using CustomComponent =
-      components::Component<std::shared_ptr<int>, class CustomComponentTag>;
-
-  factory->Register<CustomComponent>(
-      "gz_sim_components.MyCustom",
-      new components::ComponentDescriptor<CustomComponent>(),
-      components::RegistrationObjectId(this));
-
   EntityComponentManager ecm;
   Entity entity = ecm.CreateEntity();
 
@@ -90,13 +121,6 @@ TEST_F(ComponentTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(DataByMove))
   // If "data" was moved, the use count should still be 2.
   EXPECT_EQ(2u, dataCopy.use_count());
 }
-
-// Class with externally defined stream operator
-struct SimpleOperator
-{
-  int data{100};
-};
-using CustomOperator = components::Component<SimpleOperator, class CustomTag>;
 
 inline std::ostream &operator<<(std::ostream &_out, const SimpleOperator &)
 {
@@ -151,6 +175,7 @@ inline std::istream &operator>>(std::istream &_in, Inertiald &_inertial)
 // Wrap existing class and give it a Serialize function
 using InertialBase =
     components::Component<math::Inertiald, class InertialBaseTag>;
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.InertialBase", InertialBase)
 class InertialWrapper : public InertialBase
 {
   public: InertialWrapper() : InertialBase()
@@ -194,7 +219,7 @@ TEST_F(ComponentTest, OStream)
 {
   // Component with data which has stream operator
   {
-    using Custom = components::Component<std::string, class CustomTag>;
+    using Custom = CustomString;
 
     auto data = std::string("banana");
     Custom comp(data);
@@ -206,8 +231,7 @@ TEST_F(ComponentTest, OStream)
 
   // Component with data which doesn't have stream operator
   {
-    struct Simple {};
-    using Custom = components::Component<Simple, class CustomTag>;
+    using Custom = CustomSimple;
 
     auto data = Simple();
     Custom comp(data);
@@ -230,7 +254,7 @@ TEST_F(ComponentTest, OStream)
 
   // Component with data which has custom stream operator
   {
-    using Custom = components::Component<math::Inertiald, class CustomTag>;
+    using Custom = CustomInertial;
 
     auto data = math::Inertiald();
     auto comp = new Custom(data);
@@ -264,8 +288,7 @@ TEST_F(ComponentTest, OStream)
 
   // Component with shared_ptr data which has stream operator
   {
-    using Custom =
-        components::Component<std::shared_ptr<int>, class CustomTag>;
+    using Custom = CustomSharedInt;
 
     auto data = std::make_shared<int>(123);
     Custom comp(data);
@@ -278,9 +301,7 @@ TEST_F(ComponentTest, OStream)
 
   // Component with shared_ptr data which doesn't have stream operator
   {
-    struct Simple {};
-    using Custom =
-        components::Component<std::shared_ptr<Simple>, class CustomTag>;
+    using Custom = CustomSharedSimple;
 
     auto data = std::make_shared<Simple>();
     Custom comp(data);
@@ -293,8 +314,7 @@ TEST_F(ComponentTest, OStream)
 
   // Component with shared_ptr data which has custom stream operator
   {
-    using Custom = components::Component<std::shared_ptr<SimpleOperator>,
-        class CustomTag>;
+    using Custom = CustomSharedSimpleOperator;
 
     auto data = std::make_shared<SimpleOperator>();
     Custom comp(data);
@@ -307,8 +327,7 @@ TEST_F(ComponentTest, OStream)
 
   // Component with shared_ptr sdf::Element, which has custom stream operator
   {
-    using Custom = components::Component<std::shared_ptr<sdf::Element>,
-        class CustomTag>;
+    using Custom = CustomSharedSdf;
 
     auto data = std::make_shared<sdf::Element>();
     data->SetName("element");
@@ -324,8 +343,7 @@ TEST_F(ComponentTest, OStream)
 
   // Component with shared_ptr math::Inertiald, which has custom stream operator
   {
-    using Custom = components::Component<std::shared_ptr<math::Inertiald>,
-        class CustomTag>;
+    using Custom = CustomSharedInertial;
 
     auto data = std::make_shared<math::Inertiald>();
     Custom comp(data);
@@ -338,8 +356,7 @@ TEST_F(ComponentTest, OStream)
   // Component with a msgs type that gets serialized by the default
   // serializer
   {
-    using Custom = components::Component<msgs::Int32, class CustomTag,
-        serializers::MsgSerializer>;
+    using Custom = CustomMsg;
 
     msgs::Int32 data;
     data.set_data(331);
@@ -368,7 +385,7 @@ TEST_F(ComponentTest, IStream)
 {
   // Component with data which has stream operator
   {
-    using Custom = components::Component<std::string, class CustomTag>;
+    using Custom = CustomString;
 
     std::istringstream istr("banana");
     Custom comp;
@@ -378,8 +395,7 @@ TEST_F(ComponentTest, IStream)
 
   // Component with data which doesn't have stream operator
   {
-    struct Simple {};
-    using Custom = components::Component<Simple, class CustomTag>;
+    using Custom = CustomSimple;
 
     // Prints warning and doesn't modify the component
     std::istringstream istr("banana");
@@ -399,7 +415,7 @@ TEST_F(ComponentTest, IStream)
 
   // Component with data which has custom stream operator
   {
-    using Custom = components::Component<math::Inertiald, class CustomTag>;
+    using Custom = CustomInertial;
 
     auto data = math::Inertiald();
     Custom comp(data);
@@ -421,8 +437,7 @@ TEST_F(ComponentTest, IStream)
 
   // Component with shared_ptr data which has stream operator
   {
-    using Custom =
-        components::Component<std::shared_ptr<int>, class CustomTag>;
+    using Custom = CustomSharedInt;
 
     auto data = std::make_shared<int>(123);
     Custom comp(data);
@@ -435,9 +450,7 @@ TEST_F(ComponentTest, IStream)
 
   // Component with shared_ptr data which doesn't have stream operator
   {
-    struct Simple {};
-    using Custom =
-        components::Component<std::shared_ptr<Simple>, class CustomTag>;
+    using Custom = CustomSharedSimple;
 
     auto data = std::make_shared<Simple>();
     Custom comp(data);
@@ -449,8 +462,7 @@ TEST_F(ComponentTest, IStream)
 
   // Component with shared_ptr data which has custom stream operator
   {
-    using Custom = components::Component<std::shared_ptr<SimpleOperator>,
-        class CustomTag>;
+    using Custom = CustomSharedSimpleOperator;
 
     auto data = std::make_shared<SimpleOperator>();
     Custom comp(data);
@@ -463,8 +475,7 @@ TEST_F(ComponentTest, IStream)
 
   // Component with shared_ptr sdf::Element, which has custom stream operator
   {
-    using Custom = components::Component<std::shared_ptr<sdf::Element>,
-        class CustomTag>;
+    using Custom = CustomSharedSdf;
 
     auto data = std::make_shared<sdf::Element>();
     Custom comp(data);
@@ -476,8 +487,7 @@ TEST_F(ComponentTest, IStream)
 
   // Component with shared_ptr math::Inertiald, which has custom stream operator
   {
-    using Custom = components::Component<std::shared_ptr<math::Inertiald>,
-        class CustomTag>;
+    using Custom = CustomSharedInertial;
 
     auto data = std::make_shared<math::Inertiald>();
     Custom comp(data);
@@ -490,8 +500,7 @@ TEST_F(ComponentTest, IStream)
   // Component with a msgs type that gets deserialized by the message
   // deserializer
   {
-    using Custom = components::Component<msgs::Int32, class CustomTag,
-        serializers::MsgSerializer>;
+    using Custom = CustomMsg;
 
     msgs::Int32 data;
     data.set_data(482);
@@ -536,25 +545,31 @@ TEST_F(ComponentTest, TypeId)
   }
 }
 
+using CustomInt = components::Component<int, class CustomTag>;
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomInt", CustomInt)
+
+using CustomNoData = components::Component<components::NoData, class CustomTag>;
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomNoData", CustomNoData)
+
 //////////////////////////////////////////////////
 TEST_F(ComponentTest, TypeName)
 {
   // Component with data
   {
-    using Custom = components::Component<int, class CustomTag>;
-    Custom::typeName = "123456";
+    CustomInt::typeName = "123456";
 
-    Custom comp;
+    CustomInt comp;
 
     EXPECT_EQ("123456", comp.typeName);
   }
 
+  // components::Component<double
+
   // Component without data
   {
-    using Custom = components::Component<components::NoData, class CustomTag>;
-    Custom::typeName = "123456";
+    CustomNoData::typeName = "123456";
 
-    Custom comp;
+    CustomNoData comp;
 
     EXPECT_EQ("123456", comp.typeName);
   }
@@ -565,13 +580,11 @@ TEST_F(ComponentTest, Clone)
 {
   // Component with data
   {
-    using Custom = components::Component<int, class CustomTag>;
-
     // create a component and a clone of it. The clone should initially have the
     // same data as the original component
-    Custom comp(5);
+    CustomInt comp(5);
     auto clonedComp = comp.Clone();
-    auto derivedClone = static_cast<Custom *>(clonedComp.get());
+    auto derivedClone = static_cast<CustomInt *>(clonedComp.get());
     EXPECT_EQ(comp, *derivedClone);
 
     // modify the data of the cloned component, and make sure that only the
@@ -584,11 +597,9 @@ TEST_F(ComponentTest, Clone)
 
   // Component without data
   {
-    using Custom = components::Component<components::NoData, class CustomTag>;
-
-    Custom comp;
+    CustomNoData comp;
     auto clonedComp = comp.Clone();
-    auto derivedClone = static_cast<Custom *>(clonedComp.get());
+    auto derivedClone = static_cast<CustomNoData *>(clonedComp.get());
 
     // since this component has no data, we cannot do the same check as we did
     // above for a component with data. However, we can make sure that the

--- a/src/Component_TEST.cc
+++ b/src/Component_TEST.cc
@@ -59,22 +59,32 @@ GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomOperator", CustomOperator)
 using CustomInertial = components::Component<math::Inertiald, class CustomTag>;
 GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomInertial", CustomInertial)
 
-using CustomSharedInt = components::Component<std::shared_ptr<int>, class CustomTag>;
+using CustomSharedInt =
+    components::Component<std::shared_ptr<int>, class CustomTag>;
 GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomSharedInt", CustomSharedInt)
 
-using CustomSharedSimple = components::Component<std::shared_ptr<Simple>, class CustomTag>;
-GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomSharedSimple", CustomSharedSimple)
+using CustomSharedSimple =
+    components::Component<std::shared_ptr<Simple>, class CustomTag>;
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomSharedSimple",
+    CustomSharedSimple)
 
-using CustomSharedSimpleOperator = components::Component<std::shared_ptr<SimpleOperator>, class CustomTag>;
-GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomSharedSimpleOperator", CustomSharedSimpleOperator)
+using CustomSharedSimpleOperator =
+    components::Component<std::shared_ptr<SimpleOperator>, class CustomTag>;
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomSharedSimpleOperator",
+    CustomSharedSimpleOperator)
 
-using CustomSharedSdf = components::Component<std::shared_ptr<sdf::Element>, class CustomTag>;
+using CustomSharedSdf =
+    components::Component<std::shared_ptr<sdf::Element>, class CustomTag>;
 GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomSharedSdf", CustomSharedSdf)
 
-using CustomSharedInertial = components::Component<std::shared_ptr<math::Inertiald>, class CustomTag>;
-GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomSharedInertial", CustomSharedInertial)
+using CustomSharedInertial =
+    components::Component<std::shared_ptr<math::Inertiald>, class CustomTag>;
+GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomSharedInertial",
+    CustomSharedInertial)
 
-using CustomMsg = components::Component<msgs::Int32, class CustomTag, serializers::MsgSerializer>;
+using CustomMsg =
+    components::Component<msgs::Int32, class CustomTag,
+    serializers::MsgSerializer>;
 GZ_SIM_REGISTER_COMPONENT("gz_sim_components.CustomMsg", CustomMsg)
 
 //////////////////////////////////////////////////

--- a/src/Component_TEST.cc
+++ b/src/Component_TEST.cc
@@ -513,27 +513,26 @@ TEST_F(ComponentTest, IStream)
   }
 }
 
+namespace test_components
+{
+  using ConstexprComp = gz::sim::components::Component<int, class ConstexprTag>;
+  GZ_SIM_REGISTER_COMPONENT("gz_sim_components.ConstexprComp", ConstexprComp)
+}
+
 //////////////////////////////////////////////////
 TEST_F(ComponentTest, TypeId)
 {
-  // Component with data
+  // Constexpr TypeId
   {
-    using Custom = components::Component<int, class CustomTag>;
-    Custom::typeId = 123456;
-
-    Custom comp;
-
-    EXPECT_EQ(ComponentTypeId(123456), comp.TypeId());
+    using ConstexprComp = test_components::ConstexprComp;
+    EXPECT_EQ(ConstexprComp::typeId,
+        common::hash64("gz_sim_components.ConstexprComp"));
   }
 
-  // Component without data
+  // Pre-registered component
   {
-    using Custom = components::Component<components::NoData, class CustomTag>;
-    Custom::typeId = 123456;
-
-    Custom comp;
-
-    EXPECT_EQ(ComponentTypeId(123456), comp.TypeId());
+    EXPECT_EQ(components::Name::typeId,
+              common::hash64("gz_sim_components.Name"));
   }
 }
 

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -53,7 +53,7 @@ using IntComponent = Component<int, class IntComponentTag>;
 GZ_SIM_REGISTER_COMPONENT("gz_sim_components.IntComponent",
     IntComponent)
 
-using UIntComponent = Component<int, class IntComponentTag>;
+using UIntComponent = Component<uint32_t, class UIntComponentTag>;
 GZ_SIM_REGISTER_COMPONENT("gz_sim_components.UIntComponent",
     UIntComponent)
 

--- a/test/benchmark/ecm_serialize.cc
+++ b/test/benchmark/ecm_serialize.cc
@@ -44,7 +44,7 @@ using IntComponent = components::Component<int, class IntComponentTag>;
 GZ_SIM_REGISTER_COMPONENT("gz_sim_components.IntComponent",
     IntComponent)
 
-using UIntComponent = components::Component<int, class IntComponentTag>;
+using UIntComponent = components::Component<uint32_t, class UIntComponentTag>;
 GZ_SIM_REGISTER_COMPONENT("gz_sim_components.UIntComponent",
     UIntComponent)
 


### PR DESCRIPTION
# 🎉 New feature

Part of #3447 

## Summary
This PR changes registration to be fully constexpr rather than made through a function.
This is a necessity for migration to Entt since it requires type IDs to be constexpr, but is generally a good practice. Our type IDs are indeed computed through a `constexpr` function so it should be possible to have it so.
Apart from the changes that are pretty much split up from the PR (first commit), I added another commit to deprecate the typeId field and instead recommend the `TypeId()` function (if we need a virtual function) or the `TypeIdStatic()` (if we need a static / constexpr function). 
The `typeId` field being public was quite a footgun and editing at runtime would likely cause very unpredictable behavior (i.e. any part of the code that relied on its previous type ID would stop working).
This could potentially be a minor performance gain as well, since every typeId variable access will become a `constexpr` access that can be computed at compile time.

Still, if the diff from the second commit is too large I'm happy to revert it and leave the public field unchanged.

## Test it
Just through CI

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.