### PR TITLE
Fix Hydrodynamic state contamination on world reset

### DIFF
--- a/src/systems/hydrodynamics/Hydrodynamics.cc
+++ b/src/systems/hydrodynamics/Hydrodynamics.cc
@@ -113,43 +113,91 @@ class gz::sim::systems::HydrodynamicsPrivateData
   /// \brief Set the current table
   /// \param[in] _ecm - The Entity Component Manager
   /// \param[in] _currTime - The current time
+  public: bool InitializeWaterCurrentTable(
+    const components::Environment *_environment,
+    const std::chrono::steady_clock::duration &_currTime)
+  {
+    if (nullptr == _environment)
+      return false;
+
+    this->gridField = _environment->Data();
+    if (!this->gridField)
+      return false;
+
+    for (std::size_t i = 0; i < 3; i++)
+    {
+      this->session[i].reset();
+
+      if (this->axisComponents[i].empty())
+        continue;
+
+      if (!this->gridField->frame.Has(this->axisComponents[i]))
+      {
+        gzwarn << "Environmental sensor could not find field "
+          << this->axisComponents[i] << "\n";
+        continue;
+      }
+
+      this->session[i] =
+        this->gridField->frame[this->axisComponents[i]].CreateSession();
+      if (!this->gridField->staticTime)
+      {
+        this->session[i] =
+          this->gridField->frame[this->axisComponents[i]].StepTo(
+            *this->session[i],
+            std::chrono::duration<double>(_currTime).count());
+      }
+
+      if (!this->session[i].has_value())
+      {
+        gzerr << "Exceeded time stamp." << std::endl;
+      }
+    }
+
+    return true;
+  }
+
+  /// \brief Whether a current-table session is ready to be queried.
+  public: bool HasCurrentTableSession() const
+  {
+    if (!this->gridField)
+      return false;
+
+    for (const auto &sessionValue : this->session)
+    {
+      if (sessionValue.has_value())
+        return true;
+    }
+
+    return false;
+  }
+
+  /// \brief Set the current table
+  /// \param[in] _ecm - The Entity Component Manager
+  /// \param[in] _currTime - The current time
   public: void SetWaterCurrentTable(
     const EntityComponentManager &_ecm,
     const std::chrono::steady_clock::duration &_currTime)
   {
+    auto refreshFromEnvironment =
+      [&](const components::Environment *_environment) -> bool
+      {
+        return this->InitializeWaterCurrentTable(_environment, _currTime);
+      };
+
     _ecm.EachNew<components::Environment>([&](const Entity &/*_entity*/,
       const components::Environment *_environment) -> bool
     {
-      this->gridField = _environment->Data();
+      return !refreshFromEnvironment(_environment);
+    });
 
-      for (std::size_t i = 0; i < 3; i++)
-      {
-        if (!this->axisComponents[i].empty())
-        {
-          if (!this->gridField->frame.Has(this->axisComponents[i]))
-          {
-            gzwarn << "Environmental sensor could not find field "
-              << this->axisComponents[i] << "\n";
-            continue;
-          }
+    if (this->HasCurrentTableSession())
+      return;
 
-          this->session[i] =
-            this->gridField->frame[this->axisComponents[i]].CreateSession();
-          if (!this->gridField->staticTime)
-          {
-            this->session[i] =
-              this->gridField->frame[this->axisComponents[i]].StepTo(
-                *this->session[i],
-                std::chrono::duration<double>(_currTime).count());
-          }
-
-          if(!this->session[i].has_value())
-          {
-            gzerr << "Exceeded time stamp." << std::endl;
-          }
-        }
-      }
-      return true;
+    _ecm.Each<components::Environment>([&](const Entity &/*_entity*/,
+      const components::Environment *_environment) -> bool
+    {
+      return !refreshFromEnvironment(_environment);
     });
   }
 

