### PR TITLE
Backport two macos test fixes

### DIFF
--- a/src/cmd/ModelCommandAPI_TEST.cc
+++ b/src/cmd/ModelCommandAPI_TEST.cc
@@ -22,12 +22,39 @@
 #include <vector>
 
 #include <gtest/gtest.h>
+#include <gz/common/Util.hh>
 #include <gz/utils/ExtraTestMacros.hh>
 
 #include "gz/sim/Server.hh"
 #include "test_config.hh"  // NOLINT(build/include)
 
 static const std::string kGzModelCommand(std::string(GZ_PATH) + " model ");
+
+class ModelCommandAPI : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Save previous partition to restore it later
+    char *prevPartition = std::getenv("GZ_PARTITION");
+    if (prevPartition) {
+      this->oldPartition = prevPartition;
+    }
+
+    // Generate unique partition for this test
+    this->partition = gz::common::uuid();
+    gz::common::setenv("GZ_PARTITION", this->partition);
+  }
+
+  void TearDown() override {
+    if (this->oldPartition.empty()) {
+      gz::common::unsetenv("GZ_PARTITION");
+    } else {
+      gz::common::setenv("GZ_PARTITION", this->oldPartition);
+    }
+  }
+
+  std::string oldPartition;
+  std::string partition;
+};
 
 /////////////////////////////////////////////////
 /// \brief Used to avoid the cases where the zero is
@@ -74,7 +101,7 @@ std::string customExecStr(std::string _cmd)
 /////////////////////////////////////////////////
 // Test `gz model` command when no Gazebo server is running.
 // See https://github.com/gazebosim/gz-sim/issues/1175
-TEST(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_WIN32(NoServerRunning))
+TEST_F(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_WIN32(NoServerRunning))
 {
   const std::string cmd = kGzModelCommand + "--list ";
   const std::string output = customExecStr(cmd);
@@ -87,7 +114,7 @@ TEST(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_WIN32(NoServerRunning))
 
 /////////////////////////////////////////////////
 // Tests `gz model` command.
-TEST(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_WIN32(Commands))
+TEST_F(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_WIN32(Commands))
 {
   gz::sim::ServerConfig serverConfig;
   // Using an static model to avoid any movements in the simulation.
@@ -393,7 +420,7 @@ TEST(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_WIN32(Commands))
 
 /////////////////////////////////////////////////
 // Tests `gz model -s` command with an airpressure sensor.
-TEST(ModelCommandAPI, AirPressureSensor)
+TEST_F(ModelCommandAPI, AirPressureSensor)
 {
   gz::sim::ServerConfig serverConfig;
   // Using an static model to avoid any movements in the simulation.
@@ -436,7 +463,7 @@ TEST(ModelCommandAPI, AirPressureSensor)
 
 /////////////////////////////////////////////////
 // Tests `gz model -s` command with an altimeter.
-TEST(ModelCommandAPI, AltimeterSensor)
+TEST_F(ModelCommandAPI, AltimeterSensor)
 {
   gz::sim::ServerConfig serverConfig;
   // Using an static model to avoid any movements in the simulation.
@@ -486,7 +513,7 @@ TEST(ModelCommandAPI, AltimeterSensor)
 
 /////////////////////////////////////////////////
 // Tests `gz model -s` command with a gpu lidar sensor.
-TEST(ModelCommandAPI, GpuLidarSensor)
+TEST_F(ModelCommandAPI, GpuLidarSensor)
 {
   gz::sim::ServerConfig serverConfig;
   // Using an static model to avoid any movements in the simulation.
@@ -542,7 +569,7 @@ TEST(ModelCommandAPI, GpuLidarSensor)
 
 /////////////////////////////////////////////////
 // Tests `gz model -s` command with a magnetometer.
-TEST(ModelCommandAPI, MagnetometerSensor)
+TEST_F(ModelCommandAPI, MagnetometerSensor)
 {
   gz::sim::ServerConfig serverConfig;
   // Using an static model to avoid any movements in the simulation.
@@ -601,7 +628,7 @@ TEST(ModelCommandAPI, MagnetometerSensor)
 
 /////////////////////////////////////////////////
 // Tests `gz model -s` command with an rgbd camera.
-TEST(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_MAC(RgbdCameraSensor))
+TEST_F(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_MAC(RgbdCameraSensor))
 {
   gz::sim::ServerConfig serverConfig;
   // Using an static model to avoid any movements in the simulation.
@@ -672,7 +699,7 @@ TEST(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_MAC(RgbdCameraSensor))
 
 //////////////////////////////////////////////////
 /// \brief Check --help message and bash completion script for consistent flags
-TEST(ModelCommandAPI,
+TEST_F(ModelCommandAPI,
   GZ_UTILS_TEST_DISABLED_ON_WIN32(ModelHelpVsCompletionFlags))
 {
   // Flags in help message

--- a/test/integration/entity_system.cc
+++ b/test/integration/entity_system.cc
@@ -147,9 +147,11 @@ class EntitySystemTest : public InternalFixture<::testing::TestWithParam<int>>
     // publish twist msg and verify that the vehicle now moves forward
     pub.Publish(msg);
     server.Run(true, 1000, false);
-    for (unsigned int i = 1; i < poses.size(); ++i)
+    // Skip comparing poses[0], poses[1] due to issue with dartsim 6.19.1
+    // see https://github.com/gazebosim/gz-sim/issues/3697
+    for (unsigned int i = 2; i < poses.size(); ++i)
     {
-      EXPECT_GT(poses[i].Pos().X(), poses[i-1].Pos().X());
+      EXPECT_GT(poses[i].Pos().X(), poses[i-1].Pos().X()) << "i=" << i;
     }
   }
 };


### PR DESCRIPTION
This backports macOS test fixes in #3683 and #3701 to Jetty. It's helpful to backport them together to increase the changes of CI passing.

# Original PR description for #3683

## 🦟 Bug fix

Fixes #3636

## Summary
This commit implements an isolation layer for ModelCommand_API tests that have frequently been failing on mac OS X as the previous magnetometer test may not have been fully torn down.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

# Original PR description for #3701

## 🦟 Bug fix

Mitigation for https://github.com/gazebosim/gz-sim/issues/3697

## Summary

The `INTEGRATION_entity_system` test has recently been failing on macOS, and my testing in https://github.com/gazebosim/gz-sim/issues/3697 indicates that it is caused by the upgrade to dartsim 6.19.1. The test commands a diff drive robot to drive forward, records 1000 poses and expects each pose to show incremental forward travel. With dartsim 6.19.1, the first two poses are identical, but the remaining 998 show forward travel. This PR mitigates the issue by skipping the comparison of the first two poses. The issue will be left open so we can investigate the underlying issue.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

Backports: If this is a backport, please use Rebase and Merge instead.