### PR TITLE
Make EntityComponentManager State() run serially

### DIFF
--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -1683,7 +1683,10 @@ void EntityComponentManagerPrivate::CalculateStateThreadLoad()
   // Set the number of threads to spawn to the min of the calculated thread
   // count or max threads that the hardware supports
   int maxThreads = std::thread::hardware_concurrency();
-  uint64_t numThreads = std::min(numEntities, maxThreads);
+  // Assign at least 100 entities per thread to reduce the overhead
+  // of multithreaading for low entity numbers
+  uint64_t numThreads = std::min(static_cast<int>(std::ceil(
+          static_cast<double>(numEntities) / 100.0)), maxThreads);
 
   int entitiesPerThread = static_cast<int>(std::ceil(
     static_cast<double>(numEntities) / numThreads));
@@ -1766,8 +1769,15 @@ void EntityComponentManager::State(
     }
   };
 
-  // Spawn workers
+  // Bypass thread spawning if only one thread is necessary
   uint64_t numThreads = this->dataPtr->componentTypeIndexIterators.size() - 1;
+  if (numThreads == 1)
+  {
+    functor(this->dataPtr->componentTypeIndexIterators[0],
+            this->dataPtr->componentTypeIndexIterators[1]);
+    return;
+  }
+  // Spawn workers
   for (uint64_t i = 0; i < numThreads; i++)
   {
     workers.push_back(std::thread(functor,

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -70,10 +70,6 @@ class gz::sim::EntityComponentManagerPrivate
   public: void EraseEntityRecursive(Entity _entity,
       std::unordered_set<Entity> &_set);
 
-  /// \brief Allots the work for multiple threads prior to running
-  /// `AddEntityToMessage`.
-  public: void CalculateStateThreadLoad();
-
   /// \brief Copies the contents of `_from` into this object.
   /// \note This is a member function instead of a copy constructor so that
   /// it can have additional parameters if the need arises in the future.
@@ -227,26 +223,9 @@ class gz::sim::EntityComponentManagerPrivate
   /// componentStorage vector (a component of a particular type is
   /// only a key for the value map if a component of this type exists in
   /// the componentStorage vector)
-  ///
-  /// NOTE: Any modification of this data structure must be followed
-  /// by setting `componentTypeIndexDirty` to true.
   public: std::unordered_map<Entity,
            std::unordered_map<ComponentTypeId, std::size_t>>
                                 componentTypeIndex;
-
-  /// \brief A vector of iterators to evenly distributed spots in the
-  /// `componentTypeIndex` map.  Threads in the `State` function use this
-  /// vector for easy access of their pre-allocated work.  This vector
-  /// is recalculated if `componentTypeIndex` is changed (when
-  /// `componentTypeIndexDirty` == true).
-  public: std::vector<std::unordered_map<Entity,
-          std::unordered_map<ComponentTypeId, std::size_t>>::iterator>
-            componentTypeIndexIterators;
-
-  /// \brief True if the componentTypeIndex map was changed.  Primarily used
-  /// by the multithreading functionality in `State()` to allocate work to
-  /// each thread.
-  public: bool componentTypeIndexDirty{true};
 
   /// \brief During cloning, we populate two maps:
   ///  - map of cloned model entities to the non-cloned model's canonical link
@@ -326,8 +305,6 @@ void EntityComponentManagerPrivate::CopyFrom(
     }
   }
   this->componentTypeIndex = _from.componentTypeIndex;
-  this->componentTypeIndexIterators.clear();
-  this->componentTypeIndexDirty = true;
 
   // Not copying maps related to cloning since they are transient variables
   // that are used as return values of some member functions.
@@ -829,7 +806,6 @@ void EntityComponentManager::ProcessRemoveEntityRequests()
     // reset the entity component storage
     this->dataPtr->componentStorage.clear();
     this->dataPtr->componentTypeIndex.clear();
-    this->dataPtr->componentTypeIndexDirty = true;
 
     // All views are now invalid.
     this->dataPtr->views.clear();
@@ -850,7 +826,6 @@ void EntityComponentManager::ProcessRemoveEntityRequests()
       this->dataPtr->componentsMarkedAsRemoved.erase(entity);
       this->dataPtr->componentStorage.erase(entity);
       this->dataPtr->componentTypeIndex.erase(entity);
-      this->dataPtr->componentTypeIndexDirty = true;
 
       // Remove the entity from views.
       for (auto &view : this->dataPtr->views)
@@ -1157,7 +1132,6 @@ bool EntityComponentManager::CreateComponentImplementation(
     const auto vectorIdx = entityCompIter->second.size();
     entityCompIter->second.push_back(std::move(newComp));
     this->dataPtr->componentTypeIndex[_entity][_componentTypeId] = vectorIdx;
-    this->dataPtr->componentTypeIndexDirty = true;
 
     updateData = false;
     for (auto &viewPair : this->dataPtr->views)
@@ -1668,52 +1642,6 @@ void EntityComponentManager::ChangedState(
 }
 
 //////////////////////////////////////////////////
-void EntityComponentManagerPrivate::CalculateStateThreadLoad()
-{
-  // If the entity component vector is dirty, we need to recalculate the
-  // threads and each thread's work load
-  if (!this->componentTypeIndexDirty)
-    return;
-
-  this->componentTypeIndexDirty = false;
-  this->componentTypeIndexIterators.clear();
-  auto startIt = this->componentTypeIndex.begin();
-  int numEntities = this->componentTypeIndex.size();
-
-  // Set the number of threads to spawn to the min of the calculated thread
-  // count or max threads that the hardware supports
-  int maxThreads = std::thread::hardware_concurrency();
-  uint64_t numThreads = std::min(numEntities, maxThreads);
-
-  int entitiesPerThread = static_cast<int>(std::ceil(
-    static_cast<double>(numEntities) / numThreads));
-
-  gzdbg << "Updated state thread iterators: " << numThreads
-         << " threads processing around " << entitiesPerThread
-         << " entities each." << std::endl;
-
-  // Push back the starting iterator
-  this->componentTypeIndexIterators.push_back(startIt);
-  for (uint64_t i = 0; i < numThreads; ++i)
-  {
-    // If we have added all of the entities to the iterator vector, we are
-    // done so push back the end iterator
-    numEntities -= entitiesPerThread;
-    if (numEntities <= 0)
-    {
-      this->componentTypeIndexIterators.push_back(
-          this->componentTypeIndex.end());
-      break;
-    }
-
-    // Get the iterator to the next starting group of entities
-    auto nextIt = std::next(startIt, entitiesPerThread);
-    this->componentTypeIndexIterators.push_back(nextIt);
-    startIt = nextIt;
-  }
-}
-
-//////////////////////////////////////////////////
 msgs::SerializedState EntityComponentManager::State(
     const std::unordered_set<Entity> &_entities,
     const std::unordered_set<ComponentTypeId> &_types) const
@@ -1740,46 +1668,15 @@ void EntityComponentManager::State(
     const std::unordered_set<ComponentTypeId> &_types,
     bool _full) const
 {
-  std::mutex stateMapMutex;
-  std::vector<std::thread> workers;
-
-  this->dataPtr->CalculateStateThreadLoad();
-
-  auto functor = [&](auto itStart, auto itEnd)
+  for (const auto& it : this->dataPtr->componentTypeIndex)
   {
-    msgs::SerializedStateMap threadMap;
-    while (itStart != itEnd)
+    const auto& entity = it.first;
+    if (!_entities.empty() && _entities.find(entity) == _entities.end())
     {
-      auto entity = (*itStart).first;
-      if (_entities.empty() || _entities.find(entity) != _entities.end())
-      {
-        this->AddEntityToMessage(threadMap, entity, _types, _full);
-      }
-      itStart++;
+      continue;
     }
-    std::lock_guard<std::mutex> lock(stateMapMutex);
-
-    for (const auto &entity : threadMap.entities())
-    {
-      (*_state.mutable_entities())[static_cast<uint64_t>(entity.first)] =
-          entity.second;
-    }
-  };
-
-  // Spawn workers
-  uint64_t numThreads = this->dataPtr->componentTypeIndexIterators.size() - 1;
-  for (uint64_t i = 0; i < numThreads; i++)
-  {
-    workers.push_back(std::thread(functor,
-        this->dataPtr->componentTypeIndexIterators[i],
-        this->dataPtr->componentTypeIndexIterators[i+1]));
+    this->AddEntityToMessage(_state, entity, _types, _full);
   }
-
-  // Wait for each thread to finish processing its components
-  std::for_each(workers.begin(), workers.end(), [](std::thread &_t)
-  {
-    _t.join();
-  });
 }
 
 //////////////////////////////////////////////////

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -70,6 +70,10 @@ class gz::sim::EntityComponentManagerPrivate
   public: void EraseEntityRecursive(Entity _entity,
       std::unordered_set<Entity> &_set);
 
+  /// \brief Allots the work for multiple threads prior to running
+  /// `AddEntityToMessage`.
+  public: void CalculateStateThreadLoad();
+
   /// \brief Copies the contents of `_from` into this object.
   /// \note This is a member function instead of a copy constructor so that
   /// it can have additional parameters if the need arises in the future.
@@ -223,9 +227,26 @@ class gz::sim::EntityComponentManagerPrivate
   /// componentStorage vector (a component of a particular type is
   /// only a key for the value map if a component of this type exists in
   /// the componentStorage vector)
+  ///
+  /// NOTE: Any modification of this data structure must be followed
+  /// by setting `componentTypeIndexDirty` to true.
   public: std::unordered_map<Entity,
            std::unordered_map<ComponentTypeId, std::size_t>>
                                 componentTypeIndex;
+
+  /// \brief A vector of iterators to evenly distributed spots in the
+  /// `componentTypeIndex` map.  Threads in the `State` function use this
+  /// vector for easy access of their pre-allocated work.  This vector
+  /// is recalculated if `componentTypeIndex` is changed (when
+  /// `componentTypeIndexDirty` == true).
+  public: std::vector<std::unordered_map<Entity,
+          std::unordered_map<ComponentTypeId, std::size_t>>::iterator>
+            componentTypeIndexIterators;
+
+  /// \brief True if the componentTypeIndex map was changed.  Primarily used
+  /// by the multithreading functionality in `State()` to allocate work to
+  /// each thread.
+  public: bool componentTypeIndexDirty{true};
 
   /// \brief During cloning, we populate two maps:
   ///  - map of cloned model entities to the non-cloned model's canonical link
@@ -305,6 +326,8 @@ void EntityComponentManagerPrivate::CopyFrom(
     }
   }
   this->componentTypeIndex = _from.componentTypeIndex;
+  this->componentTypeIndexIterators.clear();
+  this->componentTypeIndexDirty = true;
 
   // Not copying maps related to cloning since they are transient variables
   // that are used as return values of some member functions.
@@ -806,6 +829,7 @@ void EntityComponentManager::ProcessRemoveEntityRequests()
     // reset the entity component storage
     this->dataPtr->componentStorage.clear();
     this->dataPtr->componentTypeIndex.clear();
+    this->dataPtr->componentTypeIndexDirty = true;
 
     // All views are now invalid.
     this->dataPtr->views.clear();
@@ -826,6 +850,7 @@ void EntityComponentManager::ProcessRemoveEntityRequests()
       this->dataPtr->componentsMarkedAsRemoved.erase(entity);
       this->dataPtr->componentStorage.erase(entity);
       this->dataPtr->componentTypeIndex.erase(entity);
+      this->dataPtr->componentTypeIndexDirty = true;
 
       // Remove the entity from views.
       for (auto &view : this->dataPtr->views)
@@ -1132,6 +1157,7 @@ bool EntityComponentManager::CreateComponentImplementation(
     const auto vectorIdx = entityCompIter->second.size();
     entityCompIter->second.push_back(std::move(newComp));
     this->dataPtr->componentTypeIndex[_entity][_componentTypeId] = vectorIdx;
+    this->dataPtr->componentTypeIndexDirty = true;
 
     updateData = false;
     for (auto &viewPair : this->dataPtr->views)
@@ -1642,6 +1668,52 @@ void EntityComponentManager::ChangedState(
 }
 
 //////////////////////////////////////////////////
+void EntityComponentManagerPrivate::CalculateStateThreadLoad()
+{
+  // If the entity component vector is dirty, we need to recalculate the
+  // threads and each thread's work load
+  if (!this->componentTypeIndexDirty)
+    return;
+
+  this->componentTypeIndexDirty = false;
+  this->componentTypeIndexIterators.clear();
+  auto startIt = this->componentTypeIndex.begin();
+  int numEntities = this->componentTypeIndex.size();
+
+  // Set the number of threads to spawn to the min of the calculated thread
+  // count or max threads that the hardware supports
+  int maxThreads = std::thread::hardware_concurrency();
+  uint64_t numThreads = std::min(numEntities, maxThreads);
+
+  int entitiesPerThread = static_cast<int>(std::ceil(
+    static_cast<double>(numEntities) / numThreads));
+
+  gzdbg << "Updated state thread iterators: " << numThreads
+         << " threads processing around " << entitiesPerThread
+         << " entities each." << std::endl;
+
+  // Push back the starting iterator
+  this->componentTypeIndexIterators.push_back(startIt);
+  for (uint64_t i = 0; i < numThreads; ++i)
+  {
+    // If we have added all of the entities to the iterator vector, we are
+    // done so push back the end iterator
+    numEntities -= entitiesPerThread;
+    if (numEntities <= 0)
+    {
+      this->componentTypeIndexIterators.push_back(
+          this->componentTypeIndex.end());
+      break;
+    }
+
+    // Get the iterator to the next starting group of entities
+    auto nextIt = std::next(startIt, entitiesPerThread);
+    this->componentTypeIndexIterators.push_back(nextIt);
+    startIt = nextIt;
+  }
+}
+
+//////////////////////////////////////////////////
 msgs::SerializedState EntityComponentManager::State(
     const std::unordered_set<Entity> &_entities,
     const std::unordered_set<ComponentTypeId> &_types) const
@@ -1668,15 +1740,46 @@ void EntityComponentManager::State(
     const std::unordered_set<ComponentTypeId> &_types,
     bool _full) const
 {
-  for (const auto& it : this->dataPtr->componentTypeIndex)
+  std::mutex stateMapMutex;
+  std::vector<std::thread> workers;
+
+  this->dataPtr->CalculateStateThreadLoad();
+
+  auto functor = [&](auto itStart, auto itEnd)
   {
-    const auto& entity = it.first;
-    if (!_entities.empty() && _entities.find(entity) == _entities.end())
+    msgs::SerializedStateMap threadMap;
+    while (itStart != itEnd)
     {
-      continue;
+      auto entity = (*itStart).first;
+      if (_entities.empty() || _entities.find(entity) != _entities.end())
+      {
+        this->AddEntityToMessage(threadMap, entity, _types, _full);
+      }
+      itStart++;
     }
-    this->AddEntityToMessage(_state, entity, _types, _full);
+    std::lock_guard<std::mutex> lock(stateMapMutex);
+
+    for (const auto &entity : threadMap.entities())
+    {
+      (*_state.mutable_entities())[static_cast<uint64_t>(entity.first)] =
+          entity.second;
+    }
+  };
+
+  // Spawn workers
+  uint64_t numThreads = this->dataPtr->componentTypeIndexIterators.size() - 1;
+  for (uint64_t i = 0; i < numThreads; i++)
+  {
+    workers.push_back(std::thread(functor,
+        this->dataPtr->componentTypeIndexIterators[i],
+        this->dataPtr->componentTypeIndexIterators[i+1]));
   }
+
+  // Wait for each thread to finish processing its components
+  std::for_each(workers.begin(), workers.end(), [](std::thread &_t)
+  {
+    _t.join();
+  });
 }
 
 //////////////////////////////////////////////////

--- a/test/benchmark/ecm_serialize.cc
+++ b/test/benchmark/ecm_serialize.cc
@@ -100,15 +100,7 @@ BENCHMARK_DEFINE_F(SerializeStateFixture, Serialize1Component)
   for (auto _: _st)
   {
     auto stateMsg = mgr->State({}, {IntComponent::typeId});
-#if GOOGLE_PROTOBUF_VERSION >= 3004000
-    serializedSize = stateMsg.ByteSizeLong();
-#else
-    serializedSize = stateMsg.ByteSize();
-#endif
   }
-  _st.counters["serialized_size"] = static_cast<double>(serializedSize);
-  _st.counters["num_entities"] = static_cast<double>(entityCount);
-  _st.counters["num_components"] = 1;
 }
 
 BENCHMARK_DEFINE_F(SerializeStateFixture, Serialize5Component)
@@ -119,15 +111,7 @@ BENCHMARK_DEFINE_F(SerializeStateFixture, Serialize5Component)
   for (auto _: _st)
   {
     auto stateMsg = mgr->State({}, {});
-#if GOOGLE_PROTOBUF_VERSION >= 3004000
-    serializedSize = stateMsg.ByteSizeLong();
-#else
-    serializedSize = stateMsg.ByteSize();
-#endif
   }
-  _st.counters["serialized_size"] = static_cast<double>(serializedSize);
-  _st.counters["num_entities"] = static_cast<double>(entityCount);
-  _st.counters["num_components"] = 5;
 }
 
 BENCHMARK_DEFINE_F(SerializeStateFixture, Serialize1ComponentMap)
@@ -139,15 +123,7 @@ BENCHMARK_DEFINE_F(SerializeStateFixture, Serialize1ComponentMap)
   for (auto _: _st)
   {
     mgr->State(stateMsg, {}, {IntComponent::typeId});
-#if GOOGLE_PROTOBUF_VERSION >= 3004000
-    serializedSize = stateMsg.ByteSizeLong();
-#else
-    serializedSize = stateMsg.ByteSize();
-#endif
   }
-  _st.counters["serialized_size"] = static_cast<double>(serializedSize);
-  _st.counters["num_entities"] = static_cast<double>(entityCount);
-  _st.counters["num_components"] = 1;
 }
 
 BENCHMARK_DEFINE_F(SerializeStateFixture, Serialize5ComponentMap)
