### PR TITLE
Only publish to clock and stats topics when there are subscribers

### DIFF
--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -519,9 +519,16 @@ void SimulationRunner::PublishStats()
 {
   GZ_PROFILE("SimulationRunner::PublishStats");
 
-  // Create the world statistics message.
-  msgs::WorldStatistics msg;
-  msg.set_real_time_factor(this->realTimeFactor);
+  const bool publishStats = this->statsPub.HasConnections() ||
+                            (this->rootStatsPub.Valid() &&
+                             this->rootStatsPub.HasConnections());
+
+  const bool publishClock = this->clockPub.HasConnections() ||
+                            (this->rootClockPub.Valid() &&
+                             this->rootClockPub.HasConnections());
+
+  if (!publishStats && !publishClock)
+    return;
 
   auto realTimeSecNsec =
     math::durationToSecNsec(this->currentInfo.realTime);
@@ -529,48 +536,58 @@ void SimulationRunner::PublishStats()
   auto simTimeSecNsec =
     math::durationToSecNsec(this->currentInfo.simTime);
 
-  msg.mutable_real_time()->set_sec(realTimeSecNsec.first);
-  msg.mutable_real_time()->set_nsec(realTimeSecNsec.second);
-
-  msg.mutable_sim_time()->set_sec(simTimeSecNsec.first);
-  msg.mutable_sim_time()->set_nsec(simTimeSecNsec.second);
-
-  msg.set_iterations(this->currentInfo.iterations);
-
-  msg.set_paused(this->currentInfo.paused);
-
-  msgs::Set(msg.mutable_step_size(), this->currentInfo.dt);
-
-  if (this->Stepping())
+  if (publishStats)
   {
-    // (deprecated) Remove this header in Gazebo H
-    auto headerData = msg.mutable_header()->add_data();
-    headerData->set_key("step");
+    // Create the world statistics message.
+    msgs::WorldStatistics msg;
+    msg.set_real_time_factor(this->realTimeFactor);
 
-    msg.set_stepping(true);
+    msg.mutable_real_time()->set_sec(realTimeSecNsec.first);
+    msg.mutable_real_time()->set_nsec(realTimeSecNsec.second);
+
+    msg.mutable_sim_time()->set_sec(simTimeSecNsec.first);
+    msg.mutable_sim_time()->set_nsec(simTimeSecNsec.second);
+
+    msg.set_iterations(this->currentInfo.iterations);
+
+    msg.set_paused(this->currentInfo.paused);
+
+    msgs::Set(msg.mutable_step_size(), this->currentInfo.dt);
+
+    if (this->Stepping())
+    {
+      // (deprecated) Remove this header in Gazebo H
+      auto headerData = msg.mutable_header()->add_data();
+      headerData->set_key("step");
+
+      msg.set_stepping(true);
+    }
+
+    // Publish the stats message. The stats message is throttled.
+    this->statsPub.Publish(msg);
+
+    if (this->rootStatsPub.Valid())
+      this->rootStatsPub.Publish(msg);
   }
 
-  // Publish the stats message. The stats message is throttled.
-  this->statsPub.Publish(msg);
+  if (publishClock)
+  {
+    // Create and publish the clock message. The clock message is not
+    // throttled.
+    msgs::Clock clockMsg;
+    clockMsg.mutable_real()->set_sec(realTimeSecNsec.first);
+    clockMsg.mutable_real()->set_nsec(realTimeSecNsec.second);
+    clockMsg.mutable_sim()->set_sec(simTimeSecNsec.first);
+    clockMsg.mutable_sim()->set_nsec(simTimeSecNsec.second);
+    clockMsg.mutable_system()->set_sec(GZ_SYSTEM_TIME_S());
+    clockMsg.mutable_system()->set_nsec(
+        GZ_SYSTEM_TIME_NS() - GZ_SYSTEM_TIME_S() * GZ_SEC_TO_NANO);
+    this->clockPub.Publish(clockMsg);
 
-  if (this->rootStatsPub.Valid())
-    this->rootStatsPub.Publish(msg);
-
-  // Create and publish the clock message. The clock message is not
-  // throttled.
-  msgs::Clock clockMsg;
-  clockMsg.mutable_real()->set_sec(realTimeSecNsec.first);
-  clockMsg.mutable_real()->set_nsec(realTimeSecNsec.second);
-  clockMsg.mutable_sim()->set_sec(simTimeSecNsec.first);
-  clockMsg.mutable_sim()->set_nsec(simTimeSecNsec.second);
-  clockMsg.mutable_system()->set_sec(GZ_SYSTEM_TIME_S());
-  clockMsg.mutable_system()->set_nsec(
-      GZ_SYSTEM_TIME_NS() - GZ_SYSTEM_TIME_S() * GZ_SEC_TO_NANO);
-  this->clockPub.Publish(clockMsg);
-
-  // Only publish to root topic if no others are.
-  if (this->rootClockPub.Valid())
-    this->rootClockPub.Publish(clockMsg);
+    // Only publish to root topic if no others are.
+    if (this->rootClockPub.Valid())
+      this->rootClockPub.Publish(clockMsg);
+  }
 }
 
 namespace {

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -520,12 +520,10 @@ void SimulationRunner::PublishStats()
   GZ_PROFILE("SimulationRunner::PublishStats");
 
   const bool publishStats = this->statsPub.HasConnections() ||
-                            (this->rootStatsPub.Valid() &&
-                             this->rootStatsPub.HasConnections());
+                            this->rootStatsPub.HasConnections();
 
   const bool publishClock = this->clockPub.HasConnections() ||
-                            (this->rootClockPub.Valid() &&
-                             this->rootClockPub.HasConnections());
+                            this->rootClockPub.HasConnections();
 
   if (!publishStats && !publishClock)
     return;


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary

Minor optimization. We don't need to publish to stats or clock topics if there are no subscribers. GUI always subscribes to `/world/<world_name>/stats` but I think we don't have any subscribers for the `/stats`, `/clock`, `/world/<world_name>/clock` topics in a typical out-of-box  gazebo simulation with default plugins. We can save some cpu by not publishing msgs at 1000 Hz.

Side note, I noticed that the `/stats` topic is published at 1000Hz while the `/world/<world_name>/stats` topic is 10Hz. Based on the inline comment (`// Publish the stats message. The stats message is throttled.`), I think it's not intentional and the `/stats` topic should also be throttled at 10Hz. I did not make this change in this PR.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.

