### PR TITLE
Refactor integration tests to use Server::PeekEcm and Server::PokeEcm

### DIFF
--- a/test/integration/air_pressure_system.cc
+++ b/test/integration/air_pressure_system.cc
@@ -60,42 +60,6 @@ TEST_F(AirPressureTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(AirPressure))
   auto topic = "world/air_pressure_sensor/model/air_pressure_model/link/link/"
       "sensor/air_pressure_sensor/air_pressure";
 
-  bool updateChecked{false};
-
-  // Create a system that checks sensor topic
-  test::Relay testSystem;
-  testSystem.OnPostUpdate([&](const UpdateInfo &_info,
-                              const EntityComponentManager &_ecm)
-      {
-        _ecm.Each<components::AirPressureSensor, components::Name>(
-            [&](const Entity &_entity,
-                const components::AirPressureSensor *,
-                const components::Name *_name) -> bool
-            {
-              EXPECT_EQ(_name->Data(), sensorName);
-
-              auto sensorComp = _ecm.Component<components::Sensor>(_entity);
-              EXPECT_NE(nullptr, sensorComp);
-
-              if (_info.iterations == 1)
-                return true;
-
-              // This component is created on the 2nd PreUpdate
-              auto topicComp = _ecm.Component<components::SensorTopic>(_entity);
-              EXPECT_NE(nullptr, topicComp);
-              if (topicComp)
-              {
-                EXPECT_EQ(topic, topicComp->Data());
-              }
-
-              updateChecked = true;
-
-              return true;
-            });
-      });
-
-  server.AddSystem(testSystem.systemPtr);
-
   // Subscribe to air_pressure topic
   bool received{false};
   msgs::FluidPressure msg;
@@ -116,7 +80,30 @@ TEST_F(AirPressureTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(AirPressure))
 
   // Run server
   server.Run(true, 100, false);
-  EXPECT_TRUE(updateChecked);
+
+  server.PeekEcm([&](const EntityComponentManager &_ecm)
+  {
+    _ecm.Each<components::AirPressureSensor, components::Name>(
+        [&](const Entity &_entity,
+            const components::AirPressureSensor *,
+            const components::Name *_name) -> bool
+        {
+          EXPECT_EQ(_name->Data(), sensorName);
+
+          auto sensorComp = _ecm.Component<components::Sensor>(_entity);
+          EXPECT_NE(nullptr, sensorComp);
+
+          // This component is created on the 2nd PreUpdate
+          auto topicComp = _ecm.Component<components::SensorTopic>(_entity);
+          EXPECT_NE(nullptr, topicComp);
+          if (topicComp)
+          {
+            EXPECT_EQ(topic, topicComp->Data());
+          }
+
+          return true;
+        });
+  });
 
   // Wait for message to be received
   for (int sleep = 0; !received && sleep < 30; ++sleep)