@@ -159,15 +135,7 @@ BENCHMARK_DEFINE_F(SerializeStateFixture, Serialize5ComponentMap)
   for (auto _: _st)
   {
     mgr->State(stateMsg, {}, {});
-#if GOOGLE_PROTOBUF_VERSION >= 3004000
-    serializedSize = stateMsg.ByteSizeLong();
-#else
-    serializedSize = stateMsg.ByteSize();
-#endif
   }
-  _st.counters["serialized_size"] = static_cast<double>(serializedSize);
-  _st.counters["num_entities"] = static_cast<double>(entityCount);
-  _st.counters["num_components"] = 5;
 }
 
 BENCHMARK_REGISTER_F(SerializeStateFixture, Serialize1Component)

--- a/test/benchmark/ecm_serialize.cc
+++ b/test/benchmark/ecm_serialize.cc
@@ -19,6 +19,8 @@
 
 #include <memory>
 
+#include <gz/msgs/serialized_map.pb.h>
+
 #include "gz/sim/Entity.hh"
 #include "gz/sim/EntityComponentManager.hh"
 
@@ -129,6 +131,68 @@ void BM_Serialize5Component(benchmark::State &_st)
   _st.counters["num_entities"] = static_cast<double>(entityCount);
   _st.counters["num_components"] = 5;
 }
