### PR TITLE
Backport fixes for macOS CI

### DIFF
--- a/examples/standalone/joystick/joystick.cc
+++ b/examples/standalone/joystick/joystick.cc
@@ -174,10 +174,17 @@ int main(int argc, char **argv)
             // Update number of buttons
             if (event.number >= joyMsg.buttons_size())
             {
+#if GOOGLE_PROTOBUF_VERSION >= 7035000
+              joyMsg.mutable_buttons()->resize(event.number+1, 0.0f);
+              lastJoyMsg.mutable_buttons()->resize(event.number+1, 0.0f);
+              stickyButtonsJoyMsg.mutable_buttons()->resize(
+                  event.number+1, 0.0f);
+#else
               joyMsg.mutable_buttons()->Resize(event.number+1, 0.0f);
               lastJoyMsg.mutable_buttons()->Resize(event.number+1, 0.0f);
               stickyButtonsJoyMsg.mutable_buttons()->Resize(
                   event.number+1, 0.0f);
+#endif
             }
 
             // Update the button
@@ -194,10 +201,17 @@ int main(int argc, char **argv)
           {
             if (event.number >= joyMsg.axes_size())
             {
+#if GOOGLE_PROTOBUF_VERSION >= 7035000
+              joyMsg.mutable_axes()->resize(event.number+1, 0.0f);
+              lastJoyMsg.mutable_axes()->resize(event.number+1, 0.0f);
+              stickyButtonsJoyMsg.mutable_axes()->resize(
+                  event.number+1, 0.0f);
+#else
               joyMsg.mutable_axes()->Resize(event.number+1, 0.0f);
               lastJoyMsg.mutable_axes()->Resize(event.number+1, 0.0f);
               stickyButtonsJoyMsg.mutable_axes()->Resize(
                   event.number+1, 0.0f);
+#endif
             }
 
             // Smooth the deadzone

--- a/src/cmd/ModelCommandAPI_TEST.cc
+++ b/src/cmd/ModelCommandAPI_TEST.cc
@@ -212,7 +212,10 @@ TEST(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_WIN32(Commands))
       "    - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "      [0.000000 0.000000 0.000000]\n"
       "      [0.000000 0.000000 0.000000]\n";
+    // Skip expectation on arm64 due to issue 3602
+#ifndef __aarch64__
     EXPECT_EQ(expectedOutput, output);
+#endif
   }
 
   // Tested command: gz model -m vehicle_blue --pose
@@ -361,7 +364,10 @@ TEST(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_WIN32(Commands))
       "  - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "    [0.000000 0.000000 0.000000]\n"
       "    [0.000000 0.000000 0.000000]\n";
+    // Skip expectation on arm64 due to issue 3602
+#ifndef __aarch64__
     EXPECT_EQ(expectedOutput, output);
+#endif
   }
 
   // Tested command: gz model -m vehicle_blue --joint caster_wheel

--- a/src/systems/environment_preload/VisualizationTool.cc
+++ b/src/systems/environment_preload/VisualizationTool.cc
@@ -241,7 +241,12 @@ void EnvironmentVisualizationTool::ResizeCloud(
   }
   for (auto key : _data->frame.Keys())
   {
+#if GOOGLE_PROTOBUF_VERSION >= 7035000
+    this->floatFields[key].mutable_data()->resize(
+      numberOfPoints, std::nanf(""));
+#else
     this->floatFields[key].mutable_data()->Resize(
       numberOfPoints, std::nanf(""));
+#endif
   }
 }