--- a/test/integration/joint_controller_system.cc
+++ b/test/integration/joint_controller_system.cc
@@ -69,21 +69,20 @@ TEST_F(JointControllerTestFixture,
 
   const std::string linkName = "rotor";
 
+  server.PokeEcm([&](EntityComponentManager &_ecm)
+  {
+    auto link = _ecm.EntityByComponents(components::Link(),
+                                        components::Name(linkName));
+    // Create an AngularVelocity component. This signals
+    // physics system to populate the component
+    if (nullptr == _ecm.Component<components::AngularVelocity>(link))
+    {
+      _ecm.CreateComponent(link, components::AngularVelocity());
+    }
+  });
+
   test::Relay testSystem;
   std::vector<math::Vector3d> angularVelocities;
-  testSystem.OnPreUpdate(
-      [&](const UpdateInfo &, EntityComponentManager &_ecm)
-      {
-        auto link = _ecm.EntityByComponents(components::Link(),
-                                            components::Name(linkName));
-        // Create an AngularVelocity component if it doesn't exist. This signals
-        // physics system to populate the component
-        if (nullptr == _ecm.Component<components::AngularVelocity>(link))
-        {
-          _ecm.CreateComponent(link, components::AngularVelocity());
-        }
-      });
-
   testSystem.OnPostUpdate([&](const UpdateInfo &,
                               const EntityComponentManager &_ecm)
       {

--- a/test/integration/mesh_inertia_calculation.cc
+++ b/test/integration/mesh_inertia_calculation.cc
@@ -96,66 +96,57 @@ void cylinderColladaMeshInertiaCalculation(
   // Start server and run.
   gz::sim::Server server(_serverConfig);
 
-  // Create a system just to get the ECM
-  EntityComponentManager *ecm;
-  test::Relay testSystem;
-  testSystem.OnPreUpdate(
-    [&](const UpdateInfo &, EntityComponentManager &_ecm)
-    {
-      ecm = &_ecm;
-    }
-  );
-  server.AddSystem(testSystem.systemPtr);
-
   ASSERT_FALSE(server.Running());
   ASSERT_FALSE(*server.Running(0));
   ASSERT_TRUE(server.Run(true, kIter, false));
-  ASSERT_NE(nullptr, ecm);
 
-  // Get link of collada cylinder
-  gz::sim::Entity modelEntity = ecm->EntityByComponents(
-    gz::sim::components::Name("cylinder_dae"),
-    gz::sim::components::Model()
-  );
+  server.PokeEcm([&](EntityComponentManager &_ecm)
+  {
+    // Get link of collada cylinder
+    gz::sim::Entity modelEntity = _ecm.EntityByComponents(
+      gz::sim::components::Name("cylinder_dae"),
+      gz::sim::components::Model()
+    );
 
-  gz::sim::Model model = gz::sim::Model(modelEntity);
-  ASSERT_TRUE(model.Valid(*ecm));
+    gz::sim::Model model = gz::sim::Model(modelEntity);
+    ASSERT_TRUE(model.Valid(_ecm));
 
-  gz::sim::Entity linkEntity = model.LinkByName(*ecm, "cylinder_dae");
-  gz::sim::Link link = gz::sim::Link(linkEntity);
-  ASSERT_TRUE(link.Valid(*ecm));
+    gz::sim::Entity linkEntity = model.LinkByName(_ecm, "cylinder_dae");
+    gz::sim::Link link = gz::sim::Link(linkEntity);
+    ASSERT_TRUE(link.Valid(_ecm));
 
-  // Enable checks for pose values
-  link.EnableVelocityChecks(*ecm);
+    // Enable checks for pose values
+    link.EnableVelocityChecks(_ecm);
 
-  ASSERT_NE(link.WorldInertiaMatrix(*ecm), std::nullopt);
-  ASSERT_NE(link.WorldInertialPose(*ecm), std::nullopt);
-  ASSERT_NE(link.WorldPose(*ecm), std::nullopt);
+    ASSERT_NE(link.WorldInertiaMatrix(_ecm), std::nullopt);
+    ASSERT_NE(link.WorldInertialPose(_ecm), std::nullopt);
+    ASSERT_NE(link.WorldPose(_ecm), std::nullopt);
 
-  // The cylinder has a radius of 1m, length of 2m, and density of 1240 kg/m³.
-  // Volume: πr²h = 2π ≈ 6.283
-  // Mass: ρV = (1240.0) * 2π ≈ 7791.1497
-  // Ix = Iy : 1/12 * m(3r² + h²)  = m/12 * (3 + 4) ≈ 4544.83
-  // Iz : ½mr² ≈ 3895.57
-  gz::math::Inertiald meshInertial;
-  meshInertial.SetMassMatrix(gz::math::MassMatrix3d(
-      7791.1497,
-      gz::math::Vector3d(4544.83, 4544.83, 3895.57),
-      gz::math::Vector3d::Zero
-    ));
-    meshInertial.SetPose(gz::math::Pose3d::Zero);
-  gz::math::Matrix3 inertiaMatrix = meshInertial.Moi();
+    // The cylinder has a radius of 1m, length of 2m, and density of 1240 kg/m³.
+    // Volume: πr²h = 2π ≈ 6.283
+    // Mass: ρV = (1240.0) * 2π ≈ 7791.1497
+    // Ix = Iy : 1/12 * m(3r² + h²)  = m/12 * (3 + 4) ≈ 4544.83
+    // Iz : ½mr² ≈ 3895.57
+    gz::math::Inertiald meshInertial;
+    meshInertial.SetMassMatrix(gz::math::MassMatrix3d(
+        7791.1497,
+        gz::math::Vector3d(4544.83, 4544.83, 3895.57),
+        gz::math::Vector3d::Zero
+      ));
+      meshInertial.SetPose(gz::math::Pose3d::Zero);
+    gz::math::Matrix3 inertiaMatrix = meshInertial.Moi();
 
-  // Check the Inertia Matrix within a tolerance of 0.005 since we are
-  // comparing a mesh cylinder with an ideal cylinder. For values more closer
-  // to the ideal, a higher number of vertices would be required in mesh
-  EXPECT_TRUE(
-    link.WorldInertiaMatrix(*ecm).value().Equal(inertiaMatrix, 0.005));
+    // Check the Inertia Matrix within a tolerance of 0.005 since we are
+    // comparing a mesh cylinder with an ideal cylinder. For values more closer
+    // to the ideal, a higher number of vertices would be required in mesh
+    EXPECT_TRUE(
+      link.WorldInertiaMatrix(_ecm).value().Equal(inertiaMatrix, 0.005));
 
-  // Check the Inertial Pose and Link Pose. Their world poses should be the
-  // same since the inertial pose relative to the link is zero.
-  EXPECT_EQ(link.WorldInertialPose(*ecm).value(),
-    worldPose(linkEntity, *ecm) * gz::math::Pose3d::Zero);
+    // Check the Inertial Pose and Link Pose. Their world poses should be the
+    // same since the inertial pose relative to the link is zero.
+    EXPECT_EQ(link.WorldInertialPose(_ecm).value(),
+      worldPose(linkEntity, _ecm) * gz::math::Pose3d::Zero);
+  });
 }
 
 // Tests are disabled on Windows
@@ -186,68 +177,59 @@ void cylinderColladaMeshWithNonCenterOriginInertiaCalculation(
   // Start server and run.
   gz::sim::Server server(_serverConfig);
 
-  // Create a system just to get the ECM
-  EntityComponentManager *ecm;
-  test::Relay testSystem;
-  testSystem.OnPreUpdate(
-    [&](const UpdateInfo &, EntityComponentManager &_ecm)
-    {
-      ecm = &_ecm;
-    }
-  );
-  server.AddSystem(testSystem.systemPtr);
-
   ASSERT_FALSE(server.Running());
   ASSERT_FALSE(*server.Running(0));
   ASSERT_TRUE(server.Run(true, kIter, false));
-  ASSERT_NE(nullptr, ecm);
 
-  // Get link of collada cylinder
-  gz::sim::Entity modelEntity = ecm->EntityByComponents(
-    gz::sim::components::Name("cylinder_dae_bottom_origin"),
-    gz::sim::components::Model()
-  );
+  server.PokeEcm([&](EntityComponentManager &_ecm)
+  {
+    // Get link of collada cylinder
+    gz::sim::Entity modelEntity = _ecm.EntityByComponents(
+      gz::sim::components::Name("cylinder_dae_bottom_origin"),
+      gz::sim::components::Model()
+    );
 
-  gz::sim::Model model = gz::sim::Model(modelEntity);
-  ASSERT_TRUE(model.Valid(*ecm));
+    gz::sim::Model model = gz::sim::Model(modelEntity);
+    ASSERT_TRUE(model.Valid(_ecm));
 
-  gz::sim::Entity linkEntity = model.LinkByName(*ecm,
-    "cylinder_dae_bottom_origin");
-  gz::sim::Link link = gz::sim::Link(linkEntity);
-  ASSERT_TRUE(link.Valid(*ecm));
+    gz::sim::Entity linkEntity = model.LinkByName(_ecm,
+      "cylinder_dae_bottom_origin");
+    gz::sim::Link link = gz::sim::Link(linkEntity);
+    ASSERT_TRUE(link.Valid(_ecm));
 
-  // Enable checks for pose values
-  link.EnableVelocityChecks(*ecm);
+    // Enable checks for pose values
+    link.EnableVelocityChecks(_ecm);
 
-  ASSERT_NE(link.WorldInertiaMatrix(*ecm), std::nullopt);
-  ASSERT_NE(link.WorldInertialPose(*ecm), std::nullopt);
-  ASSERT_NE(link.WorldPose(*ecm), std::nullopt);
+    ASSERT_NE(link.WorldInertiaMatrix(_ecm), std::nullopt);
+    ASSERT_NE(link.WorldInertialPose(_ecm), std::nullopt);
+    ASSERT_NE(link.WorldPose(_ecm), std::nullopt);
 
-  // The cylinder has a radius of 1m, length of 2m, and density of 1240 kg/m³.
-  // Volume: πr²h = 2π ≈ 6.283
-  // Mass: ρV = (1240.0) * 2π ≈ 7791.1497
-  // Ix = Iy : 1/12 * m(3r² + h²)  = m/12 * (3 + 4) ≈ 4544.83
-  // Iz : ½mr² ≈ 3895.57
-  gz::math::Inertiald meshInertial;
-  meshInertial.SetMassMatrix(gz::math::MassMatrix3d(
-      7791.1497,
-      gz::math::Vector3d(4544.83, 4544.83, 3895.57),
-      gz::math::Vector3d::Zero
-    ));
-    meshInertial.SetPose(gz::math::Pose3d::Zero);
-  gz::math::Matrix3 inertiaMatrix = meshInertial.Moi();
+    // The cylinder has a radius of 1m, length of 2m, and density of 1240 kg/m³.
+    // Volume: πr²h = 2π ≈ 6.283
+    // Mass: ρV = (1240.0) * 2π ≈ 7791.1497
+    // Ix = Iy : 1/12 * m(3r² + h²)  = m/12 * (3 + 4) ≈ 4544.83
+    // Iz : ½mr² ≈ 3895.57
+    gz::math::Inertiald meshInertial;
+    meshInertial.SetMassMatrix(gz::math::MassMatrix3d(
+        7791.1497,
+        gz::math::Vector3d(4544.83, 4544.83, 3895.57),
+        gz::math::Vector3d::Zero
+      ));
+      meshInertial.SetPose(gz::math::Pose3d::Zero);
+    gz::math::Matrix3 inertiaMatrix = meshInertial.Moi();
 
-  // Check the Inertia Matrix within a tolerance of 0.005 since we are
-  // comparing a mesh cylinder with an ideal cylinder. For values more closer
-  // to the ideal, a higher number of vertices would be required in mesh
-  EXPECT_TRUE(
-    link.WorldInertiaMatrix(*ecm).value().Equal(inertiaMatrix, 0.005));
+    // Check the Inertia Matrix within a tolerance of 0.005 since we are
+    // comparing a mesh cylinder with an ideal cylinder. For values more closer
+    // to the ideal, a higher number of vertices would be required in mesh
+    EXPECT_TRUE(
+      link.WorldInertiaMatrix(_ecm).value().Equal(inertiaMatrix, 0.005));
 
-  // Check the Inertial Pose
-  // Since the height of cylinder is 2m and origin is at center of bottom face
-  // the center of mass (inertial pose) will be 1m above the ground
-  EXPECT_EQ(link.WorldInertialPose(*ecm).value(),
-    worldPose(linkEntity, *ecm) * gz::math::Pose3d(0, 0, 1, 0, 0, 0));
+    // Check the Inertial Pose
+    // Since the height of cylinder is 2m and origin is at center of bottom face
+    // the center of mass (inertial pose) will be 1m above the ground
+    EXPECT_EQ(link.WorldInertialPose(_ecm).value(),
+      worldPose(linkEntity, _ecm) * gz::math::Pose3d(0, 0, 1, 0, 0, 0));
+  });
 }
 
 // Tests are disabled on Windows
@@ -282,74 +264,65 @@ void cylinderColladaOptimizedMeshInertiaCalculation(
   // Start server and run.
   gz::sim::Server server(_serverConfig);
 
-  // Create a system just to get the ECM
-  EntityComponentManager *ecm;
-  test::Relay testSystem;
-  testSystem.OnPreUpdate(
-    [&](const UpdateInfo &, EntityComponentManager &_ecm)
-    {
-      ecm = &_ecm;
-    }
-  );
-  server.AddSystem(testSystem.systemPtr);
-
   ASSERT_FALSE(server.Running());
   ASSERT_FALSE(*server.Running(0));
   ASSERT_TRUE(server.Run(true, kIter, false));
-  ASSERT_NE(nullptr, ecm);
 
-  // Get link of collada cylinder
-  gz::sim::Entity modelEntity = ecm->EntityByComponents(
-    gz::sim::components::Name("cylinder_dae_convex_decomposition"),
-    gz::sim::components::Model()
-  );
+  server.PokeEcm([&](EntityComponentManager &_ecm)
+  {
+    // Get link of collada cylinder
+    gz::sim::Entity modelEntity = _ecm.EntityByComponents(
+      gz::sim::components::Name("cylinder_dae_convex_decomposition"),
+      gz::sim::components::Model()
+    );
 
-  gz::sim::Model model = gz::sim::Model(modelEntity);
-  ASSERT_TRUE(model.Valid(*ecm));
+    gz::sim::Model model = gz::sim::Model(modelEntity);
+    ASSERT_TRUE(model.Valid(_ecm));
 
-  gz::sim::Entity linkEntity =
-      model.LinkByName(*ecm, "cylinder_dae_convex_decomposition");
-  gz::sim::Link link = gz::sim::Link(linkEntity);
-  ASSERT_TRUE(link.Valid(*ecm));
+    gz::sim::Entity linkEntity =
+        model.LinkByName(_ecm, "cylinder_dae_convex_decomposition");
+    gz::sim::Link link = gz::sim::Link(linkEntity);
+    ASSERT_TRUE(link.Valid(_ecm));
 
-  // Enable checks for pose values
-  link.EnableVelocityChecks(*ecm);
+    // Enable checks for pose values
+    link.EnableVelocityChecks(_ecm);
 
-  ASSERT_NE(link.WorldInertiaMatrix(*ecm), std::nullopt);
-  ASSERT_NE(link.WorldInertialPose(*ecm), std::nullopt);
-  ASSERT_NE(link.WorldPose(*ecm), std::nullopt);
+    ASSERT_NE(link.WorldInertiaMatrix(_ecm), std::nullopt);
+    ASSERT_NE(link.WorldInertialPose(_ecm), std::nullopt);
+    ASSERT_NE(link.WorldPose(_ecm), std::nullopt);
 
-  // The cylinder has a radius of 1m, length of 2m, and density of 1240 kg/m³.
-  // Volume: πr²h = 2π ≈ 6.283
-  // Mass: ρV = (1240.0) * 2π ≈ 7791.1497
-  // Ix = Iy : 1/12 * m(3r² + h²)  = m/12 * (3 + 4) ≈ 4544.83
-  // Iz : ½mr² ≈ 3895.57
-  gz::math::Inertiald meshInertial;
-  meshInertial.SetMassMatrix(gz::math::MassMatrix3d(
-      7791.1497,
-      gz::math::Vector3d(4544.83, 4544.83, 3895.57),
-      gz::math::Vector3d::Zero
-    ));
-    meshInertial.SetPose(gz::math::Pose3d::Zero);
+    // The cylinder has a radius of 1m, length of 2m, and density of 1240 kg/m³.
+    // Volume: πr²h = 2π ≈ 6.283
+    // Mass: ρV = (1240.0) * 2π ≈ 7791.1497
+    // Ix = Iy : 1/12 * m(3r² + h²)  = m/12 * (3 + 4) ≈ 4544.83
+    // Iz : ½mr² ≈ 3895.57
+    gz::math::Inertiald meshInertial;
+    meshInertial.SetMassMatrix(gz::math::MassMatrix3d(
+        7791.1497,
+        gz::math::Vector3d(4544.83, 4544.83, 3895.57),
+        gz::math::Vector3d::Zero
+      ));
+      meshInertial.SetPose(gz::math::Pose3d::Zero);
 
-  // Check the Inertia Matrix within a larger tolerance since we are
-  // comparing a mesh cylinder made of convex hulls with an ideal cylinder.
-  // For values more closer to the ideal, a higher number convex decomposition
-  // parameters would be required in the mesh sdf.
-  double ixxyyzzTol = meshInertial.MassMatrix().DiagonalMoments().Max() * 0.1;
-  gz::math::Vector3d actualIxxyyzz(link.WorldInertiaMatrix(*ecm).value()(0, 0),
-                                   link.WorldInertiaMatrix(*ecm).value()(1, 1),
-                                   link.WorldInertiaMatrix(*ecm).value()(2, 2));
-  gz::math::Vector3d actualIxyxzyz(link.WorldInertiaMatrix(*ecm).value()(0, 1),
-                                   link.WorldInertiaMatrix(*ecm).value()(0, 2),
-                                   link.WorldInertiaMatrix(*ecm).value()(1, 2));
-  EXPECT_TRUE(actualIxxyyzz.Equal(meshInertial.MassMatrix().DiagonalMoments(),
-              ixxyyzzTol));
-  EXPECT_TRUE(actualIxyxzyz.Equal(
-              meshInertial.MassMatrix().OffDiagonalMoments(), 3.5));
-  // Check the Inertial Pose
-  EXPECT_TRUE(link.WorldInertialPose(*ecm).value().Equal(
-              worldPose(linkEntity, *ecm) * gz::math::Pose3d::Zero, 1e-2));
+    // Check the Inertia Matrix within a larger tolerance since we are
+    // comparing a mesh cylinder made of convex hulls with an ideal cylinder.
+    // For values more closer to the ideal, a higher number convex decomposition
+    // parameters would be required in the mesh sdf.
+    double ixxyyzzTol = meshInertial.MassMatrix().DiagonalMoments().Max() * 0.1;
+    gz::math::Vector3d actualIxxyyzz(link.WorldInertiaMatrix(_ecm).value()(0, 0),
+                                     link.WorldInertiaMatrix(_ecm).value()(1, 1),
+                                     link.WorldInertiaMatrix(_ecm).value()(2, 2));
+    gz::math::Vector3d actualIxyxzyz(link.WorldInertiaMatrix(_ecm).value()(0, 1),
+                                     link.WorldInertiaMatrix(_ecm).value()(0, 2),
+                                     link.WorldInertiaMatrix(_ecm).value()(1, 2));
+    EXPECT_TRUE(actualIxxyyzz.Equal(meshInertial.MassMatrix().DiagonalMoments(),
+                ixxyyzzTol));
+    EXPECT_TRUE(actualIxyxzyz.Equal(
+                meshInertial.MassMatrix().OffDiagonalMoments(), 3.5));
+    // Check the Inertial Pose
+    EXPECT_TRUE(link.WorldInertialPose(_ecm).value().Equal(
+                worldPose(linkEntity, _ecm) * gz::math::Pose3d::Zero, 1e-2));
+  });
 }
 
 // Tests are disabled on Windows

--- a/test/integration/physics_system.cc
+++ b/test/integration/physics_system.cc
@@ -227,33 +227,26 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(CanonicalLink))
     expectedLinPoses[linkName] = model->LinkByName(linkName)->RawPose();
   ASSERT_EQ(3u, expectedLinPoses.size());
 
-  // Create a system that records the poses of the links after physics
-  test::Relay testSystem;
+  server.Run(true, 1, false);
 
   std::unordered_map<std::string, math::Pose3d> postUpLinkPoses;
-  testSystem.OnPostUpdate(
-    [&modelName, &postUpLinkPoses](const UpdateInfo &,
-    const EntityComponentManager &_ecm)
-    {
-      _ecm.Each<components::Link, components::Name, components::Pose,
-                components::ParentEntity>(
-        [&](const Entity &, const components::Link *,
-        const components::Name *_name, const components::Pose *_pose,
-        const components::ParentEntity *_parent)->bool
+  server.PeekEcm([&](const EntityComponentManager &_ecm)
+  {
+    _ecm.Each<components::Link, components::Name, components::Pose,
+              components::ParentEntity>(
+      [&](const Entity &, const components::Link *,
+      const components::Name *_name, const components::Pose *_pose,
+      const components::ParentEntity *_parent)->bool
+      {
+        auto parentModel = _ecm.Component<components::Name>(_parent->Data());
+        EXPECT_TRUE(nullptr != parentModel);
+        if (parentModel->Data() == modelName)
         {
-          auto parentModel = _ecm.Component<components::Name>(_parent->Data());
-          EXPECT_TRUE(nullptr != parentModel);
-          if (parentModel->Data() == modelName)
-          {
-            postUpLinkPoses[_name->Data()] = _pose->Data();
-          }
-          return true;
-        });
-      return true;
-    });
-
-  server.AddSystem(testSystem.systemPtr);
-  server.Run(true, 1, false);
+          postUpLinkPoses[_name->Data()] = _pose->Data();
+        }
+        return true;
+      });
+  });
 
   EXPECT_EQ(3u, postUpLinkPoses.size());
 
@@ -270,8 +263,7 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(CanonicalLink))
 
 /////////////////////////////////////////////////
 // Same as the CanonicalLink test, but with a non-default canonical link
