### PR TITLE
dvl: suppress maybe-uninitialized gcc warnings

### DIFF
--- a/src/systems/dvl/CMakeLists.txt
+++ b/src/systems/dvl/CMakeLists.txt
@@ -8,3 +8,8 @@ gz_add_system(dvl
     gz-sensors::dvl
     gz-sensors::rendering
 )
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+  target_compile_options(gz-sim-dvl-system PRIVATE
+      -Wno-maybe-uninitialized)
+endif()

--- a/src/systems/dvl/CMakeLists.txt
+++ b/src/systems/dvl/CMakeLists.txt
@@ -9,6 +9,8 @@ gz_add_system(dvl
     gz-sensors::rendering
 )
 
+# Suppress maybe-uninitialized from gcc due to issue 3627
+# https://github.com/gazebosim/gz-sim/issues/3627
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   target_compile_options(gz-sim-dvl-system PRIVATE
       -Wno-maybe-uninitialized)


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-sim/issues/3627

## Summary

As noted in https://github.com/gazebosim/gz-sim/issues/3627, there are `maybe-uninitialized` warnings with gcc on 26.04 in the `dvl` system (similar to the warning fixed in https://github.com/gazebosim/gz-transport/pull/870). This suppresses those warnings when `gcc` is detected by compiling this system with `-Wno-maybe-uninitialized` using `target_compile_options`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
