### PR TITLE
Add reset test helpers and migrate reset integration tests

### DIFF
--- a/test/helpers/ResetUtils.hh
+++ b/test/helpers/ResetUtils.hh
@@ -32,6 +32,8 @@
 #include <gz/sim/Server.hh>
 #include <gz/transport/Node.hh>
 
+#include "helpers/Util.hh"
+
 namespace gz::sim::test::reset
 {
 namespace detail
@@ -103,17 +105,7 @@ template <typename Predicate>
 bool StepUntil(
     gz::sim::Server &_server, uint64_t _maxSteps, Predicate _predicate)
 {
-  if (_predicate())
-    return true;
-
-  for (uint64_t i = 0; i < _maxSteps; ++i)
-  {
-    detail::RunOneUnpausedStep(_server);
-    if (_predicate())
-      return true;
-  }
-
-  return false;
+  return ::gz::sim::test::StepUntil(_server, _maxSteps, _predicate);
 }
 
 /////////////////////////////////////////////////
@@ -126,16 +118,7 @@ bool WaitUntil(
     const std::chrono::steady_clock::duration &_timeout,
     Predicate _predicate)
 {
-  const auto deadline = std::chrono::steady_clock::now() + _timeout;
-  while (std::chrono::steady_clock::now() < deadline)
-  {
-    if (_predicate())
-      return true;
-
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-  }
-
-  return _predicate();
+  return ::gz::sim::test::WaitUntil(_timeout, _predicate);
 }
 
 /////////////////////////////////////////////////

--- a/test/helpers/ResetUtils.hh
+++ b/test/helpers/ResetUtils.hh
@@ -24,15 +24,11 @@
 #include <gz/msgs/world_control.pb.h>
 
 #include <atomic>
-#include <chrono>
 #include <mutex>
 #include <string>
-#include <thread>
 
 #include <gz/sim/Server.hh>
 #include <gz/transport/Node.hh>
-
-#include "helpers/Util.hh"
 
 namespace gz::sim::test::reset
 {
@@ -93,32 +89,6 @@ inline void RequestAndApplyWorldReset(
   RequestWorldReset(_worldName);
   ConsumeResetRequest(_server);
   ApplyWorldReset(_server);
-}
-
-/////////////////////////////////////////////////
-/// \brief Step the server until a predicate becomes true.
-/// \param[in] _server Server to step.
-/// \param[in] _maxSteps Maximum number of single steps.
-/// \param[in] _predicate Predicate to evaluate before and after each step.
-/// \return True when the predicate became true.
-template <typename Predicate>
-bool StepUntil(
-    gz::sim::Server &_server, uint64_t _maxSteps, Predicate _predicate)
-{
-  return ::gz::sim::test::StepUntil(_server, _maxSteps, _predicate);
-}
-
-/////////////////////////////////////////////////
-/// \brief Wait without advancing simulation until a predicate becomes true.
-/// \param[in] _timeout Maximum wall-clock wait.
-/// \param[in] _predicate Predicate to evaluate.
-/// \return True when the predicate became true.
-template <typename Predicate>
-bool WaitUntil(
-    const std::chrono::steady_clock::duration &_timeout,
-    Predicate _predicate)
-{
-  return ::gz::sim::test::WaitUntil(_timeout, _predicate);
 }
 
 /////////////////////////////////////////////////

--- a/test/helpers/ResetUtils.hh
+++ b/test/helpers/ResetUtils.hh
@@ -23,8 +23,6 @@
 #include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/world_control.pb.h>
 
-#include <atomic>
-#include <mutex>
 #include <string>
 
 #include <gz/sim/Server.hh>
@@ -91,116 +89,6 @@ inline void RequestAndApplyWorldReset(
   ApplyWorldReset(_server);
 }
 
-/////////////////////////////////////////////////
-/// \brief Helper that records messages from a topic.
-template <typename T>
-class MsgReceiver
-{
-  /// \brief Destructor.
-  public: ~MsgReceiver()
-  {
-    this->Stop();
-  }
-
-  /// \brief Subscribe to a topic and clear received state.
-  /// \param[in] _topic Topic to subscribe to.
-  /// \return True when subscription succeeded.
-  public: bool Start(const std::string &_topic)
-  {
-    this->Stop();
-    this->topic = _topic;
-    this->Clear();
-
-    const bool subscribed =
-      this->node.Subscribe(_topic, &MsgReceiver<T>::Callback, this);
-    if (!subscribed)
-      this->topic.clear();
-
-    return subscribed;
-  }
-
-  /// \brief Unsubscribe from the current topic.
-  public: void Stop()
-  {
-    if (!this->topic.empty())
-    {
-      this->node.Unsubscribe(this->topic);
-      this->topic.clear();
-    }
-  }
-
-  /// \brief Clear post-reset received state and count.
-  ///
-  /// The last message is intentionally kept for debugging. Tests should check
-  /// Received() or Count() before reading Msg() after Clear().
-  public: void Clear()
-  {
-    this->msgReceived = false;
-    this->msgCount = 0u;
-  }
-
-  /// \brief Clear only the received flag while preserving the message count.
-  ///
-  /// This is useful when a test wants to wait for a fresh message but still
-  /// keep a cumulative count.
-  public: void ClearReceived()
-  {
-    this->msgReceived = false;
-  }
-
-  /// \brief Return whether a message was received after the last Clear().
-  public: bool Received() const
-  {
-    return this->msgReceived.load();
-  }
-
-  /// \brief Return the number of messages received after the last Clear().
-  public: unsigned int Count() const
-  {
-    return this->msgCount.load();
-  }
-
-  /// \brief Return the latest message.
-  public: T Msg() const
-  {
-    std::lock_guard<std::mutex> lk(this->msgMutex);
-    return this->lastMsg;
-  }
-
-  /// \brief Return the latest message.
-  public: T Last() const
-  {
-    return this->Msg();
-  }
-
-  /// \brief Topic callback.
-  /// \param[in] _msg Received message.
-  private: void Callback(const T &_msg)
-  {
-    std::lock_guard<std::mutex> lk(this->msgMutex);
-    this->lastMsg = _msg;
-    this->msgReceived = true;
-    ++this->msgCount;
-  }
-
-  /// \brief Topic name.
-  private: std::string topic;
-
-  /// \brief Guards latest message access.
-  private: mutable std::mutex msgMutex;
-
-  /// \brief Latest message.
-  private: T lastMsg;
-
-  /// \brief Transport node.
-  private: gz::transport::Node node;
-
-  /// \brief True when a message was received after the last Clear().
-  private: std::atomic<bool> msgReceived{false};
-
-  /// \brief Number of messages received after the last Clear().
-  private: std::atomic<unsigned int> msgCount{0u};
-};
 }
 
 #endif  // GZ_SIM_TEST_HELPERS_RESET_UTILS_HH_

--- a/test/helpers/ResetUtils.hh
+++ b/test/helpers/ResetUtils.hh
@@ -1,0 +1,253 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef GZ_SIM_TEST_HELPERS_RESET_UTILS_HH_
+#define GZ_SIM_TEST_HELPERS_RESET_UTILS_HH_
+
+#include <gtest/gtest.h>
+
+#include <gz/msgs/boolean.pb.h>
+#include <gz/msgs/world_control.pb.h>
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include <gz/sim/Server.hh>
+#include <gz/transport/Node.hh>
+
+namespace gz::sim::test::reset
+{
+namespace detail
+{
+/////////////////////////////////////////////////
+/// \brief Run one unpaused blocking server step.
+/// \param[in] _server Server to step.
+inline void RunOneUnpausedStep(gz::sim::Server &_server)
+{
+  _server.Run(true, 1, false);
+}
+}
+
+/////////////////////////////////////////////////
+/// \brief Request a world reset over transport.
+/// \param[in] _worldName Name of the world to reset.
+inline void RequestWorldReset(const std::string &_worldName)
+{
+  gz::msgs::WorldControl req;
+  gz::msgs::Boolean rep;
+  req.mutable_reset()->set_all(true);
+  gz::transport::Node node;
+
+  constexpr unsigned int timeout = 1000u;
+  bool result = false;
+  const bool executed = node.Request(
+      "/world/" + _worldName + "/control", req, timeout, rep, result);
+
+  ASSERT_TRUE(executed);
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(rep.data());
+}
+
+/////////////////////////////////////////////////
+/// \brief Run one step so the server consumes the reset request.
+/// \param[in] _server Server to step.
+inline void ConsumeResetRequest(gz::sim::Server &_server)
+{
+  detail::RunOneUnpausedStep(_server);
+}
+
+/////////////////////////////////////////////////
+/// \brief Run one step so the simulation runner applies the reset.
+/// \param[in] _server Server to step.
+inline void ApplyWorldReset(gz::sim::Server &_server)
+{
+  detail::RunOneUnpausedStep(_server);
+}
+
+/////////////////////////////////////////////////
+/// \brief Request and apply a world reset using the standard two-step flow.
+/// \param[in] _server Server to step.
+/// \param[in] _worldName Name of the world to reset.
+inline void RequestAndApplyWorldReset(
+    gz::sim::Server &_server, const std::string &_worldName)
+{
+  RequestWorldReset(_worldName);
+  ConsumeResetRequest(_server);
+  ApplyWorldReset(_server);
+}
+
+/////////////////////////////////////////////////
+/// \brief Step the server until a predicate becomes true.
+/// \param[in] _server Server to step.
+/// \param[in] _maxSteps Maximum number of single steps.
+/// \param[in] _predicate Predicate to evaluate before and after each step.
+/// \return True when the predicate became true.
+template <typename Predicate>
+bool StepUntil(
+    gz::sim::Server &_server, uint64_t _maxSteps, Predicate _predicate)
+{
+  if (_predicate())
+    return true;
+
+  for (uint64_t i = 0; i < _maxSteps; ++i)
+  {
+    detail::RunOneUnpausedStep(_server);
+    if (_predicate())
+      return true;
+  }
+
+  return false;
+}
+
+/////////////////////////////////////////////////
+/// \brief Wait without advancing simulation until a predicate becomes true.
+/// \param[in] _timeout Maximum wall-clock wait.
+/// \param[in] _predicate Predicate to evaluate.
+/// \return True when the predicate became true.
+template <typename Predicate>
+bool WaitUntil(
+    const std::chrono::steady_clock::duration &_timeout,
+    Predicate _predicate)
+{
+  const auto deadline = std::chrono::steady_clock::now() + _timeout;
+  while (std::chrono::steady_clock::now() < deadline)
+  {
+    if (_predicate())
+      return true;
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  return _predicate();
+}
+
+/////////////////////////////////////////////////
+/// \brief Helper that records messages from a topic.
+template <typename T>
+class MsgReceiver
+{
+  /// \brief Destructor.
+  public: ~MsgReceiver()
+  {
+    this->Stop();
+  }
+
+  /// \brief Subscribe to a topic and clear received state.
+  /// \param[in] _topic Topic to subscribe to.
+  /// \return True when subscription succeeded.
+  public: bool Start(const std::string &_topic)
+  {
+    this->Stop();
+    this->topic = _topic;
+    this->Clear();
+
+    const bool subscribed =
+      this->node.Subscribe(_topic, &MsgReceiver<T>::Callback, this);
+    if (!subscribed)
+      this->topic.clear();
+
+    return subscribed;
+  }
+
+  /// \brief Unsubscribe from the current topic.
+  public: void Stop()
+  {
+    if (!this->topic.empty())
+    {
+      this->node.Unsubscribe(this->topic);
+      this->topic.clear();
+    }
+  }
+
+  /// \brief Clear post-reset received state and count.
+  ///
+  /// The last message is intentionally kept for debugging. Tests should check
+  /// Received() or Count() before reading Msg() after Clear().
+  public: void Clear()
+  {
+    this->msgReceived = false;
+    this->msgCount = 0u;
+  }
+
+  /// \brief Clear only the received flag while preserving the message count.
+  ///
+  /// This is useful when a test wants to wait for a fresh message but still
+  /// keep a cumulative count.
+  public: void ClearReceived()
+  {
+    this->msgReceived = false;
+  }
+
+  /// \brief Return whether a message was received after the last Clear().
+  public: bool Received() const
+  {
+    return this->msgReceived.load();
+  }
+
+  /// \brief Return the number of messages received after the last Clear().
+  public: unsigned int Count() const
+  {
+    return this->msgCount.load();
+  }
+
+  /// \brief Return the latest message.
+  public: T Msg() const
+  {
+    std::lock_guard<std::mutex> lk(this->msgMutex);
+    return this->lastMsg;
+  }
+
+  /// \brief Return the latest message.
+  public: T Last() const
+  {
+    return this->Msg();
+  }
+
+  /// \brief Topic callback.
+  /// \param[in] _msg Received message.
+  private: void Callback(const T &_msg)
+  {
+    std::lock_guard<std::mutex> lk(this->msgMutex);
+    this->lastMsg = _msg;
+    this->msgReceived = true;
+    ++this->msgCount;
+  }
+
+  /// \brief Topic name.
+  private: std::string topic;
+
+  /// \brief Guards latest message access.
+  private: mutable std::mutex msgMutex;
+
+  /// \brief Latest message.
+  private: T lastMsg;
+
+  /// \brief Transport node.
+  private: gz::transport::Node node;
+
+  /// \brief True when a message was received after the last Clear().
+  private: std::atomic<bool> msgReceived{false};
+
+  /// \brief Number of messages received after the last Clear().
+  private: std::atomic<unsigned int> msgCount{0u};
+};
+}
+
+#endif  // GZ_SIM_TEST_HELPERS_RESET_UTILS_HH_

--- a/test/helpers/Subscription.hh
+++ b/test/helpers/Subscription.hh
@@ -23,8 +23,11 @@
 #ifndef GZ_SIM_TEST_HELPERS_SUBSCRIPTION_HH
 #define GZ_SIM_TEST_HELPERS_SUBSCRIPTION_HH
 
+#include <chrono>
+#include <condition_variable>
 #include <deque>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 
 #include <gz/transport/Node.hh>
@@ -108,6 +111,35 @@ class Subscription
   {
     std::lock_guard<std::mutex> lock(this->mutex);
     this->messageHistory.clear();
+  }
+
+  /// \brief Clear received messages and reset the message count.
+  public: void Clear()
+  {
+    std::lock_guard<std::mutex> lock(this->mutex);
+    this->messageHistory.clear();
+    this->messageCount = 0u;
+  }
+
+  /// \brief Return the number of messages received since subscription or clear.
+  /// \return Number of messages received.
+  public: size_t Count()
+  {
+    std::lock_guard<std::mutex> lock(this->mutex);
+    return this->messageCount;
+  }
+
+  /// \brief Read last message received without removing it.
+  /// \throws std::runtime_error if there is no message to be read.
+  /// \return Last message received.
+  public: MessageT Last()
+  {
+    std::lock_guard<std::mutex> lock(this->mutex);
+    if (this->messageHistory.empty())
+    {
+      throw std::runtime_error("No messages to read");
+    }
+    return this->messageHistory.back();
   }
 
   /// \brief Read last message received.

--- a/test/helpers/TestFixture.hh
+++ b/test/helpers/TestFixture.hh
@@ -37,6 +37,7 @@
 
 #include "helpers/ModelManipulator.hh"
 #include "helpers/ModelObserver.hh"
+#include "helpers/ResetUtils.hh"
 
 using namespace gz;
 
@@ -133,6 +134,44 @@ class TestFixture
       iterations += this->Iterations() - previous_iterations;
     } while (this->info.simTime < deadline);
     return iterations;
+  }
+
+  /// Request a world reset over transport.
+  /// \param[in] _worldName Name of the world to reset.
+  public: void RequestWorldReset(const std::string &_worldName)
+  {
+    sim::test::reset::RequestWorldReset(_worldName);
+  }
+
+  /// Run one step so the server consumes the reset request.
+  public: void ConsumeResetRequest()
+  {
+    sim::test::reset::ConsumeResetRequest(*this->Simulator());
+  }
+
+  /// Run one step so the simulation runner applies the reset.
+  public: void ApplyWorldReset()
+  {
+    sim::test::reset::ApplyWorldReset(*this->Simulator());
+  }
+
+  /// Request and apply a world reset using the standard two-step flow.
+  /// \param[in] _worldName Name of the world to reset.
+  public: void RequestAndApplyWorldReset(const std::string &_worldName)
+  {
+    sim::test::reset::RequestAndApplyWorldReset(
+        *this->Simulator(), _worldName);
+  }
+
+  /// Step until a predicate becomes true.
+  /// \param[in] _maxSteps Maximum number of single steps.
+  /// \param[in] _predicate Predicate to evaluate before and after each step.
+  /// \return True when the predicate became true.
+  public: template <typename Predicate>
+  bool StepUntil(uint64_t _maxSteps, Predicate _predicate)
+  {
+    return sim::test::reset::StepUntil(
+        *this->Simulator(), _maxSteps, _predicate);
   }
 
   /// Returns the total number of simulation iterations so far.

