### PR TITLE
Fix Contact state contamination on world reset

### DIFF
--- a/src/systems/contact/Contact.cc
+++ b/src/systems/contact/Contact.cc
@@ -85,7 +85,10 @@ class gz::sim::systems::ContactPrivate
 {
   /// \brief Create sensors that correspond to entities in the simulation
   /// \param[in] _ecm Mutable reference to ECM.
-  public: void CreateSensors(EntityComponentManager &_ecm);
+  /// \param[in] _includeExisting True to scan existing contact sensor
+  /// components as well as newly-created ones.
+  public: void CreateSensors(EntityComponentManager &_ecm,
+              bool _includeExisting = false);
 
   /// \brief Update and publish sensor data
   /// \param[in] _ecm Immutable reference to ECM.
@@ -154,61 +157,79 @@ void ContactSensor::Publish()
 }
 
 //////////////////////////////////////////////////
-void ContactPrivate::CreateSensors(EntityComponentManager &_ecm)
+void ContactPrivate::CreateSensors(EntityComponentManager &_ecm,
+    bool _includeExisting)
 {
   GZ_PROFILE("ContactPrivate::CreateSensors");
-  _ecm.EachNew<components::ContactSensor>(
-      [&](const Entity &_entity,
-          const components::ContactSensor *_contact) -> bool
+
+  auto createSensor =
+    [&](const Entity &_entity,
+        const components::ContactSensor *_contact) -> bool
+    {
+      if (this->entitySensorMap.find(_entity) != this->entitySensorMap.end())
+        return true;
+
+      // Check if the parent entity is a link
+      auto *parentEntity = _ecm.Component<components::ParentEntity>(_entity);
+      if (nullptr == parentEntity)
+        return true;
+
+      auto *linkComp = _ecm.Component<components::Link>(parentEntity->Data());
+      if (nullptr == linkComp)
       {
-        // Check if the parent entity is a link
-        auto *parentEntity = _ecm.Component<components::ParentEntity>(_entity);
-        if (nullptr == parentEntity)
-          return true;
+        // Contact sensors should only be attached to links
+        return true;
+      }
 
-        auto *linkComp = _ecm.Component<components::Link>(parentEntity->Data());
-        if (nullptr == linkComp)
+      auto collisionElem =
+          _contact->Data()->GetElement("contact")->GetElement("collision");
+
+      std::vector<Entity> collisionEntities;
+      // Get all the collision elements
+      for (; collisionElem;
+           collisionElem = collisionElem->GetNextElement("collision"))
+      {
+        auto collisionName = collisionElem->Get<std::string>();
+        // Get collision entity that matches the name given by the sensor's
+        // configuration.
+        auto childEntities = _ecm.ChildrenByComponents(
+            parentEntity->Data(), components::Collision(),
+            components::Name(collisionName));
+
+        if (!childEntities.empty())
         {
-          // Contact sensors should only be attached to links
-          return true;
-        }
+          // We assume that if childEntities is not empty, it only has one
+          // element.
+          collisionEntities.push_back(childEntities.front());
 
-        auto collisionElem =
-            _contact->Data()->GetElement("contact")->GetElement("collision");
-
-        std::vector<Entity> collisionEntities;
-        // Get all the collision elements
-        for (; collisionElem;
-             collisionElem = collisionElem->GetNextElement("collision"))
-        {
-          auto collisionName = collisionElem->Get<std::string>();
-          // Get collision entity that matches the name given by the sensor's
-          // configuration.
-          auto childEntities = _ecm.ChildrenByComponents(
-              parentEntity->Data(), components::Collision(),
-              components::Name(collisionName));
-
-          if (!childEntities.empty())
+          // Create component to be filled by physics.
+          if (nullptr == _ecm.Component<components::ContactSensorData>(
+              childEntities.front()))
           {
-            // We assume that if childEntities is not empty, it only has one
-            // element.
-            collisionEntities.push_back(childEntities.front());
-
-            // Create component to be filled by physics.
             _ecm.CreateComponent(childEntities.front(),
                                  components::ContactSensorData());
           }
         }
+      }
 
-        std::string defaultTopic = scopedName(_entity, _ecm, "/") + "/contact";
+      std::string defaultTopic = scopedName(_entity, _ecm, "/") + "/contact";
 
-        auto sensor = std::make_unique<ContactSensor>();
-        sensor->Load(_contact->Data(), defaultTopic, collisionEntities);
-        this->entitySensorMap.insert(
-            std::make_pair(_entity, std::move(sensor)));
+      auto sensor = std::make_unique<ContactSensor>();
+      sensor->Load(_contact->Data(), defaultTopic, collisionEntities);
+      this->entitySensorMap.insert(
+          std::make_pair(_entity, std::move(sensor)));
 
-        return true;
-      });
+      return true;
+    };
+
+  if (_includeExisting)
+  {
+    _ecm.Each<components::ContactSensor>(createSensor);
+  }
+  else
+  {
+    _ecm.EachNew<components::ContactSensor>(createSensor);
+  }
 }
 
 //////////////////////////////////////////////////