--- a/src/systems/multicopter_control/MulticopterVelocityControl.cc
+++ b/src/systems/multicopter_control/MulticopterVelocityControl.cc
@@ -297,8 +297,13 @@ void MulticopterVelocityControl::Configure(const Entity &_entity,
          << enableTopic << "]" << std::endl;
 
   // Create the Actuators component to take control of rotor speeds
+#if GOOGLE_PROTOBUF_VERSION >= 7035000
+  this->rotorVelocitiesMsg.mutable_velocity()->resize(
+      this->rotorVelocities.size(), 0);
+#else
   this->rotorVelocitiesMsg.mutable_velocity()->Resize(
       this->rotorVelocities.size(), 0);
+#endif
 
   _ecm.CreateComponent(this->model.Entity(),
                        components::Actuators(this->rotorVelocitiesMsg));
@@ -432,7 +437,11 @@ void MulticopterVelocityControl::PublishRotorVelocities(
 {
   if (_vels.size() != this->rotorVelocitiesMsg.velocity_size())
   {
+#if GOOGLE_PROTOBUF_VERSION >= 7035000
+    this->rotorVelocitiesMsg.mutable_velocity()->resize(_vels.size(), 0);
+#else
     this->rotorVelocitiesMsg.mutable_velocity()->Resize(_vels.size(), 0);
+#endif
   }
   for (int i = 0; i < this->rotorVelocities.size(); ++i)
   {

--- a/test/integration/multicopter.cc
+++ b/test/integration/multicopter.cc
@@ -109,7 +109,11 @@ TEST_F(MulticopterTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(CommandedMotorSpeed))
         if (_info.iterations == iterTestStart)
         {
           msgs::Actuators msg;
+#if GOOGLE_PROTOBUF_VERSION >= 7035000
+          msg.mutable_velocity()->resize(4, cmdSpeed);
+#else
           msg.mutable_velocity()->Resize(4, cmdSpeed);
+#endif
           cmdMotorSpeed.Publish(msg);
         }
         else if (_info.iterations == iterTestStart + nIters)
@@ -298,7 +302,11 @@ TEST_F(MulticopterTest,
         // Publish a motor speed command
         {
           msgs::Actuators msg;
+#if GOOGLE_PROTOBUF_VERSION >= 7035000
+          msg.mutable_velocity()->resize(4, 60);
+#else
           msg.mutable_velocity()->Resize(4, 60);
+#endif
           cmdMotorSpeed.Publish(msg);
         }
 

--- a/test/integration/spacecraft.cc
+++ b/test/integration/spacecraft.cc
@@ -93,7 +93,11 @@ TEST_F(SpacecraftTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(InputTest))
         if (_info.iterations == iterTestStart)
         {
           msgs::Actuators msg;
+#if GOOGLE_PROTOBUF_VERSION >= 7035000
+          msg.mutable_normalized()->resize(12, cmdDutyCycle);
+#else
           msg.mutable_normalized()->Resize(12, cmdDutyCycle);
+#endif
           msg.mutable_normalized()->Set(0, 1.0);
           cmdDutyCyclePublisher.Publish(msg);
         }


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-transport/issues/873 and https://github.com/gazebosim/gz-sim/issues/3602

## Summary

This backports a mitigation for a test failure (https://github.com/gazebosim/gz-sim/pull/3603) and fixes for compiler warnings (https://github.com/gazebosim/gz-sim/pull/3604). It should be safe to backport further with mergify.

Here are the original PR descriptions:

### Summary of ModelCommandAPI_TEST: skip failing check on arm64 #3603

> Some expectations in UNIT_ModelCommandAPI_TEST fail on arm64 CPUs on macOS, though the test passes with amd64 (see https://github.com/gazebosim/gz-sim/issues/3602). This suppresses the test failure by skipping the expectation on arm64.

> CI will not be fully clean yet due to compiler warnings from protobuf 35.0 (similar to https://github.com/gazebosim/gz-transport/issues/873).

### Summary of Fix compiler warnings with protobuf 35.0 #3604

> The Resize() method from protobuf/repeated_field.h was deprecated in favor of resize() in https://github.com/protocolbuffers/protobuf/pull/26025 and released in protobuf 35.0. This adds compiler directives to select the API based on the available protobuf version.

> It should fix the macOS compiler warnings:

> Build Status https://build.osrfoundation.org/job/gz_sim-ci-main-homebrew-arm64/103/clang/
I believe this is safe to backport.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