--- a/test/helpers/TestFixture.hh
+++ b/test/helpers/TestFixture.hh
@@ -37,6 +37,7 @@
 
 #include "helpers/ModelManipulator.hh"
 #include "helpers/ModelObserver.hh"
+#include "helpers/Util.hh"
 #include "helpers/ResetUtils.hh"
 
 using namespace gz;

--- a/test/helpers/TestFixture.hh
+++ b/test/helpers/TestFixture.hh
@@ -170,8 +170,7 @@ class TestFixture
   public: template <typename Predicate>
   bool StepUntil(uint64_t _maxSteps, Predicate _predicate)
   {
-    return sim::test::reset::StepUntil(
-        *this->Simulator(), _maxSteps, _predicate);
+    return sim::test::StepUntil(*this->Simulator(), _maxSteps, _predicate);
   }
 
   /// Returns the total number of simulation iterations so far.

--- a/test/helpers/Util.hh
+++ b/test/helpers/Util.hh
@@ -15,17 +15,78 @@
  *
  */
 
+#ifndef GZ_SIM_TEST_HELPERS_UTIL_HH_
+#define GZ_SIM_TEST_HELPERS_UTIL_HH_
+
 #include <chrono>
+#include <cstdint>
 #include <fstream>
 #include <optional>
 #include <string>
 #include <thread>
 #include <vector>
 