-TEST_F(PhysicsSystemFixture,
-       GZ_UTILS_TEST_DISABLED_ON_WIN32(NonDefaultCanonicalLink))
+TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(NonDefaultCanonicalLink))
 {
   ServerConfig serverConfig;
 
@@ -291,38 +283,31 @@ TEST_F(PhysicsSystemFixture,
 
   const std::string modelName{"nondefault_canonical"};
 
-  // Create a system that records the pose of the model.
-  test::Relay testSystem;
-
-  std::vector<math::Pose3d> modelPoses;
-  testSystem.OnPostUpdate(
-    [&modelName, &modelPoses](const UpdateInfo &,
-    const EntityComponentManager &_ecm)
-    {
-      _ecm.Each<components::Model, components::Name, components::Pose>(
-        [&](const Entity &, const components::Model *,
-        const components::Name *_name, const components::Pose *_pose)->bool
-        {
-          if (_name->Data() == modelName)
-          {
-            modelPoses.push_back(_pose->Data());
-          }
-          return true;
-        });
-      return true;
-    });
-
-  server.AddSystem(testSystem.systemPtr);
   std::size_t nIters{2000};
   server.Run(true, nIters, false);
 
-  EXPECT_EQ(nIters, modelPoses.size());
+  math::Pose3d modelPose;
+  server.PeekEcm([&](const EntityComponentManager &_ecm)
+  {
+    _ecm.Each<components::Model, components::Name, components::Pose>(
+      [&](const Entity &, const components::Model *,
+      const components::Name *_name, const components::Pose *_pose)->bool
+      {
+        if (_name->Data() == modelName)
+        {
+          modelPose = _pose->Data();
+          return false;
+        }
+        return true;
+      });
+  });
 
   // The model is attached to link2 (it's canonical link) so it will fall during
   // simulation. The new Z position of the model is an offset of -2 in the Z
   // direction from the center of link2.
-  EXPECT_NEAR(-(2.0 - 0.2), modelPoses.back().Pos().Z(), 1e-2);
+  EXPECT_NEAR(-(2.0 - 0.2), modelPose.Pos().Z(), 1e-2);
 }
+
 
 /////////////////////////////////////////////////
 // Test physics integration with revolute joints
@@ -411,79 +396,76 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(CreateRuntime))
   Server server(serverConfig);
   server.SetPaused(false);
 
