### PR TITLE
Fix LinearBatteryPlugin state contamination on world reset

### DIFF
--- a/src/systems/battery_plugin/LinearBatteryPlugin.cc
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.cc
@@ -172,6 +172,9 @@ class gz::sim::systems::LinearBatteryPluginPrivate
   /// \brief Flag on whether the battery should start draining
   public: std::atomic_bool startDraining{false};
 
+  /// \brief Configured initial draining state restored on reset.
+  public: bool initialStartDraining{false};
+
   /// \brief Whether warning that battery has drained has been printed once.
   public: bool drainPrinted{false};
 
@@ -285,11 +288,18 @@ void LinearBatteryPlugin::Configure(const Entity &_entity,
     this->dataPtr->batteryName = _sdf->Get<std::string>("battery_name");
     auto initVoltage = _sdf->Get<double>("voltage");
 
-    // Create battery entity and some components
-    this->dataPtr->batteryEntity = _ecm.CreateEntity();
-    _ecm.CreateComponent(this->dataPtr->batteryEntity, components::Name(
-      this->dataPtr->batteryName));
-    _ecm.SetParentEntity(this->dataPtr->batteryEntity, _entity);
+    // Reuse the existing battery entity on reset instead of creating
+    // a duplicate entity with the same name under the model.
+    this->dataPtr->batteryEntity = _ecm.EntityByComponents(
+      components::Name(this->dataPtr->batteryName));
+
+    if (this->dataPtr->batteryEntity == kNullEntity)
+    {
+      this->dataPtr->batteryEntity = _ecm.CreateEntity();
+      _ecm.CreateComponent(this->dataPtr->batteryEntity, components::Name(
+        this->dataPtr->batteryName));
+      _ecm.SetParentEntity(this->dataPtr->batteryEntity, _entity);
+    }
 
     // Create actual battery and assign update function
     this->dataPtr->battery = std::make_shared<common::Battery>(
@@ -370,7 +380,11 @@ void LinearBatteryPlugin::Configure(const Entity &_entity,
   }
 
   if (_sdf->HasElement("start_draining"))
-    this->dataPtr->startDraining = _sdf->Get<bool>("start_draining");
+  {
+    this->dataPtr->initialStartDraining =
+      _sdf->Get<bool>("start_draining");
+    this->dataPtr->startDraining = this->dataPtr->initialStartDraining;
+  }
 
   // Subscribe to power draining topics, if any.
   if (_sdf->HasElement("power_draining_topic"))
@@ -414,8 +428,17 @@ void LinearBatteryPlugin::Configure(const Entity &_entity,
 
   this->dataPtr->soc = this->dataPtr->q / this->dataPtr->c;
   // Initialize battery with initial calculated state of charge
-  _ecm.CreateComponent(this->dataPtr->batteryEntity,
-      components::BatterySoC(this->dataPtr->soc));
+  auto *batterySoCComp =
+    _ecm.Component<components::BatterySoC>(this->dataPtr->batteryEntity);
+  if (batterySoCComp)
+  {
+    batterySoCComp->Data() = this->dataPtr->soc;
+  }
+  else
+  {
+    _ecm.CreateComponent(this->dataPtr->batteryEntity,
+        components::BatterySoC(this->dataPtr->soc));
+  }
 
   // Setup battery state topic
   std::string stateTopic{"/model/" + this->dataPtr->model.Name(_ecm) +
@@ -441,7 +464,24 @@ void LinearBatteryPluginPrivate::Reset()
   this->iraw = 0.0;
   this->ismooth = 0.0;
   this->q = this->q0;
-  this->startDraining = false;
+  this->soc = this->c > 0.0 ? this->q0 / this->c : 1.0;
+  this->stepSize = std::chrono::steady_clock::duration::zero();
+  this->startCharging = false;
+  this->startDraining = this->initialStartDraining;
+  this->drainStartTime = -1;
+  this->lastPrintTime = -1;
+  this->drainPrinted = false;
+  this->iList.clear();
+  this->dtList.clear();
+
+  if (this->battery)
+  {
+    this->battery->ResetVoltage();
+    if (this->consumerId != -1)
+    {
+      this->battery->SetPowerLoad(this->consumerId, this->initialPowerLoad);
+    }
+  }
 }
 
 /////////////////////////////////////////////////
@@ -654,6 +694,32 @@ void LinearBatteryPlugin::PostUpdate(const UpdateInfo &_info,
   this->dataPtr->statePub.Publish(msg);
 }
 
+//////////////////////////////////////////////////
+void LinearBatteryPlugin::Reset(const UpdateInfo &/*_info*/,
+    EntityComponentManager &_ecm)
+{
+  if (!this->dataPtr->battery)
+    return;
+
+  this->dataPtr->Reset();
+
+  auto batteryEntity = this->dataPtr->batteryEntity;
+  if (batteryEntity == kNullEntity || !_ecm.HasEntity(batteryEntity))
+  {
+    batteryEntity = _ecm.EntityByComponents(
+      components::Name(this->dataPtr->batteryName));
+  }
+
+  if (batteryEntity == kNullEntity)
+    return;
+
+  auto *batteryComp = _ecm.Component<components::BatterySoC>(batteryEntity);
+  if (batteryComp)
+  {
+    batteryComp->Data() = this->dataPtr->StateOfCharge();
+  }
+}
+
 /////////////////////////////////////////////////
 double LinearBatteryPlugin::OnUpdateVoltage(
   const common::Battery *_battery)
@@ -750,7 +816,8 @@ GZ_ADD_PLUGIN(LinearBatteryPlugin,
                     LinearBatteryPlugin::ISystemConfigure,
                     LinearBatteryPlugin::ISystemPreUpdate,
                     LinearBatteryPlugin::ISystemUpdate,
-                    LinearBatteryPlugin::ISystemPostUpdate)
+                    LinearBatteryPlugin::ISystemPostUpdate,
+                    LinearBatteryPlugin::ISystemReset)
 
 GZ_ADD_PLUGIN_ALIAS(LinearBatteryPlugin,
   "gz::sim::systems::LinearBatteryPlugin")

--- a/src/systems/battery_plugin/LinearBatteryPlugin.cc
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.cc
@@ -157,7 +157,7 @@ class gz::sim::systems::LinearBatteryPluginPrivate
 
   /// \brief Battery consumer identifier.
   /// Current implementation limits one consumer (Model) per battery.
-  public: int32_t consumerId;
+  public: int32_t consumerId{-1};
 
   /// \brief The start time when battery starts draining in seconds
   public: int drainStartTime{-1};
@@ -291,7 +291,8 @@ void LinearBatteryPlugin::Configure(const Entity &_entity,
     // Reuse the existing battery entity on reset instead of creating
     // a duplicate entity with the same name under the model.
     this->dataPtr->batteryEntity = _ecm.EntityByComponents(
-      components::Name(this->dataPtr->batteryName));
+      components::Name(this->dataPtr->batteryName),
+      components::ParentEntity(_entity));
 
     if (this->dataPtr->batteryEntity == kNullEntity)
     {
@@ -545,10 +546,13 @@ void LinearBatteryPlugin::PreUpdate(
       return true;
     });
 
-  bool success = this->dataPtr->battery->SetPowerLoad(
-      this->dataPtr->consumerId, total_power_load);
-  if (!success)
+  if (this->dataPtr->consumerId != -1)
+  {
+    bool success = this->dataPtr->battery->SetPowerLoad(
+        this->dataPtr->consumerId, total_power_load);
+    if (!success)
       gzerr << "Failed to set consumer power load." << std::endl;
+  }
 
   // Start draining the battery if the robot has started moving
   if (!this->dataPtr->startDraining)
@@ -707,11 +711,14 @@ void LinearBatteryPlugin::Reset(const UpdateInfo &/*_info*/,
   if (batteryEntity == kNullEntity || !_ecm.HasEntity(batteryEntity))
   {
     batteryEntity = _ecm.EntityByComponents(
-      components::Name(this->dataPtr->batteryName));
+      components::Name(this->dataPtr->batteryName),
+      components::ParentEntity(this->dataPtr->model.Entity()));
   }
 
   if (batteryEntity == kNullEntity)
     return;
+
+  this->dataPtr->batteryEntity = batteryEntity;
 
   auto *batteryComp = _ecm.Component<components::BatterySoC>(batteryEntity);
   if (batteryComp)

--- a/src/systems/battery_plugin/LinearBatteryPlugin.hh
+++ b/src/systems/battery_plugin/LinearBatteryPlugin.hh
@@ -75,7 +75,8 @@ namespace systems
         public ISystemConfigure,
         public ISystemPreUpdate,
         public ISystemUpdate,
-        public ISystemPostUpdate
+        public ISystemPostUpdate,
+        public ISystemReset
   {
     /// \brief Constructor
     public: LinearBatteryPlugin();
@@ -102,6 +103,10 @@ namespace systems
     public: void PostUpdate(
                 const UpdateInfo &_info,
                 const EntityComponentManager &_ecm) override;
+
+    /// Documentation inherited
+    public: void Reset(const UpdateInfo &_info,
+                EntityComponentManager &_ecm) override;
 
     /// \brief Callback for Battery Update events.
     /// \param[in] _battery Pointer to the battery that is to be updated.

--- a/test/integration/battery_plugin.cc
+++ b/test/integration/battery_plugin.cc
@@ -17,12 +17,15 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <string>
+#include <thread>
 
 #include <gz/common/Battery.hh>
 #include <gz/common/Console.hh>
 #include <gz/common/Util.hh>
 #include <gz/common/Filesystem.hh>
+#include <gz/msgs/stringmsg.pb.h>
 #include <gz/transport/Node.hh>
 #include <gz/utils/ExtraTestMacros.hh>
 
@@ -44,9 +47,12 @@
 
 #include "plugins/MockSystem.hh"
 #include "../helpers/EnvTestFixture.hh"
+#include "../helpers/ResetUtils.hh"
+#include "../helpers/Util.hh"
 
 using namespace gz;
 using namespace sim;
+using namespace std::chrono_literals;
 
 class BatteryPluginTest : public InternalFixture<::testing::Test>
 {
@@ -425,4 +431,111 @@ TEST_F(BatteryPluginTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(PowerDrainTopic))
 
   // The state of charge should be the same since the discharge was stopped
   EXPECT_DOUBLE_EQ(batComp->Data(), stateOfCharge);
+}
+
+/////////////////////////////////////////////////
+// Battery reset should restore SoC and clear topic-triggered drain state.
+TEST_F(BatteryPluginTest,
+       GZ_UTILS_TEST_DISABLED_ON_WIN32(ResetClearsDrainState))
+{
+  const auto sdfPath = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+    "test", "worlds", "battery.sdf");
+
+  ServerConfig serverConfig;
+  serverConfig.SetSdfFile(sdfPath);
+
+  sim::EntityComponentManager *ecm = nullptr;
+  this->mockSystem->preUpdateCallback =
+    [&ecm](const sim::UpdateInfo &, sim::EntityComponentManager &_ecm)
+    {
+      ecm = &_ecm;
+    };
+
+  Server server(serverConfig);
+  server.AddSystem(this->systemPtr);
+  server.Run(true, 100, false);
+  ASSERT_NE(nullptr, ecm);
+
+  const auto findBatterySoC = [&]() -> std::pair<Entity, double>
+  {
+    const Entity batEntity = ecm->EntityByComponents(
+      components::Name("linear_battery_topics"));
+    EXPECT_NE(kNullEntity, batEntity);
+    EXPECT_TRUE(ecm->EntityHasComponentType(
+      batEntity, components::BatterySoC::typeId));
+    const auto *batComp = ecm->Component<components::BatterySoC>(batEntity);
+    EXPECT_NE(nullptr, batComp);
+    return {batEntity, batComp->Data()};
+  };
+
+  const auto batteryCount = [&]() -> int
+  {
+    int count = 0;
+    ecm->Each<components::BatterySoC, components::Name>(
+      [&](const Entity &,
+          const components::BatterySoC *,
+          const components::Name *_nameComp) -> bool
+      {
+        if (_nameComp->Data() == "linear_battery_topics")
+          ++count;
+        return true;
+      });
+    return count;
+  };
+
+  const auto [initialBatteryEntity, initialSoC] = findBatterySoC();
+  EXPECT_NE(kNullEntity, initialBatteryEntity);
+  EXPECT_DOUBLE_EQ(initialSoC, 1.0);
+  EXPECT_EQ(1, batteryCount());
+
+  gz::transport::Node node;
+  auto dischargePub = node.Advertise<msgs::StringMsg>("/battery/discharge");
+  ASSERT_TRUE(gz::sim::test::WaitUntil(5s, [&dischargePub]
+      {
+        return dischargePub.HasConnections();
+      }));
+
+  msgs::StringMsg msg;
+  ASSERT_TRUE(dischargePub.Publish(msg));
+  std::this_thread::sleep_for(100ms);
+  ASSERT_TRUE(gz::sim::test::StepUntil(server, 200u, [&]()
+      {
+        return findBatterySoC().second < 1.0;
+      }));
+
+  const auto [drainedBatteryEntity, drainedSoC] = findBatterySoC();
+  EXPECT_NE(kNullEntity, drainedBatteryEntity);
+  EXPECT_LT(drainedSoC, 1.0);
+
+  gz::sim::test::reset::RequestAndApplyWorldReset(server, "batteries");
+
+  server.Run(true, 100, false);
+
+  const auto [resetBatteryEntity, resetSoC] = findBatterySoC();
+  EXPECT_NE(kNullEntity, resetBatteryEntity);
+  EXPECT_DOUBLE_EQ(resetSoC, 1.0);
+  EXPECT_EQ(1, batteryCount());
+
+  server.Run(true, 100, false);
+  const auto [stableBatteryEntity, stableSoC] = findBatterySoC();
+  EXPECT_NE(kNullEntity, stableBatteryEntity);
+  EXPECT_DOUBLE_EQ(stableSoC, resetSoC);
+
+  gz::transport::Node postResetNode;
+  auto postResetDischargePub =
+    postResetNode.Advertise<msgs::StringMsg>("/battery/discharge");
+  ASSERT_TRUE(gz::sim::test::WaitUntil(5s, [&postResetDischargePub]
+      {
+        return postResetDischargePub.HasConnections();
+      }));
+  ASSERT_TRUE(postResetDischargePub.Publish(msg));
+  std::this_thread::sleep_for(100ms);
+  ASSERT_TRUE(gz::sim::test::StepUntil(server, 200u, [&]()
+      {
+        return findBatterySoC().second < resetSoC;
+      }));
+
+  const auto [freshBatteryEntity, freshDrainSoC] = findBatterySoC();
+  EXPECT_NE(kNullEntity, freshBatteryEntity);
+  EXPECT_LT(freshDrainSoC, resetSoC);
 }

--- a/test/integration/battery_plugin.cc
+++ b/test/integration/battery_plugin.cc
@@ -19,6 +19,7 @@
 
 #include <chrono>
 #include <cmath>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -456,16 +457,22 @@ TEST_F(BatteryPluginTest,
   server.Run(true, 100, false);
   ASSERT_NE(nullptr, ecm);
 
-  const auto findBatterySoC = [&]() -> std::pair<Entity, double>
+  const auto findBatterySoC = [&]() -> std::optional<std::pair<Entity, double>>
   {
     const Entity batEntity = ecm->EntityByComponents(
       components::Name("linear_battery_topics"));
     EXPECT_NE(kNullEntity, batEntity);
+    if (kNullEntity == batEntity)
+      return std::nullopt;
+
     EXPECT_TRUE(ecm->EntityHasComponentType(
       batEntity, components::BatterySoC::typeId));
     const auto *batComp = ecm->Component<components::BatterySoC>(batEntity);
     EXPECT_NE(nullptr, batComp);
-    return {batEntity, batComp->Data()};
+    if (nullptr == batComp)
+      return std::nullopt;
+
+    return std::make_pair(batEntity, batComp->Data());
   };
 
   const auto batteryCount = [&]() -> int
@@ -483,7 +490,9 @@ TEST_F(BatteryPluginTest,
     return count;
   };
 
-  const auto [initialBatteryEntity, initialSoC] = findBatterySoC();
+  const auto initialBattery = findBatterySoC();
+  ASSERT_TRUE(initialBattery.has_value());
+  const auto [initialBatteryEntity, initialSoC] = *initialBattery;
   EXPECT_NE(kNullEntity, initialBatteryEntity);
   EXPECT_DOUBLE_EQ(initialSoC, 1.0);
   EXPECT_EQ(1, batteryCount());
@@ -502,29 +511,38 @@ TEST_F(BatteryPluginTest,
       return gz::sim::test::StepUntil(server, 200u, [&]()
       {
         _pub.Publish(msg);
-        return findBatterySoC().second < _threshold;
+        const auto batterySoC = findBatterySoC();
+        return batterySoC.has_value() && batterySoC->second < _threshold;
       });
     };
 
   ASSERT_TRUE(publishAndWaitForDrain(dischargePub, 1.0));
 
-  const auto [drainedBatteryEntity, drainedSoC] = findBatterySoC();
+  const auto drainedBattery = findBatterySoC();
+  ASSERT_TRUE(drainedBattery.has_value());
+  const auto [drainedBatteryEntity, drainedSoC] = *drainedBattery;
   EXPECT_NE(kNullEntity, drainedBatteryEntity);
   EXPECT_LT(drainedSoC, 1.0);
 
   server.ResetAll();
   ASSERT_TRUE(gz::sim::test::StepUntil(server, 200u, [&]()
   {
-    return std::abs(findBatterySoC().second - 1.0) < 1e-12;
+    const auto batterySoC = findBatterySoC();
+    return batterySoC.has_value() &&
+        std::abs(batterySoC->second - 1.0) < 1e-12;
   }));
 
-  const auto [resetBatteryEntity, resetSoC] = findBatterySoC();
+  const auto resetBattery = findBatterySoC();
+  ASSERT_TRUE(resetBattery.has_value());
+  const auto [resetBatteryEntity, resetSoC] = *resetBattery;
   EXPECT_NE(kNullEntity, resetBatteryEntity);
   EXPECT_DOUBLE_EQ(resetSoC, 1.0);
   EXPECT_EQ(1, batteryCount());
 
   server.Run(true, 100, false);
-  const auto [stableBatteryEntity, stableSoC] = findBatterySoC();
+  const auto stableBattery = findBatterySoC();
+  ASSERT_TRUE(stableBattery.has_value());
+  const auto [stableBatteryEntity, stableSoC] = *stableBattery;
   EXPECT_NE(kNullEntity, stableBatteryEntity);
   EXPECT_DOUBLE_EQ(stableSoC, 1.0);
 
@@ -534,7 +552,9 @@ TEST_F(BatteryPluginTest,
       }));
   ASSERT_TRUE(publishAndWaitForDrain(dischargePub, resetSoC));
 