+#include <gz/sim/Server.hh>
 #include <gz/transport/Node.hh>
 
 namespace gz::sim::test
 {
+namespace detail
+{
+/////////////////////////////////////////////////
+/// \brief Run one unpaused blocking server step.
+/// \param[in] _server Server to step.
+inline void RunOneUnpausedStep(gz::sim::Server &_server)
+{
+  _server.Run(true, 1, false);
+}
+}  // namespace detail
+
+/////////////////////////////////////////////////
+/// \brief Step the server until a predicate becomes true.
+/// \param[in] _server Server to step.
+/// \param[in] _maxSteps Maximum number of single steps.
+/// \param[in] _predicate Predicate to evaluate before and after each step.
+/// \return True when the predicate becomes true.
+template <typename Predicate>
+bool StepUntil(
+    gz::sim::Server &_server, uint64_t _maxSteps, Predicate _predicate)
+{
+  if (_predicate())
+    return true;
+
+  for (uint64_t i = 0; i < _maxSteps; ++i)
+  {
+    detail::RunOneUnpausedStep(_server);
+    if (_predicate())
+      return true;
+  }
+
+  return false;
+}
+
+/////////////////////////////////////////////////
+/// \brief Wait without advancing simulation until a predicate becomes true.
+/// \param[in] _timeout Maximum wall-clock wait.
+/// \param[in] _predicate Predicate to evaluate.
+/// \return True when the predicate becomes true.
+template <typename Predicate>
+bool WaitUntil(
+    const std::chrono::steady_clock::duration &_timeout,
+    Predicate _predicate)
+{
+  const auto deadline = std::chrono::steady_clock::now() + _timeout;
+  while (std::chrono::steady_clock::now() < deadline)
+  {
+    if (_predicate())
+      return true;
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  return _predicate();
+}
+
 /// \brief Wait until a service becomes available.
 /// See https://github.com/gazebosim/gz-transport/issues/468 for why this might
 /// be necessary before make a service request.
@@ -64,3 +125,5 @@ std::optional<std::string> readFileContents(const std::string &_filePath)
                      std::istreambuf_iterator<char>());
 }
 }  // namespace gz::sim::test