@@ -294,9 +315,19 @@ void Contact::PostUpdate(const UpdateInfo &_info,
   this->dataPtr->RemoveSensors(_ecm);
 }
 
+//////////////////////////////////////////////////
+void Contact::Reset(const UpdateInfo &, EntityComponentManager &_ecm)
+{
+  this->dataPtr->entitySensorMap.clear();
+  // After reset, existing sensor entities are not reported as new entities.
+  // Re-scan them so contact sensors keep publishing in the next episode.
+  this->dataPtr->CreateSensors(_ecm, true);
+}
+
 GZ_ADD_PLUGIN(Contact, System,
   Contact::ISystemPreUpdate,
-  Contact::ISystemPostUpdate
+  Contact::ISystemPostUpdate,
+  Contact::ISystemReset
 )
 
 GZ_ADD_PLUGIN_ALIAS(Contact, "gz::sim::systems::Contact")

--- a/src/systems/contact/Contact.hh
+++ b/src/systems/contact/Contact.hh
@@ -39,7 +39,8 @@ namespace systems
   class Contact final:
     public System,
     public ISystemPreUpdate,
-    public ISystemPostUpdate
+    public ISystemPostUpdate,
+    public ISystemReset
   {
     /// \brief Constructor
     public: Contact();
@@ -54,6 +55,10 @@ namespace systems
     /// Documentation inherited
     public: void PostUpdate(const UpdateInfo &_info,
                             const EntityComponentManager &_ecm) final;
+
+    /// Documentation inherited
+    public: void Reset(const UpdateInfo &_info,
+                       EntityComponentManager &_ecm) final;
 
     /// \brief Private data pointer
     private: std::unique_ptr<ContactPrivate> dataPtr;

--- a/test/integration/contact_system.cc
+++ b/test/integration/contact_system.cc
@@ -29,11 +29,14 @@
 
 #include "gz/sim/Server.hh"
 #include "gz/sim/SystemLoader.hh"
+#include "gz/sim/components/Collision.hh"
+#include "gz/sim/components/ContactSensorData.hh"
+#include "gz/sim/components/Name.hh"
 #include "test_config.hh"
 
 #include "plugins/MockSystem.hh"
 #include "../helpers/EnvTestFixture.hh"
-#include "../helpers/Subscription.hh"
+#include "../helpers/Relay.hh"
 #include "../helpers/Util.hh"
 
 using namespace gz;
@@ -68,6 +71,32 @@ bool validMultipleCollisionContacts(const msgs::Contacts &_contacts)
       "contact_model::link::collision_sphere2";
     if (!entityNameFound)
       return false;
+  }
+
+  return true;
+}
+
+/////////////////////////////////////////////////
+bool contactsFromEcm(const EntityComponentManager &_ecm,
+    msgs::Contacts &_contacts)
+{
+  _contacts.Clear();
+
+  for (const auto &collisionName :
+       {"collision_sphere1", "collision_sphere2"})
+  {
+    const auto collision = _ecm.EntityByComponents(
+        components::Collision(), components::Name(collisionName));
+    if (kNullEntity == collision)
+      return false;
+
+    const auto contactData =
+        _ecm.Component<components::ContactSensorData>(collision);
+    if (nullptr == contactData)
+      return false;
+
+    for (const auto &contact : contactData->Data().contact())
+      *_contacts.add_contact() = contact;
   }
 
   return true;
@@ -322,33 +351,30 @@ TEST_F(ContactSystemTest,
   using namespace std::chrono_literals;
   server.SetUpdatePeriod(1ns);
 
+  msgs::Contacts contacts;
+  test::Relay contactDataRecorder;
+  contactDataRecorder.OnPostUpdate(
+      [&](const UpdateInfo &, const EntityComponentManager &_ecm)
+      {
+        contactsFromEcm(_ecm, contacts);
+      });
+  server.AddSystem(contactDataRecorder.systemPtr);
+
   auto waitForContacts =
-      [&server](Subscription<msgs::Contacts> &_subscription)
+      [&server, &contacts]()
       {
         return test::StepUntil(server, 2000, [&]
         {
-          return _subscription.Count() > 0u &&
-              validMultipleCollisionContacts(_subscription.Last());
+          return validMultipleCollisionContacts(contacts);
         });
       };
 
-  {
-    Subscription<msgs::Contacts> initialContacts;
-    transport::Node node;
-    initialContacts.Subscribe(node, "/test_multiple_collisions", 1);
-
-    ASSERT_TRUE(waitForContacts(initialContacts));
-  }
+  ASSERT_TRUE(waitForContacts());
 
   server.ResetAll();
 
-  // Use a fresh subscription after reset so pre-reset transport messages cannot
-  // be mistaken for new episode contact data.
-  Subscription<msgs::Contacts> postResetContacts;
-  transport::Node postResetNode;
-  postResetContacts.Subscribe(postResetNode, "/test_multiple_collisions", 1);
-
-  ASSERT_TRUE(waitForContacts(postResetContacts));
+  contacts.Clear();
+  ASSERT_TRUE(waitForContacts());
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/contact_system.cc
+++ b/test/integration/contact_system.cc
@@ -19,6 +19,7 @@
 
 #include <gz/msgs/contacts.pb.h>
 
+#include <cmath>
 #include <thread>
 
 #include <gz/common/Console.hh>
@@ -32,6 +33,8 @@
 
 #include "plugins/MockSystem.hh"
 #include "../helpers/EnvTestFixture.hh"
+#include "../helpers/Subscription.hh"
+#include "../helpers/Util.hh"
 
 using namespace gz;
 using namespace sim;
@@ -39,6 +42,36 @@ using namespace sim;
 class ContactSystemTest : public InternalFixture<::testing::Test>
 {
 };
+
+/////////////////////////////////////////////////
+bool validMultipleCollisionContacts(const msgs::Contacts &_contacts)
+{
+  if (_contacts.contact_size() != 4)
+    return false;
+
+  for (const auto &contact : _contacts.contact())
+  {
+    if (contact.position_size() != 1)
+      return false;
+
+    if (std::abs(std::abs(contact.position(0).x()) - 0.25) > 5e-2 ||
+        std::abs(std::abs(contact.position(0).y()) - 1.0) > 5e-2 ||
+        std::abs(contact.position(0).z() - 1.0) > 5e-2)
+    {
+      return false;
+    }
+
+    const bool entityNameFound =
+      contact.collision1().name() ==
+      "contact_model::link::collision_sphere1" ||
+      contact.collision1().name() ==
+      "contact_model::link::collision_sphere2";
+    if (!entityNameFound)
+      return false;
+  }
+
+  return true;
+}
 
 /////////////////////////////////////////////////
 // This test verifies that colliding entity names are populated in
@@ -270,6 +303,53 @@ TEST_F(ContactSystemTest,
     std::lock_guard<std::mutex> lock(contactMutex);
     EXPECT_EQ(0u, contactMsgs.size());
   }
+}
+
+/////////////////////////////////////////////////
+TEST_F(ContactSystemTest,
+       GZ_UTILS_TEST_DISABLED_ON_WIN32(ResetRestoresEarlyContacts))
+{
+  // Start server
+  ServerConfig serverConfig;
+  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
+    "/test/worlds/contact.sdf";
+  serverConfig.SetSdfFile(sdfFile);
+
+  Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  using namespace std::chrono_literals;
+  server.SetUpdatePeriod(1ns);
+
+  transport::Node node;
+  Subscription<msgs::Contacts> initialContacts;
+  initialContacts.Subscribe(node, "/test_multiple_collisions", 1);
+  auto waitForContacts =
+      [&server](Subscription<msgs::Contacts> &_subscription)
+      {
+        return test::StepUntil(server, 2000, [&]
+        {
+          return _subscription.Count() > 0u &&
+              validMultipleCollisionContacts(_subscription.Last());
+        });
+      };
+
+  ASSERT_TRUE(waitForContacts(initialContacts));
+
+  server.ResetAll();
+  server.Run(true, 2, false);
+
+  // Use a fresh subscription after reset so pre-reset transport messages cannot
+  // be mistaken for new episode contact data.
+  transport::Node postResetNode;
+  Subscription<msgs::Contacts> postResetContacts;
+  postResetContacts.Subscribe(postResetNode, "/test_multiple_collisions", 1);
+
+  ASSERT_TRUE(waitForContacts(postResetContacts));
+  const auto postResetContactMsg = postResetContacts.Last();
+
+  EXPECT_TRUE(validMultipleCollisionContacts(postResetContactMsg));
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/contact_system.cc
+++ b/test/integration/contact_system.cc
@@ -341,7 +341,6 @@ TEST_F(ContactSystemTest,
   }
 
   server.ResetAll();
-  server.Run(true, 2, false);
 
   // Use a fresh subscription after reset so pre-reset transport messages cannot
   // be mistaken for new episode contact data.

--- a/test/integration/contact_system.cc
+++ b/test/integration/contact_system.cc
@@ -322,9 +322,6 @@ TEST_F(ContactSystemTest,
   using namespace std::chrono_literals;
   server.SetUpdatePeriod(1ns);
 
-  transport::Node node;
-  Subscription<msgs::Contacts> initialContacts;
-  initialContacts.Subscribe(node, "/test_multiple_collisions", 1);
   auto waitForContacts =
       [&server](Subscription<msgs::Contacts> &_subscription)
       {
@@ -335,21 +332,24 @@ TEST_F(ContactSystemTest,
         });
       };
 
-  ASSERT_TRUE(waitForContacts(initialContacts));
+  {
+    Subscription<msgs::Contacts> initialContacts;
+    transport::Node node;
+    initialContacts.Subscribe(node, "/test_multiple_collisions", 1);
+
+    ASSERT_TRUE(waitForContacts(initialContacts));
+  }
 
   server.ResetAll();
   server.Run(true, 2, false);
 
   // Use a fresh subscription after reset so pre-reset transport messages cannot
   // be mistaken for new episode contact data.
-  transport::Node postResetNode;
   Subscription<msgs::Contacts> postResetContacts;
+  transport::Node postResetNode;
   postResetContacts.Subscribe(postResetNode, "/test_multiple_collisions", 1);
 
   ASSERT_TRUE(waitForContacts(postResetContacts));
-  const auto postResetContactMsg = postResetContacts.Last();
-
-  EXPECT_TRUE(validMultipleCollisionContacts(postResetContactMsg));
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #

## Summary

During the reset audit, the `Contact` system failed the reset behavior test. After a world reset, contact sensor data did not reliably recover for the next episode.

## Test logic

1. Loaded the existing `contact.sdf` world.
2. Subscribed to the contact sensor topic and waited for valid contact data.
3. Executed a direct world reset with `Server::ResetAll()` to avoid transport reset flakiness.
4. Re-subscribed after reset to avoid late pre-reset transport messages.
5. Checked that contact data is published again and that the contact count / contact positions are valid after reset.

## Root cause

`Contact` created its runtime sensor objects from `EachNew<ContactSensor>`. After a world reset, the sensor entities still exist in the ECM, so they are not reported as “new” again. If the runtime sensor map is cleared or becomes stale across reset, the system cannot rebuild contact sensors from `EachNew`, and contact publishing may not recover correctly.

## Fix logic

1. Add `ISystemReset` support to `Contact`.
2. Clear the runtime `entitySensorMap` on reset.
3. Re-scan existing `ContactSensor` components during reset using a full `Each<ContactSensor>` pass.
4. Keep the normal `PreUpdate` path using `EachNew<ContactSensor>` so regular runtime behavior remains unchanged.
5. Avoid recreating duplicate `ContactSensorData` components when rebuilding after reset.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.

