### PR TITLE
Don't merge: debugging macos glxinfo

### DIFF
--- a/test/find_dri.cmake
+++ b/test/find_dri.cmake
@@ -57,8 +57,9 @@ if((DEFINED ENV{DISPLAY}) AND NOT ("$ENV{DISPLAY}" STREQUAL ""))
         execute_process(
           COMMAND glxinfo
           OUTPUT_VARIABLE GLX2
+          ERROR_VARIABLE GLX2_ERROR
         )
-        message(STATUS "glxinfo ${GLX2}")
+        message(STATUS "glxinfo ${GLX2}\n${GLX2_ERROR")
         message(STATUS "\n-------- Debugging glxinfo --------\n")
       endif()
     else()

--- a/test/find_dri.cmake
+++ b/test/find_dri.cmake
@@ -59,7 +59,7 @@ if((DEFINED ENV{DISPLAY}) AND NOT ("$ENV{DISPLAY}" STREQUAL ""))
           OUTPUT_VARIABLE GLX2
           ERROR_VARIABLE GLX2_ERROR
         )
-        message(STATUS "glxinfo ${GLX2}\n${GLX2_ERROR")
+        message(STATUS "glxinfo ${GLX2}\n${GLX2_ERROR}")
         message(STATUS "\n-------- Debugging glxinfo --------\n")
       endif()
     else()

--- a/test/find_dri.cmake
+++ b/test/find_dri.cmake
@@ -53,6 +53,14 @@ if((DEFINED ENV{DISPLAY}) AND NOT ("$ENV{DISPLAY}" STREQUAL ""))
         set(VALID_DRI_DISPLAY TRUE)
       else()
         set(CHECKER_ERROR "using glxinfo")
+        message(STATUS "\n-------- Debugging glxinfo --------\n")
+        execute_process(
+          COMMAND glxinfo
+          COMMAND grep -C 5 "direct rendering"
+          OUTPUT_VARIABLE GLX2
+        )
+        message(STATUS "glxinfo ${GLX2}")
+        message(STATUS "\n-------- Debugging glxinfo --------\n")
       endif()
     else()
       message(STATUS

--- a/test/find_dri.cmake
+++ b/test/find_dri.cmake
@@ -56,7 +56,6 @@ if((DEFINED ENV{DISPLAY}) AND NOT ("$ENV{DISPLAY}" STREQUAL ""))
         message(STATUS "\n-------- Debugging glxinfo --------\n")
         execute_process(
           COMMAND glxinfo
-          COMMAND grep -C 5 "direct rendering"
           OUTPUT_VARIABLE GLX2
         )
         message(STATUS "glxinfo ${GLX2}")


### PR DESCRIPTION
# 🦟 Bug fix

debugging https://github.com/gazebo-tooling/release-tools/issues/1490

## Summary

print more glxinfo output if check fails

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
