### PR TITLE
feat: support default network interface binding and persist SSL certificate paths

### DIFF
--- a/src/systems/websocket_server/WebsocketServer.cc
+++ b/src/systems/websocket_server/WebsocketServer.cc
@@ -457,20 +457,20 @@ void WebsocketServer::Configure(const Entity & /*_entity*/,
     }
   }
 
-  std::string sslCertFile = "";
-  std::string sslPrivateKeyFile = "";
+  this->sslCertFile = "";
+  this->sslPrivateKeyFile = "";
   sdf::ElementConstPtr sslElem = _sdf->FindElement("ssl");
   if (sslElem != nullptr)
   {
     // Get the ssl cert file, if present.
     sdf::ElementConstPtr certElem = sslElem->FindElement("cert_file");
     if (certElem)
-      sslCertFile = certElem->Get<std::string>();
+      this->sslCertFile = certElem->Get<std::string>();
 
     // Get the ssl private key file, if present.
     sdf::ElementConstPtr keyElem = sslElem->FindElement("private_key_file");
     if (keyElem)
-      sslPrivateKeyFile = keyElem->Get<std::string>();
+      this->sslPrivateKeyFile = keyElem->Get<std::string>();
   }
 
   // All of the protocols handled by this server.
@@ -502,26 +502,70 @@ void WebsocketServer::Configure(const Entity & /*_entity*/,
   // We will handle logging
   lws_set_log_level( 0, lwsl_emit_syslog);
 
+  this->address = "127.0.0.1";
+  if (sdf::ElementConstPtr addressElem = _sdf->FindElement("address"))
+  {
+    this->address = addressElem->Get<std::string>();
+  }
+  else if (sdf::ElementConstPtr ifaceElem = _sdf->FindElement("iface"))
+  {
+    this->address = ifaceElem->Get<std::string>();
+  }
+
+  // Sanitize the address to prevent potential security/injection issues
+  bool validAddress = true;
+  if (this->address.empty() || this->address.length() > 255)
+  {
+    validAddress = false;
+  }
+  else if (this->address != "*")
+  {
+    for (char c : this->address)
+    {
+      if (!std::isalnum(static_cast<unsigned char>(c)) &&
+          c != '.' && c != ':' && c != '-' && c != '_')
+      {
+        validAddress = false;
+        break;
+      }
+    }
+  }
+
+  if (!validAddress)
+  {
+    gzwarn << "Invalid characters or excessive length in address/iface ["
+           << this->address << "]. Falling back to 127.0.0.1.\n";
+    this->address = "127.0.0.1";
+  }
+
   struct lws_context_creation_info info;
   memset(&info, 0, sizeof info);
   info.port = port;
-  info.iface = nullptr;
+  if (this->address == "0.0.0.0" || this->address == "all" ||
+      this->address == "*")
+  {
+    info.iface = nullptr;
+  }
+  else
+  {
+    info.iface = this->address.c_str();
+  }
   info.protocols = &this->protocols[0];
 
-  if (!sslCertFile.empty() && !sslPrivateKeyFile.empty())
+  if (!this->sslCertFile.empty() && !this->sslPrivateKeyFile.empty())
   {
     // Fail if the certificate file cannot be opened.
-    if (!gz::common::exists(sslCertFile))
+    if (!gz::common::exists(this->sslCertFile))
     {
-      gzerr << "SSL certificate file[" << sslCertFile
+      gzerr << "SSL certificate file[" << this->sslCertFile
         << "] does not exist. Quitting.\n";
       return;
     }
 
     // Fail if the private key file cannot be opened.
-    if (!gz::common::exists(sslPrivateKeyFile))
+    if (!gz::common::exists(this->sslPrivateKeyFile))
     {
-      gzerr << "SSL private key file[" << sslPrivateKeyFile
+      gzerr << "SSL private key file[" << this->sslPrivateKeyFile
         << "] does not exist. Quitting.\n";
       return;
     }
@@ -529,10 +573,10 @@ void WebsocketServer::Configure(const Entity & /*_entity*/,
     // Store SSL configuration.
     info.options = LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
 
-    info.ssl_cert_filepath = sslCertFile.c_str();
-    info.ssl_private_key_filepath = sslPrivateKeyFile.c_str();
+    info.ssl_cert_filepath = this->sslCertFile.c_str();
+    info.ssl_private_key_filepath = this->sslPrivateKeyFile.c_str();
   }
-  else if (sslCertFile.empty() || sslPrivateKeyFile.empty())
+  else if (this->sslCertFile.empty() || this->sslPrivateKeyFile.empty())
   {
     gzwarn << "Partial SSL configuration specified. Please specify:\n"
     << "\t<ssl>\n"

--- a/src/systems/websocket_server/WebsocketServer.hh
+++ b/src/systems/websocket_server/WebsocketServer.hh
@@ -56,6 +56,11 @@ namespace systems
     ///
     /// * `<port>` : An integer that is websocket port.
     ///
+    /// * `<address>` or `<iface>` : A string that specifies the network
+    /// address or interface to bind the websocket server to. The default is
+    /// "127.0.0.1". Set to "0.0.0.0", "all", or "*" to listen on all
+    /// network interfaces.
+    ///
     /// * `<authorization_key>` : A key used for authentication. If this is
     /// set, then a connection must provide the matching key using an "auth"
     /// call on the websocket. If the `<admin_authorization_key>` is set, then
@@ -363,6 +368,15 @@ namespace systems
       /// \brief Administrator authorization key used to validate a web-socket
       /// connection.
       private: std::string adminAuthorizationKey;
+
+      /// \brief Network address or interface to bind the websocket server to.
+      private: std::string address;
+
+      /// \brief SSL certificate file path.
+      private: std::string sslCertFile;
+
+      /// \brief SSL private key file path.
+      private: std::string sslPrivateKeyFile;
     };
 }
 }


### PR DESCRIPTION

# 🎉 New feature

Closes #<NUMBER>

## Summary
Split out from #3590, this PR changes the WebSocket server's default listening address from 0.0.0.0 to 127.0.0.1 (localhost).

Binding to 0.0.0.0 exposes the server to all network interfaces, opening the door to remote exploits like the one detailed in #3589. Restricting the default to 127.0.0.1 ensures a "secure by default" posture, limiting access to local traffic only.

Streamlined Review: Isolating this from #3590 allows us to land this critical security hardening measure immediately without it being blocked by broader feature work.

Backport Recommendation: Breaks behaviour, don't backport

Ive also bundled in some lifetime related fixes.
## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.

