### PR TITLE
QuickStart.qml: fileUrl -> selectedFile

### DIFF
--- a/src/gui/resources/QuickStart.qml
+++ b/src/gui/resources/QuickStart.qml
@@ -158,7 +158,7 @@ Rectangle {
               width: 220
               height: 150
               smooth: true
-              source: fileURL
+              source: selectedFile
               border.color: getColor(fileName.split('.')[1])
             }
           }


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebo-tooling/release-tools/issues/1485

## Summary

The `fileUrl` parameter from qt5 changed to `selectedFile` in qt6 (see https://github.com/gazebosim/gz-gui/pull/711 and https://github.com/gazebosim/gz-sim/pull/2832/changes#diff-dd74c558abfb62d53bfde23c0145a811675f7907e7dc42c14fdd0ad927b38351). This currently causes a runtime console warning that is registered as a GCC compiler warning by jenkins.

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_sim-ci-main-resolute-amd64&build=20)](https://build.osrfoundation.org/job/gz_sim-ci-main-resolute-amd64/20/) https://build.osrfoundation.org/job/gz_sim-ci-main-resolute-amd64/20/gcc/

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
