### PR TITLE
Benchmark for scopedName function in Utils.cc

### DIFF
--- a/test/benchmark/CMakeLists.txt
+++ b/test/benchmark/CMakeLists.txt
@@ -6,6 +6,7 @@ if (GzBenchmark_FOUND)
   set(tests
     each.cc
     ecm_serialize.cc
+    utils_benchmark.cc
   )
 
   gz_add_benchmarks(SOURCES ${tests})

--- a/test/benchmark/utils_benchmark.cc
+++ b/test/benchmark/utils_benchmark.cc
@@ -31,7 +31,7 @@
 using namespace gz;
 using namespace sim;
 
-void BM_ScopedName(benchmark::State &_st, const std::string &_entityType) 
+void BM_ScopedName(benchmark::State &_st, const std::string &_entityType)
 {
   // world
   // - modelA
@@ -81,7 +81,7 @@ void BM_ScopedName(benchmark::State &_st, const std::string &_entityType)
   {
     ecm.CreateComponent(entity, components::Model());
   }
-  for (auto _ : _st) 
+  for (auto _ : _st)
   {
     for (int64_t ii = 0; ii < iterations; ++ii)
     {

--- a/test/benchmark/utils_benchmark.cc
+++ b/test/benchmark/utils_benchmark.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Open Source Robotics Foundation
+ * Copyright (C) 2026 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
-*/
+ */
 
 #include <benchmark/benchmark.h>
 
+#include "gz/sim/EntityComponentManager.hh"
 #include "gz/sim/components/Link.hh"
 #include "gz/sim/components/Model.hh"
 #include "gz/sim/components/Name.hh"
@@ -24,23 +25,19 @@
 #include "gz/sim/components/Projector.hh"
 #include "gz/sim/components/Sensor.hh"
 #include "gz/sim/components/World.hh"
-#include "gz/sim/components/Link.hh"
-#include "gz/sim/EntityComponentManager.hh"
 
 #include "gz/sim/Util.hh"
 
 using namespace gz;
 using namespace sim;
 
-void BM_ScopedName(benchmark::State &_st, const std::string &_entityType) {
-
+void BM_ScopedName(benchmark::State &_st, const std::string &_entityType) 
+{
   // world
   // - modelA
   //   - modelB
   //     - linkC
-  //       - sensorD
-  //       - projectorE
-  //       - modelF
+  //       - entity
 
   EntityComponentManager ecm;
 
@@ -84,8 +81,9 @@ void BM_ScopedName(benchmark::State &_st, const std::string &_entityType) {
   {
     ecm.CreateComponent(entity, components::Model());
   }
-  for (auto _ : _st) {
-    for (int ii = 0; ii < iterations; ++ii)
+  for (auto _ : _st) 
+  {
+    for (int64_t ii = 0; ii < iterations; ++ii)
     {
       scopedName(entity, ecm);
     }
@@ -93,15 +91,15 @@ void BM_ScopedName(benchmark::State &_st, const std::string &_entityType) {
 }
 
 // NOLINTNEXTLINE
-BENCHMARK_CAPTURE(BM_ScopedName, bullet_sensor, "sensor")
+BENCHMARK_CAPTURE(BM_ScopedName, sensor, "sensor")
     ->Arg(1000)
     ->Unit(benchmark::kMillisecond);
 
-BENCHMARK_CAPTURE(BM_ScopedName, bullet_projector, "projector")
+BENCHMARK_CAPTURE(BM_ScopedName, projector, "projector")
     ->Arg(1000)
     ->Unit(benchmark::kMillisecond);
 
-BENCHMARK_CAPTURE(BM_ScopedName, bullet_model, "model")
+BENCHMARK_CAPTURE(BM_ScopedName, model, "model")
     ->Arg(1000)
     ->Unit(benchmark::kMillisecond);
 

--- a/test/benchmark/utils_benchmark.cc
+++ b/test/benchmark/utils_benchmark.cc
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <benchmark/benchmark.h>
+
+#include "gz/sim/components/Link.hh"
+#include "gz/sim/components/Model.hh"
+#include "gz/sim/components/Name.hh"
+#include "gz/sim/components/ParentEntity.hh"
+#include "gz/sim/components/Sensor.hh"
+#include "gz/sim/components/World.hh"
+#include "gz/sim/components/Link.hh"
+#include "gz/sim/EntityComponentManager.hh"
+
+#include "gz/sim/Util.hh"
+
+using namespace gz;
+using namespace sim;
+
+void BM_ScopedName(benchmark::State &_st) {
+
+  // world
+  // - modelA
+  //   - modelB
+  //     - linkC
+  //       - sensorD
+
+  // todo:
+  // call on different entity types
+  // call on different depth levels
+  EntityComponentManager ecm;
+
+  auto worldEntity = ecm.CreateEntity();
+  ecm.CreateComponent(worldEntity, components::World());
+  ecm.CreateComponent(worldEntity, components::Name("world_name"));
+
+  // Model A
+  auto modelAEntity = ecm.CreateEntity();
+  ecm.CreateComponent(modelAEntity, components::Model());
+  ecm.CreateComponent(modelAEntity, components::Name("modelA_name"));
+  ecm.CreateComponent(modelAEntity, components::ParentEntity(worldEntity));
+
+  // Model B
+  auto modelBEntity = ecm.CreateEntity();
+  ecm.CreateComponent(modelBEntity, components::Model());
+  ecm.CreateComponent(modelBEntity, components::Name("modelB_name"));
+  ecm.CreateComponent(modelBEntity, components::ParentEntity(modelAEntity));
+
+  // Link C
+  auto linkCEntity = ecm.CreateEntity();
+  ecm.CreateComponent(linkCEntity, components::Link());
+  ecm.CreateComponent(linkCEntity, components::Name("linkC_name"));
+  ecm.CreateComponent(linkCEntity, components::ParentEntity(modelBEntity));
+
+  // Sensor D
+  auto sensorDEntity = ecm.CreateEntity();
+  ecm.CreateComponent(sensorDEntity, components::Sensor());
+  ecm.CreateComponent(sensorDEntity, components::Name("sensorD_name"));
+  ecm.CreateComponent(sensorDEntity, components::ParentEntity(linkCEntity));
+
+  auto iterations = _st.range(0);
+  for (auto _ : _st) {
+    for (int ii = 0; ii < iterations; ++ii)
+    {
+      scopedName(sensorDEntity, ecm);
+    }
+  }
+}
+
+// NOLINTNEXTLINE
+BENCHMARK(BM_ScopedName)
+    ->Arg(1000)
+    ->Unit(benchmark::kMillisecond);
+
+// OSX needs the semicolon, Ubuntu complains that there's an extra ';'
+#if !defined(_MSC_VER)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+BENCHMARK_MAIN();
+#if !defined(_MSC_VER)
+#pragma GCC diagnostic pop
+#endif

--- a/test/benchmark/utils_benchmark.cc
+++ b/test/benchmark/utils_benchmark.cc
@@ -92,15 +92,15 @@ void BM_ScopedName(benchmark::State &_st, const std::string &_entityType)
 
 // NOLINTNEXTLINE
 BENCHMARK_CAPTURE(BM_ScopedName, sensor, "sensor")
-    ->Arg(1000)
-    ->Unit(benchmark::kMillisecond);
+    ->Arg(1)
+    ->Unit(benchmark::kNanosecond);
 
 BENCHMARK_CAPTURE(BM_ScopedName, projector, "projector")
-    ->Arg(1000)
-    ->Unit(benchmark::kMillisecond);
+    ->Arg(1)
+    ->Unit(benchmark::kNanosecond);
 
 BENCHMARK_CAPTURE(BM_ScopedName, model, "model")
-    ->Arg(1000)
-    ->Unit(benchmark::kMillisecond);
+    ->Arg(1)
+    ->Unit(benchmark::kNanosecond);
 
 BENCHMARK_MAIN();

--- a/test/benchmark/utils_benchmark.cc
+++ b/test/benchmark/utils_benchmark.cc
@@ -21,6 +21,7 @@
 #include "gz/sim/components/Model.hh"
 #include "gz/sim/components/Name.hh"
 #include "gz/sim/components/ParentEntity.hh"
+#include "gz/sim/components/Projector.hh"
 #include "gz/sim/components/Sensor.hh"
 #include "gz/sim/components/World.hh"
 #include "gz/sim/components/Link.hh"
@@ -31,17 +32,16 @@
 using namespace gz;
 using namespace sim;
 
-void BM_ScopedName(benchmark::State &_st) {
+void BM_ScopedName(benchmark::State &_st, const std::string &_entityType) {
 
   // world
   // - modelA
   //   - modelB
   //     - linkC
   //       - sensorD
+  //       - projectorE
+  //       - modelF
 
-  // todo:
-  // call on different entity types
-  // call on different depth levels
   EntityComponentManager ecm;
 
   auto worldEntity = ecm.CreateEntity();
@@ -66,23 +66,42 @@ void BM_ScopedName(benchmark::State &_st) {
   ecm.CreateComponent(linkCEntity, components::Name("linkC_name"));
   ecm.CreateComponent(linkCEntity, components::ParentEntity(modelBEntity));
 
-  // Sensor D
-  auto sensorDEntity = ecm.CreateEntity();
-  ecm.CreateComponent(sensorDEntity, components::Sensor());
-  ecm.CreateComponent(sensorDEntity, components::Name("sensorD_name"));
-  ecm.CreateComponent(sensorDEntity, components::ParentEntity(linkCEntity));
-
   auto iterations = _st.range(0);
+
+  auto entity = ecm.CreateEntity();
+  ecm.CreateComponent(entity, components::Name("entity_name"));
+  ecm.CreateComponent(entity, components::ParentEntity(linkCEntity));
+
+  if (_entityType == "sensor")
+  {
+    ecm.CreateComponent(entity, components::Sensor());
+  }
+  else if (_entityType == "projector")
+  {
+    ecm.CreateComponent(entity, components::Projector());
+  }
+  else if (_entityType == "model")
+  {
+    ecm.CreateComponent(entity, components::Model());
+  }
   for (auto _ : _st) {
     for (int ii = 0; ii < iterations; ++ii)
     {
-      scopedName(sensorDEntity, ecm);
+      scopedName(entity, ecm);
     }
   }
 }
 
 // NOLINTNEXTLINE
-BENCHMARK(BM_ScopedName)
+BENCHMARK_CAPTURE(BM_ScopedName, bullet_sensor, "sensor")
+    ->Arg(1000)
+    ->Unit(benchmark::kMillisecond);
+
+BENCHMARK_CAPTURE(BM_ScopedName, bullet_projector, "projector")
+    ->Arg(1000)
+    ->Unit(benchmark::kMillisecond);
+
+BENCHMARK_CAPTURE(BM_ScopedName, bullet_model, "model")
     ->Arg(1000)
     ->Unit(benchmark::kMillisecond);
 

--- a/test/benchmark/utils_benchmark.cc
+++ b/test/benchmark/utils_benchmark.cc
@@ -103,12 +103,4 @@ BENCHMARK_CAPTURE(BM_ScopedName, model, "model")
     ->Arg(1000)
     ->Unit(benchmark::kMillisecond);
 
-// OSX needs the semicolon, Ubuntu complains that there's an extra ';'
-#if !defined(_MSC_VER)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-#endif
 BENCHMARK_MAIN();
-#if !defined(_MSC_VER)
-#pragma GCC diagnostic pop
-#endif


### PR DESCRIPTION
# 🎉 New feature

#3656

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->
Adds a benchmark for the `scopedName` function which as described in #3656 is quite inefficient. This benchmark can be used to quantify if any optimization done on the function improves performance. 

Also, this flamegraph (generated with help from https://github.com/caguero/gz-profiling.git) shows that the scopedName function does take up a significant portion of CPU when contacts are enabled.

<img width="1200" height="894" alt="3k_shapes_static_bullet_contact" src="https://github.com/user-attachments/assets/798d48e0-452a-470b-9a37-0dbc6427c035" />


## Test it
<!--Explain how reviewers can test this new feature manually.-->
1. `colcon build --packages-select gz-sim --merge-install`
2. `build/gz-sim/bin/BENCHMARK_utils_benchmark`
3. Result should look like 
```
--------------------------------------------------------------------
Benchmark                          Time             CPU   Iterations
--------------------------------------------------------------------
BM_ScopedName/sensor/1           420 ns          420 ns      1652865
BM_ScopedName/projector/1        419 ns          419 ns      1673972
BM_ScopedName/model/1            401 ns          400 ns      1805916
```

## Checklist
- [X] Signed all commits for DCO
- [X] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.