### PR TITLE
Add CollideBitmaskCmd and CategoryBitmaskCmd components

### DIFF
--- a/include/gz/sim/components/CollisionBitmask.hh
+++ b/include/gz/sim/components/CollisionBitmask.hh
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef GZ_SIM_COMPONENTS_COLLISIONBITMASKCMD_HH_
+#define GZ_SIM_COMPONENTS_COLLISIONBITMASKCMD_HH_
+
+#include <cstdint>
+#include <gz/sim/components/Factory.hh>
+#include <gz/sim/components/Component.hh>
+#include <gz/sim/config.hh>
+
+namespace gz
+{
+namespace sim
+{
+// Inline bracket to help doxygen filtering.
+inline namespace GZ_SIM_VERSION_NAMESPACE {
+namespace components
+{
+  /// \brief A component that contains a uint16_t command to change the collide
+  /// bitmask of an entity.
+  using CollideBitmaskCmd = Component<uint16_t, class CollideBitmaskCmdTag>;
+  GZ_SIM_REGISTER_COMPONENT(
+      "gz_sim_components.CollideBitmaskCmd", CollideBitmaskCmd)
+
+  /// \brief A component that contains a uint16_t command to change the category
+  /// bitmask of an entity.
+  using CategoryBitmaskCmd = Component<uint16_t, class CategoryBitmaskCmdTag>;
+  GZ_SIM_REGISTER_COMPONENT(
+      "gz_sim_components.CategoryBitmaskCmd", CategoryBitmaskCmd)
+}
+}
+}
+}
+
+#endif

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -110,6 +110,7 @@
 #include "gz/sim/components/CanonicalLink.hh"
 #include "gz/sim/components/ChildLinkName.hh"
 #include "gz/sim/components/Collision.hh"
+#include "gz/sim/components/CollisionBitmask.hh"
 #include "gz/sim/components/ContactSensorData.hh"
 #include "gz/sim/components/Geometry.hh"
 #include "gz/sim/components/Gravity.hh"
@@ -394,6 +395,14 @@ class gz::sim::systems::PhysicsPrivate
   /// be deleted the following iteration.
   public: std::unordered_set<Entity> staticCmdsToRemove;
 
+  /// \brief Entities whose collide bitmask commands have been processed
+  /// and should be deleted the following iteration.
+  public: std::unordered_set<Entity> collideBitmaskCmdsToRemove;
+
+  /// \brief Entities whose category bitmask commands have been processed
+  /// and should be deleted the following iteration.
+  public: std::unordered_set<Entity> categoryBitmaskCmdsToRemove;
+
   /// \brief Entities whose gravity enabled commands have been processed and
   /// should be deleted the following iteration.
   public: std::unordered_set<Entity> gravityEnabledCmdsToRemove;
@@ -607,7 +616,8 @@ class gz::sim::systems::PhysicsPrivate
   /// \brief Feature list to filter collisions with bitmasks.
   public: struct CollisionMaskFeatureList : physics::FeatureList<
           CollisionFeatureList,
-          physics::CollisionFilterMaskFeature>{};
+          physics::CollisionFilterMaskFeature,
+          physics::CategoryFilterMaskFeature>{};
 
   //////////////////////////////////////////////////
   // Link force
@@ -2295,6 +2305,78 @@ void PhysicsPrivate::UpdatePhysics(EntityComponentManager &_ecm)
         return true;
       });
 
