### PR TITLE
Bring back parallel PostUpdate but disabled by default

### DIFF
--- a/src/Barrier.cc
+++ b/src/Barrier.cc
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "Barrier.hh"
+
+class gz::sim::BarrierPrivate
+{
+  /// \brief Mutex for synchronization
+  public: std::mutex mutex;
+
+  /// \brief Condition Variable for signaling
+  public: std::condition_variable cv;
+
+  /// \brief Flag to indicate if the barrier was cancelled
+  public: std::atomic<bool> cancelled { false };
+
+  /// \brief Number of participating threads
+  public: unsigned int threadCount;
+
+  /// \brief Current remaining thread count (decrements from threadCount)
+  public: unsigned int count;
+
+  /// \brief Barrier generation, incremented when all threads report
+  public: unsigned int generation{0};
+};
+
+using namespace gz::sim;
+
+//////////////////////////////////////////////////
+Barrier::Barrier(unsigned int _threadCount)
+  : dataPtr(std::make_unique<BarrierPrivate>())
+{
+  this->dataPtr->threadCount = _threadCount;
+  this->dataPtr->count = _threadCount;
+}
+
+//////////////////////////////////////////////////
+Barrier::~Barrier() = default;
+
+//////////////////////////////////////////////////
+Barrier::ExitStatus Barrier::Wait()
+{
+  if (this->dataPtr->cancelled)
+  {
+    return Barrier::ExitStatus::CANCELLED;
+  }
+
+  std::unique_lock<std::mutex> lock(this->dataPtr->mutex);
+  unsigned int gen = this->dataPtr->generation;
+
+  if (--this->dataPtr->count == 0)
+  {
+    // All threads have reached the wait, so reset the barrier.
+    this->dataPtr->generation++;
+    this->dataPtr->count = this->dataPtr->threadCount;
+    this->dataPtr->cv.notify_all();
+    return Barrier::ExitStatus::DONE_LAST;
+  }
+
+  while (gen == this->dataPtr->generation && !this->dataPtr->cancelled)
+  {
+    // All threads haven't reached, so wait until generation is reached
+    // or a cancel occurs
+    this->dataPtr->cv.wait(lock);
+  }
+
+  if (this->dataPtr->cancelled)
+  {
+    return Barrier::ExitStatus::CANCELLED;
+  }
+  else
+  {
+    return Barrier::ExitStatus::DONE;
+  }
+}
+
+//////////////////////////////////////////////////
+void Barrier::Cancel()
+{
+  std::unique_lock<std::mutex> lock(this->dataPtr->mutex);
+  // This forces pending threads to release
+  this->dataPtr->generation++;
+  this->dataPtr->cancelled = true;
+  this->dataPtr->cv.notify_all();
+}

--- a/src/Barrier.hh
+++ b/src/Barrier.hh
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef GZ_SIM_BARRIER_HH_
+#define GZ_SIM_BARRIER_HH_
+
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+
+#include <gz/sim/config.hh>
+#include <gz/sim/Export.hh>
+
+namespace gz
+{
+  namespace sim
+  {
+    // Inline bracket to help doxygen filtering.
+    inline namespace GZ_SIM_VERSION_NAMESPACE {
+    // Forward declarations.
+    class BarrierPrivate;
+
+    /// \class Barrier Barrier.hh
+    /// \brief Synchronization barrier for multiple threads
+    ///
+    /// A Barrier is a synchronization mechanism that will block until
+    /// all required threads have reached the wait() method.  This is useful
+    /// for synchronizing work across many threads.
+    ///
+    /// Note that this can likely be replaced once the C++ concurrency TS
+    /// is ratified: https://en.cppreference.com/w/cpp/experimental/barrier
+    class GZ_SIM_VISIBLE Barrier
+    {
+      /// \brief Constructor
+      /// \param[in] _threadCount Number of threads to synchronize
+      /// Note: it is important to include a main thread (if used) in this
+      ///       count.  For instance, controlling 10 worker threads from
+      ///       1 main thread would require _threadCount=11.
+      public: explicit Barrier(unsigned int _threadCount);
+
+      /// \brief Destructor
+      public: ~Barrier();
+
+      /// \brief Enumeration of possible return values from wait()
+      public: enum class ExitStatus
+      {
+        /// \brief Returned if the caller was not the last to call wait()
+        DONE,
+        /// \brief Returned if the caller was the last to call wait()
+        DONE_LAST,
+        /// \brief Returned if the barrier was cancelled.
+        CANCELLED,
+      };
+
+      /// \brief Block until _threadCount, specified in the constructor, have
+      /// reached the wait() function.
+      /// \returns An exit status
+      ///
+      /// In general, all threads should return DONE or DONE_LAST,
+      /// depending on the order that the wait function was reached.
+      ///
+      /// Exactly one thread in each generation of Wait will return
+      /// DONE_LAST.
+      ///
+      /// Alternatively, if the barrier is cancelled, the ExitStatus will
+      /// reflect that.
+      public: ExitStatus Wait();
+
+      /// \brief Cancel the barrier, causing all threads to unblock and
+      ///        return CANCELLED
+      public: void Cancel();
+
+      /// \brief Pointer to private data.
+      private: std::unique_ptr<BarrierPrivate> dataPtr;
+    };
+    }  // namespace GZ_SIM_VERSION_NAMESPACE
+  }  // namespace sim
+}  // namespace gz
+
+#endif  // GZ_SIM_BARRIER_HH_