-  const auto [freshBatteryEntity, freshDrainSoC] = findBatterySoC();
+  const auto freshBattery = findBatterySoC();
+  ASSERT_TRUE(freshBattery.has_value());
+  const auto [freshBatteryEntity, freshDrainSoC] = *freshBattery;
   EXPECT_NE(kNullEntity, freshBatteryEntity);
   EXPECT_LT(freshDrainSoC, resetSoC);
 }

--- a/test/integration/battery_plugin.cc
+++ b/test/integration/battery_plugin.cc
@@ -513,7 +513,6 @@ TEST_F(BatteryPluginTest,
 
   server.ResetAll();
   server.Run(true, 2, false);
-  server.Run(true, 100, false);
 
   const auto [resetBatteryEntity, resetSoC] = findBatterySoC();
   EXPECT_NE(kNullEntity, resetBatteryEntity);

--- a/test/integration/battery_plugin.cc
+++ b/test/integration/battery_plugin.cc
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <string>
 #include <thread>
+#include <utility>
 
 #include <gz/common/Battery.hh>
 #include <gz/common/Console.hh>
@@ -47,7 +48,6 @@
 
 #include "plugins/MockSystem.hh"
 #include "../helpers/EnvTestFixture.hh"
-#include "../helpers/ResetUtils.hh"
 #include "../helpers/Util.hh"
 
 using namespace gz;
@@ -507,8 +507,8 @@ TEST_F(BatteryPluginTest,
   EXPECT_NE(kNullEntity, drainedBatteryEntity);
   EXPECT_LT(drainedSoC, 1.0);
 
-  gz::sim::test::reset::RequestAndApplyWorldReset(server, "batteries");
-
+  server.ResetAll();
+  server.Run(true, 2, false);
   server.Run(true, 100, false);
 
   const auto [resetBatteryEntity, resetSoC] = findBatterySoC();

--- a/test/integration/battery_plugin.cc
+++ b/test/integration/battery_plugin.cc
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cmath>
 #include <string>
 #include <utility>
 
@@ -512,7 +513,10 @@ TEST_F(BatteryPluginTest,
   EXPECT_LT(drainedSoC, 1.0);
 
   server.ResetAll();
-  server.Run(true, 2, false);
+  ASSERT_TRUE(gz::sim::test::StepUntil(server, 200u, [&]()
+  {
+    return std::abs(findBatterySoC().second - 1.0) < 1e-12;
+  }));
 
   const auto [resetBatteryEntity, resetSoC] = findBatterySoC();
   EXPECT_NE(kNullEntity, resetBatteryEntity);
@@ -522,16 +526,13 @@ TEST_F(BatteryPluginTest,
   server.Run(true, 100, false);
   const auto [stableBatteryEntity, stableSoC] = findBatterySoC();
   EXPECT_NE(kNullEntity, stableBatteryEntity);
-  EXPECT_DOUBLE_EQ(stableSoC, resetSoC);
+  EXPECT_DOUBLE_EQ(stableSoC, 1.0);
 
-  gz::transport::Node postResetNode;
-  auto postResetDischargePub =
-    postResetNode.Advertise<msgs::StringMsg>("/battery/discharge");
-  ASSERT_TRUE(gz::sim::test::WaitUntil(5s, [&postResetDischargePub]
+  ASSERT_TRUE(gz::sim::test::WaitUntil(5s, [&dischargePub]
       {
-        return postResetDischargePub.HasConnections();
+        return dischargePub.HasConnections();
       }));
-  ASSERT_TRUE(publishAndWaitForDrain(postResetDischargePub, resetSoC));
+  ASSERT_TRUE(publishAndWaitForDrain(dischargePub, resetSoC));
 
   const auto [freshBatteryEntity, freshDrainSoC] = findBatterySoC();
   EXPECT_NE(kNullEntity, freshBatteryEntity);

--- a/test/integration/battery_plugin.cc
+++ b/test/integration/battery_plugin.cc
@@ -19,7 +19,6 @@
 
 #include <chrono>
 #include <string>
-#include <thread>
 #include <utility>
 
 #include <gz/common/Battery.hh>
@@ -496,12 +495,17 @@ TEST_F(BatteryPluginTest,
       }));
 
   msgs::StringMsg msg;
-  ASSERT_TRUE(dischargePub.Publish(msg));
-  std::this_thread::sleep_for(100ms);
-  ASSERT_TRUE(gz::sim::test::StepUntil(server, 200u, [&]()
+  const auto publishAndWaitForDrain =
+    [&](auto &_pub, double _threshold) -> bool
+    {
+      return gz::sim::test::StepUntil(server, 200u, [&]()
       {
-        return findBatterySoC().second < 1.0;
-      }));
+        _pub.Publish(msg);
+        return findBatterySoC().second < _threshold;
+      });
+    };
+
+  ASSERT_TRUE(publishAndWaitForDrain(dischargePub, 1.0));
 
   const auto [drainedBatteryEntity, drainedSoC] = findBatterySoC();
   EXPECT_NE(kNullEntity, drainedBatteryEntity);
@@ -528,12 +532,7 @@ TEST_F(BatteryPluginTest,
       {
         return postResetDischargePub.HasConnections();
       }));
-  ASSERT_TRUE(postResetDischargePub.Publish(msg));
-  std::this_thread::sleep_for(100ms);
-  ASSERT_TRUE(gz::sim::test::StepUntil(server, 200u, [&]()
-      {
-        return findBatterySoC().second < resetSoC;
-      }));
+  ASSERT_TRUE(publishAndWaitForDrain(postResetDischargePub, resetSoC));
 
   const auto [freshBatteryEntity, freshDrainSoC] = findBatterySoC();
   EXPECT_NE(kNullEntity, freshBatteryEntity);


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

Add reset test for `LinearBatteryPlugin` and Fix its state contamination on world reset.

## Test logic

1. Started from the standard `battery.sdf` test world.
2. Sent a runtime message to `/battery/discharge` and waited until the `linear_battery_topics` State of Charge (SoC) dropped below `1.0`.
3. Reset the world directly with `Server::ResetAll()`.
4. Checked that the battery SoC was restored to `1.0`.
5. Ran additional steps without sending a new discharge message and confirmed the SoC stayed stable, proving the old drain trigger did not leak into the new episode.
6. Sent a fresh `/battery/discharge` message after reset and confirmed the battery could still drain normally in the new episode.
7. Also checked that only one `BatterySoC` entity named `linear_battery_topics` exists across reset, so reset does not leave duplicate battery entities behind.

## Root cause

`LinearBatteryPlugin` did not fully reset its runtime state across world reset. Runtime values such as drain / charge flags, smoothed current state, drain timing, warning state, and current history could carry over into the next episode.

There was also an ECM issue during reset reload: the plugin could create a new battery entity instead of reusing the existing one, leaving duplicate battery entities with the same name.

## Fix logic

- Added `ISystemReset` support for `LinearBatteryPlugin`.
- Reset runtime battery state, including current values, SoC, step size, drain / charge flags, drain timing, warning state, and history buffers.
- Cached the configured initial drain state so reset restores the SDF-defined behavior instead of blindly forcing drain off.
- Restored the initial power load on reset.
- Reused the existing battery entity when possible instead of creating a duplicate entity with the same name.
- Updated the existing `BatterySoC` component after reset so ECM state matches the restored internal battery state.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.