### PR TITLE
Fix INTEGRATION_reset_sensors dangling pointer on reset

### DIFF
--- a/include/gz/sim/EntityComponentManager.hh
+++ b/include/gz/sim/EntityComponentManager.hh
@@ -77,11 +77,12 @@ namespace gz
       /// it can have additional parameters if the need arises in the future.
       /// Additionally, not every data member is copied making its behavior
       /// different from what would be expected from a copy constructor.
-      /// \warning This rebuilds the underlying component storage: every existing
-      /// component is destroyed and replaced by a freshly allocated clone. Any
-      /// raw component pointer previously obtained from this ECM (e.g. via
-      /// Component()) is therefore left dangling and must be re-fetched after
-      /// this call. Dereferencing a stale pointer is undefined behavior.
+      /// \warning This rebuilds the underlying component storage: every
+      /// existing component is destroyed and replaced by a freshly allocated
+      /// clone. Any raw component pointer previously obtained from this ECM
+      /// (e.g. via Component()) is therefore left dangling and must be
+      /// re-fetched after this call. Dereferencing a stale pointer is
+      /// undefined behavior.
       /// \param[in] _fromEcm Object to copy from
       public: void CopyFrom(const EntityComponentManager &_fromEcm);
 
@@ -672,11 +673,11 @@ namespace gz
       /// \brief Reset this ECM back to the state captured in `_other`,
       /// reconciling any entities that were added or removed since `_other` was
       /// taken. This is the operation used to implement world reset/rewind.
-      /// \warning This rebuilds the underlying component storage via CopyFrom().
-      /// Any raw component pointer obtained from this ECM before the reset
-      /// (e.g. via Component()) is invalidated and must be re-fetched
-      /// afterwards. Holding such a pointer across a reset and dereferencing it
-      /// is undefined behavior (see issue
+      /// \warning This rebuilds the underlying component storage via
+      /// CopyFrom(). Any raw component pointer obtained from this ECM before
+      /// the reset (e.g. via Component()) is invalidated and must be
+      /// re-fetched afterwards. Holding such a pointer across a reset and
+      /// dereferencing it is undefined behavior (see issue
       /// https://github.com/gazebosim/gz-sim/issues/3635).
       /// \param[in] _other Original EntityComponentManager from which the diff
       /// was computed.

--- a/include/gz/sim/EntityComponentManager.hh
+++ b/include/gz/sim/EntityComponentManager.hh
@@ -77,6 +77,11 @@ namespace gz
       /// it can have additional parameters if the need arises in the future.
       /// Additionally, not every data member is copied making its behavior
       /// different from what would be expected from a copy constructor.
+      /// \warning This rebuilds the underlying component storage: every existing
+      /// component is destroyed and replaced by a freshly allocated clone. Any
+      /// raw component pointer previously obtained from this ECM (e.g. via
+      /// Component()) is therefore left dangling and must be re-fetched after
+      /// this call. Dereferencing a stale pointer is undefined behavior.
       /// \param[in] _fromEcm Object to copy from
       public: void CopyFrom(const EntityComponentManager &_fromEcm);
 
@@ -664,9 +669,15 @@ namespace gz
       /// \param[in] _offset Offset value.
       public: void SetEntityCreateOffset(uint64_t _offset);
 
-      /// \brief Given a diff, apply it to this ECM. Note that for removed
-      /// entities, this would mark them for removal instead of actually
-      /// removing the entities.
+      /// \brief Reset this ECM back to the state captured in `_other`,
+      /// reconciling any entities that were added or removed since `_other` was
+      /// taken. This is the operation used to implement world reset/rewind.
+      /// \warning This rebuilds the underlying component storage via CopyFrom().
+      /// Any raw component pointer obtained from this ECM before the reset
+      /// (e.g. via Component()) is invalidated and must be re-fetched
+      /// afterwards. Holding such a pointer across a reset and dereferencing it
+      /// is undefined behavior (see issue
+      /// https://github.com/gazebosim/gz-sim/issues/3635).
       /// \param[in] _other Original EntityComponentManager from which the diff
       /// was computed.
       public: void ResetTo(const EntityComponentManager &_other);

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -317,6 +317,13 @@ void EntityComponentManagerPrivate::CopyFrom(
   this->removedComponents = _from.removedComponents;
   this->componentsMarkedAsRemoved = _from.componentsMarkedAsRemoved;
 
+  // Rebuild component storage by cloning every component from `_from`.
+  // \warning This destroys the existing component objects and replaces them
+  // with freshly allocated clones at new addresses. Any raw component pointer
+  // handed out earlier (Component(), ComponentImplementation(), ...) is left
+  // dangling by this loop and must be re-fetched by callers afterwards.
+  // Holding such a pointer across CopyFrom()/ResetTo() and dereferencing it is
+  // undefined behavior (see gazebosim/gz-sim#3635).
   for (const auto &[entity, comps] : _from.componentStorage)
   {
     this->componentStorage[entity].clear();
@@ -2344,6 +2351,9 @@ void EntityComponentManager::ApplyEntityDiff(
 /////////////////////////////////////////////////
 void EntityComponentManager::ResetTo(const EntityComponentManager &_other)
 {
+  // \warning The final CopyFrom() below rebuilds the component storage, so any
+  // raw component pointer obtained before this call is invalidated. Callers
+  // must re-fetch components after a reset (see gazebosim/gz-sim#3635).
   auto ecmDiff = this->ComputeEntityDiff(_other);
   EntityComponentManager tmpCopy;
   tmpCopy.CopyFrom(_other);

--- a/test/integration/reset_sensors.cc
+++ b/test/integration/reset_sensors.cc
@@ -255,6 +255,14 @@ TEST_F(ResetFixture, GZ_UTILS_TEST_DISABLED_ON_MAC(HandleReset))
 
   // The second iteration is where the reset actually occurs.
   reset::ApplyWorldReset(server);
+
+  // The reset rebuilds the ECM component storage (ResetTo -> CopyFrom clones
+  // every component into freshly allocated objects), which invalidates any
+  // component pointer cached before the reset. Re-fetch the pose component
+  // see issue #3635).
+  poseComp = ecm->Component<components::Pose>(entity);
+  ASSERT_NE(nullptr, poseComp);
+
   {
     EXPECT_EQ(1u, this->mockSystem->configureCallCount);
     EXPECT_EQ(1u, this->mockSystem->resetCallCount);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #3635

## Summary

INTEGRATION_reset_sensors failed on Ubuntu 26.04 because the test cached the box's Pose component pointer once and dereferenced it after a world reset. EntityComponentManager::ResetTo() calls CopyFrom(), which clears the component storage and re-emplaces freshly cloned component objects at new addresses. Any raw component pointer obtained before the reset is therefore left dangling, and reading it after the reset is undefined behavior.

The pre-reset reads passed everywhere, but the post-reset reads hit freed memory.

It might be triggered on Resolute due to a change in the allocator, just a hypothesis but on older platforms it coincidentally still held the prior value, while on Ubuntu 26.04's allocator the memory was reused and some random value ended up there.

The issue #3653 was created to collect this point of failure in the code.

Fix the test by re-fetching the Pose component after ApplyWorldReset, and document the pointer-invalidation contract on CopyFrom()/ResetTo() and at the storage-rebuild site so this class of bug is easier to avoid.

## Tested

Passed here https://build.osrfoundation.org/job/_test_gz_sim-ci-pr_any-resolute-amd64/1/

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Opus 4.8