### PR TITLE
Fix issue #3656: refactor entity string conversion

### DIFF
--- a/include/gz/sim/Types.hh
+++ b/include/gz/sim/Types.hh
@@ -77,6 +77,23 @@ namespace gz
       OneTimeChange = 2
     };
 
+    /// \brief A high-level entity classification for fast type lookup.
+    enum class EntityType
+    {
+      Invalid = 0,
+      World = 1,
+      Model = 2,
+      Light = 3,
+      Link = 4,
+      Collision = 5,
+      Visual = 6,
+      Joint = 7,
+      Sensor = 8,
+      Actor = 9,
+      ParticleEmitter = 10,
+      Projector = 11,
+    };
+
     /// \brief A unique identifier for a component type. A component type
     /// must be derived from `components::BaseComponent` and can contain plain
     /// data or something more complex like `gz::math::Pose3d`.

--- a/include/gz/sim/Util.hh
+++ b/include/gz/sim/Util.hh
@@ -139,6 +139,16 @@ namespace gz
     std::string GZ_SIM_VISIBLE entityTypeStr(const Entity &_entity,
         const EntityComponentManager &_ecm);
 
+    /// \brief Set cached entity type on an entity.
+    void GZ_SIM_VISIBLE setEntityTypeTag(EntityComponentManager &_ecm,
+        Entity _entity, EntityType _type);
+
+    /// \brief Get string label for a known EntityType (no ECM lookup)
+    std::string GZ_SIM_VISIBLE entityTypeStr(EntityType _type);
+
+    /// \brief Get component type ID for a known EntityType (no ECM lookup)
+    ComponentTypeId GZ_SIM_VISIBLE entityTypeComponentTypeId(EntityType _type);
+
     /// \brief Get the world to which the given entity belongs.
     /// \param[in] _entity Entity to get the world for.
     /// \param[in] _ecm Immutable reference to ECM.

--- a/include/gz/sim/components/EntityTypeTag.hh
+++ b/include/gz/sim/components/EntityTypeTag.hh
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef GZ_SIM_COMPONENTS_ENTITYTYPETAG_HH_
+#define GZ_SIM_COMPONENTS_ENTITYTYPETAG_HH_
+
+#include "gz/sim/Types.hh"
+#include "gz/sim/components/Component.hh"
+#include "gz/sim/components/Factory.hh"
+#include "gz/sim/config.hh"
+
+namespace gz
+{
+namespace sim
+{
+// Inline bracket to help doxygen filtering.
+inline namespace GZ_SIM_VERSION_NAMESPACE {
+namespace components
+{
+  using EntityTypeTag = Component<EntityType, class EntityTypeTagTag>;
+  GZ_SIM_REGISTER_COMPONENT("gz_sim_components.EntityTypeTag", EntityTypeTag)
+}
+}
+}
+}
+
+#endif

--- a/include/gz/sim/detail/EntityComponentManager.hh
+++ b/include/gz/sim/detail/EntityComponentManager.hh
@@ -32,6 +32,19 @@
 
 #include "gz/sim/EntityComponentManager.hh"
 
