### PR TITLE
Allow to enable/disable static and gravity

### DIFF
--- a/include/gz/sim/Model.hh
+++ b/include/gz/sim/Model.hh
@@ -187,6 +187,18 @@ namespace gz
       public: void SetWorldPoseCmd(EntityComponentManager &_ecm,
           const math::Pose3d &_pose);
 
+      /// \brief Set a new state to change the model's static.
+      /// \param[in] _ecm Entity-component manager.
+      /// \param[in] _state New model static state.
+      public: void SetStaticStateCmd(EntityComponentManager &_ecm,
+          bool _state);
+
+      /// \brief Set a new state to change the model's gravity.
+      /// \param[in] _ecm Entity-component manager.
+      /// \param[in] _enabled True gravity enabled false otherwise.
+      public: void SetGravityEnabledCmd(EntityComponentManager &_ecm,
+          bool _enabled);
+
       /// \brief Get the model's canonical link entity.
       /// \param[in] _ecm Entity-component manager.
       /// \return Link entity.

--- a/include/gz/sim/components/Gravity.hh
+++ b/include/gz/sim/components/Gravity.hh
@@ -37,10 +37,15 @@ namespace components
   using Gravity = Component<math::Vector3d, class GravityTag>;
   GZ_SIM_REGISTER_COMPONENT("gz_sim_components.Gravity", Gravity)
 
-  /// \brief Store the gravity acceleration.
+  /// \brief Store the gravity enabled flag.
   using GravityEnabled = Component<bool, class GravityEnabledTag>;
   GZ_SIM_REGISTER_COMPONENT(
       "gz_sim_components.GravityEnabled", GravityEnabled)
+
+  /// \brief Store the gravity enabled CMD.
+  using GravityEnabledCmd = Component<bool, class GravityEnabledCmdTag>;
+  GZ_SIM_REGISTER_COMPONENT(
+    "gz_sim_components.GravityEnabledCmd", GravityEnabledCmd)
 }
 }
 }

--- a/include/gz/sim/components/Static.hh
+++ b/include/gz/sim/components/Static.hh
@@ -33,6 +33,13 @@ namespace components
   /// moveable).
   using Static = Component<bool, class StaticTag>;
   GZ_SIM_REGISTER_COMPONENT("gz_sim_components.Static", Static)
+
+  // \brief A component type that contains the commanded static state of an
+  /// entity represented by bool.
+  using StaticStateCmd = Component<
+    bool, class StaticStateCmdTag>;
+  GZ_SIM_REGISTER_COMPONENT(
+      "gz_sim_components.StaticStateCmd", StaticStateCmd)
 }
 }
 }

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -16,6 +16,7 @@
 */
 
 #include "gz/sim/components/CanonicalLink.hh"
+#include "gz/sim/components/Gravity.hh"
 #include "gz/sim/components/Joint.hh"
 #include "gz/sim/components/Link.hh"
 #include "gz/sim/components/Model.hh"
@@ -216,6 +217,45 @@ void Model::SetWorldPoseCmd(EntityComponentManager &_ecm,
         [](const math::Pose3d &, const math::Pose3d &){return false;});
     _ecm.SetChanged(this->dataPtr->id,
         components::WorldPoseCmd::typeId, ComponentState::OneTimeChange);
