### PR TITLE
Fix ECM view update when component is added, then removed before the view is queried

### DIFF
--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -1193,8 +1193,20 @@ bool EntityComponentManager::CreateComponentImplementation(
 
       for (auto &viewPair : this->dataPtr->views)
       {
-        viewPair.second.first->NotifyComponentAddition(_entity,
-            this->IsNewEntity(_entity), _componentTypeId);
+        auto &view = viewPair.second.first;
+        // There are two cases to handle here:
+        // 1. Entity is associated with this view. Call
+        //    `NotifyComponentAddition` to update the cached component data.
+        // 2. Entity is not associated with this view yet. This can happen
+        //    if the entity was in `toAddEntities`, but removed before
+        //    processing because `NotifyComponentRemoval` was called.
+        //    Call `MarkEntityToAdd` to add the entity again to the view.
+        if (this->EntityMatches(_entity, view->ComponentTypes()) &&
+            !view->NotifyComponentAddition(_entity,
+                this->IsNewEntity(_entity), _componentTypeId))
+        {
+          view->MarkEntityToAdd(_entity, this->IsNewEntity(_entity));
+        }
       }
     }
   }

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -711,32 +711,38 @@ TEST_P(EntityComponentManagerFixture,
 
 //////////////////////////////////////////////////
 TEST_P(EntityComponentManagerFixture,
-       GZ_UTILS_TEST_DISABLED_ON_WIN32(ViewsRecreateRemovedComponentBeforeQuery))
+       GZ_UTILS_TEST_DISABLED_ON_WIN32(ViewsRecreateRemovedComponent))
 {
-  // Create an entity and initialize it with one component of a two-component view
+  // Create an entity and initialize it with one component of a two-component
+  // view
   Entity entity = manager.CreateEntity();
-  auto comp1 = manager.CreateComponent<IntComponent>(entity, IntComponent(123));
+  auto comp1 = manager.CreateComponent<IntComponent>(entity,
+      IntComponent(123));
   ASSERT_NE(nullptr, comp1);
 
   // Initialize the view by calling Each with both components.
   // It shouldn't match yet because the entity only has IntComponent.
   int count = 0;
   manager.Each<IntComponent, DoubleComponent>(
-      [&](const Entity &, const IntComponent *, const DoubleComponent *) -> bool
+      [&](const Entity &, const IntComponent *,
+          const DoubleComponent *) -> bool
       {
         count++;
         return true;
       });
   EXPECT_EQ(0, count);
 
-  // Add the second component. This matches the view and marks the entity to add.
-  auto comp2 = manager.CreateComponent<DoubleComponent>(entity, DoubleComponent(0.456));
+  // Add the second component. This matches the view and marks the entity to
+  // add.
+  auto comp2 = manager.CreateComponent<DoubleComponent>(entity,
+      DoubleComponent(0.456));
   ASSERT_NE(nullptr, comp2);
 
   // Remove, then re-add the second component.
   EXPECT_TRUE(manager.RemoveComponent(entity, DoubleComponent::typeId));
 
-  auto comp3 = manager.CreateComponent<DoubleComponent>(entity, DoubleComponent(0.789));
+  auto comp3 = manager.CreateComponent<DoubleComponent>(entity,
+      DoubleComponent(0.789));
   ASSERT_NE(nullptr, comp3);
 
   // Query the view. The entity should match and be found.

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -711,6 +711,52 @@ TEST_P(EntityComponentManagerFixture,
 
 //////////////////////////////////////////////////
 TEST_P(EntityComponentManagerFixture,
+       GZ_UTILS_TEST_DISABLED_ON_WIN32(ViewsRecreateRemovedComponentBeforeQuery))
+{
+  // Create an entity and initialize it with one component of a two-component view
+  Entity entity = manager.CreateEntity();
+  auto comp1 = manager.CreateComponent<IntComponent>(entity, IntComponent(123));
+  ASSERT_NE(nullptr, comp1);
+
+  // Initialize the view by calling Each with both components.
+  // It shouldn't match yet because the entity only has IntComponent.
+  int count = 0;
+  manager.Each<IntComponent, DoubleComponent>(
+      [&](const Entity &, const IntComponent *, const DoubleComponent *) -> bool
+      {
+        count++;
+        return true;
+      });
+  EXPECT_EQ(0, count);
+
+  // Add the second component. This matches the view and marks the entity to add.
+  auto comp2 = manager.CreateComponent<DoubleComponent>(entity, DoubleComponent(0.456));
+  ASSERT_NE(nullptr, comp2);
+
+  // Remove, then re-add the second component.
+  EXPECT_TRUE(manager.RemoveComponent(entity, DoubleComponent::typeId));
+
+  auto comp3 = manager.CreateComponent<DoubleComponent>(entity, DoubleComponent(0.789));
+  ASSERT_NE(nullptr, comp3);
+
+  // Query the view. The entity should match and be found.
+  count = 0;
+  manager.Each<IntComponent, DoubleComponent>(
+      [&](const Entity &_entity, const IntComponent *_intComp,
+          const DoubleComponent *_doubleComp) -> bool
+      {
+        EXPECT_EQ(entity, _entity);
+        EXPECT_EQ(123, _intComp->Data());
+        EXPECT_DOUBLE_EQ(0.789, _doubleComp->Data());
+        count++;
+        return true;
+      });
+  EXPECT_EQ(1, count);
+}
+
+
+//////////////////////////////////////////////////
+TEST_P(EntityComponentManagerFixture,
        GZ_UTILS_TEST_DISABLED_ON_WIN32(ViewsAddEntity))
 {
   // Create some entities


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fixes an issue where an ECM view incorrectly skips an entity for which a view component is added and then removed before the view is queried. `ecm.Each` always skips the entity, even if the view component is added back later.

@iche033 and I ran into this bug specifically for the `ContactSensorData` component, where the `Physics` system wouldn't populate the data for a gripper collision entity if the component was previously added, then removed in a single step's `PreUpdate` calls. (The `ContactSensorData` component was being removed in our setup to minimize copying contact data from the physics engine to the ECM, which is expensive for a large number of contacts.)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Agentic Gemini Flash 3.5 in AntiGravity

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.