+// NOLINTNEXTLINE
+void BM_Serialize1ComponentMap(benchmark::State &_st)
+{
+  msgs::SerializedStateMap stateMsg;
+  size_t serializedSize = 0;
+  auto entityCount = _st.range(0);
+  for (auto _: _st)
+  {
+    _st.PauseTiming();
+    auto mgr = std::make_unique<EntityComponentManager>();
+    for (int ii = 0; ii < entityCount; ++ii)
+    {
+      auto e = mgr->CreateEntity();
+      mgr->CreateComponent(e, IntComponent(ii));
+    }
+    _st.ResumeTiming();
+
+    mgr->State(stateMsg);
+#if GOOGLE_PROTOBUF_VERSION >= 3004000
+    serializedSize = stateMsg.ByteSizeLong();
+#else
+    serializedSize = stateMsg.ByteSize();
+#endif
+  }
+  _st.counters["serialized_size"] = static_cast<double>(serializedSize);
+  _st.counters["num_entities"] = static_cast<double>(entityCount);
+  _st.counters["num_components"] = 1;
+}
+
+// NOLINTNEXTLINE
+void BM_Serialize5ComponentMap(benchmark::State &_st)
+{
+  msgs::SerializedStateMap stateMsg;
+  size_t serializedSize = 0;
+  auto entityCount = _st.range(0);
+  for (auto _: _st)
+  {
+    _st.PauseTiming();
+    auto mgr = std::make_unique<EntityComponentManager>();
+    for (int ii = 0; ii < entityCount; ++ii)
+    {
+      auto e = mgr->CreateEntity();
+      mgr->CreateComponent(e, IntComponent(ii));
+      mgr->CreateComponent(e, UIntComponent(ii));
+      mgr->CreateComponent(e, DoubleComponent(ii));
+      mgr->CreateComponent(e, StringComponent("foobar"));
+      mgr->CreateComponent(e, BoolComponent(ii%2));
+    }
+    _st.ResumeTiming();
+
+    mgr->State(stateMsg);
+#if GOOGLE_PROTOBUF_VERSION >= 3004000
+    serializedSize = stateMsg.ByteSizeLong();
+#else
+    serializedSize = stateMsg.ByteSize();
+#endif
+  }
+  _st.counters["serialized_size"] = static_cast<double>(serializedSize);
+  _st.counters["num_entities"] = static_cast<double>(entityCount);
+  _st.counters["num_components"] = 5;
+}
+
 
 // NOLINTNEXTLINE
 BENCHMARK(BM_Serialize1Component)
