### PR TITLE
Add a default for touch plugin namespace

### DIFF
--- a/src/systems/touch_plugin/TouchPlugin.cc
+++ b/src/systems/touch_plugin/TouchPlugin.cc
@@ -266,6 +266,8 @@ void TouchPluginPrivate::Load(EntityComponentManager &_ecm,
   else
   {
     nsParam = this->model.Name(_ecm) + "/touch";
+    gzmsg << "No namespace specified for TouchPlugin, defaulting to " <<
+      nsParam << std::endl;
   }
   this->ns = transport::TopicUtils::AsValidTopic(nsParam);
   if (this->ns.empty())

--- a/src/systems/touch_plugin/TouchPlugin.cc
+++ b/src/systems/touch_plugin/TouchPlugin.cc
@@ -257,18 +257,20 @@ void TouchPluginPrivate::Load(EntityComponentManager &_ecm,
     return;
   }
 
+  std::string nsParam;
   // Namespace
-  if (!_sdf->HasElement("namespace"))
+  if (_sdf->HasElement("namespace"))
   {
-    gzerr << "Missing required parameter <namespace>" << std::endl;
-    return;
+    nsParam = _sdf->Get<std::string>("namespace");
   }
-  this->ns = transport::TopicUtils::AsValidTopic(_sdf->Get<std::string>(
-      "namespace"));
+  else
+  {
+    nsParam = this->model.Name(_ecm) + "/touch";
+  }
+  this->ns = transport::TopicUtils::AsValidTopic(nsParam);
   if (this->ns.empty())
   {
-    gzerr << "<namespace> [" << _sdf->Get<std::string>("namespace")
-           << "] is invalid." << std::endl;
+    gzerr << "<namespace> [" << nsParam << "] is invalid." << std::endl;
     return;
   }
 

--- a/src/systems/touch_plugin/TouchPlugin.cc
+++ b/src/systems/touch_plugin/TouchPlugin.cc
@@ -261,11 +261,11 @@ void TouchPluginPrivate::Load(EntityComponentManager &_ecm,
   // Namespace
   if (_sdf->HasElement("namespace"))
   {
-    nsParam = _sdf->Get<std::string>("namespace");
+    nsParam = "/" + _sdf->Get<std::string>("namespace");
   }
   else
   {
-    nsParam = scopedName(this->model.Entity(), _ecm) + "/touch";
+    nsParam = topicFromScopedName(this->model.Entity(), _ecm, true) + "/touch";
     gzmsg << "No namespace specified for TouchPlugin, defaulting to " <<
       nsParam << std::endl;
   }
@@ -286,7 +286,7 @@ void TouchPluginPrivate::Load(EntityComponentManager &_ecm,
   this->targetTime = DurationType(_sdf->Get<double>("time"));
 
   // Start/stop "service"
-  std::string enableService{"/" + this->ns + "/enable"};
+  std::string enableService{this->ns + "/enable"};
   std::function<void(const msgs::Boolean &)> enableCb =
       [this](const msgs::Boolean &_req)
       {
@@ -313,7 +313,7 @@ void TouchPluginPrivate::Enable(const bool _value)
   {
     if (!this->touchedPub.has_value()){
       this->touchedPub = this->node.Advertise<msgs::Boolean>(
-          "/" + this->ns + "/touched");
+          this->ns + "/touched");
     }
 
     this->touchStart = DurationType::zero();

--- a/src/systems/touch_plugin/TouchPlugin.cc
+++ b/src/systems/touch_plugin/TouchPlugin.cc
@@ -265,7 +265,7 @@ void TouchPluginPrivate::Load(EntityComponentManager &_ecm,
   }
   else
   {
-    nsParam = this->model.Name(_ecm) + "/touch";
+    nsParam = scopedName(this->model.Entity(), _ecm) + "/touch";
     gzmsg << "No namespace specified for TouchPlugin, defaulting to " <<
       nsParam << std::endl;
   }

--- a/src/systems/touch_plugin/TouchPlugin.hh
+++ b/src/systems/touch_plugin/TouchPlugin.hh
@@ -65,13 +65,14 @@ namespace systems
   ///                 TouchPlugin system to be used without explicitly defining
   ///                 contact sensors inside links in SDF. Default to false.
   ///
-  /// - `<time>` Target time in seconds to maintain contact.
-  ///
-  /// - `<namespace>` Namespace for transport topics/services:
+  /// - `<namespace>` Optional parameter. Namespace for transport topics and
+  ///                 services. Defaults to `<model_name>/touch`.
   ///   - `/<namespace>/enable` : Service used to enable and disable
   ///                             the plugin.
   ///   - `/<namespace>/touched` : Topic where a message is published
   ///                              once the touch event occurs.
+  ///
+  /// - `<time>` Target time in seconds to maintain contact.
   ///
   /// - `<enabled>` Set this to true so the plugin works from the start and
   ///               doesn't need to be enabled.

--- a/src/systems/touch_plugin/TouchPlugin.hh
+++ b/src/systems/touch_plugin/TouchPlugin.hh
@@ -66,7 +66,7 @@ namespace systems
   ///                 contact sensors inside links in SDF. Default to false.
   ///
   /// - `<namespace>` Optional parameter. Namespace for transport topics and
-  ///                 services. Defaults to `<model_name>/touch`.
+  ///                 services. Defaults to `<scoped_name>/touch`.
   ///                 Note that if multiple touch plugins without a namespace
   ///                 are added to a model their topic / service will conflict.
   ///                 In this case, it is recommended to either specify the

--- a/src/systems/touch_plugin/TouchPlugin.hh
+++ b/src/systems/touch_plugin/TouchPlugin.hh
@@ -67,6 +67,11 @@ namespace systems
   ///
   /// - `<namespace>` Optional parameter. Namespace for transport topics and
   ///                 services. Defaults to `<model_name>/touch`.
+  ///                 Note that if multiple touch plugins without a namespace
+  ///                 are added to a model their topic / service will conflict.
+  ///                 In this case, it is recommended to either specify the
+  ///                 namespace or use nested models to have only one touch
+  ///                 plugin per model.
   ///   - `/<namespace>/enable` : Service used to enable and disable
   ///                             the plugin.
   ///   - `/<namespace>/touched` : Topic where a message is published


### PR DESCRIPTION
# 🎉 New feature

Adds a default value to the namespace for `TouchPlugin`.

## Summary

Previously, namespace was a mandatory parameter. This makes it a bit harder to have multiple instances of the same model without having to edit the SDF.
Specifically, if a user had a model with a TouchPlugin in its SDF, two instances of the same model would inevitably publish to the same topic (unless they did some SDF experimental params overrides).
With this PR, if users skip the `namespace` parameter, the plugin's namespace will default to `model_name/touch` making it easier to have models publish to unique topics.

## Test it

Run the touch_plugin demo then list the topics:

Current main:

```
$ gz sim -r touch_plugin.sdf
$ gz topic -l
[...]
/white_touches_only_green/touched
```

Then change the demo world to remove the `namespace` parameter

```
$ gz sim -r touch_plugin.sdf
$ gz topic -l
[...]
/white_box/touch/touched
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.