+  // Update Collision Bitmasks
+  auto olderCollideBitmaskCmdsToRemove =
+      std::move(this->collideBitmaskCmdsToRemove);
+  this->collideBitmaskCmdsToRemove.clear();
+
+  _ecm.Each<components::Collision, components::CollideBitmaskCmd>(
+      [&](const Entity &_entity, const components::Collision *,
+          const components::CollideBitmaskCmd *_bitmaskCmd) -> bool
+      {
+        this->collideBitmaskCmdsToRemove.insert(_entity);
+        auto filterMaskFeature =
+            this->entityCollisionMap.EntityCast<CollisionMaskFeatureList>(
+                _entity);
+        if (filterMaskFeature)
+        {
+          filterMaskFeature->SetCollisionFilterMask(_bitmaskCmd->Data());
+        }
+        else
+        {
+          static bool informed{false};
+          if (!informed)
+          {
+            gzdbg << "Attempting to set collide bitmasks, but the physics "
+                   << "engine doesn't support feature [CollisionFilterMask]. "
+                   << "Collision bitmasks will be ignored." << std::endl;
+            informed = true;
+          }
+        }
+        return true;
+      });
+
+  for (const Entity &entity : olderCollideBitmaskCmdsToRemove)
+  {
+    _ecm.RemoveComponent<components::CollideBitmaskCmd>(entity);
+  }
+
+  // Update Category Bitmasks
+  auto olderCategoryBitmaskCmdsToRemove =
+      std::move(this->categoryBitmaskCmdsToRemove);
+  this->categoryBitmaskCmdsToRemove.clear();
+
+  _ecm.Each<components::Collision, components::CategoryBitmaskCmd>(
+      [&](const Entity &_entity, const components::Collision *,
+          const components::CategoryBitmaskCmd *_bitmaskCmd) -> bool
+      {
+        this->categoryBitmaskCmdsToRemove.insert(_entity);
+        auto filterMaskFeature =
+            this->entityCollisionMap.EntityCast<CollisionMaskFeatureList>(
+                _entity);
+        if (filterMaskFeature)
+        {
+          filterMaskFeature->SetCategoryFilterMask(_bitmaskCmd->Data());
+        }
+        else
+        {
+          static bool informed{false};
+          if (!informed)
+          {
+            gzdbg << "Attempting to set category bitmasks, but the physics "
+                   << "engine doesn't support feature [CategoryFilterMask]. "
+                   << "Category bitmasks will be ignored." << std::endl;
+            informed = true;
+          }
+        }
+        return true;
+      });
+
+  for (const Entity &entity : olderCategoryBitmaskCmdsToRemove)
+  {
+    _ecm.RemoveComponent<components::CategoryBitmaskCmd>(entity);
+  }
+
   // Handle joint state
   _ecm.Each<components::Joint, components::Name>(
       [&](const Entity &_entity, const components::Joint *,
@@ -3306,6 +3388,8 @@ void PhysicsPrivate::ResetPhysics(EntityComponentManager &_ecm)
   this->modelWorldPoses.clear();
   this->worldPoseCmdsToRemove.clear();
   this->staticCmdsToRemove.clear();
+  this->collideBitmaskCmdsToRemove.clear();
+  this->categoryBitmaskCmdsToRemove.clear();
   this->gravityEnabledCmdsToRemove.clear();
   this->collisionEnabledCmdsToRemove.clear();
 

--- a/test/integration/physics_system.cc
+++ b/test/integration/physics_system.cc
@@ -84,6 +84,7 @@
 #include "gz/sim/components/Static.hh"
 #include "gz/sim/components/Visual.hh"
 #include "gz/sim/components/World.hh"
+#include "gz/sim/components/CollisionBitmask.hh"
 
 #include "../helpers/Relay.hh"
 #include "../helpers/EnvTestFixture.hh"
@@ -3499,4 +3500,201 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(StaticCmd))
 
   // Check that velocity is non-zero again
   EXPECT_GT(getLinkAngVel().Length(), 1e-3);
+}
+
+/////////////////////////////////////////////////
+// Test setting CollideBitmaskCmd and verify that the object falls
+// through other objects when the AND bitwise operation of the bitmasks
+// evaluates to zero
+TEST_F(PhysicsSystemFixture,
+       GZ_UTILS_TEST_DISABLED_ON_WIN32(CollideBitmaskCmd))
+{
+  ServerConfig serverConfig;
+
+  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
+    "/test/worlds/contact.sdf";
+  serverConfig.SetSdfFile(sdfFile);
+
+  Server server(serverConfig);
+
+  server.SetUpdatePeriod(0ns);
+
+  // Create a system just to get the ECM
+  EntityComponentManager *ecm{nullptr};
+  test::Relay relaySystem;
+  relaySystem.OnPreUpdate([&](const UpdateInfo &,
+                              EntityComponentManager &_ecm)
+      {
+        ecm = &_ecm;
+      });
+  server.AddSystem(relaySystem.systemPtr);
+
+  // Run server and check we have the ECM
+  EXPECT_EQ(nullptr, ecm);
+  server.Run(true, 1, false);
+  EXPECT_NE(nullptr, ecm);
+
+  const std::string modelName = "contact_model";
+  const std::string collision1Name = "collision_sphere1";
+  const std::string collision2Name = "collision_sphere2";
+  const std::string box1CollisionName = "collision_box1_box";
+  const std::string box2CollisionName = "collision_box2_box";
+
+  auto modelEntity = ecm->EntityByComponents(
+      components::Model(), components::Name(modelName));
+  auto collision1Entity = ecm->EntityByComponents(
+      components::Collision(), components::Name(collision1Name));
+  auto collision2Entity = ecm->EntityByComponents(
+      components::Collision(), components::Name(collision2Name));
+
+  auto box1CollisionEntity = ecm->EntityByComponents(
+      components::Collision(), components::Name(box1CollisionName));
+  auto box2CollisionEntity = ecm->EntityByComponents(
+      components::Collision(), components::Name(box2CollisionName));
+
+  ASSERT_NE(modelEntity, kNullEntity);
+  ASSERT_NE(collision1Entity, kNullEntity);
+  ASSERT_NE(collision2Entity, kNullEntity);
+  ASSERT_NE(box1CollisionEntity, kNullEntity);
+  ASSERT_NE(box2CollisionEntity, kNullEntity);
+
+  // Set the collide bitmasks for spheres and boxes so they do not collide
+  // with each other
+  ecm->CreateComponent(collision1Entity,
+      components::CollideBitmaskCmd(0x0002));
+  ecm->CreateComponent(collision2Entity,
+      components::CollideBitmaskCmd(0x0002));
+  ecm->CreateComponent(box1CollisionEntity,
+      components::CollideBitmaskCmd(0x0004));
+  ecm->CreateComponent(box2CollisionEntity,
+      components::CollideBitmaskCmd(0x0004));
+
+  // Run for 2 iterations. On the first iteration, the commands will be
+  // processed. On the second iteration, the command components will be
+  // removed.
+  server.Run(true, 2, false);
+
+  // Verify that the command components are gone.
+  EXPECT_EQ(nullptr,
+      ecm->Component<components::CollideBitmaskCmd>(collision1Entity));
+  EXPECT_EQ(nullptr,
+      ecm->Component<components::CollideBitmaskCmd>(collision2Entity));
+  EXPECT_EQ(nullptr,
+      ecm->Component<components::CollideBitmaskCmd>(box1CollisionEntity));
+  EXPECT_EQ(nullptr,
+      ecm->Component<components::CollideBitmaskCmd>(box2CollisionEntity));
+
+  // Now run for a significant number of iterations (e.g. 1000) so it falls
+  // past the boxes.
+  server.Run(true, 1000, false);
+
+  // The top of the boxes is at z=1.0. If the sphere fell through, the
+  // model's z pose should be significantly below 1.0 (e.g. < 0.0).
+  auto modelPose = ecm->Component<components::Pose>(modelEntity)->Data();
+  double zFinal = modelPose.Pos().Z();
+  EXPECT_LT(zFinal, 0.0);
+}
+
+/////////////////////////////////////////////////
+// Test setting CategoryBitmaskCmd and verify that the object falls
+// through other objects when category bitmask is 0.
+TEST_F(PhysicsSystemFixture,
+       GZ_UTILS_TEST_DISABLED_ON_WIN32(CategoryBitmaskCmd))
+{
+  ServerConfig serverConfig;
+
+  const auto sdfFile = std::string(PROJECT_SOURCE_PATH) +
+    "/test/worlds/contact.sdf";
+  serverConfig.SetSdfFile(sdfFile);
+
+  Server server(serverConfig);
+
+  server.SetUpdatePeriod(0ns);
+
+  // Create a system just to get the ECM
+  EntityComponentManager *ecm{nullptr};
+  test::Relay relaySystem;
+  relaySystem.OnPreUpdate([&](const UpdateInfo &,
+                              EntityComponentManager &_ecm)
+      {
+        ecm = &_ecm;
+      });
+  server.AddSystem(relaySystem.systemPtr);
+
+  // Run server and check we have the ECM
+  EXPECT_EQ(nullptr, ecm);
+  server.Run(true, 1, false);
+  EXPECT_NE(nullptr, ecm);
+
+  const std::string modelName = "contact_model";
+  const std::string collision1Name = "collision_sphere1";
+  const std::string collision2Name = "collision_sphere2";
+  const std::string box1CollisionName = "collision_box1_box";
+  const std::string box2CollisionName = "collision_box2_box";
+
+  auto modelEntity = ecm->EntityByComponents(
+      components::Model(), components::Name(modelName));
+  auto collision1Entity = ecm->EntityByComponents(
+      components::Collision(), components::Name(collision1Name));
+  auto collision2Entity = ecm->EntityByComponents(
+      components::Collision(), components::Name(collision2Name));
+
+  auto box1CollisionEntity = ecm->EntityByComponents(
+      components::Collision(), components::Name(box1CollisionName));
+  auto box2CollisionEntity = ecm->EntityByComponents(
+      components::Collision(), components::Name(box2CollisionName));
+
+  ASSERT_NE(modelEntity, kNullEntity);
+  ASSERT_NE(collision1Entity, kNullEntity);
+  ASSERT_NE(collision2Entity, kNullEntity);
+  ASSERT_NE(box1CollisionEntity, kNullEntity);
+  ASSERT_NE(box2CollisionEntity, kNullEntity);
+
+  // Set collide bitmask to 0x0001 and category bitmask to 0x0002 for all
+  // shapes. Because the bitmasks do not overlap (0x0001 & 0x0002 == 0),
+  // they should not collide. If CategoryBitmaskCmd is not working, the
+  // category bitmasks will fallback to their collide bitmasks (0x0001),
+  // which do overlap (0x0001 & 0x0001 != 0), causing them to collide.
+  ecm->CreateComponent(collision1Entity,
+      components::CollideBitmaskCmd(0x0001));
+  ecm->CreateComponent(collision1Entity,
+      components::CategoryBitmaskCmd(0x0002));
+
+  ecm->CreateComponent(collision2Entity,
+      components::CollideBitmaskCmd(0x0001));
+  ecm->CreateComponent(collision2Entity,
+      components::CategoryBitmaskCmd(0x0002));
+
+  ecm->CreateComponent(box1CollisionEntity,
+      components::CollideBitmaskCmd(0x0001));
+  ecm->CreateComponent(box1CollisionEntity,
+      components::CategoryBitmaskCmd(0x0002));
+
+  ecm->CreateComponent(box2CollisionEntity,
+      components::CollideBitmaskCmd(0x0001));
+  ecm->CreateComponent(box2CollisionEntity,
+      components::CategoryBitmaskCmd(0x0002));
+
+  // Run for 2 iterations. On the first iteration, the commands will be
+  // processed. On the second iteration, the command components will be
+  // removed.
+  server.Run(true, 2, false);
+
+  // Verify that the command components are gone.
+  EXPECT_EQ(nullptr,
+      ecm->Component<components::CategoryBitmaskCmd>(collision1Entity));
+  EXPECT_EQ(nullptr,
+      ecm->Component<components::CategoryBitmaskCmd>(collision2Entity));
+  EXPECT_EQ(nullptr,
+      ecm->Component<components::CategoryBitmaskCmd>(box1CollisionEntity));
+  EXPECT_EQ(nullptr,
+      ecm->Component<components::CategoryBitmaskCmd>(box2CollisionEntity));
+
+  // Now run for 1000 iterations.
+  server.Run(true, 1000, false);
+
+  // The sphere should fall through.
+  auto modelPose = ecm->Component<components::Pose>(modelEntity)->Data();
+  double zFinal = modelPose.Pos().Z();
+  EXPECT_LT(zFinal, 0.0);
 }

--- a/test/integration/physics_system.cc
+++ b/test/integration/physics_system.cc
@@ -3597,7 +3597,14 @@ TEST_F(PhysicsSystemFixture,
 
 /////////////////////////////////////////////////
 // Test setting CategoryBitmaskCmd and verify that the object falls
-// through other objects when category bitmask is 0.
+// through other objects. Collision occurs when the following evaluates
+// to non-zero:
+//   (category_bitmask1 & collide_bitmask2) |
+//   (category_bitmask2 & collide_bitmask1)
+// In this test, all objects will have a category bitmask of 0x0002
+// and a collide bitmask of 0x0001 so
+//   (0x0002 & 0x0001) | (0x0002 & 0x0001)
+// evaluates to zero, hence the objects do not collide
 TEST_F(PhysicsSystemFixture,
        GZ_UTILS_TEST_DISABLED_ON_WIN32(CategoryBitmaskCmd))
 {


### PR DESCRIPTION


# 🎉 New feature

## Summary
Add components for setting the collide bitmask and category bitmask properties of a collision entity.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)
## Test it


## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.

