### PR TITLE
package.xml: depend on gz-tools

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -23,7 +23,7 @@
   <depend>gz-plugin</depend>
   <depend>gz-rendering</depend>
   <depend>gz-sensors</depend>
-  <depend>gz-tools2</depend>
+  <depend>gz-tools</depend>
   <depend>gz-transport</depend>
   <depend>gz-utils</depend>
   <depend>libdw-dev</depend>


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebo-tooling/release-tools/issues/1446

## Summary

The Rotary `package.xml` is updated from depending on `gz-tools2` to `gz-tools`. This dependency is left over from Jetty and needs to be updated in all Rotary packages.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