+  }
+}
+
+//////////////////////////////////////////////////
+void Model::SetStaticStateCmd(EntityComponentManager &_ecm,
+    bool _state)
+{
+  auto staticComp = _ecm.Component<components::StaticStateCmd>(
+      this->dataPtr->id);
+  if (!staticComp)
+  {
+    _ecm.CreateComponent(this->dataPtr->id, components::StaticStateCmd(_state));
+  }
+  else
+  {
+    staticComp->SetData(_state,
+        [](const bool &, const bool &){return false;});
+    _ecm.SetChanged(this->dataPtr->id,
+        components::StaticStateCmd::typeId, ComponentState::OneTimeChange);
+  }
+}
+
+//////////////////////////////////////////////////
+void Model::SetGravityEnabledCmd(EntityComponentManager &_ecm,
+    bool _enabled)
+{
+  auto staticComp = _ecm.Component<components::GravityEnabledCmd>(
+      this->dataPtr->id);
+  if (!staticComp)
+  {
+    _ecm.CreateComponent(this->dataPtr->id,
+        components::GravityEnabledCmd(_enabled));
+  }
+  else
+  {
+    staticComp->SetData(_enabled,
+        [](const bool &, const bool &){return false;});
+    _ecm.SetChanged(this->dataPtr->id,
+        components::GravityEnabledCmd::typeId, ComponentState::OneTimeChange);
   }
 }
 

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -62,8 +62,10 @@
 #include <gz/physics/GetBoundingBox.hh>
 #include <gz/physics/GetEntities.hh>
 #include <gz/physics/GetRayIntersection.hh>
+#include <gz/physics/Gravity.hh>
 #include <gz/physics/Joint.hh>
 #include <gz/physics/Link.hh>
+#include <gz/physics/Model.hh>
 #include <gz/physics/RemoveEntities.hh>
 #include <gz/physics/Shape.hh>
 #include <gz/physics/SphereShape.hh>
@@ -387,6 +389,14 @@ class gz::sim::systems::PhysicsPrivate
   /// deleted the following iteration.
   public: std::unordered_set<Entity> worldPoseCmdsToRemove;
 
+  /// \brief Entities whose static commands have been processed and should be
+  /// deleted the following iteration.
+  public: std::unordered_set<Entity> staticStateCmdsToRemove;
+
+  /// \brief Entities whose gravity enabled commands have been processed and
+  /// should be deleted the following iteration.
+  public: std::unordered_set<Entity> gravityEnabledCmdsToRemove;
+
   /// \brief IDs of the ContactSurfaceHandler callbacks registered for worlds
   public: std::unordered_map<Entity, std::string> worldContactCallbackIDs;
 
@@ -587,6 +597,20 @@ class gz::sim::systems::PhysicsPrivate
 
 
   //////////////////////////////////////////////////
+  // static
+  /// \brief Feature list for model static state.
+  public: struct StaticStateFeatureList : physics::FeatureList<
+            MinimumFeatureList,
+            physics::ModelStaticState>{};
+
+  //////////////////////////////////////////////////
+  // enabled gravity
+  /// \brief Feature list for model gravity enabled.
+  public: struct GravityEnabledFeatureList : physics::FeatureList<
+            MinimumFeatureList,
+            physics::GravityEnabled>{};
+
+  //////////////////////////////////////////////////
   // Model Bounding box
   /// \brief Feature list for model bounding box.
   public: struct ModelBoundingBoxFeatureList : physics::FeatureList<
@@ -722,7 +746,9 @@ class gz::sim::systems::PhysicsPrivate
             ModelBoundingBoxFeatureList,
             NestedModelFeatureList,
             ConstructSdfLinkFeatureList,
-            ConstructSdfJointFeatureList>;
+            ConstructSdfJointFeatureList,
+            StaticStateFeatureList,
+            GravityEnabledFeatureList>;
 
   /// \brief A map between model entity ids in the ECM to Model Entities in
   /// gz-physics.
@@ -2539,6 +2565,116 @@ void PhysicsPrivate::UpdatePhysics(EntityComponentManager &_ecm)
         return true;
       });
 
