### PR TITLE
Added update rate param to Joint state publisher

### DIFF
--- a/src/systems/joint_state_publisher/JointStatePublisher.cc
+++ b/src/systems/joint_state_publisher/JointStatePublisher.cc
@@ -19,6 +19,7 @@
 
 #include <gz/msgs/model.pb.h>
 
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -100,6 +101,19 @@ void JointStatePublisher::Configure(
     this->topic = _sdf->Get<std::string>("topic");
   }
 
+  const double updateRate = _sdf->Get<double>("update_rate", 0.0).first;
+  if (updateRate < 0)
+  {
+    gzwarn << "JointStatePublisher: <update_rate> must be >= 0, got ["
+           << updateRate << "]. Publishing every simulation iteration.\n";
+  }
+  else if (updateRate > 0)
+  {
+    const std::chrono::duration<double> period{1.0 / updateRate};
+    this->updatePeriod =
+      std::chrono::duration_cast<std::chrono::steady_clock::duration>(period);
+  }
+
 }
 
 //////////////////////////////////////////////////
@@ -139,6 +153,13 @@ void JointStatePublisher::CreateComponents(EntityComponentManager &_ecm,
 void JointStatePublisher::PostUpdate(const UpdateInfo &_info,
                                 const EntityComponentManager &_ecm)
 {
+  const auto diff = _info.simTime - this->lastUpdateTime;
+  if ((diff > std::chrono::steady_clock::duration::zero()) &&
+      (diff < this->updatePeriod))
+  {
+    return;
+  }
+
   // Create the model state publisher. This can't be done in ::Configure
   // because the World is not guaranteed to be accessible.
   if (!this->modelPub)
@@ -181,6 +202,8 @@ void JointStatePublisher::PostUpdate(const UpdateInfo &_info,
   // Skip if we couldn't create the publisher.
   if (!this->modelPub)
     return;
+
+  this->lastUpdateTime = _info.simTime;
 
   // Create the message
   msgs::Model msg;

--- a/src/systems/joint_state_publisher/JointStatePublisher.hh
+++ b/src/systems/joint_state_publisher/JointStatePublisher.hh
@@ -21,6 +21,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <chrono>
 #include <gz/sim/Model.hh>
 #include <gz/transport/Node.hh>
 #include <gz/sim/System.hh>
@@ -50,6 +51,10 @@ namespace systems
   /// - `<joint_name>`: Name of a joint to publish. This parameter can be
   /// specified multiple times, and is optional. All joints in a model will
   /// be published if joint names are not specified.
+  ///
+  /// - `<update_rate>`: Maximum publication frequency in Hz. Optional.
+  /// Values > 0 throttle publications using sim time. If absent or set to 0,
+  /// publish every simulation iteration.
   class JointStatePublisher
       : public System,
         public ISystemConfigure,
@@ -90,6 +95,12 @@ namespace systems
 
     /// \brief The topic
     private: std::string topic;
+
+    /// \brief Publication period derived from `<update_rate>`.
+    private: std::chrono::steady_clock::duration updatePeriod{0};
+
+    /// \brief Simulation time of last publication.
+    private: std::chrono::steady_clock::duration lastUpdateTime{0};
   };
   }
 }


### PR DESCRIPTION
# 🎉 New feature

## Summary

Add `update_rate` param to Joint state publisher plugin

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.