### PR TITLE
Fix QuickStart.qml fileURL error

### DIFF
--- a/src/gui/resources/QuickStart.qml
+++ b/src/gui/resources/QuickStart.qml
@@ -158,7 +158,7 @@ Rectangle {
               width: 220
               height: 150
               smooth: true
-              source: fileURL
+              source: fileUrl
               border.color: getColor(fileName.split('.')[1])
             }
           }


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

Fixes this error on Ubuntu Resolute:

```
16:26:17 65: (2026-06-15 23:26:06.307) [warning] [Application.cc:923] [GUI] [QT] qrc:/Gazebo/QuickStart.qml:161: ReferenceError: fileURL is not defined
```

The fix: `fileURL` -> `fileUrl`.

`fileURL` was deprecated in favor or `fileUrl`. `fileURL` still works on Ubuntu Noble but removed in the Qt version in Resolute. Here's the [official doc on FolderListModel](https://doc.qt.io/qt-6/qml-qt-labs-folderlistmodel-folderlistmodel.html) that show the `fileUrl` property. 

Test build: https://build.osrfoundation.org/job/_test_gz_sim-ci-pr_any-resolute-amd64/3/gcc/


## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
