### PR TITLE
Add parallel_postupdates gz policy

### DIFF
--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -221,6 +221,22 @@ SimulationRunner::SimulationRunner(const sdf::World &_world,
   );
   this->currentInfo.simTime = this->simTimeEpoch;
 
+  // Get policies from the world SDF
+  {
+    auto worldElem = _world.Element();
+    if (worldElem)
+    {
+      auto policies = worldElem->FindElement(std::string(kPoliciesTag));
+      if (policies)
+      {
+        this->disableParallelPostUpdate =
+          policies->Get<bool>("disable_parallel_postupdate",
+          this->disableParallelPostUpdate).first;
+      }
+    }
+  }
+
+
 #ifdef _WIN32
   HANDLE winPrecisionTimerHandle = CreateWaitableTimerExA(NULL, NULL,
     CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
@@ -615,6 +631,13 @@ void SimulationRunner::ProcessSystemQueue()
   if (0 == pending && !this->threadsNeedCleanUp)
     return;
 
+  if (this->disableParallelPostUpdate)
+  {
+    this->threadsNeedCleanUp = false;
+    this->systemMgr->ActivatePendingSystems();
+    return;
+  }
+
   // If additional systems are to be added or have been removed,
   // stop the existing threads.
   this->StopWorkerThreads();
@@ -702,16 +725,26 @@ void SimulationRunner::UpdateSystems()
   {
     GZ_PROFILE("PostUpdate");
     this->entityCompMgr.LockAddingEntitiesToViews(true);
-    // If no systems implementing PostUpdate have been added, then
-    // the barriers will be uninitialized, so guard against that condition.
-    if (this->postUpdateStartBarrier && this->postUpdateStopBarrier)
+    if (this->disableParallelPostUpdate)
     {
-      // Release the GIL from the main thread to run PostUpdate threads which
-      // might be calling into python. The system that does call into python
-      // needs to lock the GIL from its thread.
-      MaybeGilScopedRelease release;
-      this->postUpdateStartBarrier->Wait();
-      this->postUpdateStopBarrier->Wait();
+      for (auto &system : this->systemMgr->SystemsPostUpdate())
+      {
+        system->PostUpdate(this->currentInfo, this->entityCompMgr);
+      }
+    }
+    else
+    {
+      // If no systems implementing PostUpdate have been added, then
+      // the barriers will be uninitialized, so guard against that condition.
+      if (this->postUpdateStartBarrier && this->postUpdateStopBarrier)
+      {
+        // Release the GIL from the main thread to run PostUpdate threads which
+        // might be calling into python. The system that does call into python
+        // needs to lock the GIL from its thread.
+        MaybeGilScopedRelease release;
+        this->postUpdateStartBarrier->Wait();
+        this->postUpdateStopBarrier->Wait();
+      }
     }
     this->entityCompMgr.LockAddingEntitiesToViews(false);
   }
@@ -1258,6 +1291,12 @@ void SimulationRunner::LoadPlugins(const Entity _entity,
 bool SimulationRunner::Running() const
 {
   return this->running;
+}
+
+/////////////////////////////////////////////////
+bool SimulationRunner::DisableParallelPostUpdate() const
+{
+  return this->disableParallelPostUpdate;
 }
 
 /////////////////////////////////////////////////

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -229,9 +229,9 @@ SimulationRunner::SimulationRunner(const sdf::World &_world,
       auto policies = worldElem->FindElement(std::string(kPoliciesTag));
       if (policies)
       {
-        this->disableParallelPostUpdate =
-          policies->Get<bool>("disable_parallel_postupdate",
-          this->disableParallelPostUpdate).first;
+        this->parallelPostUpdates =
+          policies->Get<bool>("parallel_postupdates",
+          this->parallelPostUpdates).first;
       }
     }
   }
@@ -631,7 +631,7 @@ void SimulationRunner::ProcessSystemQueue()
   if (0 == pending && !this->threadsNeedCleanUp)
     return;
 
-  if (this->disableParallelPostUpdate)
+  if (!this->parallelPostUpdates)
   {
     this->threadsNeedCleanUp = false;
     this->systemMgr->ActivatePendingSystems();
@@ -725,7 +725,7 @@ void SimulationRunner::UpdateSystems()
   {
     GZ_PROFILE("PostUpdate");
     this->entityCompMgr.LockAddingEntitiesToViews(true);
-    if (this->disableParallelPostUpdate)
+    if (!this->parallelPostUpdates)
     {
       for (auto &system : this->systemMgr->SystemsPostUpdate())
       {
@@ -1294,9 +1294,9 @@ bool SimulationRunner::Running() const
 }
 
 /////////////////////////////////////////////////
-bool SimulationRunner::DisableParallelPostUpdate() const
+bool SimulationRunner::ParallelPostUpdates() const
 {
-  return this->disableParallelPostUpdate;
+  return this->parallelPostUpdates;
 }
 
 /////////////////////////////////////////////////

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -171,9 +171,9 @@ namespace gz
       /// \return True if the server is running.
       public: bool Running() const;
 
-      /// \brief Get whether parallel PostUpdate is disabled.
-      /// \return True if parallel PostUpdate is disabled, false otherwise.
-      public: bool DisableParallelPostUpdate() const;
+      /// \brief Get whether parallel PostUpdate is enabled.
+      /// \return True if parallel PostUpdate is enabled, false otherwise.
+      public: bool ParallelPostUpdates() const;
 
       /// \brief Get whether the runner has received a stop event
       /// \return True if the event has been received.
@@ -597,8 +597,8 @@ namespace gz
       /// `SetExitedWithErrors()`.
       private: bool exitedWithErrors{false};
 
-      /// \brief Whether parallel PostUpdate are disabled.
-      private: bool disableParallelPostUpdate{false};
+      /// \brief Whether parallel PostUpdate is enabled.
+      private: bool parallelPostUpdates{true};
 #ifdef _WIN32
       private: std::unique_ptr<SimulationRunnerWinHandleStorage>
         winPrecisionTimer;

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -171,6 +171,10 @@ namespace gz
       /// \return True if the server is running.
       public: bool Running() const;
 
+      /// \brief Get whether parallel PostUpdate is disabled.
+      /// \return True if parallel PostUpdate is disabled, false otherwise.
+      public: bool DisableParallelPostUpdate() const;
+
       /// \brief Get whether the runner has received a stop event
       /// \return True if the event has been received.
       public: bool StopReceived() const;
@@ -592,6 +596,9 @@ namespace gz
       /// initialization and should exit immediately. See
       /// `SetExitedWithErrors()`.
       private: bool exitedWithErrors{false};
+
+      /// \brief Whether parallel PostUpdate are disabled.
+      private: bool disableParallelPostUpdate{false};
 #ifdef _WIN32
       private: std::unique_ptr<SimulationRunnerWinHandleStorage>
         winPrecisionTimer;

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -1653,7 +1653,7 @@ TEST_P(SimulationRunnerTest, GeneratedSdfHasNoSpuriousPlugins)
 }
 
 /////////////////////////////////////////////////
-TEST_P(SimulationRunnerTest, DisableParallelPostUpdatesPolicy)
+TEST_P(SimulationRunnerTest, ParallelPostUpdatesPolicy)
 {
   // Test default behavior
   {
@@ -1671,29 +1671,7 @@ TEST_P(SimulationRunnerTest, DisableParallelPostUpdatesPolicy)
     auto systemLoader = std::make_shared<SystemLoader>();
     SimulationRunner runner(*root.WorldByIndex(0), systemLoader);
 
-    EXPECT_FALSE(runner.DisableParallelPostUpdate());
-  }
-
-  // Test when disabled
-  {
-    std::string sdfStr = "<?xml version='1.0' ?>"
-      "<sdf version='1.6'>"
-      "  <world name='default'>"
-      "    <gz:policies>"
-      "      <disable_parallel_postupdate>false</disable_parallel_postupdate>"
-      "    </gz:policies>"
-      "  </world>"
-      "</sdf>";
-
-    sdf::Root root;
-    sdf::Errors errors = root.LoadSdfString(sdfStr);
-    ASSERT_TRUE(errors.empty());
-    ASSERT_EQ(1u, root.WorldCount());
-
-    auto systemLoader = std::make_shared<SystemLoader>();
-    SimulationRunner runner(*root.WorldByIndex(0), systemLoader);
-
-    EXPECT_FALSE(runner.DisableParallelPostUpdate());
+    EXPECT_TRUE(runner.ParallelPostUpdates());
   }
 
   // Test when enabled
@@ -1702,7 +1680,7 @@ TEST_P(SimulationRunnerTest, DisableParallelPostUpdatesPolicy)
       "<sdf version='1.6'>"
       "  <world name='default'>"
       "    <gz:policies>"
-      "      <disable_parallel_postupdate>true</disable_parallel_postupdate>"
+      "      <parallel_postupdates>true</parallel_postupdates>"
       "    </gz:policies>"
       "  </world>"
       "</sdf>";
@@ -1715,7 +1693,29 @@ TEST_P(SimulationRunnerTest, DisableParallelPostUpdatesPolicy)
     auto systemLoader = std::make_shared<SystemLoader>();
     SimulationRunner runner(*root.WorldByIndex(0), systemLoader);
 
-    EXPECT_TRUE(runner.DisableParallelPostUpdate());
+    EXPECT_TRUE(runner.ParallelPostUpdates());
+  }
+
+  // Test when disabled
+  {
+    std::string sdfStr = "<?xml version='1.0' ?>"
+      "<sdf version='1.6'>"
+      "  <world name='default'>"
+      "    <gz:policies>"
+      "      <parallel_postupdates>false</parallel_postupdates>"
+      "    </gz:policies>"
+      "  </world>"
+      "</sdf>";
+
+    sdf::Root root;
+    sdf::Errors errors = root.LoadSdfString(sdfStr);
+    ASSERT_TRUE(errors.empty());
+    ASSERT_EQ(1u, root.WorldCount());
+
+    auto systemLoader = std::make_shared<SystemLoader>();
+    SimulationRunner runner(*root.WorldByIndex(0), systemLoader);
+
+    EXPECT_FALSE(runner.ParallelPostUpdates());
   }
 }
 

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -1652,6 +1652,73 @@ TEST_P(SimulationRunnerTest, GeneratedSdfHasNoSpuriousPlugins)
   EXPECT_TRUE(checkForSpuriousPlugins(newRoot.Element()));
 }
 
+/////////////////////////////////////////////////
+TEST_P(SimulationRunnerTest, DisableParallelPostUpdatesPolicy)
+{
+  // Test default behavior
+  {
+    std::string sdfStr = "<?xml version='1.0' ?>"
+      "<sdf version='1.6'>"
+      "  <world name='default'>"
+      "  </world>"
+      "</sdf>";
+
+    sdf::Root root;
+    sdf::Errors errors = root.LoadSdfString(sdfStr);
+    ASSERT_TRUE(errors.empty());
+    ASSERT_EQ(1u, root.WorldCount());
+
+    auto systemLoader = std::make_shared<SystemLoader>();
+    SimulationRunner runner(*root.WorldByIndex(0), systemLoader);
+
+    EXPECT_FALSE(runner.DisableParallelPostUpdate());
+  }
+
+  // Test when disabled
+  {
+    std::string sdfStr = "<?xml version='1.0' ?>"
+      "<sdf version='1.6'>"
+      "  <world name='default'>"
+      "    <gz:policies>"
+      "      <disable_parallel_postupdate>false</disable_parallel_postupdate>"
+      "    </gz:policies>"
+      "  </world>"
+      "</sdf>";
+
+    sdf::Root root;
+    sdf::Errors errors = root.LoadSdfString(sdfStr);
+    ASSERT_TRUE(errors.empty());
+    ASSERT_EQ(1u, root.WorldCount());
+
+    auto systemLoader = std::make_shared<SystemLoader>();
+    SimulationRunner runner(*root.WorldByIndex(0), systemLoader);
+
+    EXPECT_FALSE(runner.DisableParallelPostUpdate());
+  }
+
+  // Test when enabled
+  {
+    std::string sdfStr = "<?xml version='1.0' ?>"
+      "<sdf version='1.6'>"
+      "  <world name='default'>"
+      "    <gz:policies>"
+      "      <disable_parallel_postupdate>true</disable_parallel_postupdate>"
+      "    </gz:policies>"
+      "  </world>"
+      "</sdf>";
+
+    sdf::Root root;
+    sdf::Errors errors = root.LoadSdfString(sdfStr);
+    ASSERT_TRUE(errors.empty());
+    ASSERT_EQ(1u, root.WorldCount());
+
+    auto systemLoader = std::make_shared<SystemLoader>();
+    SimulationRunner runner(*root.WorldByIndex(0), systemLoader);
+
+    EXPECT_TRUE(runner.DisableParallelPostUpdate());
+  }
+}
+
 // Run multiple times. We want to make sure that static globals don't cause
 // problems.
 INSTANTIATE_TEST_SUITE_P(ServerRepeat, SimulationRunnerTest,

--- a/tutorials/server_config.md
+++ b/tutorials/server_config.md
@@ -395,3 +395,35 @@ GUI `GzScene` plugin.
 ### Order of Execution of Plugins
 The order of execution of plugins can be controlled by setting
 the `<gz:system_priority>` tag inside `<plugin>`. See example in examples/plugin/priority_printer_plugin and the associated README.md file to learn more.
+
+
+## Parallel PostUpdates
+
+By default, the `PostUpdate` phase of system plugins is executed in parallel
+using worker threads. This parallel execution is beneficial for worlds with a
+large number of plugins that perform heavy computational tasks during
+`PostUpdate`.
+
+However, in many typical simulations, most plugins perform trivial tasks on
+`PostUpdate`. In these scenarios, the overhead introduced by thread
+synchronization primitives can become a bottleneck and degrade simulation
+performance.
+
+To address this, you can configure `PostUpdate` functions to run sequentially
+instead of in parallel and see if it helps increase the Real Time Factor (RTF).
+This is done by setting the `<disable_parallel_postupdate>` policy to `true`:
+
+```xml
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="default">
+    <gz:policies>
+      <disable_parallel_postupdate>true</disable_parallel_postupdate>
+    </gz:policies>
+
+    <!-- plugins and models... -->
+  </world>
+</sdf>
+```
+
+By default, this policy is set to `false`.

--- a/tutorials/server_config.md
+++ b/tutorials/server_config.md
@@ -411,14 +411,14 @@ performance.
 
 To address this, you can configure `PostUpdate` functions to run sequentially
 instead of in parallel and see if it helps increase the Real Time Factor (RTF).
-This is done by setting the `<disable_parallel_postupdate>` policy to `true`:
+This is done by setting the `<parallel_postupdates>` policy to `false`:
 
 ```xml
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="default">
     <gz:policies>
-      <disable_parallel_postupdate>true</disable_parallel_postupdate>
+      <parallel_postupdates>false</parallel_postupdates>
     </gz:policies>
 
     <!-- plugins and models... -->
@@ -426,4 +426,4 @@ This is done by setting the `<disable_parallel_postupdate>` policy to `true`:
 </sdf>
 ```
 
-By default, this policy is set to `false`.
+By default, this policy is set to `true`.


### PR DESCRIPTION


# 🎉 New feature

Alternative to https://github.com/gazebosim/gz-sim/pull/3586

## Summary

Supports configuring whether to run PostUpdate serially or in parallel. By default, it keeps the current behavior that runs the PostUpdate functions in parallel.

To disable it, add this SDF element to your world file:

```
        <gz:policies>
          <parallel_postupdates>false</parallel_postupdates>
        </gz:policies>
```

## Test it

Run the test from your colcon workspace:

```
./build/gz-sim/bin/UNIT_SimulationRunner_TEST --gtest_filter="*ParallelPostUpdate*"
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3