### PR TITLE
Suppress cmake warning about FetchContent_Populate

### DIFF
--- a/examples/plugin/custom_sensor_system/CMakeLists.txt
+++ b/examples/plugin/custom_sensor_system/CMakeLists.txt
@@ -22,6 +22,12 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/gazebosim/gz-sensors
   GIT_TAG gz-sensors8
 )
+if(POLICY CMP0169)
+  # FetchContent_Populate with a single argument is deprecated in cmake 3.30, but
+  # the recommended replacement was added in 3.14. Since this uses an older cmake
+  # version, set the policy to old to suppress the warning.
+  cmake_policy(SET CMP0169 OLD)
+endif()
 FetchContent_Populate(sensors_clone)
 add_subdirectory(${sensors_clone_SOURCE_DIR}/examples/custom_sensor ${sensors_clone_BINARY_DIR})
 


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebo-tooling/release-tools/issues/1485.

## Summary

This suppresses a cmake warning on Ubuntu 26.04 (and macOS with homebrew). `FetchContent_Populate` with a single argument is deprecated in cmake 3.30 (see [CMP0169](https://cmake.org/cmake/help/latest/policy/CMP0169.html)) in favor of `FetchContent_MakeAvailable`, which was added in cmake 3.14. Since Harmonic only requires cmake 3.10.2 in general (and 3.11.0 in this specific example), this suppresses the warning by using the old behavior for CMP0169 to avoid disruption. See #3613 for the fix made in newer Gazebo versions.

I believe this is safe to backport to Fortress.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
