### PR TITLE
fix(test): adapt ray miss assertion to gz-physics#880

### DIFF
--- a/test/integration/physics_system.cc
+++ b/test/integration/physics_system.cc
@@ -3135,7 +3135,7 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(RayIntersections))
           ASSERT_TRUE(
             math::eigen3::convert(results2[i].normal).array().isNaN().all());
           ASSERT_TRUE(
-            std::isnan(results2[i].fraction));
+            std::isinf(results2[i].fraction));
         }
       });
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

gazebosim/gz-physics#880 changed the no-hit ray fraction from `NaN` to `+INF`, which broke the `RayIntersections` test in this repo. My bad for not catching this sooner. @azeey pointed it out and suggested extracting the fix into its own PR, which is what this is.

One-line change: `std::isnan` -> `std::isinf` on the no-hit fraction assertion.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Sonnet 4.6

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
