### PR TITLE
Detect Wayland via WAYLAND_DISPLAY on WSLg

### DIFF
--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -360,7 +360,8 @@ std::unique_ptr<gz::gui::Application> createGui(
   }
 
   // check for wayland and force to use X for rendering
-  if (QString::fromLocal8Bit(qgetenv("XDG_SESSION_TYPE")) == "wayland")
+  if (QString::fromLocal8Bit(qgetenv("XDG_SESSION_TYPE")) == "wayland" ||
+      !QString::fromLocal8Bit(qgetenv("WAYLAND_DISPLAY")).isEmpty())
   {
     if (QString::fromLocal8Bit(qgetenv("QT_QPA_PLATFORM")).isEmpty())
     {


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
This is the same class of issue tracked in [gazebosim/gz-sim#1934](https://github.com/gazebosim/gz-sim/issues/1934) and documented in the [Gazebo troubleshooting guide](https://gazebosim.org/docs/latest/troubleshooting/#wayland-issues). 

Tool already had a Wayland workaround (added in [PR #2526](https://github.com/gazebosim/gz-sim/pull/2526)): when Qt runs on Wayland, Ogre cannot create a GLX window sharing the "current" GL context, so the GUI forces Qt onto the X11 backend (xcb). 

However, the solution does not cover WSLg. It only checked `XDG_SESSION_TYPE == "wayland"`. On WSLg, the environment looks like this:
<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html>
<body>

Variable | Typical WSLg value
-- | --
WAYLAND_DISPLAY | wayland-0
XDG_SESSION_TYPE | (empty)
DISPLAY | :0
</body>
</html>

WSLg exposes Wayland via WAYLAND_DISPLAY but does not set XDG_SESSION_TYPE. Qt therefore picks the Wayland platform plugin, Ogre requests a shared GLX context that was never made current, and you get the repeated currentGLContext was specified with no current GL context errors followed by a segfault.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

