### PR TITLE
Fix cmake warning with FetchContent_MakeAvailable

### DIFF
--- a/examples/plugin/custom_sensor_system/CMakeLists.txt
+++ b/examples/plugin/custom_sensor_system/CMakeLists.txt
@@ -18,9 +18,9 @@ FetchContent_Declare(
   sensors_clone
   GIT_REPOSITORY https://github.com/gazebosim/gz-sensors
   GIT_TAG main
+  SOURCE_SUBDIR examples/custom_sensor
 )
-FetchContent_Populate(sensors_clone)
-add_subdirectory(${sensors_clone_SOURCE_DIR}/examples/custom_sensor ${sensors_clone_BINARY_DIR})
+FetchContent_MakeAvailable(sensors_clone)
 
 add_library(${PROJECT_NAME} SHARED ${PROJECT_NAME}.cc)
 target_link_libraries(${PROJECT_NAME}


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebo-tooling/release-tools/issues/1485.

## Summary

This fixes a cmake warning on Ubuntu 26.04 (and macOS with homebrew). `FetchContent_Populate` with a single argument is deprecated in cmake 3.30 (see [CMP0169](https://cmake.org/cmake/help/latest/policy/CMP0169.html)) in favor of `FetchContent_MakeAvailable`, which was added in cmake 3.14. Since `FetchContent_MakeAvailable` automatically calls `add_subdirectory`, specify `SOURCE_SUBDIR` as `examples/custom_sensor` and remove the explicit `add_subdirectory` call.

I believe this is safe to backport to Jetty and Ionic, which both require a minimum cmake version of 3.22.1. An alternative fix can be made for Harmonic and Fortress.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
