### PR TITLE
Fix crash aftering loading Hydrodynamics scene

### DIFF
--- a/test/integration/hydrodynamics.cc
+++ b/test/integration/hydrodynamics.cc
@@ -133,9 +133,9 @@ TEST_F(HydrodynamicsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(VelocityTestinOil))
 
     // Expect sphere1 to fall faster than sphere 2 as no hydro
     // drag is applied to it.
-    EXPECT_LE(sphere1Vels[i].Z(), sphere2Vels[i].Z());
-    if(sphere1Vels[i].Z() < sphere2Vels[i].Z()
-      &&  whenSphere1ExceedsSphere2Vel > 1000)
+    EXPECT_GE(sphere1Vels[i].Z(), sphere2Vels[i].Z());
+    if (sphere1Vels[i].Z() > sphere2Vels[i].Z() &&
+        whenSphere1ExceedsSphere2Vel > 1000)
     {
       // Mark this as the time when velocity of sphere1 exceeds sphere 2
       whenSphere1ExceedsSphere2Vel = i;
@@ -200,4 +200,24 @@ TEST_F(HydrodynamicsTest,
     EXPECT_NEAR(sphereVel[i-1].Y(), 0, 1e-6);
     EXPECT_GT(sphereVel[i-1].X(), 0);
   }
+}
+
+/////////////////////////////////////////////////
+/// Regression test for https://github.com/gazebosim/gz-sim/issues/3530.
+/// The current-loaded model used to go unstable after the short 1000-step
+/// tests above and eventually triggered an ODE AABB assertion.
+TEST_F(HydrodynamicsTest,
+       GZ_UTILS_TEST_DISABLED_ON_WIN32(CurrentWorldLongRun))
+{
+  common::Console::SetVerbosity(1);
+
+  auto world = common::joinPaths(std::string(PROJECT_BINARY_PATH),
+      "test", "worlds", "hydrodynamics.sdf");
+
+  ServerConfig serverConfig;
+  serverConfig.SetSdfFile(world);
+
+  TestFixture fixture(serverConfig);
+
+  EXPECT_TRUE(fixture.Server()->Run(true, 18000, false));
 }

--- a/test/worlds/hydrodynamics.sdf.in
+++ b/test/worlds/hydrodynamics.sdf.in
@@ -115,7 +115,7 @@
         <water_density>918</water_density>
         <xDotU>0</xDotU>
         <yDotV>0</yDotV>
-        <zDotW>15.381</zDotW>
+        <zDotW>-15.381</zDotW>
         <kDotP>0</kDotP>
         <mDotQ>0</mDotQ>
         <nDotR>0</nDotR>
@@ -123,8 +123,8 @@
         <xU>0</xU>
         <yVabsV>0</yVabsV>
         <yV>0</yV>
-        <zWabsW>11.5359</zWabsW>
-        <zW>0.211869</zW>
+        <zWabsW>-11.5359</zWabsW>
+        <zW>-0.211869</zW>
         <kPabsP>0</kPabsP>
         <kP>0</kP>
         <mQabsQ>0</mQabsQ>
@@ -174,7 +174,7 @@
         <water_density>1000</water_density>
         <xDotU>0</xDotU>
         <yDotV>0</yDotV>
-        <zDotW>12.5664</zDotW>
+        <zDotW>-12.5664</zDotW>
         <kDotP>0</kDotP>
         <mDotQ>0</mDotQ>
         <nDotR>0</nDotR>
@@ -182,8 +182,8 @@
         <xU>0</xU>
         <yVabsV>0</yVabsV>
         <yV>0</yV>
-        <zWabsW>94.2475</zWabsW>
-        <zW>0.0037699</zW>
+        <zWabsW>-94.2475</zWabsW>
+        <zW>-0.0037699</zW>
         <kPabsP>0</kPabsP>
         <kP>0</kP>
         <mQabsQ>0</mQabsQ>
@@ -233,7 +233,7 @@
         <water_density>1000</water_density>
         <xDotU>0</xDotU>
         <yDotV>0</yDotV>
-        <zDotW>12.5664</zDotW>
+        <zDotW>-12.5664</zDotW>
         <kDotP>0</kDotP>
         <mDotQ>0</mDotQ>
         <nDotR>0</nDotR>
@@ -241,8 +241,8 @@
         <xU>0</xU>
         <yVabsV>0</yVabsV>
         <yV>0</yV>
-        <zWabsW>94.2475</zWabsW>
-        <zW>0.0037699</zW>
+        <zWabsW>-94.2475</zWabsW>
+        <zW>-0.0037699</zW>
         <kPabsP>0</kPabsP>
         <kP>0</kP>
         <mQabsQ>0</mQabsQ>
@@ -292,7 +292,7 @@
         <water_density>1000</water_density>
         <xDotU>0</xDotU>
         <yDotV>0</yDotV>
-        <zDotW>12.5664</zDotW>
+        <zDotW>-12.5664</zDotW>
         <kDotP>0</kDotP>
         <mDotQ>0</mDotQ>
         <nDotR>0</nDotR>
@@ -300,8 +300,8 @@
         <xU>0</xU>
         <yVabsV>0</yVabsV>
         <yV>0</yV>
-        <zWabsW>94.2475</zWabsW>
-        <zW>0.0037699</zW>
+        <zWabsW>-94.2475</zWabsW>
+        <zW>-0.0037699</zW>
         <kPabsP>0</kPabsP>
         <kP>0</kP>
         <mQabsQ>0</mQabsQ>
@@ -347,23 +347,23 @@
         name="gz::sim::systems::Hydrodynamics">
         <link_name>sphere_current_link</link_name>
         <water_density>918</water_density>
-        <xDotU>15.381</xDotU>
-        <yDotV>15.381</yDotV>
-        <zDotW>15.381</zDotW>
+        <xDotU>-15.381</xDotU>
+        <yDotV>-15.381</yDotV>
+        <zDotW>-15.381</zDotW>
         <kDotP>0</kDotP>
         <mDotQ>0</mDotQ>
         <nDotR>0</nDotR>
-        <xUU>94.2475</xUU>
+        <xUabsU>-94.2475</xUabsU>
         <xU>0</xU>
-        <yVV>94.2475</yVV>
+        <yVabsV>-94.2475</yVabsV>
         <yV>0</yV>
-        <zWW>94.2475</zWW>
+        <zWabsW>-94.2475</zWabsW>
         <zW>0</zW>
-        <kPP>0</kPP>
+        <kPabsP>0</kPabsP>
         <kP>0</kP>
-        <mQQ>0</mQQ>
+        <mQabsQ>0</mQabsQ>
         <mQ>0</mQ>
-        <nRR>0</nRR>
+        <nRabsR>0</nRabsR>
         <nR>0</nR>
         <lookup_current_x>current_x</lookup_current_x>
         <lookup_current_y>current_y</lookup_current_y>


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #3530 

## Summary

According [Gazebo API Reference](https://gazebosim.org/api/gazebo/6/classignition_1_1gazebo_1_1systems_1_1Hydrodynamics.html#:~:text=Fossen%20sign%20convention%20(values%20should%20be%20negative)%3A) here, fix the scene.

The test before fix should be also failed, but it did not. The reason is that `fixture.Server()->Run(true, 1000, false);` uses too short steps to run. It crashed when use long steps(e.g. `18000`, `20000`)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