-  // Create a system just to get the ECM
-  // TODO(louise) It would be much more convenient if the Server just returned
-  // the ECM for us. This would save all the trouble which is causing us to
-  // create `Relay` systems in the first place. Consider keeping the ECM in a
-  // shared pointer owned by the SimulationRunner.
-  EntityComponentManager *ecm{nullptr};
-  test::Relay testSystem;
-  testSystem.OnPreUpdate([&](const UpdateInfo &,
-                             EntityComponentManager &_ecm)
-      {
-        ecm = &_ecm;
-      });
-  server.AddSystem(testSystem.systemPtr);
-
-  // Run server and check we have the ECM
-  EXPECT_EQ(nullptr, ecm);
+  // Run server
   server.Run(true, 1, false);
-  EXPECT_NE(nullptr, ecm);
 
-  // Check we don't have a new model yet
-  EXPECT_EQ(kNullEntity, ecm->EntityByComponents(components::Model(),
-      components::Name("new_model")));
+  Entity worldEntity{kNullEntity};
+  Entity modelEntity{kNullEntity};
 
-  // Get world
-  auto worldEntity = ecm->EntityByComponents(components::World());
-  EXPECT_NE(kNullEntity, worldEntity);
+  server.PokeEcm([&](EntityComponentManager &_ecm)
+  {
+    // Check we don't have a new model yet
+    EXPECT_EQ(kNullEntity, _ecm.EntityByComponents(components::Model(),
+        components::Name("new_model")));
 
-  // Spawn a new model
-  auto modelEntity = ecm->CreateEntity();
-  ecm->CreateComponent(modelEntity, components::Model());
-  ecm->CreateComponent(modelEntity, components::Pose(math::Pose3d::Zero));
-  ecm->CreateComponent(modelEntity, components::Name("new_model"));
-  ecm->CreateComponent(modelEntity, components::Static(false));
-  ecm->SetParentEntity(modelEntity, worldEntity);
-  ecm->CreateComponent(modelEntity, components::ParentEntity(worldEntity));
+    // Get world
+    worldEntity = _ecm.EntityByComponents(components::World());
+    EXPECT_NE(kNullEntity, worldEntity);
 
-  auto linkEntity = ecm->CreateEntity();
-  ecm->CreateComponent(linkEntity, components::Link());
-  ecm->CreateComponent(linkEntity, components::CanonicalLink());
-  ecm->CreateComponent(linkEntity, components::Pose(math::Pose3d::Zero));
-  ecm->CreateComponent(linkEntity, components::Name("link"));
-  ecm->CreateComponent(modelEntity, components::ModelCanonicalLink(linkEntity));
+    // Spawn a new model
+    modelEntity = _ecm.CreateEntity();
+    _ecm.CreateComponent(modelEntity, components::Model());
+    _ecm.CreateComponent(modelEntity, components::Pose(math::Pose3d::Zero));
+    _ecm.CreateComponent(modelEntity, components::Name("new_model"));
+    _ecm.CreateComponent(modelEntity, components::Static(false));
+    _ecm.SetParentEntity(modelEntity, worldEntity);
+    _ecm.CreateComponent(modelEntity, components::ParentEntity(worldEntity));
 
-  math::MassMatrix3d massMatrix;
-  massMatrix.SetMass(1.0);
-  massMatrix.SetInertiaMatrix(0.4, 0.4, 0.4, 0, 0, 0);
-  math::Inertiald inertia;
-  inertia.SetMassMatrix(massMatrix);
-  ecm->CreateComponent(linkEntity, components::Inertial(inertia));
+    auto linkEntity = _ecm.CreateEntity();
+    _ecm.CreateComponent(linkEntity, components::Link());
+    _ecm.CreateComponent(linkEntity, components::CanonicalLink());
+    _ecm.CreateComponent(linkEntity, components::Pose(math::Pose3d::Zero));
+    _ecm.CreateComponent(linkEntity, components::Name("link"));
+    _ecm.CreateComponent(modelEntity, components::ModelCanonicalLink(linkEntity));
 
-  ecm->SetParentEntity(linkEntity, modelEntity);
-  ecm->CreateComponent(linkEntity, components::ParentEntity(modelEntity));
+    math::MassMatrix3d massMatrix;
+    massMatrix.SetMass(1.0);
+    massMatrix.SetInertiaMatrix(0.4, 0.4, 0.4, 0, 0, 0);
+    math::Inertiald inertia;
+    inertia.SetMassMatrix(massMatrix);
+    _ecm.CreateComponent(linkEntity, components::Inertial(inertia));
 
-  // Check we have a new model
-  EXPECT_NE(kNullEntity, ecm->EntityByComponents(components::Model(),
-      components::Name("new_model")));
+    _ecm.SetParentEntity(linkEntity, modelEntity);
+    _ecm.CreateComponent(linkEntity, components::ParentEntity(modelEntity));
 
-  // Run server and check new model keeps falling due to gravity
-  auto poseComp = ecm->Component<components::Pose>(modelEntity);
-  ASSERT_NE(nullptr, poseComp);
+    // Check we have a new model
+    EXPECT_NE(kNullEntity, _ecm.EntityByComponents(components::Model(),
+        components::Name("new_model")));
+  });
 
