### PR TITLE
fix: Only update physics parameters that are present in the update msg

### DIFF
--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -479,56 +479,60 @@ void SimulationRunner::UpdatePhysicsParams()
   }
   const auto& physicsParams = physicsCmdComp->Data();
 
-  auto gravityComp =
-    this->entityCompMgr.Component<components::Gravity>(worldEntity);
-  if (gravityComp)
+  if(physicsParams.has_gravity())
   {
-    const  gz::math::Vector3<double>  newGravity =
+    auto gravityComp =
+      this->entityCompMgr.Component<components::Gravity>(worldEntity);
+    if (gravityComp)
     {
-        physicsParams.gravity().x(),
-        physicsParams.gravity().y(),
-        physicsParams.gravity().z()
-    };
-    gravityComp->Data() = newGravity;
-    this->entityCompMgr.SetChanged(worldEntity, components::Gravity::typeId,
-          ComponentState::OneTimeChange);
+      const  gz::math::Vector3<double>  newGravity =
+      {
+          physicsParams.gravity().x(),
+          physicsParams.gravity().y(),
+          physicsParams.gravity().z()
+      };
+      gravityComp->Data() = newGravity;
+      this->entityCompMgr.SetChanged(worldEntity, components::Gravity::typeId,
+            ComponentState::OneTimeChange);
   }
 
   auto physicsComp =
     this->entityCompMgr.Component<components::Physics>(worldEntity);
+  bool pyhsicsUpdated = false;
 
-  const auto newStepSize =
-    std::chrono::duration<double>(physicsParams.max_step_size());
-  const double newRTF = physicsParams.real_time_factor();
-
-  const double eps = 0.00001;
-  if (newStepSize != this->stepSize ||
-      std::abs(newRTF - this->desiredRtf) > eps)
+  if (physicsParams.has_max_step_size())
   {
-    bool updated = false;
+    const auto newStepSize =
+      std::chrono::duration<double>(physicsParams.max_step_size());
     // Make sure the values are valid before setting them
-    if (newStepSize.count() > 0.0)
+    if (newStepSize.count() > 0.0 && newStepSize != this->stepSize)
     {
       this->SetStepSize(
         std::chrono::duration_cast<std::chrono::steady_clock::duration>(
           newStepSize));
       physicsComp->Data().SetMaxStepSize(physicsParams.max_step_size());
-      updated = true;
+      pyhsicsUpdated = true;
     }
-    if (newRTF > 0.0)
+  }
+
+  if (physicsParams.has_real_time_factor())
+  {
+    const double eps = 0.00001;
+    const double newRTF = physicsParams.real_time_factor();
+    if(newRTF > 0.0 && std::abs(newRTF - this->desiredRtf) > eps)
     {
       this->desiredRtf = newRTF;
       this->updatePeriod = std::chrono::nanoseconds(
           static_cast<int>(this->stepSize.count() / this->desiredRtf));
       physicsComp->Data().SetRealTimeFactor(newRTF);
-      updated = true;
+      pyhsicsUpdated = true;
     }
-    if (updated)
-    {
-      // Set as OneTimeChange to make sure the update is not missed
-      this->entityCompMgr.SetChanged(worldEntity, components::Physics::typeId,
-          ComponentState::OneTimeChange);
-    }
+  }
+  if (pyhsicsUpdated)
+  {
+    // Set as OneTimeChange to make sure the update is not missed
+    this->entityCompMgr.SetChanged(worldEntity, components::Physics::typeId,
+        ComponentState::OneTimeChange);
   }
   this->entityCompMgr.RemoveComponent<components::PhysicsCmd>(worldEntity);
 }


### PR DESCRIPTION
# 🦟 Bug fix
This fixes a bug, where if one would change the realtime factor in the UI the gravity would be set to zero.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [ ] Ionic
    - [x] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.