--- a/src/Barrier_TEST.cc
+++ b/src/Barrier_TEST.cc
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <thread>
+
+#include "Barrier.hh"
+
+using namespace gz;
+
+//////////////////////////////////////////////////
+inline bool wasCancelled(const sim::Barrier::ExitStatus &_ret)
+{
+  return _ret == sim::Barrier::ExitStatus::CANCELLED;
+}
+
+//////////////////////////////////////////////////
+void syncThreadsTest(unsigned int _threadCount)
+{
+  auto barrier = std::make_unique<sim::Barrier>(_threadCount + 1);
+
+  unsigned int preBarrier { 0 };
+  unsigned int postBarrier { 0 };
+  std::vector<std::thread> threads;
+
+  std::mutex mutex;
+  std::condition_variable cv;
+
+  for (size_t ii = 0; ii < _threadCount; ++ii)
+  {
+    threads.push_back(std::thread([&](){
+        {
+          std::lock_guard<std::mutex> lock(mutex);
+          preBarrier++;
+          cv.notify_one();
+        }
+
+        EXPECT_EQ(barrier->Wait(),
+            sim::Barrier::ExitStatus::DONE);
+
+        {
+          std::lock_guard<std::mutex> lock(mutex);
+          postBarrier++;
+          cv.notify_one();
+        }
+    }));
+  }
+
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    auto ret = cv.wait_for(lock, std::chrono::milliseconds(100),
+        [&]()
+        {
+          return preBarrier == _threadCount;
+        });
+    ASSERT_TRUE(ret);
+  }
+
+  // Give time for the last thread to call Wait
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  EXPECT_EQ(barrier->Wait(), sim::Barrier::ExitStatus::DONE_LAST);
+
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    auto ret = cv.wait_for(lock, std::chrono::milliseconds(100),
+        [&]()
+        {
+          return postBarrier == _threadCount;
+        });
+    ASSERT_TRUE(ret);
+  }
+
+  for (auto & t : threads)
+    t.join();
+}
+
+//////////////////////////////////////////////////
+TEST(Barrier, Sync1Thread)
+{
+  syncThreadsTest(1);
+}
+
+//////////////////////////////////////////////////
+TEST(Barrier, Sync5Threads)
+{
+  syncThreadsTest(5);
+}
+
+//////////////////////////////////////////////////
+TEST(Barrier, Sync10Threads)
+{
+  syncThreadsTest(10);
+}
+
+//////////////////////////////////////////////////
+TEST(Barrier, Sync20Threads)
+{
+  syncThreadsTest(20);
+}
+
+//////////////////////////////////////////////////
+TEST(Barrier, Sync50Threads)
+{
+  syncThreadsTest(50);
+}
+
+//////////////////////////////////////////////////
+TEST(Barrier, Cancel)
+{
+  // Use 3 as number of threads, but only create one, which
+  // guarantees it won't make it past `wait`
+  auto barrier = std::make_unique<sim::Barrier>(3);
+
+  unsigned int preBarrier { 0 };
+  unsigned int postBarrier { 0 };
+
+  std::mutex mutex;
+  std::condition_variable cv;
+
+  auto t = std::thread([&](){
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        preBarrier++;
+        cv.notify_one();
+      }
+
+      EXPECT_TRUE(wasCancelled(barrier->Wait()));
+
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        postBarrier++;
+        cv.notify_one();
+      }
+  });
+
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    auto ret = cv.wait_for(lock, std::chrono::milliseconds(100),
+        [&]()
+        {
+          return preBarrier == 1;
+        });
+    ASSERT_TRUE(ret);
+  }
+
+  // Cancel the barrier immediately
+  barrier->Cancel();
+
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    auto ret = cv.wait_for(lock, std::chrono::milliseconds(100),
+        [&]()
+        {
+          return postBarrier == 1;
+        });
+    ASSERT_TRUE(ret);
+  }
+
+  t.join();
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,6 +68,7 @@ set(material_sources
 
 set (sources
   Actor.cc
+  Barrier.cc
   BaseView.cc
   Conversions.cc
   ComponentFactory.cc
@@ -104,6 +105,7 @@ set (gtest_sources
   ${gtest_sources}
   Actor_TEST.cc
   AddedMass_TEST.cc
+  Barrier_TEST.cc
   BaseView_TEST.cc
   ComponentFactory_TEST.cc
   Component_TEST.cc

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -221,6 +221,22 @@ SimulationRunner::SimulationRunner(const sdf::World &_world,
   );
   this->currentInfo.simTime = this->simTimeEpoch;
 
+  // Get policies from the world SDF
+  {
+    auto worldElem = _world.Element();
+    if (worldElem)
+    {
+      auto policies = worldElem->FindElement(std::string(kPoliciesTag));
+      if (policies)
+      {
+        this->parallelPostUpdates =
+          policies->Get<bool>("parallel_postupdates",
+          this->parallelPostUpdates).first;
+      }
+    }
+  }
+
+
 #ifdef _WIN32
   HANDLE winPrecisionTimerHandle = CreateWaitableTimerExA(NULL, NULL,
     CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
@@ -630,6 +646,13 @@ void SimulationRunner::ProcessSystemQueue()
   if (0 == pending && !this->threadsNeedCleanUp)
     return;
 
+  if (!this->parallelPostUpdates)
+  {
+    this->threadsNeedCleanUp = false;
+    this->systemMgr->ActivatePendingSystems();
+    return;
+  }
+
   // If additional systems are to be added or have been removed,
   // stop the existing threads.
   this->StopWorkerThreads();
@@ -717,16 +740,26 @@ void SimulationRunner::UpdateSystems()
   {
     GZ_PROFILE("PostUpdate");
     this->entityCompMgr.LockAddingEntitiesToViews(true);
-    // If no systems implementing PostUpdate have been added, then
-    // the barriers will be uninitialized, so guard against that condition.
-    if (this->postUpdateStartBarrier && this->postUpdateStopBarrier)
+    if (!this->parallelPostUpdates)
     {
-      // Release the GIL from the main thread to run PostUpdate threads which
-      // might be calling into python. The system that does call into python
-      // needs to lock the GIL from its thread.
-      MaybeGilScopedRelease release;
-      this->postUpdateStartBarrier->Wait();
-      this->postUpdateStopBarrier->Wait();
+      for (auto &system : this->systemMgr->SystemsPostUpdate())
+      {
+        system->PostUpdate(this->currentInfo, this->entityCompMgr);
+      }
+    }
+    else
+    {
+      // If no systems implementing PostUpdate have been added, then
+      // the barriers will be uninitialized, so guard against that condition.
+      if (this->postUpdateStartBarrier && this->postUpdateStopBarrier)
+      {
+        // Release the GIL from the main thread to run PostUpdate threads which
+        // might be calling into python. The system that does call into python
+        // needs to lock the GIL from its thread.
+        MaybeGilScopedRelease release;
+        this->postUpdateStartBarrier->Wait();
+        this->postUpdateStopBarrier->Wait();
+      }
     }
     this->entityCompMgr.LockAddingEntitiesToViews(false);
   }
@@ -1273,6 +1306,12 @@ void SimulationRunner::LoadPlugins(const Entity _entity,
 bool SimulationRunner::Running() const
 {
   return this->running;
+}
+
+/////////////////////////////////////////////////
+bool SimulationRunner::ParallelPostUpdates() const
+{
+  return this->parallelPostUpdates;
 }
 
 /////////////////////////////////////////////////

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -369,7 +369,10 @@ SimulationRunner::SimulationRunner(const sdf::World &_world,
 }
 
 //////////////////////////////////////////////////
-SimulationRunner::~SimulationRunner() = default;
+SimulationRunner::~SimulationRunner()
+{
+  this->StopWorkerThreads();
+}
 
 /////////////////////////////////////////////////
 void SimulationRunner::UpdateCurrentInfo()
@@ -624,10 +627,52 @@ void SimulationRunner::ProcessSystemQueue()
 {
   auto pending = this->systemMgr->PendingCount();
 
-  if (0 == pending)
+  if (0 == pending && !this->threadsNeedCleanUp)
     return;
 
+  // If additional systems are to be added or have been removed,
+  // stop the existing threads.
+  this->StopWorkerThreads();
+
+  this->threadsNeedCleanUp = false;
+
   this->systemMgr->ActivatePendingSystems();
+
+  unsigned int threadCount =
+    static_cast<unsigned int>(this->systemMgr->SystemsPostUpdate().size() + 1u);
+
+  gzdbg << "Creating PostUpdate worker threads: "
+    << threadCount << std::endl;
+
+  this->postUpdateStartBarrier = std::make_unique<Barrier>(threadCount);
+  this->postUpdateStopBarrier = std::make_unique<Barrier>(threadCount);
+
+  this->postUpdateThreadsRunning = true;
+  int id = 0;
+
+  for (auto &system : this->systemMgr->SystemsPostUpdate())
+  {
+    gzdbg << "Creating postupdate worker thread (" << id << ")" << std::endl;
+
+    this->postUpdateThreads.push_back(std::thread([&, id]()
+    {
+      std::stringstream ss;
+      ss << "PostUpdateThread: " << id;
+      GZ_PROFILE_THREAD_NAME(ss.str().c_str());
+      while (this->postUpdateThreadsRunning)
+      {
+        this->postUpdateStartBarrier->Wait();
+        if (this->postUpdateThreadsRunning)
+        {
+          system->PostUpdate(this->currentInfo, this->entityCompMgr);
+        }
+        this->postUpdateStopBarrier->Wait();
+      }
+      gzdbg << "Exiting postupdate worker thread ("
+        << id << ")" << std::endl;
+    }));
+    id++;
+  }
 }
 
 /////////////////////////////////////////////////
@@ -671,10 +716,19 @@ void SimulationRunner::UpdateSystems()
 
   {
     GZ_PROFILE("PostUpdate");
-    for (auto &system : this->systemMgr->SystemsPostUpdate())
+    this->entityCompMgr.LockAddingEntitiesToViews(true);
+    // If no systems implementing PostUpdate have been added, then
+    // the barriers will be uninitialized, so guard against that condition.
+    if (this->postUpdateStartBarrier && this->postUpdateStopBarrier)
     {
-      system->PostUpdate(this->currentInfo, this->entityCompMgr);
+      // Release the GIL from the main thread to run PostUpdate threads which
+      // might be calling into python. The system that does call into python
+      // needs to lock the GIL from its thread.
+      MaybeGilScopedRelease release;
+      this->postUpdateStartBarrier->Wait();
+      this->postUpdateStopBarrier->Wait();
     }
+    this->entityCompMgr.LockAddingEntitiesToViews(false);
   }
 }
 
@@ -689,6 +743,25 @@ void SimulationRunner::OnStop()
 {
   this->stopReceived = true;
   this->running = false;
+}
+
+/////////////////////////////////////////////////
+void SimulationRunner::StopWorkerThreads()
+{
+  this->postUpdateThreadsRunning = false;
+  if (this->postUpdateStartBarrier)
+  {
+    this->postUpdateStartBarrier->Cancel();
+  }
+  if (this->postUpdateStopBarrier)
+  {
+    this->postUpdateStopBarrier->Cancel();
+  }
+  for (auto &thread : this->postUpdateThreads)
+  {
+    thread.join();
+  }
+  this->postUpdateThreads.clear();
 }
 
 /////////////////////////////////////////////////
@@ -1053,7 +1126,8 @@ void SimulationRunner::Step(const UpdateInfo &_info)
   this->ProcessRecreateEntitiesCreate();
 
   // Process entity removals.
-  this->systemMgr->ProcessRemovedEntities(this->entityCompMgr);
+  this->systemMgr->ProcessRemovedEntities(this->entityCompMgr,
+    this->threadsNeedCleanUp);
   this->entityCompMgr.ProcessRemoveEntityRequests();
 
   // Process components removals

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -56,6 +56,7 @@
 #include "network/NetworkManager.hh"
 #include "LevelManager.hh"
 #include "SystemManager.hh"
+#include "Barrier.hh"
 #include "WorldControl.hh"
 
 using namespace std::chrono_literals;
@@ -94,6 +95,9 @@ namespace gz
 
       /// \brief Internal method for handling stop event (to prevent recursion)
       private: void OnStop();
+
+      /// \brief Stop and join all post update worker threads
+      private: void StopWorkerThreads();
 
       /// \brief Run the simulationrunner.
       /// \param[in] _iterations Number of iterations.
@@ -541,6 +545,18 @@ namespace gz
       /// \brief Copy of the server configuration.
       public: ServerConfig serverConfig;
 
+      /// \brief Collection of threads running system PostUpdates
+      private: std::vector<std::thread> postUpdateThreads;
+
+      /// \brief Flag to indicate running status of PostUpdate threads
+      private: std::atomic<bool> postUpdateThreadsRunning{false};
+
+      /// \brief Barrier to signal beginning of PostUpdate thread execution
+      private: std::unique_ptr<Barrier> postUpdateStartBarrier;
+
+      /// \brief Barrier to signal end of PostUpdate thread execution
+      private: std::unique_ptr<Barrier> postUpdateStopBarrier;
+
       /// \brief Map from file paths to Fuel URIs.
       private: std::unordered_map<std::string, std::string> fuelUriMap;
 
@@ -557,6 +573,9 @@ namespace gz
       /// \brief Holds new world state information so that it can be processed
       /// at the appropriate time.
       private: std::unique_ptr<msgs::WorldControlState> newWorldControlState;
+
+      /// \brief Set if we need to remove systems due to entity removal
+      private: bool threadsNeedCleanUp{false};
 
       /// \brief During a forced pause, the user may request that simulation
       /// should run. This flag will capture that request, and then be used

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -171,6 +171,10 @@ namespace gz
       /// \return True if the server is running.
       public: bool Running() const;
 
+      /// \brief Get whether parallel PostUpdate is enabled.
+      /// \return True if parallel PostUpdate is enabled, false otherwise.
+      public: bool ParallelPostUpdates() const;
+
       /// \brief Get whether the runner has received a stop event
       /// \return True if the event has been received.
       public: bool StopReceived() const;
@@ -592,6 +596,9 @@ namespace gz
       /// initialization and should exit immediately. See
       /// `SetExitedWithErrors()`.
       private: bool exitedWithErrors{false};
+
+      /// \brief Whether parallel PostUpdate is enabled.
+      private: bool parallelPostUpdates{true};
 #ifdef _WIN32
       private: std::unique_ptr<SimulationRunnerWinHandleStorage>
         winPrecisionTimer;

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -598,7 +598,7 @@ namespace gz
       private: bool exitedWithErrors{false};
 
       /// \brief Whether parallel PostUpdate is enabled.
-      private: bool parallelPostUpdates{true};
+      private: bool parallelPostUpdates{false};
 #ifdef _WIN32
       private: std::unique_ptr<SimulationRunnerWinHandleStorage>
         winPrecisionTimer;

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -1687,7 +1687,7 @@ TEST_P(SimulationRunnerTest, ParallelPostUpdatesPolicy)
     auto systemLoader = std::make_shared<SystemLoader>();
     SimulationRunner runner(*root.WorldByIndex(0), systemLoader);
 
-    EXPECT_TRUE(runner.ParallelPostUpdates());
+    EXPECT_FALSE(runner.ParallelPostUpdates());
   }
 
   // Test when enabled

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -1668,6 +1668,73 @@ TEST_P(SimulationRunnerTest, GeneratedSdfHasNoSpuriousPlugins)
   EXPECT_TRUE(checkForSpuriousPlugins(newRoot.Element()));
 }
 
+/////////////////////////////////////////////////
+TEST_P(SimulationRunnerTest, ParallelPostUpdatesPolicy)
+{
+  // Test default behavior
+  {
+    std::string sdfStr = "<?xml version='1.0' ?>"
+      "<sdf version='1.6'>"
+      "  <world name='default'>"
+      "  </world>"
+      "</sdf>";
+
+    sdf::Root root;
+    sdf::Errors errors = root.LoadSdfString(sdfStr);
+    ASSERT_TRUE(errors.empty());
+    ASSERT_EQ(1u, root.WorldCount());
+
+    auto systemLoader = std::make_shared<SystemLoader>();
+    SimulationRunner runner(*root.WorldByIndex(0), systemLoader);
+
+    EXPECT_TRUE(runner.ParallelPostUpdates());
+  }
+
+  // Test when enabled
+  {
+    std::string sdfStr = "<?xml version='1.0' ?>"
+      "<sdf version='1.6'>"
+      "  <world name='default'>"
+      "    <gz:policies>"
+      "      <parallel_postupdates>true</parallel_postupdates>"
+      "    </gz:policies>"
+      "  </world>"
+      "</sdf>";
+
+    sdf::Root root;
+    sdf::Errors errors = root.LoadSdfString(sdfStr);
+    ASSERT_TRUE(errors.empty());
+    ASSERT_EQ(1u, root.WorldCount());
+
+    auto systemLoader = std::make_shared<SystemLoader>();
+    SimulationRunner runner(*root.WorldByIndex(0), systemLoader);
+
+    EXPECT_TRUE(runner.ParallelPostUpdates());
+  }
+
+  // Test when disabled
+  {
+    std::string sdfStr = "<?xml version='1.0' ?>"
+      "<sdf version='1.6'>"
+      "  <world name='default'>"
+      "    <gz:policies>"
+      "      <parallel_postupdates>false</parallel_postupdates>"
+      "    </gz:policies>"
+      "  </world>"
+      "</sdf>";
+
+    sdf::Root root;
+    sdf::Errors errors = root.LoadSdfString(sdfStr);
+    ASSERT_TRUE(errors.empty());
+    ASSERT_EQ(1u, root.WorldCount());
+
+    auto systemLoader = std::make_shared<SystemLoader>();
+    SimulationRunner runner(*root.WorldByIndex(0), systemLoader);
+
+    EXPECT_FALSE(runner.ParallelPostUpdates());
+  }
+}
+
 // Run multiple times. We want to make sure that static globals don't cause
 // problems.
 INSTANTIATE_TEST_SUITE_P(ServerRepeat, SimulationRunnerTest,

--- a/src/SystemManager.cc
+++ b/src/SystemManager.cc
@@ -481,7 +481,9 @@ void RemoveFromVectorIf(std::vector<Tp>& vec,
 }
 
 //////////////////////////////////////////////////
-void SystemManager::ProcessRemovedEntities(const EntityComponentManager &_ecm)
+void SystemManager::ProcessRemovedEntities(
+  const EntityComponentManager &_ecm,
+  bool &_needsCleanUp)
 {
   // Note: This function has  O(n) time when an entity is removed
   // where n is number of systems. Ideally we would only iterate
@@ -518,6 +520,9 @@ void SystemManager::ProcessRemovedEntities(const EntityComponentManager &_ecm)
       if (system.postupdate)
       {
         postupdateSystemsToBeRemoved.insert(system.postupdate);
+        // If system with a PostUpdate is marked for removal
+        // mark all worker threads for removal.
+        _needsCleanUp = true;
       }
       if (system.configure)
       {

--- a/src/SystemManager.hh
+++ b/src/SystemManager.hh
@@ -160,8 +160,11 @@ namespace gz
 
       /// \brief Remove systems that are attached to removed entities
       /// \param[in] _entityCompMgr - ECM with entities marked for removal
+      /// \param[out] _needsCleanUp - Set to true if a system with a
+      /// PostUpdate was removed, and its thread needs to be terminated
       public: void ProcessRemovedEntities(
-        const EntityComponentManager &_entityCompMgr);
+        const EntityComponentManager &_entityCompMgr,
+        bool &_needsCleanUp);
 
       /// \brief Implementation for AddSystem functions that takes an SDF
       /// element. This calls the AddSystemImpl that accepts an SDF Plugin.

--- a/src/SystemManager_TEST.cc
+++ b/src/SystemManager_TEST.cc
@@ -320,8 +320,10 @@ TEST(SystemManager, AddAndRemoveSystemEcm)
 
   // Remove the entity
   ecm.RequestRemoveEntity(entity);
-  systemMgr.ProcessRemovedEntities(ecm);
+  bool needsCleanUp;
+  systemMgr.ProcessRemovedEntities(ecm, needsCleanUp);
 
+  EXPECT_TRUE(needsCleanUp);
   EXPECT_EQ(1u, systemMgr.ActiveCount());
   EXPECT_EQ(0u, systemMgr.PendingCount());
   EXPECT_EQ(1u, systemMgr.TotalCount());

--- a/tutorials/server_config.md
+++ b/tutorials/server_config.md
@@ -395,3 +395,35 @@ GUI `GzScene` plugin.
 ### Order of Execution of Plugins
 The order of execution of plugins can be controlled by setting
 the `<gz:system_priority>` tag inside `<plugin>`. See example in examples/plugin/priority_printer_plugin and the associated README.md file to learn more.
+
+
+## Parallel PostUpdates
+
+By default, the `PostUpdate` phase of system plugins is executed in parallel
+using worker threads. This parallel execution is beneficial for worlds with a
+large number of plugins that perform heavy computational tasks during
+`PostUpdate`.
+
+However, in many typical simulations, most plugins perform trivial tasks on
+`PostUpdate`. In these scenarios, the overhead introduced by thread
+synchronization primitives can become a bottleneck and degrade simulation
+performance.
+
+To address this, you can configure `PostUpdate` functions to run sequentially
+instead of in parallel and see if it helps increase the Real Time Factor (RTF).
+This is done by setting the `<parallel_postupdates>` policy to `false`:
+
+```xml
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="default">
+    <gz:policies>
+      <parallel_postupdates>false</parallel_postupdates>
+    </gz:policies>
+
+    <!-- plugins and models... -->
+  </world>
+</sdf>
+```
+
+By default, this policy is set to `true`.

--- a/tutorials/server_config.md
+++ b/tutorials/server_config.md
@@ -399,26 +399,24 @@ the `<gz:system_priority>` tag inside `<plugin>`. See example in examples/plugin
 
 ## Parallel PostUpdates
 
-By default, the `PostUpdate` phase of system plugins is executed in parallel
-using worker threads. This parallel execution is beneficial for worlds with a
-large number of plugins that perform heavy computational tasks during
-`PostUpdate`.
+By default, the `PostUpdate` phase of system plugins is executed sequentially.
+In many typical simulations, most plugins perform trivial tasks on `PostUpdate`,
+so the overhead introduced by thread synchronization primitives for parallel
+execution can degrade simulation performance.
 
-However, in many typical simulations, most plugins perform trivial tasks on
-`PostUpdate`. In these scenarios, the overhead introduced by thread
-synchronization primitives can become a bottleneck and degrade simulation
-performance.
+However, if you have a large number of plugins that perform heavy computational
+tasks during `PostUpdate`, running them in parallel might be beneficial.
 
-To address this, you can configure `PostUpdate` functions to run sequentially
-instead of in parallel and see if it helps increase the Real Time Factor (RTF).
-This is done by setting the `<parallel_postupdates>` policy to `false`:
+To address this, you can configure `PostUpdate` functions to run in parallel
+instead of sequentially. This is done by setting the `<parallel_postupdates>`
+policy to `true`:
 
 ```xml
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="default">
     <gz:policies>
-      <parallel_postupdates>false</parallel_postupdates>
+      <parallel_postupdates>true</parallel_postupdates>
     </gz:policies>
 
     <!-- plugins and models... -->
@@ -426,4 +424,4 @@ This is done by setting the `<parallel_postupdates>` policy to `false`:
 </sdf>
 ```
 
-By default, this policy is set to `true`.
+By default, this policy is set to `false`.


### PR DESCRIPTION
# 🦟 Bug fix



## Summary

This PR brings back the parallel PostUpdate feature that was removed in https://github.com/gazebosim/gz-sim/pull/3512. There are use cases for doing parallel post updates, and we should keep supporting those use cases. This will however be disabled by default so that typical gazebo simulation with out-of-box plugins can keep the performance improvement of running post updates sequentially.

The main changes in this PR are:
* fbb93a3d59fb69cae8d7a5f44002e9e72ace367e: revert the commit in https://github.com/gazebosim/gz-sim/pull/3512
* 6c60a9dfddca7e7051c97f28c8e1de207f52f9d1: cherry-pick the gz policies changes from https://github.com/gazebosim/gz-sim/pull/3648
* 800f0f88a4823fbf6ac1af60f1e11f221467169b: Set `parallel_postupdates` gz policy to false by default

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [x] This **should not** be backported 
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
