### PR TITLE
Skip Recreate component query if no component exists

### DIFF
--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -1437,6 +1437,10 @@ void SimulationRunner::ProcessRecreateEntitiesRemove()
 {
   GZ_PROFILE("SimulationRunner::ProcessRecreateEntitiesRemove");
 
+  if (!this->entityCompMgr.HasComponentType(components::Recreate::typeId))
+  {
+    return;
+  }
   // store the original entities to recreate and put in request to remove them
   this->entityCompMgr.EachNoCache<components::Model,
                            components::Recreate>(


### PR DESCRIPTION
# 🎉 New feature

Skip `EachNoCache` if no component was ever created.

## Summary

`EachNoCache` is a very expensive operation that goes through all the entities to look for an entity with a specific component.
We have only one instance of usage in the `ProcessRecreateEntitiesRemove`, which looks for entities with the `Recreate` component.
However, this component is only ever instantiated in the Component Inspector Editor GUI plugin which is rarely used by users, and the cost of traversing the whole graph in an uncached way can be very expensive.
The trivial solution is to just bypass the call if the component was never created.
Based on the findings by @caguero in his [Gazebo profiling report](https://caguero.github.io/gz-profiling/2026-04-21/findings_report.pdf), first optimization recommendation.

Note that in the current ECM implementation we never clear the `createdCompTypes` map so as soon as the component is created once the short circuit will stop being effective for the rest of the run, however I feel this is not a big issue for two reasons:

1) Again the component is only created in a GUI plugin that most people might not be familiar with.
2) The Entt rewrite in #3447 makes `Each` and `EachNoCache` perfectly equivalent. The `EachNoCache` will just return immediately and do nothing if no entities with the component exist.

## Test it

With and without this PR run the 3k_shapes demo:

```bash
$ gz sim -v3 3k_shapes.sdf -r --physics-engine gz-physics-bullet-featherstone-plugin
```

On my machine, before the PR I get about 20%, after the PR about 50% so a RTF of more than 2x, but happy to hear if other people can reproduce or not.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