@@ -141,6 +205,24 @@ BENCHMARK(BM_Serialize1Component)
 
 // NOLINTNEXTLINE
 BENCHMARK(BM_Serialize5Component)
+  ->Arg(10)
+  ->Arg(50)
+  ->Arg(100)
+  ->Arg(500)
+  ->Arg(1000)
+  ->Unit(benchmark::kMillisecond);
+
+// NOLINTNEXTLINE
+BENCHMARK(BM_Serialize1ComponentMap)
+  ->Arg(10)
+  ->Arg(50)
+  ->Arg(100)
+  ->Arg(500)
+  ->Arg(1000)
+  ->Unit(benchmark::kMillisecond);
+
+// NOLINTNEXTLINE
+BENCHMARK(BM_Serialize5ComponentMap)
   ->Arg(10)
   ->Arg(50)
   ->Arg(100)

--- a/test/benchmark/ecm_serialize.cc
+++ b/test/benchmark/ecm_serialize.cc
@@ -72,23 +72,34 @@ using namespace gz;
 using namespace sim;
 using namespace components;
 
-// NOLINTNEXTLINE
-void BM_Serialize1Component(benchmark::State &_st)
+class SerializeStateFixture: public benchmark::Fixture
+{
+  protected: void SetUp(const ::benchmark::State &_state) override
+  {
+    auto entityCount = _state.range(0);
+    mgr = std::make_unique<EntityComponentManager>();
+    for (int ii = 0; ii < entityCount; ++ii)
+    {
+      auto e = mgr->CreateEntity();
+      mgr->CreateComponent(e, IntComponent(ii));
+      mgr->CreateComponent(e, UIntComponent(ii));
+      mgr->CreateComponent(e, DoubleComponent(ii));
+      mgr->CreateComponent(e, StringComponent("foobar"));
+      mgr->CreateComponent(e, BoolComponent(ii%2));
+    }
+  }
+
+  protected: std::unique_ptr<EntityComponentManager> mgr;
+};
+
+BENCHMARK_DEFINE_F(SerializeStateFixture, Serialize1Component)
+(benchmark::State &_st)
 {
   size_t serializedSize = 0;
   auto entityCount = _st.range(0);
   for (auto _: _st)
   {
-    _st.PauseTiming();
-    auto mgr = std::make_unique<EntityComponentManager>();
-    for (int ii = 0; ii < entityCount; ++ii)
-    {
-      auto e = mgr->CreateEntity();
-      mgr->CreateComponent(e, IntComponent(ii));
-    }
-    _st.ResumeTiming();
-
-    auto stateMsg = mgr->State();
+    auto stateMsg = mgr->State({}, {IntComponent::typeId});
 #if GOOGLE_PROTOBUF_VERSION >= 3004000
     serializedSize = stateMsg.ByteSizeLong();
 #else
@@ -100,27 +111,14 @@ void BM_Serialize1Component(benchmark::State &_st)
   _st.counters["num_components"] = 1;
 }
 
-// NOLINTNEXTLINE
-void BM_Serialize5Component(benchmark::State &_st)
+BENCHMARK_DEFINE_F(SerializeStateFixture, Serialize5Component)
+(benchmark::State &_st)
 {
   size_t serializedSize = 0;
   auto entityCount = _st.range(0);
   for (auto _: _st)
   {
-    _st.PauseTiming();
-    auto mgr = std::make_unique<EntityComponentManager>();
-    for (int ii = 0; ii < entityCount; ++ii)
-    {
-      auto e = mgr->CreateEntity();
-      mgr->CreateComponent(e, IntComponent(ii));
-      mgr->CreateComponent(e, UIntComponent(ii));
-      mgr->CreateComponent(e, DoubleComponent(ii));
-      mgr->CreateComponent(e, StringComponent("foobar"));
-      mgr->CreateComponent(e, BoolComponent(ii%2));
-    }
-    _st.ResumeTiming();
-
-    auto stateMsg = mgr->State();
+    auto stateMsg = mgr->State({}, {});
 #if GOOGLE_PROTOBUF_VERSION >= 3004000
     serializedSize = stateMsg.ByteSizeLong();
 #else
@@ -131,24 +129,16 @@ void BM_Serialize5Component(benchmark::State &_st)
   _st.counters["num_entities"] = static_cast<double>(entityCount);
   _st.counters["num_components"] = 5;
 }
-// NOLINTNEXTLINE
-void BM_Serialize1ComponentMap(benchmark::State &_st)
+
+BENCHMARK_DEFINE_F(SerializeStateFixture, Serialize1ComponentMap)
+(benchmark::State &_st)
 {
   msgs::SerializedStateMap stateMsg;
   size_t serializedSize = 0;
   auto entityCount = _st.range(0);
   for (auto _: _st)
   {
-    _st.PauseTiming();
-    auto mgr = std::make_unique<EntityComponentManager>();
-    for (int ii = 0; ii < entityCount; ++ii)
-    {
-      auto e = mgr->CreateEntity();
-      mgr->CreateComponent(e, IntComponent(ii));
-    }
-    _st.ResumeTiming();
-
-    mgr->State(stateMsg);
+    mgr->State(stateMsg, {}, {IntComponent::typeId});
 #if GOOGLE_PROTOBUF_VERSION >= 3004000
     serializedSize = stateMsg.ByteSizeLong();
 #else
@@ -160,28 +150,15 @@ void BM_Serialize1ComponentMap(benchmark::State &_st)
   _st.counters["num_components"] = 1;
 }
 
-// NOLINTNEXTLINE
-void BM_Serialize5ComponentMap(benchmark::State &_st)
+BENCHMARK_DEFINE_F(SerializeStateFixture, Serialize5ComponentMap)
+(benchmark::State &_st)
 {
   msgs::SerializedStateMap stateMsg;
   size_t serializedSize = 0;
   auto entityCount = _st.range(0);
   for (auto _: _st)
   {
-    _st.PauseTiming();
-    auto mgr = std::make_unique<EntityComponentManager>();
-    for (int ii = 0; ii < entityCount; ++ii)
-    {
-      auto e = mgr->CreateEntity();
-      mgr->CreateComponent(e, IntComponent(ii));
-      mgr->CreateComponent(e, UIntComponent(ii));
-      mgr->CreateComponent(e, DoubleComponent(ii));
-      mgr->CreateComponent(e, StringComponent("foobar"));
-      mgr->CreateComponent(e, BoolComponent(ii%2));
-    }
-    _st.ResumeTiming();
-
-    mgr->State(stateMsg);
+    mgr->State(stateMsg, {}, {});
 #if GOOGLE_PROTOBUF_VERSION >= 3004000
     serializedSize = stateMsg.ByteSizeLong();
 #else
@@ -193,9 +170,7 @@ void BM_Serialize5ComponentMap(benchmark::State &_st)
   _st.counters["num_components"] = 5;
 }
 
-
-// NOLINTNEXTLINE
-BENCHMARK(BM_Serialize1Component)
+BENCHMARK_REGISTER_F(SerializeStateFixture, Serialize1Component)
   ->Arg(10)
   ->Arg(50)
   ->Arg(100)
@@ -203,8 +178,7 @@ BENCHMARK(BM_Serialize1Component)
   ->Arg(1000)
   ->Unit(benchmark::kMillisecond);
 
-// NOLINTNEXTLINE
-BENCHMARK(BM_Serialize5Component)
+BENCHMARK_REGISTER_F(SerializeStateFixture, Serialize5Component)
   ->Arg(10)
   ->Arg(50)
   ->Arg(100)
@@ -212,8 +186,7 @@ BENCHMARK(BM_Serialize5Component)
   ->Arg(1000)
   ->Unit(benchmark::kMillisecond);
 
-// NOLINTNEXTLINE
-BENCHMARK(BM_Serialize1ComponentMap)
+BENCHMARK_REGISTER_F(SerializeStateFixture, Serialize1ComponentMap)
   ->Arg(10)
   ->Arg(50)
   ->Arg(100)
@@ -221,8 +194,7 @@ BENCHMARK(BM_Serialize1ComponentMap)
   ->Arg(1000)
   ->Unit(benchmark::kMillisecond);
 
-// NOLINTNEXTLINE
-BENCHMARK(BM_Serialize5ComponentMap)
+BENCHMARK_REGISTER_F(SerializeStateFixture, Serialize5ComponentMap)
   ->Arg(10)
   ->Arg(50)
   ->Arg(100)


### PR DESCRIPTION
# 🎉 New feature

## Summary

Split out from #3447.
While working on the Entt refactor I noticed that there really wasn't a lot of performance to be gained by running the State() function in a multithreaded way, I commented it out there and left as a TODO to figure out whether it was needed or not.
The idea was that we might be able to make things a bit faster by parallelizing but at the same time we currently:

* Launch a number of threads that will pretty much be equal to the number of cores in the machine, even if we have very few entities.
* Need to wait for all of them to be finished.
* When they are all finished we need to iterate through all the maps they populated and merge them into one.

This is really fairly complex and requires additional book-keeping (i.e. through the `componentTypeIndexDirty` flag). Turns out, I _think_ it's actually counter productive?

I split this PR in two commits:

* https://github.com/gazebosim/gz-sim/commit/c456ac01dec1ccabb167a23a51b64d6d027d2ca8 adds a benchmark for the multithreaded function. Note that we have two `State` functions, one that gets an input parameter and is multithreaded and one that doesn't. Now the benchmark tests both.
* https://github.com/gazebosim/gz-sim/commit/f6831d08bc60369d9d1ad4f05503643472c6cb4c is the real commit that removes all the multithreaded behavior and makes it run serially.

## Test it

Checkout https://github.com/gazebosim/gz-sim/commit/c456ac01dec1ccabb167a23a51b64d6d027d2ca8, build and run the test:

```
$ colcon build --packages-select gz-sim --merge-install --mixin rel-with-deb-info
$ build/gz-sim/bin/BENCHMARK_ecm_serialize
```

Checkout the commit that removes the multithreaded logic https://github.com/gazebosim/gz-sim/commit/f6831d08bc60369d9d1ad4f05503643472c6cb4c and rebuild + rerun the benchmark.

On my machine (12 core Ryzen Threadripper 5945WX):

```
Before:
BM_Serialize1ComponentMap/10        0.369 ms        0.365 ms         1782 num_components=1 num_entities=10 serialized_size=370
BM_Serialize1ComponentMap/50        0.661 ms        0.656 ms         1013 num_components=1 num_entities=50 serialized_size=1.89k
BM_Serialize1ComponentMap/100       0.826 ms        0.818 ms          847 num_components=1 num_entities=100 serialized_size=3.79k
BM_Serialize1ComponentMap/500        1.20 ms         1.19 ms          538 num_components=1 num_entities=500 serialized_size=20.136k
BM_Serialize1ComponentMap/1000       1.43 ms         1.42 ms          492 num_components=1 num_entities=1k serialized_size=40.636k
BM_Serialize5ComponentMap/10        0.389 ms        0.381 ms         1875 num_components=5 num_entities=10 serialized_size=1.52k
BM_Serialize5ComponentMap/50        0.712 ms        0.705 ms          990 num_components=5 num_entities=50 serialized_size=7.72k
BM_Serialize5ComponentMap/100       0.898 ms        0.891 ms          760 num_components=5 num_entities=100 serialized_size=15.47k
BM_Serialize5ComponentMap/500        1.92 ms         1.65 ms          414 num_components=5 num_entities=500 serialized_size=79.416k
BM_Serialize5ComponentMap/1000       3.48 ms         2.33 ms          345 num_components=5 num_entities=1k serialized_size=159.416k

After:
BM_Serialize1ComponentMap/10        0.004 ms        0.004 ms       167356 num_components=1 num_entities=10 serialized_size=370
BM_Serialize1ComponentMap/50        0.015 ms        0.015 ms        45818 num_components=1 num_entities=50 serialized_size=1.89k
BM_Serialize1ComponentMap/100       0.030 ms        0.030 ms        23847 num_components=1 num_entities=100 serialized_size=3.79k
BM_Serialize1ComponentMap/500       0.155 ms        0.155 ms         4688 num_components=1 num_entities=500 serialized_size=20.136k
BM_Serialize1ComponentMap/1000      0.325 ms        0.324 ms         2315 num_components=1 num_entities=1k serialized_size=40.636k
BM_Serialize5ComponentMap/10        0.013 ms        0.013 ms        55122 num_components=5 num_entities=10 serialized_size=1.52k
BM_Serialize5ComponentMap/50        0.058 ms        0.058 ms        12132 num_components=5 num_entities=50 serialized_size=7.72k
BM_Serialize5ComponentMap/100       0.117 ms        0.117 ms         6065 num_components=5 num_entities=100 serialized_size=15.47k
BM_Serialize5ComponentMap/500       0.619 ms        0.618 ms         1017 num_components=5 num_entities=500 serialized_size=79.416k
BM_Serialize5ComponentMap/1000       1.25 ms         1.25 ms          570 num_components=5 num_entities=1k serialized_size=159.416k
```

It really looks like it is counter-productive regardless of the number of entities, with the largest penalty showing up when there are very few entities (makes sense, running a for loop with 10 iterations is going to be a lot faster than spinning up 10 threads and synchronizing them).
The same as my serial postupdate PR applies, there might be some case that I overlooked but I can't really find any, unless my benchmark is ill designed.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.