+
+#endif  // GZ_SIM_TEST_HELPERS_UTIL_HH_

--- a/test/integration/reset.cc
+++ b/test/integration/reset.cc
@@ -17,9 +17,6 @@
 
 #include <gtest/gtest.h>
 
-#include <gz/msgs/boolean.pb.h>
-#include <gz/msgs/world_control.pb.h>
-
 #include <string>
 #include <vector>
 
@@ -27,7 +24,6 @@
 #include <sdf/Root.hh>
 #include <sdf/World.hh>
 
-#include <gz/transport/Node.hh>
 #include <gz/utils/ExtraTestMacros.hh>
 
 #include "gz/sim/Entity.hh"
@@ -46,11 +42,13 @@
 
 #include "plugins/MockSystem.hh"
 #include "../helpers/EnvTestFixture.hh"
+#include "helpers/ResetUtils.hh"
 
 using namespace gz;
 using namespace sim;
 using namespace std::chrono_literals;
 namespace components = gz::sim::components;
+namespace reset = gz::sim::test::reset;
 
 //////////////////////////////////////////////////
 class ResetFixture: public InternalFixture<::testing::Test>
@@ -74,24 +72,6 @@ class ResetFixture: public InternalFixture<::testing::Test>
 
   private: sim::SystemLoader sm;
 };
-
-/////////////////////////////////////////////////
-void worldReset()
-{
-  gz::msgs::WorldControl req;
-  gz::msgs::Boolean rep;
-  req.mutable_reset()->set_all(true);
-  transport::Node node;
-
-  unsigned int timeout = 1000;
-  bool result;
-  bool executed =
-    node.Request("/world/default/control", req, timeout, rep, result);
-
-  ASSERT_TRUE(executed);
-  ASSERT_TRUE(result);
-  ASSERT_TRUE(rep.data());
-}
 
 /////////////////////////////////////////////////
 /// This test checks that that the physics system handles cases where entities
@@ -165,11 +145,11 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(HandleReset))
     };
 
   // Send command to reset to initial state
-  worldReset();
+  reset::RequestWorldReset("default");
 
   // It takes two iterations for this to propagate,
   // the first is for the message to be received and internal state setup
-  server.Run(true, 1, false);
+  reset::ConsumeResetRequest(server);
   EXPECT_EQ(1u, this->mockSystem->configureCallCount);
   EXPECT_EQ(0u, this->mockSystem->resetCallCount);
   EXPECT_EQ(101u, this->mockSystem->preUpdateCallCount);
@@ -177,7 +157,7 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(HandleReset))
   EXPECT_EQ(101u, this->mockSystem->postUpdateCallCount);
 
   // The second iteration is where the reset actually occurs.
