### PR TITLE
Implement an isolation layer for `ModelCommand_API` tests

### DIFF
--- a/src/cmd/ModelCommandAPI_TEST.cc
+++ b/src/cmd/ModelCommandAPI_TEST.cc
@@ -30,23 +30,31 @@
 
 static const std::string kGzModelCommand(std::string(GZ_PATH) + " model ");
 
-class UniquePartitionEnvironment : public ::testing::Environment {
- public:
-  ~UniquePartitionEnvironment() override {}
-
+class ModelCommandAPI : public ::testing::Test {
+ protected:
   void SetUp() override {
-    // Generate unique partition
-    std::string partition = gz::common::uuid();
-    gz::common::setenv("GZ_PARTITION", partition);
+    // Save previous partition to restore it later
+    char *prevPartition = std::getenv("GZ_PARTITION");
+    if (prevPartition) {
+      this->oldPartition = prevPartition;
+    }
+
+    // Generate unique partition for this test
+    this->partition = gz::common::uuid();
+    gz::common::setenv("GZ_PARTITION", this->partition);
   }
 
   void TearDown() override {
-    gz::common::unsetenv("GZ_PARTITION");
+    if (this->oldPartition.empty()) {
+      gz::common::unsetenv("GZ_PARTITION");
+    } else {
+      gz::common::setenv("GZ_PARTITION", this->oldPartition);
+    }
   }
-};
 
-testing::Environment* const foo_env =
-    testing::AddGlobalTestEnvironment(new UniquePartitionEnvironment);
+  std::string oldPartition;
+  std::string partition;
+};
 
 /////////////////////////////////////////////////
 /// \brief Used to avoid the cases where the zero is
@@ -93,7 +101,7 @@ std::string customExecStr(std::string _cmd)
 /////////////////////////////////////////////////
 // Test `gz model` command when no Gazebo server is running.
 // See https://github.com/gazebosim/gz-sim/issues/1175
-TEST(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_WIN32(NoServerRunning))
+TEST_F(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_WIN32(NoServerRunning))
 {
   const std::string cmd = kGzModelCommand + "--list ";
   const std::string output = customExecStr(cmd);
@@ -106,7 +114,7 @@ TEST(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_WIN32(NoServerRunning))
 
 /////////////////////////////////////////////////
 // Tests `gz model` command.
-TEST(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_WIN32(Commands))
+TEST_F(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_WIN32(Commands))
 {
   gz::sim::ServerConfig serverConfig;
   // Using an static model to avoid any movements in the simulation.
@@ -412,7 +420,7 @@ TEST(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_WIN32(Commands))
 
 /////////////////////////////////////////////////
 // Tests `gz model -s` command with an airpressure sensor.
-TEST(ModelCommandAPI, AirPressureSensor)
+TEST_F(ModelCommandAPI, AirPressureSensor)
 {
   gz::sim::ServerConfig serverConfig;
   // Using an static model to avoid any movements in the simulation.
@@ -455,7 +463,7 @@ TEST(ModelCommandAPI, AirPressureSensor)
 
 /////////////////////////////////////////////////
 // Tests `gz model -s` command with an altimeter.
-TEST(ModelCommandAPI, AltimeterSensor)
+TEST_F(ModelCommandAPI, AltimeterSensor)
 {
   gz::sim::ServerConfig serverConfig;
   // Using an static model to avoid any movements in the simulation.
@@ -505,7 +513,7 @@ TEST(ModelCommandAPI, AltimeterSensor)
 
 /////////////////////////////////////////////////
 // Tests `gz model -s` command with a gpu lidar sensor.
-TEST(ModelCommandAPI, GpuLidarSensor)
+TEST_F(ModelCommandAPI, GpuLidarSensor)
 {
   gz::sim::ServerConfig serverConfig;
   // Using an static model to avoid any movements in the simulation.
@@ -561,7 +569,7 @@ TEST(ModelCommandAPI, GpuLidarSensor)
 
 /////////////////////////////////////////////////
 // Tests `gz model -s` command with a magnetometer.
-TEST(ModelCommandAPI, MagnetometerSensor)
+TEST_F(ModelCommandAPI, MagnetometerSensor)
 {
   gz::sim::ServerConfig serverConfig;
   // Using an static model to avoid any movements in the simulation.
@@ -620,7 +628,7 @@ TEST(ModelCommandAPI, MagnetometerSensor)
 
 /////////////////////////////////////////////////
 // Tests `gz model -s` command with an rgbd camera.
-TEST(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_MAC(RgbdCameraSensor))
+TEST_F(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_MAC(RgbdCameraSensor))
 {
   gz::sim::ServerConfig serverConfig;
   // Using an static model to avoid any movements in the simulation.
@@ -691,7 +699,7 @@ TEST(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_MAC(RgbdCameraSensor))
 
 //////////////////////////////////////////////////
 /// \brief Check --help message and bash completion script for consistent flags
-TEST(ModelCommandAPI,
+TEST_F(ModelCommandAPI,
   GZ_UTILS_TEST_DISABLED_ON_WIN32(ModelHelpVsCompletionFlags))
 {
   // Flags in help message

--- a/src/cmd/ModelCommandAPI_TEST.cc
+++ b/src/cmd/ModelCommandAPI_TEST.cc
@@ -22,12 +22,31 @@
 #include <vector>
 
 #include <gtest/gtest.h>
+#include <gz/common/Util.hh>
 #include <gz/utils/ExtraTestMacros.hh>
 
 #include "gz/sim/Server.hh"
 #include "test_config.hh"  // NOLINT(build/include)
 
 static const std::string kGzModelCommand(std::string(GZ_PATH) + " model ");
+
+class UniquePartitionEnvironment : public ::testing::Environment {
+ public:
+  ~UniquePartitionEnvironment() override {}
+
+  void SetUp() override {
+    // Generate unique partition
+    std::string partition = gz::common::uuid();
+    gz::common::setenv("GZ_PARTITION", partition);
+  }
+
+  void TearDown() override {
+    gz::common::unsetenv("GZ_PARTITION");
+  }
+};
+
+testing::Environment* const foo_env =
+    testing::AddGlobalTestEnvironment(new UniquePartitionEnvironment);
 
 /////////////////////////////////////////////////
 /// \brief Used to avoid the cases where the zero is


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #3636

## Summary
This commit implements an isolation layer for ModelCommand_API tests that have frequently been failing on mac OS X as the previous magnetometer test may not have been fully torn down.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.

