### PR TITLE
Fix Windows Build

### DIFF
--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -368,6 +368,9 @@ SimulationRunner::SimulationRunner(const sdf::World &_world,
          << "/" << genWorldSdfService << "]" << std::endl;
 }
 
+//////////////////////////////////////////////////
+SimulationRunner::~SimulationRunner() = default;
+
 /////////////////////////////////////////////////
 void SimulationRunner::UpdateCurrentInfo()
 {

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -87,7 +87,7 @@ namespace gz
                                 bool _createEntities = true);
 
       /// \brief Destructor.
-      public: virtual ~SimulationRunner() = default;
+      public: virtual ~SimulationRunner();
 
       /// \brief Stop running
       public: void Stop();


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary

#3512 accidentally broke windows tests. This PR resolves the breakage.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.

