### PR TITLE
Fix regression in tactile plugin

### DIFF
--- a/test/integration/optical_tactile_plugin.cc
+++ b/test/integration/optical_tactile_plugin.cc
@@ -169,4 +169,6 @@ TEST_F(OpticalTactilePluginTest,
   EXPECT_EQ(math::Vector3f(-1, 0, 0), upperLeftNormalForce);
   EXPECT_EQ(math::Vector3f(-1, 0, 0), lowerLeftNormalForce);
   EXPECT_EQ(math::Vector3f(-1, 0, 0), lowerRightNormalForce);
+
+  this->server.reset();
 }


### PR DESCRIPTION

# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
We have been getting a lot of regressions in the OpticalTactilePlugin test. The stack trace produced in CI looks like:
```
INTEGRATION_optical_tactile_plugin ......................***Exception: SegFault  6.83 sec
  Running main() from /github/workspace/test/gtest_vendor/src/gtest_main.cc
  [==========] Running 1 test from 1 test suite.
  [----------] Global test environment set-up.
  [----------] 1 test from OpticalTactilePluginTest
  [ RUN      ] OpticalTactilePluginTest.ForcesOnPlane
  (2026-05-25 01:43:24.228) [info] [ServerPrivate.cc:697] Loading SDF world file[/github/workspace/test/worlds/optical_tactile_plugin.sdf].
  (2026-05-25 01:43:26.218) [info] [SystemManager.cc:54] Serving entity system service on [/entity/system/add]
  (2026-05-25 01:43:26.219) [info] [SimulationRunner.cc:331] Serving world controls on [/world/optical_tactile_plugin/control], [/world/optical_tactile_plugin/control/state] and [/world/optical_tactile_plugin/playback/control]
  (2026-05-25 01:43:26.219) [info] [SimulationRunner.cc:357] Serving GUI information on [/world/optical_tactile_plugin/gui/info]
  (2026-05-25 01:43:26.219) [info] [SimulationRunner.cc:360] World [optical_tactile_plugin] initialized with [fast] physics profile.
  (2026-05-25 01:43:26.219) [info] [SimulationRunner.cc:367] Serving world SDF generation service on [/world/optical_tactile_plugin/generate_world_sdf]
  (2026-05-25 01:43:26.219) [info] [ServerPrivate.cc:357] Serving world names on [/gazebo/worlds]
  (2026-05-25 01:43:26.219) [info] [ServerPrivate.cc:370] Resource path add service on [/gazebo/resource_paths/add].
  (2026-05-25 01:43:26.219) [info] [ServerPrivate.cc:383] Resource path get service on [/gazebo/resource_paths/get].
  (2026-05-25 01:43:26.219) [info] [ServerPrivate.cc:398] Resource path resolve service on [/gazebo/resource_paths/resolve].
  (2026-05-25 01:43:26.219) [info] [ServerPrivate.cc:412] Resource paths published on [/gazebo/resource_paths].
  (2026-05-25 01:43:26.219) [info] [ServerPrivate.cc:425] Server control service on [/server_control].
  (2026-05-25 01:43:26.318) [debug] [Physics.cc:1011] Loaded [gz::physics::dartsim::Plugin] from library [/usr/lib/x86_64-linux-gnu/gz-physics/engine-plugins/libgz-physics-dartsim-plugin.so]
  (2026-05-25 01:43:26.318) [debug] [SystemManager.cc:80] Loaded system [gz::sim::systems::Physics] for entity [1]
  (2026-05-25 01:43:26.319) [debug] [SystemManager.cc:80] Loaded system [gz::sim::systems::Contact] for entity [1]
  (2026-05-25 01:43:26.322) [debug] [Sensors.cc:697] Configuring Sensors system
  (2026-05-25 01:43:26.322) [debug] [Sensors.cc:557] SensorsPrivate::Run
  (2026-05-25 01:43:26.322) [debug] [SystemManager.cc:80] Loaded system [gz::sim::systems::Sensors] for entity [1]
  (2026-05-25 01:43:26.322) [debug] [Sensors.cc:532] SensorsPrivate::RenderThread started
  (2026-05-25 01:43:26.322) [debug] [Sensors.cc:337] Waiting for init
  (2026-05-25 01:43:26.323) [info] [OpticalTactilePlugin.cc:345] Topic publishing normal forces [/optical_tactile_sensor/normal_forces]
  (2026-05-25 01:43:26.323) [info] [OpticalTactilePlugin.cc:359] Service to enable tactile sensor [/optical_tactile_sensor/enable]
  (2026-05-25 01:43:26.323) [debug] [SystemManager.cc:80] Loaded system [gz::sim::systems::OpticalTactilePlugin] for entity [8]
  (2026-05-25 01:43:26.323) [info] [LevelManager.cc:646] Loaded level [default]
  (2026-05-25 01:43:26.324) [info] [ServerConfig.cc:1027] Copied installed config [/usr/share/gz/gz-sim/server.config] to default config [/tmp/test/fake_home/.gz/sim/11/server.config].
  (2026-05-25 01:43:26.324) [debug] [ServerConfig.cc:1042] Loading (3) plugins from file [/tmp/test/fake_home/.gz/sim/11/server.config]
  (2026-05-25 01:43:26.324) [debug] [SimulationRunner.cc:1806] Additional plugins to load:
  (2026-05-25 01:43:26.324) [debug] [SimulationRunner.cc:1809] gz::sim::systems::UserCommands gz-sim-user-commands-system
  (2026-05-25 01:43:26.324) [debug] [SimulationRunner.cc:1809] gz::sim::systems::SceneBroadcaster gz-sim-scene-broadcaster-system
  (2026-05-25 01:43:26.325) [info] [UserCommands.cc:751] Create service on [/world/optical_tactile_plugin/create_multiple] (async)
  (2026-05-25 01:43:26.325) [info] [UserCommands.cc:753] Create service on [/world/optical_tactile_plugin/create_multiple/blocking] (blocking)
  (2026-05-25 01:43:26.325) [info] [UserCommands.cc:751] Remove service on [/world/optical_tactile_plugin/remove] (async)
  (2026-05-25 01:43:26.325) [info] [UserCommands.cc:753] Remove service on [/world/optical_tactile_plugin/remove/blocking] (blocking)
  (2026-05-25 01:43:26.326) [info] [UserCommands.cc:751] Pose service on [/world/optical_tactile_plugin/set_pose] (async)
  (2026-05-25 01:43:26.326) [info] [UserCommands.cc:753] Pose service on [/world/optical_tactile_plugin/set_pose/blocking] (blocking)
  (2026-05-25 01:43:26.326) [info] [UserCommands.cc:751] Pose service on [/world/optical_tactile_plugin/set_pose_vector] (async)
  (2026-05-25 01:43:26.326) [info] [UserCommands.cc:753] Pose service on [/world/optical_tactile_plugin/set_pose_vector/blocking] (blocking)
  (2026-05-25 01:43:26.326) [info] [UserCommands.cc:751] Light configuration service on [/world/optical_tactile_plugin/light_config] (async)
  (2026-05-25 01:43:26.326) [info] [UserCommands.cc:753] Light configuration service on [/world/optical_tactile_plugin/light_config/blocking] (blocking)
  (2026-05-25 01:43:26.326) [info] [UserCommands.cc:751] Physics service on [/world/optical_tactile_plugin/set_physics] (async)
  (2026-05-25 01:43:26.326) [info] [UserCommands.cc:753] Physics service on [/world/optical_tactile_plugin/set_physics/blocking] (blocking)
  (2026-05-25 01:43:26.326) [info] [UserCommands.cc:751] SphericalCoordinates service on [/world/optical_tactile_plugin/set_spherical_coordinates] (async)
  (2026-05-25 01:43:26.326) [info] [UserCommands.cc:753] SphericalCoordinates service on [/world/optical_tactile_plugin/set_spherical_coordinates/blocking] (blocking)
  (2026-05-25 01:43:26.326) [info] [UserCommands.cc:751] Enable collision service on [/world/optical_tactile_plugin/enable_collision] (async)
  (2026-05-25 01:43:26.326) [info] [UserCommands.cc:753] Enable collision service on [/world/optical_tactile_plugin/enable_collision/blocking] (blocking)
  (2026-05-25 01:43:26.326) [info] [UserCommands.cc:751] Disable collision service on [/world/optical_tactile_plugin/disable_collision] (async)
  (2026-05-25 01:43:26.326) [info] [UserCommands.cc:753] Disable collision service on [/world/optical_tactile_plugin/disable_collision/blocking] (blocking)
  (2026-05-25 01:43:26.327) [info] [UserCommands.cc:751] Material service on [/world/optical_tactile_plugin/visual_config] (async)
  (2026-05-25 01:43:26.327) [info] [UserCommands.cc:753] Material service on [/world/optical_tactile_plugin/visual_config/blocking] (blocking)
  (2026-05-25 01:43:26.327) [info] [UserCommands.cc:751] Material service on [/world/optical_tactile_plugin/wheel_slip] (async)
  (2026-05-25 01:43:26.327) [info] [UserCommands.cc:753] Material service on [/world/optical_tactile_plugin/wheel_slip/blocking] (blocking)
  (2026-05-25 01:43:26.327) [debug] [SystemManager.cc:80] Loaded system [gz::sim::systems::UserCommands] for entity [1]
  (2026-05-25 01:43:26.327) [debug] [SystemManager.cc:80] Loaded system [gz::sim::systems::SceneBroadcaster] for entity [1]
  (2026-05-25 01:43:26.328) [info] [SimulationRunner.cc:759] Found no publishers on /stats, adding root stats topic
  (2026-05-25 01:43:26.328) [info] [SimulationRunner.cc:793] Found no publishers on /clock, adding root clock topic
  (2026-05-25 01:43:26.328) [info] [Contact.cc:128] Contact system publishing on world/optical_tactile_plugin/model/tactile_sensor/link/contact_surface/sensor/contact_sensor/contact
  (2026-05-25 01:43:26.330) [debug] [Sensors.cc:953] Initialization needed
  (2026-05-25 01:43:26.330) [debug] [Sensors.cc:349] Initializing render context
  (2026-05-25 01:43:26.330) [info] [SceneBroadcaster.cc:634] Serving scene information on [/world/optical_tactile_plugin/scene/info]
  (2026-05-25 01:43:26.330) [info] [SceneBroadcaster.cc:643] Serving graph information on [/world/optical_tactile_plugin/scene/graph]
  (2026-05-25 01:43:26.330) [info] [SceneBroadcaster.cc:654] Serving full state on [/world/optical_tactile_plugin/state]
  (2026-05-25 01:43:26.330) [info] [SceneBroadcaster.cc:663] Serving full state (async) on [/world/optical_tactile_plugin/state_async]
  (2026-05-25 01:43:26.330) [info] [SceneBroadcaster.cc:671] Publishing scene information on [/world/optical_tactile_plugin/scene/info]
  (2026-05-25 01:43:26.331) [info] [SceneBroadcaster.cc:680] Publishing entity deletions on [/world/optical_tactile_plugin/scene/deletion]
  (2026-05-25 01:43:26.331) [info] [SceneBroadcaster.cc:689] Publishing state changes on [/world/optical_tactile_plugin/state]
  (2026-05-25 01:43:26.331) [info] [SceneBroadcaster.cc:700] Publishing pose messages on [/world/optical_tactile_plugin/pose/info]
  (2026-05-25 01:43:26.331) [info] [SceneBroadcaster.cc:711] Publishing dynamic pose messages on [/world/optical_tactile_plugin/dynamic_pose/info]
  (2026-05-25 01:43:26.331) [info] [RenderEngineManager.cc:501] Loading plugin [gz-rendering-ogre2]
  (2026-05-25 01:43:26.467) [debug] [RenderUtil.cc:2646] Create scene [scene]
  (2026-05-25 01:43:26.582) [debug] [Sensors.cc:391] Rendering Thread initialized
  (2026-05-25 01:43:26.582) [debug] [Sensors.cc:953] Initialization needed
  (2026-05-25 01:43:26.584) [debug] [DepthCameraSensor.cc:285] Depth images for [tactile_sensor::contact_surface::depth_camera] advertised on [depth_camera]
  (2026-05-25 01:43:26.584) [debug] [CameraSensor.cc:629] Camera info for [tactile_sensor::contact_surface::depth_camera] advertised on [/camera_info]
  (2026-05-25 01:43:26.584) [debug] [DepthCameraSensor.cc:313] Points for [tactile_sensor::contact_surface::depth_camera] advertised on [depth_camera/points]
  (2026-05-25 01:43:27.694) [info] [OpticalTactilePlugin.cc:632] Enabling optical tactile sensor with namespace [optical_tactile_sensor]: 1
  (2026-05-25 01:43:27.694) [debug] [OpticalTactilePlugin.cc:598] Depth camera publishing to depth_camera topic
  Stack trace (most recent call last):
  #14   Object "/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2", at 0xffffffffffffffff, in 
  #13   Object "/github/workspace/build/bin/INTEGRATION_optical_tactile_plugin", at 0x5635be4aebe4, in _start
  #12   Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7f1de692828a, in __libc_start_main
  #11   Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7f1de69281c9, in 
  #10 | Source "/github/workspace/test/gtest_vendor/src/gtest_main.cc", line 51, in RUN_ALL_TESTS
      |    49:   printf("Running main() from %s\n", __FILE__);
      |    50:   testing::InitGoogleTest(&argc, argv);
      | >  51:   return RUN_ALL_TESTS();
      |    52: }
      |    53: #endif
        Source "/github/workspace/test/gtest_vendor/include/gtest/gtest.h", line 2293, in main [0x5635be4aebb3]
         2290: // namespace and has an all-caps name.
         2291: int RUN_ALL_TESTS() GTEST_MUST_USE_RESULT_;
         2292: 
        >2293: inline int RUN_ALL_TESTS() { return ::testing::UnitTest::GetInstance()->Run(); }
         2294: 
         2295: GTEST_DISABLE_MSC_WARNINGS_POP_()  //  4251
  #9    Source "/github/workspace/test/gtest_vendor/src/gtest.cc", line 5444, in Run [0x5635be4df852]
         5441:   }
         5442: #endif  // GTEST_OS_WINDOWS
         5443: 
        >5444:   return internal::HandleExceptionsInMethodIfSupported(
         5445:              impl(), &internal::UnitTestImpl::RunAllTests,
         5446:              "auxiliary test code (environments or event listeners)")
         5447:              ? 0
  #8  | Source "/github/workspace/test/gtest_vendor/src/gtest.cc", line 2635, in HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>
      |  2633: #if GTEST_HAS_EXCEPTIONS
      |  2634:     try {
      | >2635:       return HandleSehExceptionsInMethodIfSupported(object, method, location);
      |  2636:     } catch (const AssertionException&) {  // NOLINT
      |  2637:       // This failure was reported already.
        Source "/github/workspace/test/gtest_vendor/src/gtest.cc", line 2599, in HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> [0x5635be4f76c6]
         2596:   }
         2597: #else
         2598:   (void)location;
        >2599:   return (object->*method)();
         2600: #endif  // GTEST_HAS_SEH
         2601: }
  #7  | Source "/github/workspace/test/gtest_vendor/src/gtest.cc", line 5870, in Run
      |  5868:         for (int test_index = 0; test_index < total_test_suite_count();
      |  5869:              test_index++) {
      | >5870:           GetMutableSuiteCase(test_index)->Run();
      |  5871:           if (GTEST_FLAG_GET(fail_fast) &&
      |  5872:               GetMutableSuiteCase(test_index)->Failed()) {
        Source "/github/workspace/test/gtest_vendor/src/gtest.cc", line 2986, in RunAllTests [0x5635be4eca84]
         2984: // Runs every test in this TestSuite.
         2985: void TestSuite::Run() {
        >2986:   if (!should_run_) return;
         2987: 
         2988:   internal::UnitTestImpl* const impl = internal::GetUnitTestImpl();
         2989:   impl->set_current_test_suite(this);
  #6    Source "/github/workspace/test/gtest_vendor/src/gtest.cc", line 3012, in Run [0x5635be4df612]
         3009:     if (skip_all) {
         3010:       GetMutableTestInfo(i)->Skip();
         3011:     } else {
        >3012:       GetMutableTestInfo(i)->Run();
         3013:     }
         3014:     if (GTEST_FLAG_GET(fail_fast) &&
         3015:         GetMutableTestInfo(i)->result()->Failed()) {
  #5    Source "/github/workspace/test/gtest_vendor/src/gtest.cc", line 2853, in Run [0x5635be4df444]
         2850:   if (!Test::HasFatalFailure() && !Test::IsSkipped()) {
         2851:     // This doesn't throw as all user code that can throw are wrapped into
         2852:     // exception handling code.
        >2853:     test->Run();
         2854:   }
         2855: 
         2856:   if (test != nullptr) {
  #4  | Source "/github/workspace/test/gtest_vendor/src/gtest.cc", line 2635, in HandleSehExceptionsInMethodIfSupported<testing::Test, void>
      |  2633: #if GTEST_HAS_EXCEPTIONS
      |  2634:     try {
      | >2635:       return HandleSehExceptionsInMethodIfSupported(object, method, location);
      |  2636:     } catch (const AssertionException&) {  // NOLINT
      |  2637:       // This failure was reported already.
        Source "/github/workspace/test/gtest_vendor/src/gtest.cc", line 2599, in HandleExceptionsInMethodIfSupported<testing::Test, void> [0x5635be4f6fee]
         2596:   }
         2597: #else
         2598:   (void)location;
        >2599:   return (object->*method)();
         2600: #endif  // GTEST_HAS_SEH
         2601: }
  #3    Source "/github/workspace/test/integration/../helpers/EnvTestFixture.hh", line 52, in TearDown [0x5635be4b1ce0]
           49:   protected: void TearDown() override
           50:   {
           51:     // Clean up fake home directory so that subsequent tests run on a clean slate.
        >  52:     common::removeAll(this->kFakeHome);
           53:     // Restore $HOME
           54:     EXPECT_TRUE(common::setenv(GZ_HOMEDIR, this->realHome.c_str()));
           55:   }
  #2    Object "/usr/lib/x86_64-linux-gnu/libgz-common.so.8.0.0~pre1", at 0x7f1de7703909, in gz::common::removeAll(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, gz::common::FilesystemWarningOp)
  #1    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33", at 0x7f1de6d9d8d8, in std::filesystem::remove_all(std::filesystem::__cxx11::path const&, std::error_code&)
  #0    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33", at 0x7f1de6d98df6, in std::filesystem::__cxx11::recursive_directory_iterator::~recursive_directory_iterator()
  Segmentation fault (Address not mapped to object [0x80000008])
  
          Start 308: check_INTEGRATION_optical_tactile_plugin
```

This suggests a race condition occuring during tear down. I _think_ this might fix the issue, but it is very hard to reproduce this issue locally.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
