### PR TITLE
[bazel] Fixes build on macos

### DIFF
--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -65,6 +65,7 @@ cc_library(
         "@gz-common",
         "@gz-common//testing",
         "@gz-math",
+        "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-transport",
     ],
 )


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Fixes the following error on MacOS:
```
$ bazel build @gz-sim//test:all
...
test/helpers/ResetUtils.hh:23:10: error: module //test:Helpers does not depend on a module exporting 'gz/msgs/boolean.pb.h'
   23 | #include <gz/msgs/boolean.pb.h>
      |          ^
test/helpers/ResetUtils.hh:24:10: error: module //test:Helpers does not depend on a module exporting 'gz/msgs/world_control.pb.h'
   24 | #include <gz/msgs/world_control.pb.h>
```


## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