-  auto pose = poseComp->Data();
-  EXPECT_EQ(math::Pose3d::Zero, pose);
+  math::Pose3d pose;
+  server.PeekEcm([&](const EntityComponentManager &_ecm)
+  {
+    // Run server and check new model keeps falling due to gravity
+    auto poseComp = _ecm.Component<components::Pose>(modelEntity);
+    ASSERT_NE(nullptr, poseComp);
+
+    pose = poseComp->Data();
+    EXPECT_EQ(math::Pose3d::Zero, pose);
+  });
 
   for (int i = 0; i < 10; ++i)
   {
     server.Run(true, 100, false);
 
-    poseComp = ecm->Component<components::Pose>(modelEntity);
-    ASSERT_NE(nullptr, poseComp);
+    server.PeekEcm([&](const EntityComponentManager &_ecm)
+    {
+      auto poseComp = _ecm.Component<components::Pose>(modelEntity);
+      ASSERT_NE(nullptr, poseComp);
 
-    EXPECT_GT(pose.Pos().Z(), poseComp->Data().Pos().Z());
-    pose = poseComp->Data();
+      EXPECT_GT(pose.Pos().Z(), poseComp->Data().Pos().Z());
+      pose = poseComp->Data();
+    });
   }
 }
 

--- a/test/integration/scene_broadcaster_system.cc
+++ b/test/integration/scene_broadcaster_system.cc
@@ -49,6 +49,7 @@
 #include <gz/transport/Node.hh>
 #include <gz/utils/ExtraTestMacros.hh>
 