+#include "gz/sim/components/Actor.hh"
+#include "gz/sim/components/Collision.hh"
+#include "gz/sim/components/EntityTypeTag.hh"
+#include "gz/sim/components/Joint.hh"
+#include "gz/sim/components/Light.hh"
+#include "gz/sim/components/Link.hh"
+#include "gz/sim/components/Model.hh"
+#include "gz/sim/components/ParticleEmitter.hh"
+#include "gz/sim/components/Projector.hh"
+#include "gz/sim/components/Sensor.hh"
+#include "gz/sim/components/Visual.hh"
+#include "gz/sim/components/World.hh"
+
 namespace gz
 {
 namespace sim
@@ -64,6 +77,49 @@ namespace traits
 #if !defined(_MSC_VER)
 #pragma GCC diagnostic pop
 #endif
+  };
+
+  /// \brief Maps type-defining components to EntityType values.
+  template<typename ComponentTypeT>
+  struct EntityTypeForComponent
+  {
+    static constexpr bool kHasEntityType =
+        std::is_same_v<ComponentTypeT, components::World> ||
+        std::is_same_v<ComponentTypeT, components::Model> ||
+        std::is_same_v<ComponentTypeT, components::Light> ||
+        std::is_same_v<ComponentTypeT, components::Link> ||
+        std::is_same_v<ComponentTypeT, components::Collision> ||
+        std::is_same_v<ComponentTypeT, components::Visual> ||
+        std::is_same_v<ComponentTypeT, components::Joint> ||
+        std::is_same_v<ComponentTypeT, components::Sensor> ||
+        std::is_same_v<ComponentTypeT, components::Actor> ||
+        std::is_same_v<ComponentTypeT, components::ParticleEmitter> ||
+        std::is_same_v<ComponentTypeT, components::Projector>;
+
+    static constexpr EntityType kEntityType =
+        std::is_same_v<ComponentTypeT, components::World> ?
+            EntityType::World :
+        std::is_same_v<ComponentTypeT, components::Model> ?
+            EntityType::Model :
+        std::is_same_v<ComponentTypeT, components::Light> ?
+            EntityType::Light :
+        std::is_same_v<ComponentTypeT, components::Link> ?
+            EntityType::Link :
+        std::is_same_v<ComponentTypeT, components::Collision> ?
+            EntityType::Collision :
+        std::is_same_v<ComponentTypeT, components::Visual> ?
+            EntityType::Visual :
+        std::is_same_v<ComponentTypeT, components::Joint> ?
+            EntityType::Joint :
+        std::is_same_v<ComponentTypeT, components::Sensor> ?
+            EntityType::Sensor :
+        std::is_same_v<ComponentTypeT, components::Actor> ?
+            EntityType::Actor :
+        std::is_same_v<ComponentTypeT, components::ParticleEmitter> ?
+            EntityType::ParticleEmitter :
+        std::is_same_v<ComponentTypeT, components::Projector> ?
+            EntityType::Projector :
+            EntityType::Invalid;
   };
 }
 
@@ -108,6 +164,16 @@ ComponentTypeT *EntityComponentManager::CreateComponent(const Entity _entity,
     }
     *comp = _data;
   }
+
+  if (comp)
+  {
+    if constexpr (traits::EntityTypeForComponent<ComponentTypeT>::kHasEntityType)
+    {
+      this->CreateComponent(_entity, components::EntityTypeTag(
+          traits::EntityTypeForComponent<ComponentTypeT>::kEntityType));
+    }
+  }
+
   return comp;
 }
 

