### PR TITLE
Fix potential iterator invalidation in EntityTree

### DIFF
--- a/src/gui/plugins/entity_tree/EntityTree.cc
+++ b/src/gui/plugins/entity_tree/EntityTree.cc
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <iterator>
 #include <mutex>
 #include <set>
 #include <string>
@@ -184,11 +185,16 @@ void TreeModel::AddEntity(Entity _entity, const QString &_entityName,
         return _entityInfo.parentEntity != _entity;
       });
 
-  for (auto it = sep; it != this->pendingEntities.end(); ++it)
+  if (sep != this->pendingEntities.end())
   {
-    this->AddEntity(it->entity, it->name, it->parentEntity, it->type);
+    const std::vector<EntityInfo> children(std::make_move_iterator(sep), std::make_move_iterator(this->pendingEntities.end()));
+    this->pendingEntities.erase(sep, this->pendingEntities.end());
+
+    for (const auto &child : children)
+    {
+      this->AddEntity(child.entity, child.name, child.parentEntity, child.type);
+    }
   }
-  this->pendingEntities.erase(sep, this->pendingEntities.end());
 }
 
 /////////////////////////////////////////////////

--- a/src/gui/plugins/entity_tree/EntityTree.cc
+++ b/src/gui/plugins/entity_tree/EntityTree.cc
@@ -187,7 +187,8 @@ void TreeModel::AddEntity(Entity _entity, const QString &_entityName,
 
   if (sep != this->pendingEntities.end())
   {
-    const std::vector<EntityInfo> children(std::make_move_iterator(sep), std::make_move_iterator(this->pendingEntities.end()));
+    const std::vector<EntityInfo> children(std::make_move_iterator(sep),
+        std::make_move_iterator(this->pendingEntities.end()));
     this->pendingEntities.erase(sep, this->pendingEntities.end());
 
     for (const auto &child : children)


### PR DESCRIPTION
# 🦟 Bug fix

Taken from #3447, fix a potential iterator invalidation in `EntityTree`

## Summary

The `AddEntity` function calculates an iterator to its internal `pendingEntities` data structure to find children of a specified entity, then recursively calls itself. After iterating over all the children it will call erase on this previously computed iterator.
This is potentially problematic because the function (called recursively) also includes a potential `push_back` [call](https://github.com/gazebosim/gz-sim/blob/250b39315ffc6eb01617ebd17af177608d9f9804/src/gui/plugins/entity_tree/EntityTree.cc#L164-L165). If `push_back` reallocates it will invalidate all existing iterators, hence the following call to `erase` will try to erase an invalid iterator resulting in undefined behavior.
This PR just moves all the entities to be iterated on into a separate vector and immediately erases them from the `pendingEntities`, then the iterator isn't used anymore. This assures that any operation that potentially invalidates iterators (such as the push_back) doesn't create any undefined behavior.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3.0

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.