+#include <gz/sim/EntityComponentManager.hh>
 #include "gz/sim/Server.hh"
 #include "test_config.hh"
 
@@ -56,6 +57,7 @@
 #include "../helpers/Relay.hh"
 
 using namespace gz;
+using namespace sim;
 
 /// \brief Test SceneBroadcaster system
 class SceneBroadcasterTest
@@ -659,99 +661,6 @@ TEST_P(SceneBroadcasterTest, DISABLED_AddRemoveEntitiesComponents)
   EXPECT_FALSE(server.Running());
   EXPECT_FALSE(*server.Running(0));
 
-  // Create a system that removes a component
-  gz::sim::test::Relay testSystem;
-
-  testSystem.OnUpdate([](const sim::UpdateInfo &_info,
-    sim::EntityComponentManager &_ecm)
-    {
-      static bool periodicChangeMade = false;
-
-      // remove a component from an entity
-      if (_info.iterations == 2)
-      {
-        std::vector<sim::Entity> entitiesToRemoveFrom;
-        _ecm.Each<gz::sim::components::Model,
-                  gz::sim::components::Name,
-                  gz::sim::components::Pose>(
-          [&](const gz::sim::Entity &_entity,
-              const gz::sim::components::Model *,
-              const gz::sim::components::Name *_name,
-              const gz::sim::components::Pose *)->bool
-          {
-            if (_name->Data() == "box")
-            {
-              entitiesToRemoveFrom.push_back(_entity);
-            }
-            return true;
-          });
-        for (const auto &entity : entitiesToRemoveFrom)
-        {
-          _ecm.RemoveComponent<gz::sim::components::Pose>(entity);
-        }
-      }
-      // add a component to an entity
-      else if (_info.iterations == 3)
-      {
-        auto boxEntity = _ecm.EntityByComponents(
-            sim::components::Name("box"), sim::components::Model());
-        ASSERT_NE(sim::kNullEntity, boxEntity);
-        EXPECT_FALSE(_ecm.EntityHasComponentType(boxEntity,
-              gz::sim::components::Pose::typeId));
-        _ecm.CreateComponent<gz::sim::components::Pose>(boxEntity,
-            gz::sim::components::Pose({1, 2, 3, 4, 5, 6}));
-        EXPECT_TRUE(_ecm.EntityHasComponentType(boxEntity,
-              gz::sim::components::Pose::typeId));
-      }
-      // remove an entity
-      else if (_info.iterations == 4)
-      {
-        auto boxEntity = _ecm.EntityByComponents(
-            sim::components::Name("box"), sim::components::Model());
-        ASSERT_NE(sim::kNullEntity, boxEntity);
-        _ecm.RequestRemoveEntity(boxEntity);
-      }
-      // create an entity
-      else if (_info.iterations == 5)
-      {
-        EXPECT_EQ(sim::kNullEntity, _ecm.EntityByComponents(
-              sim::components::Name("newEntity"),
-              sim::components::Model()));
-        auto newEntity = _ecm.CreateEntity();
-        _ecm.CreateComponent(newEntity, sim::components::Name("newEntity"));
-        _ecm.CreateComponent(newEntity, sim::components::Model());
-        EXPECT_NE(sim::kNullEntity, _ecm.EntityByComponents(
-              sim::components::Name("newEntity"),
-              sim::components::Model()));
-      }
-      // modify an existing component via OneTimeChange
-      else if (_info.iterations == 6)
-      {
-        auto entity = _ecm.EntityByComponents(
-            sim::components::Name("newEntity"),
-            sim::components::Model());
-        ASSERT_NE(sim::kNullEntity, entity);
-        EXPECT_TRUE(_ecm.SetComponentData<sim::components::Name>(entity,
-            "newEntity1"));
-        _ecm.SetChanged(entity, sim::components::Name::typeId,
-            sim::ComponentState::OneTimeChange);
-      }
-      // modify an existing component via PeriodicChange
-      else if (_info.iterations > 6 && !periodicChangeMade)
-      {
-        auto entity = _ecm.EntityByComponents(
-            sim::components::Name("newEntity1"),
-            sim::components::Model());
-        ASSERT_NE(sim::kNullEntity, entity);
-        EXPECT_TRUE(_ecm.SetComponentData<sim::components::Name>(entity,
-            "newEntity2"));
-        _ecm.SetChanged(entity, sim::components::Name::typeId,
-            sim::ComponentState::PeriodicChange);
-        periodicChangeMade = true;
-      }
-    });
-  server.AddSystem(testSystem.systemPtr);
-
   int receivedStates = 0;
   bool received = false;
   bool hasState = false;