+  // update Static State
+  auto olderStaticStateCmdsToRemove = std::move(this->staticStateCmdsToRemove);
+  this->staticStateCmdsToRemove.clear();
+
+  _ecm.Each<components::Model,
+    components::StaticStateCmd,
+    components::Name>(
+      [&](const Entity &_entity, const components::Model *,
+          const components::StaticStateCmd *_staticSateCmd,
+          const components::Name *_name)->bool
+      {
+        this->staticStateCmdsToRemove.insert(_entity);
+
+        auto modelPtrPhys = this->entityModelMap.Get(_entity);
+        if (nullptr == modelPtrPhys)
+          return true;
+
+        auto ssModel =
+          this->entityModelMap.EntityCast<StaticStateFeatureList>(_entity);
+
+        if (!ssModel)
+        {
+          static bool informed{false};
+          if (!informed)
+          {
+            gzdbg << "Attempting to set a static state, but the physics "
+                   << "engine doesn't support feature "
+                   << "[ModelStaticState]. static state won't be populated."
+                   << " " << _name->Data()
+                   << std::endl;
+            informed = true;
+          }
+
+          // Break Each call since no Static state'es can be processed
+          return false;
+        }
+
+        bool is_static = this->staticEntities.find(_entity) !=
+            this->staticEntities.end();
+        if (is_static != _staticSateCmd->Data())
+        {
+          if (is_static)
+          {
+            this->staticEntities.erase(_entity);
+          }
+          else
+          {
+            this->staticEntities.insert(_entity);
+          }
+        }
+
+        ssModel->SetStatic(_staticSateCmd->Data());
+        return true;
+      });
+
+  // Remove world commands from previous iteration. We let them rotate one
+  // iteration so other systems have a chance to react to them too.
+  for (const Entity &entity : olderStaticStateCmdsToRemove)
+  {
+    _ecm.RemoveComponent<components::StaticStateCmd>(entity);
+  }
+
+  // update Gravity enabled
+  auto olderGravityEnabledCmdsToRemove =
+    std::move(this->gravityEnabledCmdsToRemove);
+  this->gravityEnabledCmdsToRemove.clear();
+
+  _ecm.Each<components::Model,
+    components::GravityEnabledCmd,
+    components::Name>(
+      [&](const Entity &_entity, const components::Model *,
+          const components::GravityEnabledCmd *_gravityEnabledCmd,
+          const components::Name *_name)->bool
+      {
+        this->gravityEnabledCmdsToRemove.insert(_entity);
+
+        auto modelPtrPhys = this->entityModelMap.Get(_entity);
+        if (nullptr == modelPtrPhys)
+          return true;
+
+        auto ssModel =
+          this->entityModelMap.EntityCast<GravityEnabledFeatureList>(_entity);
+
+        if (!ssModel)
+        {
+          static bool informed{false};
+          if (!informed)
+          {
+            gzdbg << "Attempting to set gravity enabled, but the physics "
+                   << "engine doesn't support feature "
+                   << "[GravityEnabled]. gravity enabled won't be populated."
+                   << " " << _name->Data()
+                   << std::endl;
+            informed = true;
+          }
+
+          // Break Each call since no Gravity enabled can be processed
+          return false;
+        }
+        ssModel->SetGravityEnabled(_gravityEnabledCmd->Data());
+        return true;
+      });
+
+  // Remove world commands from previous iteration. We let them rotate one
+  // iteration so other systems have a chance to react to them too.
+  for (const Entity &entity : olderGravityEnabledCmdsToRemove)
+  {
+    _ecm.RemoveComponent<components::GravityEnabledCmd>(entity);
+  }
+
   // Update model pose
   auto olderWorldPoseCmdsToRemove = std::move(this->worldPoseCmdsToRemove);
   this->worldPoseCmdsToRemove.clear();
@@ -2996,6 +3132,8 @@ void PhysicsPrivate::ResetPhysics(EntityComponentManager &_ecm)
   this->canonicalLinkModelTracker = CanonicalLinkModelTracker();
   this->modelWorldPoses.clear();
   this->worldPoseCmdsToRemove.clear();
+  this->staticStateCmdsToRemove.clear();
+  this->gravityEnabledCmdsToRemove.clear();
 
   this->RemovePhysicsEntities(_ecm);
   this->CreatePhysicsEntities(_ecm, false);


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/gazebosim/gz-physics/pull/919

## Summary

Support enable/disable static and gravity

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