-  server.Run(true, 1, false);
+  reset::ApplyWorldReset(server);
   {
     ASSERT_NE(nullptr, ecm);
     auto entity = ecm->EntityByComponents(components::Name("box"));

--- a/test/integration/reset_detachable_joint.cc
+++ b/test/integration/reset_detachable_joint.cc
@@ -33,9 +33,7 @@
 
 #include <gtest/gtest.h>
 
-#include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/contacts.pb.h>
-#include <gz/msgs/world_control.pb.h>
 
 #include <string>
 #include <vector>
@@ -44,7 +42,6 @@
 #include <sdf/Root.hh>
 #include <sdf/World.hh>
 
-#include <gz/transport/Node.hh>
 #include <gz/utils/ExtraTestMacros.hh>
 
 #include "gz/sim/Entity.hh"
@@ -69,10 +66,12 @@
 
 #include "plugins/MockSystem.hh"
 #include "../helpers/EnvTestFixture.hh"
+#include "helpers/ResetUtils.hh"
 
 using namespace gz;
 using namespace sim;
 using namespace std::chrono_literals;
+namespace reset = gz::sim::test::reset;
 
 /// \brief Name of the arm model
 constexpr const char* kArmName = "simple_arm";
@@ -261,25 +260,6 @@ class ResetDetachableJointTest : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-/// \brief Reset the simulation world via transport
-void worldReset()
-{
-  gz::msgs::WorldControl req;
-  gz::msgs::Boolean rep;
-  req.mutable_reset()->set_all(true);
-  transport::Node node;
-
-  unsigned int timeout = 1000;
-  bool result;
-  bool executed =
-    node.Request("/world/default/control", req, timeout, rep, result);
-
-  ASSERT_TRUE(executed);
-  ASSERT_TRUE(result);
-  ASSERT_TRUE(rep.data());
-}
-
-/////////////////////////////////////////////////
 TEST_F(ResetDetachableJointTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(HandleReset))
 {
   this->StartServer("/test/worlds/reset_detachable_joint.sdf");
@@ -288,14 +268,14 @@ TEST_F(ResetDetachableJointTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(HandleReset))
   ASSERT_FALSE(this->system->errorLogged);
 
   // First Reset
-  worldReset();
-  this->server->Run(true, 5000, false);
+  reset::RequestAndApplyWorldReset(*this->server, "default");
+  this->server->Run(true, 4998, false);
   ASSERT_TRUE(this->system->didReset);
   ASSERT_FALSE(this->system->errorLogged);
 
   // Second Reset
-  worldReset();
-  server->Run(true, 1000, false);
+  reset::RequestAndApplyWorldReset(*this->server, "default");
+  server->Run(true, 998, false);
   ASSERT_TRUE(this->system->didReset);
   ASSERT_FALSE(this->system->errorLogged);
 }

--- a/test/integration/reset_detachable_joint.cc
+++ b/test/integration/reset_detachable_joint.cc
@@ -66,12 +66,10 @@
 
 #include "plugins/MockSystem.hh"
 #include "../helpers/EnvTestFixture.hh"
-#include "helpers/ResetUtils.hh"
 
 using namespace gz;
 using namespace sim;
 using namespace std::chrono_literals;
-namespace reset = gz::sim::test::reset;
 
 /// \brief Name of the arm model
 constexpr const char* kArmName = "simple_arm";
@@ -268,14 +266,16 @@ TEST_F(ResetDetachableJointTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(HandleReset))
   ASSERT_FALSE(this->system->errorLogged);
 
   // First Reset
-  reset::RequestAndApplyWorldReset(*this->server, "default");
+  this->server->ResetAll();
+  this->server->Run(true, 2, false);
   this->server->Run(true, 4998, false);
   ASSERT_TRUE(this->system->didReset);
   ASSERT_FALSE(this->system->errorLogged);
 
   // Second Reset
-  reset::RequestAndApplyWorldReset(*this->server, "default");
-  server->Run(true, 998, false);
+  this->server->ResetAll();
+  this->server->Run(true, 2, false);
+  this->server->Run(true, 998, false);
   ASSERT_TRUE(this->system->didReset);
   ASSERT_FALSE(this->system->errorLogged);
 }

--- a/test/integration/reset_sensors.cc
+++ b/test/integration/reset_sensors.cc
@@ -38,6 +38,7 @@
 
 #include "plugins/MockSystem.hh"
 #include "helpers/EnvTestFixture.hh"
+#include "helpers/Util.hh"
 #include "helpers/ResetUtils.hh"
 
 using namespace gz;
@@ -164,7 +165,7 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
   // Run until a sensor measurement
   ASSERT_TRUE(pressureReceiver.Start(topic));
   ASSERT_TRUE(imageReceiver.Start("camera"));