@@ -859,33 +768,104 @@ TEST_P(SceneBroadcasterTest, DISABLED_AddRemoveEntitiesComponents)
   // Run server once. The first time should send the state message
   runServerOnce(true);
 
-  // Run server again. The second time shouldn't have state info. The
-  // message can still arrive due the passage of time (see `itsPubTime` in
-  // SceneBroadcaster::PostUpdate.
+  // Run server again. The second time shouldn't have state info.
+  // Before running, remove a component from an entity
+  server.PokeEcm([](EntityComponentManager &_ecm)
+  {
+    std::vector<sim::Entity> entitiesToRemoveFrom;
+    _ecm.Each<gz::sim::components::Model,
+              gz::sim::components::Name,
+              gz::sim::components::Pose>(
+      [&](const gz::sim::Entity &_entity,
+          const gz::sim::components::Model *,
+          const gz::sim::components::Name *_name,
+          const gz::sim::components::Pose *)->bool
+      {
+        if (_name->Data() == "box")
+        {
+          entitiesToRemoveFrom.push_back(_entity);
+        }
+        return true;
+      });
+    for (const auto &entity : entitiesToRemoveFrom)
+    {
+      _ecm.RemoveComponent<gz::sim::components::Pose>(entity);
+    }
+  });
   runServerOnce(false);
 
   // Run server again. The third time should send the state message because