--- a/src/systems/hydrodynamics/Hydrodynamics.cc
+++ b/src/systems/hydrodynamics/Hydrodynamics.cc
@@ -72,6 +72,9 @@ class gz::sim::systems::HydrodynamicsPrivateData
   /// \brief Ocean current experienced by this body
   public: math::Vector3d currentVector {0, 0, 0};
 
+  /// \brief Configured default current restored on reset.
+  public: math::Vector3d defaultCurrentVector {0, 0, 0};
+
   /// \brief Added mass of vehicle;
   /// See: https://en.wikipedia.org/wiki/Added_mass
   public: Eigen::Matrix<double, 6, 6> Ma;
@@ -444,8 +447,10 @@ void Hydrodynamics::Configure(
 
   if(_sdf->HasElement("default_current"))
   {
-    this->dataPtr->currentVector = _sdf->Get<math::Vector3d>("default_current");
+    this->dataPtr->defaultCurrentVector =
+      _sdf->Get<math::Vector3d>("default_current");
   }
+  this->dataPtr->currentVector = this->dataPtr->defaultCurrentVector;
 
   this->dataPtr->prevState = Eigen::Matrix<double, 6, 1>::Zero();
 
@@ -649,6 +654,15 @@ void Hydrodynamics::Reset(
 {
   this->dataPtr->prevState = Eigen::Matrix<double, 6, 1>::Zero();
   this->dataPtr->firstIteration = true;
+  {
+    std::lock_guard lock(this->dataPtr->mtx);
+    this->dataPtr->currentVector = this->dataPtr->defaultCurrentVector;
+  }
+  this->dataPtr->gridField.reset();
+  for (auto &session : this->dataPtr->session)
+  {
+    session.reset();
+  }
 }
 
 GZ_ADD_PLUGIN(

--- a/src/systems/hydrodynamics/Hydrodynamics.cc
+++ b/src/systems/hydrodynamics/Hydrodynamics.cc
@@ -14,9 +14,11 @@
  * limitations under the License.
  *
  */
+#include <chrono>
 #include <cmath>
+#include <cstddef>
 #include <string>
-
+#include <iterator>
 #include <Eigen/Eigen>
 
 #include <gz/msgs/vector3d.pb.h>
@@ -110,9 +112,9 @@ class gz::sim::systems::HydrodynamicsPrivateData
   public: void UpdateCurrent(const msgs::Vector3d &_msg);
 
   /////////////////////////////////////////////////
-  /// \brief Set the current table
-  /// \param[in] _ecm - The Entity Component Manager
-  /// \param[in] _currTime - The current time
+  /// \brief Initialize the environment lookup sessions for the current table.
+  /// \param[in] _environment The environment component holding lookup fields.
+  /// \param[in] _currTime The current simulation time.
   public: bool InitializeWaterCurrentTable(
     const components::Environment *_environment,
     const std::chrono::steady_clock::duration &_currTime)
@@ -124,7 +126,7 @@ class gz::sim::systems::HydrodynamicsPrivateData
     if (!this->gridField)
       return false;
 
-    for (std::size_t i = 0; i < 3; i++)
+    for (std::size_t i = 0; i < std::size(this->axisComponents); ++i)
     {
       this->session[i].reset();
 
@@ -221,7 +223,7 @@ class gz::sim::systems::HydrodynamicsPrivateData
       return current;
     }
 
-    for (std::size_t i = 0; i < 3; i++)
+    for (std::size_t i = 0; i < std::size(this->axisComponents); ++i)
     {
       if (!this->axisComponents[i].empty())
       {

--- a/test/integration/hydrodynamics.cc
+++ b/test/integration/hydrodynamics.cc
@@ -17,7 +17,11 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <thread>
+
 #include <gz/msgs/double.pb.h>
+#include <gz/msgs/vector3d.pb.h>
 
 #include <gz/common/Console.hh>
 #include <gz/common/Util.hh>
@@ -31,9 +35,14 @@
 #include "gz/sim/TestFixture.hh"
 #include "gz/sim/Util.hh"
 #include "gz/sim/World.hh"
+#include "gz/sim/components/Model.hh"
+#include "gz/sim/components/Name.hh"
 
 #include "test_config.hh"
 #include "../helpers/EnvTestFixture.hh"
+#include "../helpers/Relay.hh"
+#include "../helpers/ResetUtils.hh"
+#include "../helpers/Util.hh"
 
 using namespace gz;
 using namespace sim;
@@ -200,4 +209,112 @@ TEST_F(HydrodynamicsTest,
     EXPECT_NEAR(sphereVel[i-1].Y(), 0, 1e-6);
     EXPECT_GT(sphereVel[i-1].X(), 0);
   }
+}
+
+/////////////////////////////////////////////////
+TEST_F(HydrodynamicsTest,
+       GZ_UTILS_TEST_DISABLED_ON_WIN32(ResetClearsRuntimeCurrentState))
+{
+  using namespace std::chrono_literals;
+
+  ServerConfig serverConfig;
+  serverConfig.SetSdfFile(common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+      "test", "worlds", "hydrodynamics_reset.sdf"));
+
+  Server server(serverConfig);
+  server.SetUpdatePeriod(0ns);
+
+  Link body;
+  std::vector<math::Pose3d> poses;
+  std::vector<math::Vector3d> linearVelocities;
+  test::Relay recorder;
+  recorder.OnPreUpdate(
+      [&](const UpdateInfo &,
+          EntityComponentManager &_ecm)
+      {
+        if (body.Entity() != kNullEntity)
+          return;
+
+        const auto modelEntity = _ecm.EntityByComponents(
+            components::Model(), components::Name("reset_body"));
+        ASSERT_NE(kNullEntity, modelEntity);
+
+        Model model(modelEntity);
+        const auto bodyEntity = model.LinkByName(_ecm, "body");
+        ASSERT_NE(kNullEntity, bodyEntity);
+
+        body = Link(bodyEntity);
+        body.EnableVelocityChecks(_ecm);
+      });
+  recorder.OnPostUpdate([&](const UpdateInfo &,
+      const EntityComponentManager &_ecm)
+      {
+        const auto bodyPose = body.WorldPose(_ecm);
+        const auto bodyVelocity = body.WorldLinearVelocity(_ecm);
+        ASSERT_TRUE(bodyPose.has_value());
+        ASSERT_TRUE(bodyVelocity.has_value());
+        poses.push_back(bodyPose.value());
+        linearVelocities.push_back(bodyVelocity.value());
+      });
+  server.AddSystem(recorder.systemPtr);
+
+  transport::Node node;
+  auto currentPub = node.Advertise<msgs::Vector3d>(
+      "/model/reset_body/ocean_current");
+  ASSERT_TRUE(gz::sim::test::WaitUntil(2s, [&currentPub]
+      {
+        return currentPub.HasConnections();
+      }));
+
+  server.Run(true, 50, false);
+  ASSERT_FALSE(poses.empty());
+  const auto initialPose = poses.front();
+  EXPECT_NEAR(initialPose.Pos().X(), poses.back().Pos().X(), 1e-6);
+  EXPECT_NEAR(0.0, linearVelocities.back().X(), 1e-6);
+
+  // Drive the plugin with runtime current so any stale input or derivative
+  // state becomes visible after reset.
+  msgs::Vector3d currentMsg;
+  currentMsg.set_x(1.0);
+  currentMsg.set_y(0.0);
+  currentMsg.set_z(0.0);
+  EXPECT_TRUE(currentPub.Publish(currentMsg));
+  std::this_thread::sleep_for(100ms);
+
+  poses.clear();
+  linearVelocities.clear();
+  server.Run(true, 500, false);
+  ASSERT_FALSE(poses.empty());
+  ASSERT_FALSE(linearVelocities.empty());
+  EXPECT_LT(poses.back().Pos().X(), initialPose.Pos().X() - 0.05);
+  EXPECT_LT(linearVelocities.back().X(), -0.05);
+
+  gz::sim::test::reset::RequestAndApplyWorldReset(server,
+      "hydrodynamics_reset");
+
+  poses.clear();
+  linearVelocities.clear();
+  server.Run(true, 200, false);
+  ASSERT_FALSE(poses.empty());
+  ASSERT_FALSE(linearVelocities.empty());
+
+  // Without a fresh current message, reset should return the model to a calm
+  // episode instead of continuing the pre-reset ocean current.
+  EXPECT_NEAR(poses.back().Pos().X(), initialPose.Pos().X(), 0.02);
+  EXPECT_NEAR(poses.back().Pos().Y(), initialPose.Pos().Y(), 0.02);
+  EXPECT_NEAR(linearVelocities.back().X(), 0.0, 0.02);
+  EXPECT_NEAR(linearVelocities.back().Y(), 0.0, 0.02);
+  EXPECT_NEAR(linearVelocities.back().Z(), 0.0, 0.02);
+
+  // Fresh runtime current should still influence the body after reset.
+  EXPECT_TRUE(currentPub.Publish(currentMsg));
+  std::this_thread::sleep_for(100ms);
+
+  poses.clear();
+  linearVelocities.clear();
+  server.Run(true, 500, false);
+  ASSERT_FALSE(poses.empty());
+  ASSERT_FALSE(linearVelocities.empty());
+  EXPECT_LT(poses.back().Pos().X(), initialPose.Pos().X() - 0.05);
+  EXPECT_LT(linearVelocities.back().X(), -0.05);
 }

--- a/test/integration/hydrodynamics.cc
+++ b/test/integration/hydrodynamics.cc
@@ -19,6 +19,8 @@
 
 #include <chrono>
 #include <thread>
+#include <utility>
+#include <vector>
 
 #include <gz/msgs/double.pb.h>
 #include <gz/msgs/vector3d.pb.h>
@@ -232,16 +234,18 @@ TEST_F(HydrodynamicsTest,
       [&](const UpdateInfo &,
           EntityComponentManager &_ecm)
       {
-        if (body.Entity() != kNullEntity)
+        if (body.Entity() != kNullEntity && _ecm.HasEntity(body.Entity()))
           return;
 
         const auto modelEntity = _ecm.EntityByComponents(
             components::Model(), components::Name("reset_body"));
-        ASSERT_NE(kNullEntity, modelEntity);
+        if (kNullEntity == modelEntity)
+          return;
 
         Model model(modelEntity);
         const auto bodyEntity = model.LinkByName(_ecm, "body");
-        ASSERT_NE(kNullEntity, bodyEntity);
+        if (kNullEntity == bodyEntity)
+          return;
 
         body = Link(bodyEntity);
         body.EnableVelocityChecks(_ecm);
@@ -249,10 +253,14 @@ TEST_F(HydrodynamicsTest,
   recorder.OnPostUpdate([&](const UpdateInfo &,
       const EntityComponentManager &_ecm)
       {
+        if (body.Entity() == kNullEntity || !_ecm.HasEntity(body.Entity()))
+          return;
+
         const auto bodyPose = body.WorldPose(_ecm);
         const auto bodyVelocity = body.WorldLinearVelocity(_ecm);
-        ASSERT_TRUE(bodyPose.has_value());
-        ASSERT_TRUE(bodyVelocity.has_value());
+        if (!bodyPose.has_value() || !bodyVelocity.has_value())
+          return;
+
         poses.push_back(bodyPose.value());
         linearVelocities.push_back(bodyVelocity.value());
       });
@@ -317,4 +325,104 @@ TEST_F(HydrodynamicsTest,
   ASSERT_FALSE(linearVelocities.empty());
   EXPECT_LT(poses.back().Pos().X(), initialPose.Pos().X() - 0.05);
   EXPECT_LT(linearVelocities.back().X(), -0.05);
+}
+
+/////////////////////////////////////////////////
+TEST_F(HydrodynamicsTest,
+       GZ_UTILS_TEST_DISABLED_ON_WIN32(ResetRestoresLookupCurrentTable))
+{
+  using namespace std::chrono_literals;
+
+  ServerConfig serverConfig;
+  serverConfig.SetSdfFile(common::joinPaths(std::string(PROJECT_BINARY_PATH),
+      "test", "worlds", "hydrodynamics.sdf"));
+
+  Server server(serverConfig);
+  server.SetUpdatePeriod(0ns);
+
+  Link body;
+  std::vector<math::Pose3d> poses;
+  std::vector<math::Vector3d> linearVelocities;
+  test::Relay recorder;
+  recorder.OnPreUpdate(
+      [&](const UpdateInfo &,
+          EntityComponentManager &_ecm)
+      {
+        if (body.Entity() != kNullEntity && _ecm.HasEntity(body.Entity()))
+          return;
+
+        const auto modelEntity = _ecm.EntityByComponents(
+            components::Model(), components::Name("sphere_current"));
+        if (kNullEntity == modelEntity)
+          return;
+
+        Model model(modelEntity);
+        const auto bodyEntity = model.LinkByName(_ecm, "sphere_current_link");
+        if (kNullEntity == bodyEntity)
+          return;
+
+        body = Link(bodyEntity);
+        body.EnableVelocityChecks(_ecm);
+      });
+  recorder.OnPostUpdate([&](const UpdateInfo &,
+      const EntityComponentManager &_ecm)
+      {
+        if (body.Entity() == kNullEntity || !_ecm.HasEntity(body.Entity()))
+          return;
+
+        const auto bodyPose = body.WorldPose(_ecm);
+        const auto bodyVelocity = body.WorldLinearVelocity(_ecm);
+        if (!bodyPose.has_value() || !bodyVelocity.has_value())
+          return;
+
+        poses.push_back(bodyPose.value());
+        linearVelocities.push_back(bodyVelocity.value());
+      });
+  server.AddSystem(recorder.systemPtr);
+
+  auto runAndCapture = [&](uint64_t _iterations)
+      -> std::pair<std::vector<math::Pose3d>, std::vector<math::Vector3d>>
+      {
+        poses.clear();
+        linearVelocities.clear();
+        server.Run(true, _iterations, false);
+        EXPECT_FALSE(poses.empty());
+        EXPECT_FALSE(linearVelocities.empty());
+        return {poses, linearVelocities};
+      };
+
+  const auto preResetSamples = runAndCapture(1000);
+  const auto &preResetPoses = preResetSamples.first;
+  const auto &preResetVelocities = preResetSamples.second;
+  ASSERT_FALSE(preResetPoses.empty());
+  ASSERT_FALSE(preResetVelocities.empty());
+  const auto preResetStartPose = preResetPoses.front();
+  const auto preResetEndPose = preResetPoses.back();
+  const auto preResetEndVelocity = preResetVelocities.back();
+  const auto preResetDeltaX =
+      preResetEndPose.Pos().X() - preResetStartPose.Pos().X();
+  EXPECT_GT(preResetDeltaX, 0.05);
+  EXPECT_GT(preResetEndVelocity.X(), 0.05);
+
+  gz::sim::test::reset::RequestAndApplyWorldReset(server, "hydrodynamics");
+
+  const auto postResetSamples = runAndCapture(1000);
+  const auto &postResetPoses = postResetSamples.first;
+  const auto &postResetVelocities = postResetSamples.second;
+  ASSERT_FALSE(postResetPoses.empty());
+  ASSERT_FALSE(postResetVelocities.empty());
+  const auto postResetStartPose = postResetPoses.front();
+  const auto postResetEndPose = postResetPoses.back();
+  const auto postResetEndVelocity = postResetVelocities.back();
+  const auto postResetDeltaX =
+      postResetEndPose.Pos().X() - postResetStartPose.Pos().X();
+
+  // Reset should restore the early episode baseline and also rebuild the
+  // lookup-table current path so the body sees the same steady drift again.
+  EXPECT_NEAR(postResetStartPose.Pos().X(), preResetStartPose.Pos().X(), 0.02);
+  EXPECT_NEAR(postResetStartPose.Pos().Y(), preResetStartPose.Pos().Y(), 0.02);
+  EXPECT_GT(postResetDeltaX, 0.05);
+  EXPECT_GT(postResetEndVelocity.X(), 0.05);
+  EXPECT_NEAR(postResetDeltaX, preResetDeltaX, 0.05);
+  EXPECT_NEAR(postResetEndVelocity.X(), preResetEndVelocity.X(), 0.05);
 }

--- a/test/integration/hydrodynamics.cc
+++ b/test/integration/hydrodynamics.cc
@@ -43,7 +43,6 @@
 #include "test_config.hh"
 #include "../helpers/EnvTestFixture.hh"
 #include "../helpers/Relay.hh"
-#include "../helpers/ResetUtils.hh"
 #include "../helpers/Util.hh"
 
 using namespace gz;
@@ -266,14 +265,6 @@ TEST_F(HydrodynamicsTest,
       });
   server.AddSystem(recorder.systemPtr);
 
-  transport::Node node;
-  auto currentPub = node.Advertise<msgs::Vector3d>(
-      "/model/reset_body/ocean_current");
-  ASSERT_TRUE(gz::sim::test::WaitUntil(2s, [&currentPub]
-      {
-        return currentPub.HasConnections();
-      }));
-
   server.Run(true, 50, false);
   ASSERT_FALSE(poses.empty());
   const auto initialPose = poses.front();
@@ -286,19 +277,29 @@ TEST_F(HydrodynamicsTest,
   currentMsg.set_x(1.0);
   currentMsg.set_y(0.0);
   currentMsg.set_z(0.0);
-  EXPECT_TRUE(currentPub.Publish(currentMsg));
+  {
+    transport::Node node;
+    auto currentPub = node.Advertise<msgs::Vector3d>(
+        "/model/reset_body/ocean_current");
+    ASSERT_TRUE(gz::sim::test::WaitUntil(2s, [&currentPub]
+        {
+          return currentPub.HasConnections();
+        }));
+    EXPECT_TRUE(currentPub.Publish(currentMsg));
+    std::this_thread::sleep_for(100ms);
+
+    poses.clear();
+    linearVelocities.clear();
+    server.Run(true, 500, false);
+    ASSERT_FALSE(poses.empty());
+    ASSERT_FALSE(linearVelocities.empty());
+    EXPECT_LT(poses.back().Pos().X(), initialPose.Pos().X() - 0.05);
+    EXPECT_LT(linearVelocities.back().X(), -0.05);
+  }
   std::this_thread::sleep_for(100ms);
 
-  poses.clear();
-  linearVelocities.clear();
-  server.Run(true, 500, false);
-  ASSERT_FALSE(poses.empty());
-  ASSERT_FALSE(linearVelocities.empty());
-  EXPECT_LT(poses.back().Pos().X(), initialPose.Pos().X() - 0.05);
-  EXPECT_LT(linearVelocities.back().X(), -0.05);
-
-  gz::sim::test::reset::RequestAndApplyWorldReset(server,
-      "hydrodynamics_reset");
+  server.ResetAll();
+  server.Run(true, 2, false);
 
   poses.clear();
   linearVelocities.clear();
@@ -315,6 +316,13 @@ TEST_F(HydrodynamicsTest,
   EXPECT_NEAR(linearVelocities.back().Z(), 0.0, 0.02);
 
   // Fresh runtime current should still influence the body after reset.
+  transport::Node node;
+  auto currentPub = node.Advertise<msgs::Vector3d>(
+      "/model/reset_body/ocean_current");
+  ASSERT_TRUE(gz::sim::test::WaitUntil(2s, [&currentPub]
+      {
+        return currentPub.HasConnections();
+      }));
   EXPECT_TRUE(currentPub.Publish(currentMsg));
   std::this_thread::sleep_for(100ms);
 
@@ -391,6 +399,8 @@ TEST_F(HydrodynamicsTest,
         return {poses, linearVelocities};
       };
 
+  server.Run(true, 2, false);
+
   const auto preResetSamples = runAndCapture(1000);
   const auto &preResetPoses = preResetSamples.first;
   const auto &preResetVelocities = preResetSamples.second;
@@ -404,7 +414,8 @@ TEST_F(HydrodynamicsTest,
   EXPECT_GT(preResetDeltaX, 0.05);
   EXPECT_GT(preResetEndVelocity.X(), 0.05);
 
-  gz::sim::test::reset::RequestAndApplyWorldReset(server, "hydrodynamics");
+  server.ResetAll();
+  server.Run(true, 2, false);
 
   const auto postResetSamples = runAndCapture(1000);
   const auto &postResetPoses = postResetSamples.first;

--- a/test/worlds/hydrodynamics_reset.sdf
+++ b/test/worlds/hydrodynamics_reset.sdf
@@ -1,0 +1,71 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="hydrodynamics_reset">
+    <physics name="1ms" type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
+    <gravity>0 0 0</gravity>
+
+    <plugin
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+
+    <model name="reset_body">
+      <link name="body">
+        <pose>0 0 0 0 0 0</pose>
+        <inertial>
+          <mass>25</mass>
+          <inertia>
+            <ixx>0.4</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.4</iyy>
+            <iyz>0</iyz>
+            <izz>0.4</izz>
+          </inertia>
+        </inertial>
+
+        <visual name="visual">
+          <geometry>
+            <sphere>
+              <radius>0.2</radius>
+            </sphere>
+          </geometry>
+        </visual>
+
+        <collision name="collision">
+          <geometry>
+            <sphere>
+              <radius>0.2</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+
+      <plugin
+        filename="gz-sim-hydrodynamics-system"
+        name="gz::sim::systems::Hydrodynamics">
+        <namespace>reset_body</namespace>
+        <link_name>body</link_name>
+        <water_density>918</water_density>
+        <disable_coriolis>true</disable_coriolis>
+        <disable_added_mass>true</disable_added_mass>
+        <xUabsU>0</xUabsU>
+        <xU>10</xU>
+        <yVabsV>0</yVabsV>
+        <yV>10</yV>
+        <zWabsW>0</zWabsW>
+        <zW>10</zW>
+        <kPabsP>0</kPabsP>
+        <kP>0</kP>
+        <mQabsQ>0</mQabsQ>
+        <mQ>0</mQ>
+        <nRabsR>0</nRabsR>
+        <nR>0</nR>
+      </plugin>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
Add reset test for hydrodynamics and Fix its state contamination on world reset

## Test logic
1. Started from a small dedicated reset world with a single body.
2. Applied a runtime ocean current command and let the body move away from its initial state.
3. Reset the world.
4. Checked that, without a fresh current command, the body returned to its calm initial behavior.
5. Sent a fresh current command after reset and confirmed the body responded again.

I did not reuse the original `hydrodynamics.sdf` test scene here. That world is heavier and can crash when run directly(see in [Issue#3530)](https://github.com/gazebosim/gz-sim/issues/3530). So I used a smaller reset world to keep the signal clean and make the reset behavior easier to audit.

## Root cause
`Hydrodynamics` kept runtime state across reset, including the current vector, previous state used for derivatives, and environment lookup state.  

Because of that, the new episode could still be influenced by pre-reset current state.

## Fix logic

- Added `ISystemReset` to `Hydrodynamics`
- Restored the runtime current back to the configured default current in `Reset()`
- Cleared reset-sensitive runtime state like:
  - `prevState`
  - `firstIteration`
  - `gridField`
  - `session`

## Result

After the fix, reset clears the old runtime current state, and fresh current commands still work normally in the new episode.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