-  ASSERT_TRUE(reset::StepUntil(server, target,
+  ASSERT_TRUE(gz::sim::test::StepUntil(server, target,
       [&pressureReceiver]()
       {
         return pressureReceiver.Received();
@@ -173,7 +174,7 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
   EXPECT_GE(server.IterationCount().value(), current);
   EXPECT_FLOAT_EQ(kStartingPressure, pressureReceiver.Last().pressure());
 
-  ASSERT_TRUE(reset::StepUntil(server, target,
+  ASSERT_TRUE(gz::sim::test::StepUntil(server, target,
       [&imageReceiver]()
       {
         return imageReceiver.Received();
@@ -191,7 +192,7 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
   pressureReceiver.ClearReceived();
   imageReceiver.ClearReceived();
   server.Run(true, target - server.IterationCount().value(), false);
-  ASSERT_TRUE(reset::WaitUntil(5s,
+  ASSERT_TRUE(gz::sim::test::WaitUntil(5s,
       [&pressureReceiver, &imageReceiver]()
       {
         return pressureReceiver.Received() && imageReceiver.Received();
@@ -222,7 +223,7 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
 
   // wait until expected no. of messages are received.
   // sim runs for 2000 iterations with camera at 10 Hz + 1 msg at t=0
-  ASSERT_TRUE(reset::WaitUntil(5s,
+  ASSERT_TRUE(gz::sim::test::WaitUntil(5s,
       [&imageReceiver]()
       {
         return imageReceiver.Count() >= 21u;
@@ -263,7 +264,7 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
 
   target = 4001;
 
-  ASSERT_TRUE(reset::StepUntil(server, 2000u,
+  ASSERT_TRUE(gz::sim::test::StepUntil(server, 2000u,
       [&pressureReceiver]()
       {
         return pressureReceiver.Received();
@@ -271,7 +272,7 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
   EXPECT_GE(server.IterationCount().value(), 1u);
   EXPECT_FLOAT_EQ(kStartingPressure, pressureReceiver.Last().pressure());
 
-  ASSERT_TRUE(reset::StepUntil(server, 2000u,
+  ASSERT_TRUE(gz::sim::test::StepUntil(server, 2000u,
       [&imageReceiver]()
       {
         return imageReceiver.Received();
@@ -291,7 +292,7 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
   imageReceiver.ClearReceived();
 
   server.Run(true, 2000 - server.IterationCount().value(), false);
-  ASSERT_TRUE(reset::WaitUntil(5s,
+  ASSERT_TRUE(gz::sim::test::WaitUntil(5s,
       [&pressureReceiver, &imageReceiver]()
       {
         return pressureReceiver.Received() && imageReceiver.Received();

--- a/test/integration/reset_sensors.cc
+++ b/test/integration/reset_sensors.cc
@@ -40,6 +40,7 @@
 #include "helpers/EnvTestFixture.hh"
 #include "helpers/Util.hh"
 #include "helpers/ResetUtils.hh"
+#include "helpers/Subscription.hh"
 
 using namespace gz;
 using namespace sim;
@@ -117,8 +118,9 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
   auto topic = "world/default/model/box/link/link/"
       "sensor/air_pressure_sensor/air_pressure";
 
-  auto pressureReceiver = reset::MsgReceiver<msgs::FluidPressure>();
-  auto imageReceiver = reset::MsgReceiver<msgs::Image>();
+  transport::Node node;
+  Subscription<msgs::FluidPressure> pressureReceiver;
+  Subscription<msgs::Image> imageReceiver;
 
   // A pointer to the ecm. This will be valid once we run the mock system
   sim::EntityComponentManager *ecm = nullptr;
@@ -161,23 +163,28 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
 
   auto current = 1u;
   auto target = 2000u;
+  const auto remainingSteps = [&server](uint64_t _target)
+  {
+    const auto iteration = server.IterationCount().value_or(0u);
+    return iteration < _target ? _target - iteration : 0u;
+  };
 
   // Run until a sensor measurement
-  ASSERT_TRUE(pressureReceiver.Start(topic));
-  ASSERT_TRUE(imageReceiver.Start("camera"));
-  ASSERT_TRUE(gz::sim::test::StepUntil(server, target,
+  pressureReceiver.Subscribe(node, topic, 1u);
+  imageReceiver.Subscribe(node, "camera", 1u);
+  ASSERT_TRUE(gz::sim::test::StepUntil(server, remainingSteps(target),
       [&pressureReceiver]()
       {
-        return pressureReceiver.Received();
+        return pressureReceiver.Count() > 0u;
       }));
 
   EXPECT_GE(server.IterationCount().value(), current);
   EXPECT_FLOAT_EQ(kStartingPressure, pressureReceiver.Last().pressure());
 
-  ASSERT_TRUE(gz::sim::test::StepUntil(server, target,
+  ASSERT_TRUE(gz::sim::test::StepUntil(server, remainingSteps(target),
       [&imageReceiver]()
       {
-        return imageReceiver.Received();
+        return imageReceiver.Count() > 0u;
       }));
 
   // Mostly green box
@@ -189,13 +196,15 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
     EXPECT_FLOAT_EQ(0.0, centerPix.B());
   }
   // Run until 2000 steps
-  pressureReceiver.ClearReceived();
-  imageReceiver.ClearReceived();
-  server.Run(true, target - server.IterationCount().value(), false);
+  const auto pressureCountBeforeRun = pressureReceiver.Count();
+  const auto imageCountBeforeRun = imageReceiver.Count();
+  server.Run(true, remainingSteps(target), false);
   ASSERT_TRUE(gz::sim::test::WaitUntil(5s,
-      [&pressureReceiver, &imageReceiver]()
+      [&pressureReceiver, &imageReceiver, pressureCountBeforeRun,
+       imageCountBeforeRun]()
       {
-        return pressureReceiver.Received() && imageReceiver.Received();
+        return pressureReceiver.Count() > pressureCountBeforeRun &&
+            imageReceiver.Count() > imageCountBeforeRun;
       }));
 
   // Check iterator state
@@ -207,8 +216,8 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
   EXPECT_EQ(target, this->mockSystem->postUpdateCallCount);
 
   // Check world state
-  EXPECT_TRUE(pressureReceiver.Received());
-  EXPECT_TRUE(imageReceiver.Received());
+  EXPECT_GT(pressureReceiver.Count(), pressureCountBeforeRun);
+  EXPECT_GT(imageReceiver.Count(), imageCountBeforeRun);
   EXPECT_FLOAT_EQ(kEndingAltitude, poseComp->Data().Z());
   EXPECT_FLOAT_EQ(kEndingPressure, pressureReceiver.Last().pressure());
 
@@ -241,8 +250,8 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
   EXPECT_EQ(target + 1, this->mockSystem->updateCallCount);
   EXPECT_EQ(target + 1, this->mockSystem->postUpdateCallCount);
 
-  imageReceiver.ClearReceived();
-  pressureReceiver.ClearReceived();
+  const auto imageCountBeforeResetApply = imageReceiver.Count();
+  const auto pressureCountBeforeResetApply = pressureReceiver.Count();
 
   // The second iteration is where the reset actually occurs.
   reset::ApplyWorldReset(server);
@@ -258,24 +267,27 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
     EXPECT_FLOAT_EQ(kStartingAltitude, poseComp->Data().Z());
 
     // Reset does not cause messages to be sent
-    EXPECT_FALSE(imageReceiver.Received());
-    EXPECT_FALSE(pressureReceiver.Received());
+    EXPECT_EQ(imageCountBeforeResetApply, imageReceiver.Count());
+    EXPECT_EQ(pressureCountBeforeResetApply, pressureReceiver.Count());
   }
 
   target = 4001;
+  const auto postResetTarget = 2000u;
 
-  ASSERT_TRUE(gz::sim::test::StepUntil(server, 2000u,
-      [&pressureReceiver]()
+  const auto pressureCountBeforePostReset = pressureReceiver.Count();
+  ASSERT_TRUE(gz::sim::test::StepUntil(server, remainingSteps(postResetTarget),
+      [&pressureReceiver, pressureCountBeforePostReset]()
       {
-        return pressureReceiver.Received();
+        return pressureReceiver.Count() > pressureCountBeforePostReset;
       }));
   EXPECT_GE(server.IterationCount().value(), 1u);
   EXPECT_FLOAT_EQ(kStartingPressure, pressureReceiver.Last().pressure());
 
-  ASSERT_TRUE(gz::sim::test::StepUntil(server, 2000u,
-      [&imageReceiver]()
+  const auto imageCountBeforePostReset = imageReceiver.Count();
+  ASSERT_TRUE(gz::sim::test::StepUntil(server, remainingSteps(postResetTarget),
+      [&imageReceiver, imageCountBeforePostReset]()
       {
-        return imageReceiver.Received();
+        return imageReceiver.Count() > imageCountBeforePostReset;
       }));
 
   // Mostly green box
@@ -288,18 +300,20 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
   }
 
   // Run until target steps
-  pressureReceiver.ClearReceived();
-  imageReceiver.ClearReceived();
+  const auto pressureCountBeforeSecondRun = pressureReceiver.Count();
+  const auto imageCountBeforeSecondRun = imageReceiver.Count();
 
-  server.Run(true, 2000 - server.IterationCount().value(), false);
+  server.Run(true, remainingSteps(postResetTarget), false);
   ASSERT_TRUE(gz::sim::test::WaitUntil(5s,
-      [&pressureReceiver, &imageReceiver]()
+      [&pressureReceiver, &imageReceiver, pressureCountBeforeSecondRun,
+       imageCountBeforeSecondRun]()
       {
-        return pressureReceiver.Received() && imageReceiver.Received();
+        return pressureReceiver.Count() > pressureCountBeforeSecondRun &&
+            imageReceiver.Count() > imageCountBeforeSecondRun;
       }));
 
   // Check iterator state
-  EXPECT_EQ(2000u, server.IterationCount().value());
+  EXPECT_EQ(postResetTarget, server.IterationCount().value());
   EXPECT_EQ(1u, this->mockSystem->configureCallCount);
   EXPECT_EQ(1u, this->mockSystem->resetCallCount);
   EXPECT_EQ(target, this->mockSystem->preUpdateCallCount);
@@ -307,8 +321,8 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
   EXPECT_EQ(target, this->mockSystem->postUpdateCallCount);
 
   // Check world state
-  EXPECT_TRUE(pressureReceiver.Received());
-  EXPECT_TRUE(imageReceiver.Received());
+  EXPECT_GT(pressureReceiver.Count(), pressureCountBeforeSecondRun);
+  EXPECT_GT(imageReceiver.Count(), imageCountBeforeSecondRun);
   EXPECT_FLOAT_EQ(kEndingAltitude, poseComp->Data().Z());
   EXPECT_FLOAT_EQ(kEndingPressure, pressureReceiver.Last().pressure());
 

--- a/test/integration/reset_sensors.cc
+++ b/test/integration/reset_sensors.cc
@@ -261,7 +261,6 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
     EXPECT_FALSE(pressureReceiver.Received());
   }
 
-  current = 2001;
   target = 4001;
 
   ASSERT_TRUE(reset::StepUntil(server, 2000u,

--- a/test/integration/reset_sensors.cc
+++ b/test/integration/reset_sensors.cc
@@ -17,19 +17,16 @@
 
 #include <gtest/gtest.h>
 
-#include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/image.pb.h>
 #include <gz/msgs/fluid_pressure.pb.h>
-#include <gz/msgs/world_control.pb.h>
 
+#include <chrono>
 #include <string>
-#include <thread>
 #include <vector>
 
 #include <sdf/Element.hh>
 #include <sdf/Root.hh>
 #include <gz/common/Image.hh>
-#include <gz/transport/Node.hh>
 #include <gz/utils/ExtraTestMacros.hh>
 
 #include "gz/sim/Server.hh"
@@ -41,10 +38,12 @@
 
 #include "plugins/MockSystem.hh"
 #include "helpers/EnvTestFixture.hh"
+#include "helpers/ResetUtils.hh"
 
 using namespace gz;
 using namespace sim;
 using namespace std::chrono_literals;
+namespace reset = gz::sim::test::reset;
 
 constexpr double kStartingAltitude = 100.0f;
 constexpr double kStartingPressure = 100129.46;
@@ -74,58 +73,6 @@ class ResetFixture: public InternalFixture<InternalFixture<::testing::Test>>
 
   private: sim::SystemLoader sm;
 };
-
-template <typename T>
-struct MsgReceiver
-{
-  std::string topic;
-  std::mutex msgMutex;
-  T lastMsg;
-  transport::Node node;
-
-  std::atomic<bool> msgReceived = {false};
-  std::atomic<unsigned int> msgCount = 0;
-
-  void Start(const std::string &_topic) {
-    this->msgReceived = false;
-    this->node.Subscribe(_topic, &MsgReceiver<T>::Callback, this);
-    this->topic = _topic;
-  }
-
-  void Stop() {
-    this->node.Unsubscribe(this->topic);
-  }
-
-  void Callback(const T &_msg) {
-    std::lock_guard<std::mutex> lk(this->msgMutex);
-    this->lastMsg = _msg;
-    this->msgReceived = true;
-    this->msgCount++;
-  }
-
-  T Last() {
-    std::lock_guard<std::mutex> lk(this->msgMutex);
-    return this->lastMsg;
-  }
-};
-
-/////////////////////////////////////////////////
-void worldReset()
-{
-  gz::msgs::WorldControl req;
-  gz::msgs::Boolean rep;
-  req.mutable_reset()->set_all(true);
-  transport::Node node;
-
-  unsigned int timeout = 1000;
-  bool result;
-  bool executed =
-    node.Request("/world/default/control", req, timeout, rep, result);
-
-  ASSERT_TRUE(executed);
-  ASSERT_TRUE(result);
-  ASSERT_TRUE(rep.data());
-}
 
 common::Image toImage(const msgs::Image &_msg)
 {
@@ -169,8 +116,8 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
   auto topic = "world/default/model/box/link/link/"
       "sensor/air_pressure_sensor/air_pressure";
 
-  auto pressureReceiver = MsgReceiver<msgs::FluidPressure>();
-  auto imageReceiver = MsgReceiver<msgs::Image>();
+  auto pressureReceiver = reset::MsgReceiver<msgs::FluidPressure>();
+  auto imageReceiver = reset::MsgReceiver<msgs::Image>();
 
   // A pointer to the ecm. This will be valid once we run the mock system
   sim::EntityComponentManager *ecm = nullptr;
@@ -215,22 +162,22 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
   auto target = 2000u;
 
   // Run until a sensor measurement
-  pressureReceiver.Start(topic);
-  imageReceiver.Start("camera");
-  while (!pressureReceiver.msgReceived)
-  {
-    // Step once to get sensor to output measurement
-    server.Run(true, 1, false);
-  }
+  ASSERT_TRUE(pressureReceiver.Start(topic));
+  ASSERT_TRUE(imageReceiver.Start("camera"));
+  ASSERT_TRUE(reset::StepUntil(server, target,
+      [&pressureReceiver]()
+      {
+        return pressureReceiver.Received();
+      }));
 
   EXPECT_GE(server.IterationCount().value(), current);
   EXPECT_FLOAT_EQ(kStartingPressure, pressureReceiver.Last().pressure());
 
-  while (!imageReceiver.msgReceived)
-  {
-    // Step once to get sensor to output measurement
-    server.Run(true, 1, false);
-  }
+  ASSERT_TRUE(reset::StepUntil(server, target,
+      [&imageReceiver]()
+      {
+        return imageReceiver.Received();
+      }));
 
   // Mostly green box
   {
@@ -241,9 +188,14 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
     EXPECT_FLOAT_EQ(0.0, centerPix.B());
   }
   // Run until 2000 steps
-  pressureReceiver.msgReceived = false;
-  imageReceiver.msgReceived = false;
+  pressureReceiver.ClearReceived();
+  imageReceiver.ClearReceived();
   server.Run(true, target - server.IterationCount().value(), false);
+  ASSERT_TRUE(reset::WaitUntil(5s,
+      [&pressureReceiver, &imageReceiver]()
+      {
+        return pressureReceiver.Received() && imageReceiver.Received();
+      }));
 
   // Check iterator state
   EXPECT_EQ(target, server.IterationCount().value());
@@ -254,8 +206,8 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
   EXPECT_EQ(target, this->mockSystem->postUpdateCallCount);
 
   // Check world state
-  EXPECT_TRUE(pressureReceiver.msgReceived);
-  EXPECT_TRUE(imageReceiver.msgReceived);
+  EXPECT_TRUE(pressureReceiver.Received());
+  EXPECT_TRUE(imageReceiver.Received());
   EXPECT_FLOAT_EQ(kEndingAltitude, poseComp->Data().Z());
   EXPECT_FLOAT_EQ(kEndingPressure, pressureReceiver.Last().pressure());
 
@@ -270,26 +222,29 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
 
   // wait until expected no. of messages are received.
   // sim runs for 2000 iterations with camera at 10 Hz + 1 msg at t=0
-  while (imageReceiver.msgCount < 21)
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  ASSERT_TRUE(reset::WaitUntil(5s,
+      [&imageReceiver]()
+      {
+        return imageReceiver.Count() >= 21u;
+      }));
 
   // Send command to reset to initial state
-  worldReset();
+  reset::RequestWorldReset("default");
 
   // It takes two iterations for this to propagate,
   // the first is for the message to be received and internal state setup
-  server.Run(true, 1, false);
+  reset::ConsumeResetRequest(server);
   EXPECT_EQ(1u, this->mockSystem->configureCallCount);
   EXPECT_EQ(0u, this->mockSystem->resetCallCount);
   EXPECT_EQ(target + 1, this->mockSystem->preUpdateCallCount);
   EXPECT_EQ(target + 1, this->mockSystem->updateCallCount);
   EXPECT_EQ(target + 1, this->mockSystem->postUpdateCallCount);
 
-  imageReceiver.msgReceived = false;
-  pressureReceiver.msgReceived = false;
+  imageReceiver.ClearReceived();
+  pressureReceiver.ClearReceived();
 
   // The second iteration is where the reset actually occurs.
-  server.Run(true, 1, false);
+  reset::ApplyWorldReset(server);
   {
     EXPECT_EQ(1u, this->mockSystem->configureCallCount);
     EXPECT_EQ(1u, this->mockSystem->resetCallCount);
@@ -302,26 +257,26 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
     EXPECT_FLOAT_EQ(kStartingAltitude, poseComp->Data().Z());
 
     // Reset does not cause messages to be sent
-    EXPECT_FALSE(imageReceiver.msgReceived);
-    EXPECT_FALSE(pressureReceiver.msgReceived);
+    EXPECT_FALSE(imageReceiver.Received());
+    EXPECT_FALSE(pressureReceiver.Received());
   }
 
   current = 2001;
   target = 4001;
 
-  while (!pressureReceiver.msgReceived)
-  {
-    // Step once to get sensor to output measurement
-    server.Run(true, 1, false);
-  }
+  ASSERT_TRUE(reset::StepUntil(server, 2000u,
+      [&pressureReceiver]()
+      {
+        return pressureReceiver.Received();
+      }));
   EXPECT_GE(server.IterationCount().value(), 1u);
   EXPECT_FLOAT_EQ(kStartingPressure, pressureReceiver.Last().pressure());
 
-  while (!imageReceiver.msgReceived)
-  {
-    // Step once to get sensor to output measurement
-    server.Run(true, 1, false);
-  }
+  ASSERT_TRUE(reset::StepUntil(server, 2000u,
+      [&imageReceiver]()
+      {
+        return imageReceiver.Received();
+      }));
 
   // Mostly green box
   {
@@ -333,11 +288,15 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
   }
 
   // Run until target steps
-  pressureReceiver.msgReceived = false;
-  imageReceiver.msgReceived = false;
+  pressureReceiver.ClearReceived();
+  imageReceiver.ClearReceived();
 
   server.Run(true, 2000 - server.IterationCount().value(), false);
-  std::this_thread::sleep_for(20ms);
+  ASSERT_TRUE(reset::WaitUntil(5s,
+      [&pressureReceiver, &imageReceiver]()
+      {
+        return pressureReceiver.Received() && imageReceiver.Received();
+      }));
 
   // Check iterator state
   EXPECT_EQ(2000u, server.IterationCount().value());
@@ -348,8 +307,8 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
   EXPECT_EQ(target, this->mockSystem->postUpdateCallCount);
 
   // Check world state
-  EXPECT_TRUE(pressureReceiver.msgReceived);
-  EXPECT_TRUE(imageReceiver.msgReceived);
+  EXPECT_TRUE(pressureReceiver.Received());
+  EXPECT_TRUE(imageReceiver.Received());
   EXPECT_FLOAT_EQ(kEndingAltitude, poseComp->Data().Z());
   EXPECT_FLOAT_EQ(kEndingPressure, pressureReceiver.Last().pressure());
 


### PR DESCRIPTION

## Summary
This PR adds shared reset test utilities and migrates the existing reset integration tests to use them.

The new helper centralizes:

- world reset requests through `/world/<name>/control`
- the two-step reset propagation flow
- stepping until simulation-side conditions become true
- waiting for asynchronous transport messages
- topic message capture through a reusable `MsgReceiver`

## Details

The reset flow intentionally keeps `ConsumeResetRequest` and `ApplyWorldReset` as separate public helpers. They currently share the same one-step implementation, but represent different observable reset phases in tests:

1. consume the reset request and set internal reset state
2. apply the reset through the simulation runner


This split is mainly for auditing the reset lifecycle itself. Most plugin reset tests can use `RequestAndApplyWorldReset` directly.

Migrated tests:
- `reset.cc`
- `reset_sensors.cc`
- `reset_detachable_joint.cc`

No system plugin behavior is changed.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