-  // the test system removed a component.
+  // we add a component.
+  server.PokeEcm([](EntityComponentManager &_ecm)
+  {
+    auto boxEntity = _ecm.EntityByComponents(
+        sim::components::Name("box"), sim::components::Model());
+    ASSERT_NE(sim::kNullEntity, boxEntity);
+    EXPECT_FALSE(_ecm.EntityHasComponentType(boxEntity,
+          gz::sim::components::Pose::typeId));
+    _ecm.CreateComponent<gz::sim::components::Pose>(boxEntity,
+        gz::sim::components::Pose({1, 2, 3, 4, 5, 6}));
+    EXPECT_TRUE(_ecm.EntityHasComponentType(boxEntity,
+          gz::sim::components::Pose::typeId));
+  });
   runServerOnce(true);
 
   // Run server again. The fourth time should send the state message because
-  // the test system added a component.
+  // we requested to remove an entity.
+  server.PokeEcm([](EntityComponentManager &_ecm)
+  {
+    auto boxEntity = _ecm.EntityByComponents(
+        sim::components::Name("box"), sim::components::Model());
+    ASSERT_NE(sim::kNullEntity, boxEntity);
+    _ecm.RequestRemoveEntity(boxEntity);
+  });
   runServerOnce(true);
 
   // Run server again. The fifth time should send the state message because
-  // the test system requested to remove an entity.
+  // we created an entity.
+  server.PokeEcm([](EntityComponentManager &_ecm)
+  {
+    EXPECT_EQ(sim::kNullEntity, _ecm.EntityByComponents(
+          sim::components::Name("newEntity"),
+          sim::components::Model()));
+    auto newEntity = _ecm.CreateEntity();
+    _ecm.CreateComponent(newEntity, sim::components::Name("newEntity"));
+    _ecm.CreateComponent(newEntity, sim::components::Model());
+    EXPECT_NE(sim::kNullEntity, _ecm.EntityByComponents(
+          sim::components::Name("newEntity"),
+          sim::components::Model()));
+  });
   runServerOnce(true);
 
   // Run server again. The sixth time should send the state message because
-  // the test system created an entity.
-  runServerOnce(true);
-
-  // Run server again. The seventh time should send the state message because
-  // the test system modified a component and marked it as a OneTimeChange.
+  // we modified a component and marked it as a OneTimeChange.
+  server.PokeEcm([](EntityComponentManager &_ecm)
+  {
+    auto entity = _ecm.EntityByComponents(
+        sim::components::Name("newEntity"),
+        sim::components::Model());
+    ASSERT_NE(sim::kNullEntity, entity);
+    EXPECT_TRUE(_ecm.SetComponentData<sim::components::Name>(entity,
+        "newEntity1"));
+    _ecm.SetChanged(entity, sim::components::Name::typeId,
+        sim::ComponentState::OneTimeChange);
+  });
   runServerOnce(true);
 
   // Run server for a few iterations to make sure that the periodic change
-  // made by the test system is received.
+  // is received.
+  server.PokeEcm([](EntityComponentManager &_ecm)
+  {
+    auto entity = _ecm.EntityByComponents(
+        sim::components::Name("newEntity1"),
+        sim::components::Model());
+    ASSERT_NE(sim::kNullEntity, entity);
+    EXPECT_TRUE(_ecm.SetComponentData<sim::components::Name>(entity,
+        "newEntity2"));
+    _ecm.SetChanged(entity, sim::components::Name::typeId,
+        sim::ComponentState::PeriodicChange);
+  });
+
   received = false;
   hasState = false;
   server.Run(true, 10, false);


### PR DESCRIPTION
This replaces the usage of Relay systems for accessing the EntityComponentManager
in tests with the more direct PeekEcm and PokeEcm APIs.

Generated-by: Gemini CLI
Signed-off-by: Arjo Chakravarty <arjoc@intrinsic.ai>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>