### PR TITLE
Cache physics step output

### DIFF
--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -866,6 +866,9 @@ class gz::sim::systems::PhysicsPrivate
   /// \brief Flag to store whether the names of colliding entities should
   /// be populated in the contact points.
   public: bool contactsEntityNames = true;
+
+  /// \brief Cached physics output, to reduce allocations / deallocations
+  physics::ForwardStep::Output stepOutput;
 };
 
 //////////////////////////////////////////////////
@@ -3429,16 +3432,15 @@ gz::physics::ForwardStep::Output PhysicsPrivate::Step(
   GZ_PROFILE("PhysicsPrivate::Step");
   physics::ForwardStep::Input input;
   physics::ForwardStep::State state;
-  physics::ForwardStep::Output output;
 
   input.Get<std::chrono::steady_clock::duration>() = _dt;
 
   for (const auto &world : this->entityWorldMap.Map())
   {
-    world.second->Step(output, state, input);
+    world.second->Step(this->stepOutput, state, input);
   }
 
-  return output;
+  return this->stepOutput;
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
# 🎉 New feature

Part of #3608 

Cache forward step output in Physics system.

Marking as a draft while I test CI and whether this has any implications I'm not aware of.

## Summary

When benchmarking a large world (3k_shapes), I noticed that a large amount of time was spent in reserving vectors to push the [world poses](https://github.com/gazebosim/gz-physics/blob/8a48173082a38b591ce1d5ca2829227d87ae8505/bullet-featherstone/src/SimulationFeatures.cc#L355) and the [changed poses](https://github.com/gazebosim/gz-physics/blob/8a48173082a38b591ce1d5ca2829227d87ae8505/bullet-featherstone/src/SimulationFeatures.cc#L371).
This was puzzling, since we call `clear()` just before the reserve but `clear()` does not change the capacity of the underlying memory, it only resets the size of the vector.
With some printouts and backtracing I realized we are creating a brand new `ForwardStep::Output` object at every simulation iteration, which means allocating + deallocating two possibly large vectors at every simulation step.
I just cached the step output in the private data member.


## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)
## Test it

Run the 3k_shapes world with bullet featherstone:

```
$ gz sim -v3 3k_shapes.sdf --physics-engine libgz-physics-bullet-featherstone-plugin -z 1000000 -r
$ gz sim -g
```

In my (fast) machine this brings up the RTF of the 3k_shapes.sdf with bullet featherstone from ~110% to ~160%, so about a 50% increase.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.