--- a/include/gz/sim/detail/EntityComponentManager.hh
+++ b/include/gz/sim/detail/EntityComponentManager.hh
@@ -167,7 +167,8 @@ ComponentTypeT *EntityComponentManager::CreateComponent(const Entity _entity,
 
   if (comp)
   {
-    if constexpr (traits::EntityTypeForComponent<ComponentTypeT>::kHasEntityType)
+    if constexpr (
+        traits::EntityTypeForComponent<ComponentTypeT>::kHasEntityType)
     {
       this->CreateComponent(_entity, components::EntityTypeTag(
           traits::EntityTypeForComponent<ComponentTypeT>::kEntityType));

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -61,6 +61,8 @@
 #include "gz/sim/InstallationDirectories.hh"
 #include "gz/sim/Util.hh"
 
+#include "gz/sim/components/EntityTypeTag.hh"
+
 namespace gz
 {
 namespace sim
@@ -152,18 +154,23 @@ std::string scopedName(const Entity &_entity,
       break;
     auto name = nameComp->Data();
 
-    // Get entity type
-    std::string prefix = entityTypeStr(entity, _ecm);
-    if (prefix.empty())
-    {
+    auto parentComp = _ecm.Component<components::ParentEntity>(entity);
+
+    bool hasKnownType = false;
+    std::string prefix;
+    if (_includePrefix) {
+      prefix = entityTypeStr(entity, _ecm);
+      hasKnownType = !prefix.empty();
+    } else {
+      hasKnownType =
+          entityTypeId(entity, _ecm) != kComponentTypeIdInvalid;
+    }
+
+    if (!hasKnownType) {
       gzwarn << "Skipping entity [" << name
               << "] when generating scoped name, entity type not known."
               << std::endl;
-    }
-
-    auto parentComp = _ecm.Component<components::ParentEntity>(entity);
-    if (!prefix.empty())
-    {
+    } else {
       result.insert(0, name);
       if (_includePrefix)
       {
@@ -175,7 +182,7 @@ std::string scopedName(const Entity &_entity,
     if (nullptr == parentComp)
       break;
 
-    if (!prefix.empty())
+    if (hasKnownType)
       result.insert(0, _delim);
 
     entity = parentComp->Data();
@@ -277,9 +284,61 @@ std::unordered_set<Entity> entitiesFromScopedName(
 }
 
 //////////////////////////////////////////////////
+std::string entityTypeStr(const EntityType _type)
+{
+  switch (_type)
+  {
+    case EntityType::World:           return "world";
+    case EntityType::Model:           return "model";
+    case EntityType::Light:           return "light";
+    case EntityType::Link:            return "link";
+    case EntityType::Collision:       return "collision";
+    case EntityType::Visual:          return "visual";
+    case EntityType::Joint:           return "joint";
+    case EntityType::Sensor:          return "sensor";
+    case EntityType::Actor:           return "actor";
+    case EntityType::ParticleEmitter: return "particle_emitter";
+    case EntityType::Projector:       return "projector";
+    default:                          return "";
+  }
+}
+
+//////////////////////////////////////////////////
+ComponentTypeId entityTypeComponentTypeId(const EntityType _type)
+{
+  switch (_type)
+  {
+    case EntityType::World:           return components::World::typeId;
+    case EntityType::Model:           return components::Model::typeId;
+    case EntityType::Light:           return components::Light::typeId;
+    case EntityType::Link:            return components::Link::typeId;
+    case EntityType::Collision:       return components::Collision::typeId;
+    case EntityType::Visual:          return components::Visual::typeId;
+    case EntityType::Joint:           return components::Joint::typeId;
+    case EntityType::Sensor:          return components::Sensor::typeId;
+    case EntityType::Actor:           return components::Actor::typeId;
+    case EntityType::ParticleEmitter: return components::ParticleEmitter::typeId;
+    case EntityType::Projector:       return components::Projector::typeId;
+    default:                          return kComponentTypeIdInvalid;
+  }
+}
+
+//////////////////////////////////////////////////
+void setEntityTypeTag(EntityComponentManager &_ecm, Entity _entity,
+    EntityType _type)
+{
+  _ecm.CreateComponent(_entity, components::EntityTypeTag(_type));
+}
+
+//////////////////////////////////////////////////
 ComponentTypeId entityTypeId(const Entity &_entity,
     const EntityComponentManager &_ecm)
 {
+  if (auto typeComp = _ecm.Component<components::EntityTypeTag>(_entity))
+  {
+    return entityTypeComponentTypeId(typeComp->Data());
+  }
+
   ComponentTypeId type{kComponentTypeIdInvalid};
 
   if (_ecm.Component<components::World>(_entity))
@@ -334,6 +393,11 @@ ComponentTypeId entityTypeId(const Entity &_entity,
 std::string entityTypeStr(const Entity &_entity,
     const EntityComponentManager &_ecm)
 {
+  if (auto typeComp = _ecm.Component<components::EntityTypeTag>(_entity))
+  {
+    return entityTypeStr(typeComp->Data());
+  }
+
   std::string type;
 
   if (_ecm.Component<components::World>(_entity))

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -317,7 +317,8 @@ ComponentTypeId entityTypeComponentTypeId(const EntityType _type)
     case EntityType::Joint:           return components::Joint::typeId;
     case EntityType::Sensor:          return components::Sensor::typeId;
     case EntityType::Actor:           return components::Actor::typeId;
-    case EntityType::ParticleEmitter: return components::ParticleEmitter::typeId;
+    case EntityType::ParticleEmitter:
+      return components::ParticleEmitter::typeId;
     case EntityType::Projector:       return components::Projector::typeId;
     default:                          return kComponentTypeIdInvalid;
   }

--- a/test/benchmark/CMakeLists.txt
+++ b/test/benchmark/CMakeLists.txt
@@ -6,6 +6,7 @@ if (GzBenchmark_FOUND)
   set(tests
     each.cc
     ecm_serialize.cc
+    scoped_name.cc
   )
 
   gz_add_benchmarks(SOURCES ${tests})

--- a/test/benchmark/CMakeLists.txt
+++ b/test/benchmark/CMakeLists.txt
@@ -6,7 +6,7 @@ if (GzBenchmark_FOUND)
   set(tests
     each.cc
     ecm_serialize.cc
-    scoped_name.cc
+    entity_string.cc
   )
 
   gz_add_benchmarks(SOURCES ${tests})

--- a/test/benchmark/entity_string.cc
+++ b/test/benchmark/entity_string.cc
@@ -1,0 +1,105 @@
+#include <benchmark/benchmark.h>
+
+#include <string>
+#include <vector>
+
+#include "gz/sim/Entity.hh"
+#include "gz/sim/EntityComponentManager.hh"
+#include "gz/sim/Util.hh"
+#include "gz/sim/components/Collision.hh"
+#include "gz/sim/components/Link.hh"
+#include "gz/sim/components/Model.hh"
+#include "gz/sim/components/Name.hh"
+#include "gz/sim/components/ParentEntity.hh"
+#include "gz/sim/components/World.hh"
+
+using namespace gz;
+using namespace sim;
+
+void PopulateDeepHierarchy(EntityComponentManager &_ecm, int _modelCount,
+    std::vector<Entity> &_collisions)
+{
+  Entity world = _ecm.CreateEntity();
+  _ecm.CreateComponent(world, components::World());
+  _ecm.CreateComponent(world, components::Name("world"));
+
+  for (int i = 0; i < _modelCount; ++i)
+  {
+    const std::string suffix = std::to_string(i);
+
+    Entity outerModel = _ecm.CreateEntity();
+    _ecm.CreateComponent(outerModel, components::Model());
+    _ecm.CreateComponent(outerModel, components::Name("model_" + suffix));
+    _ecm.CreateComponent(outerModel, components::ParentEntity(world));
+
+    Entity innerModel = _ecm.CreateEntity();
+    _ecm.CreateComponent(innerModel, components::Model());
+    _ecm.CreateComponent(innerModel, components::Name("nested_" + suffix));
+    _ecm.CreateComponent(innerModel, components::ParentEntity(outerModel));
+
+    Entity link = _ecm.CreateEntity();
+    _ecm.CreateComponent(link, components::Link());
+    _ecm.CreateComponent(link, components::Name("link_" + suffix));
+    _ecm.CreateComponent(link, components::ParentEntity(innerModel));
+
+    Entity collision = _ecm.CreateEntity();
+    _ecm.CreateComponent(collision, components::Collision());
+    _ecm.CreateComponent(collision, components::Name("collision_" + suffix));
+    _ecm.CreateComponent(collision, components::ParentEntity(link));
+
+    _collisions.push_back(collision);
+  }
+}
+
+void BM_ScopedNameDeepHierarchy(benchmark::State &_st)
+{
+  EntityComponentManager ecm;
+  std::vector<Entity> collisions;
+  PopulateDeepHierarchy(ecm, static_cast<int>(_st.range(0)), collisions);
+
+  for (auto _ : _st)
+  {
+    for (const auto &collision : collisions)
+    {
+      benchmark::DoNotOptimize(scopedName(collision, ecm, "::", false));
+    }
+  }
+
+  _st.SetItemsProcessed(
+      static_cast<int64_t>(_st.iterations() * collisions.size()));
+}
+
+void BM_EntityTypeStr(benchmark::State &_st)
+{
+  EntityComponentManager ecm;
+  std::vector<Entity> collisions;
+  PopulateDeepHierarchy(ecm, static_cast<int>(_st.range(0)), collisions);
+
+  for (auto _ : _st)
+  {
+    for (const auto &collision : collisions)
+    {
+      Entity e = collision;
+      while (e != kNullEntity)
+      {
+        benchmark::DoNotOptimize(entityTypeStr(e, ecm));
+        auto p = ecm.Component<components::ParentEntity>(e);
+        e = p ? p->Data() : kNullEntity;
+      }
+    }
+  }
+}
+
+BENCHMARK(BM_ScopedNameDeepHierarchy)
+    ->Arg(10)
+    ->Arg(100)
+    ->Arg(1000)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK(BM_EntityTypeStr)
+    ->Arg(10)
+    ->Arg(100)
+    ->Arg(1000)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🎉 New feature

Closes #3656 

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->
Cache entity type with an `EntityType` enum and `EntityTypeTag`, set automatically in `CreateComponent`. 
Old approach is kept as a fallback when tag is unknown, e.g., manual ECM setup by plugins, spawners not updated in current phase, etc.
Added in Google benchmark set for metrics and quantization.

## Test it
<!--Explain how reviewers can test this new feature manually.-->
Toggle code back and forth to run BENCHMARK_scoped_name and compare result before vs after.

## Checklist
- [x] Signed all commits for DCO
- [x] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)