### PR TITLE
Use components::ParentEntity for parent lookup

### DIFF
--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -1264,11 +1264,7 @@ bool EntityComponentManager::CreateComponentImplementation(
       return updateData;
     }
     const auto *parent = static_cast<const components::ParentEntity *>(_data);
-    if (!this->dataPtr->SetParentEntityGraph(_entity, parent->Data()))
-    {
-      gzerr << "Failed setting parent for entity " << _entity << " to "
-            << parent->Data() << std::endl;
-    }
+    this->dataPtr->SetParentEntityGraph(_entity, parent->Data());
   }
 
   return updateData;

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -924,6 +924,12 @@ bool EntityComponentManager::RemoveComponent(
     this->dataPtr->removedComponents[_entity].insert(_typeId);
   }
 
+  // If the component is a components::ParentEntity, leave the entity parentless
+  if (_typeId == components::ParentEntity::typeId)
+  {
+    this->dataPtr->SetParentEntityGraph(_entity, kNullEntity);
+  }
+
   return true;
 }
 
@@ -1090,17 +1096,21 @@ Entity EntityComponentManager::ParentEntity(const Entity _entity) const
 bool EntityComponentManager::SetParentEntity(const Entity _child,
     const Entity _parent)
 {
-  bool successful = this->dataPtr->SetParentEntityGraph(_child, _parent);
+  // Validate input, child must exist and parent must either be kNullEntity
+  // (in which case we remove the parent) or a valid entity to set.
+  if (!this->HasEntity(_child))
+    return false;
+  if (_parent != kNullEntity && !this->HasEntity(_parent))
+    return false;
+
+  // Component creation and deletion take care of updating the graph
+  this->RemoveComponent<components::ParentEntity>(_child);
   if (_parent == kNullEntity)
   {
-    this->RemoveComponent<components::ParentEntity>(_child);
     return true;
   }
-  else if (successful)
-  {
-    this->CreateComponent(_child, components::ParentEntity(_parent));
-  }
-  return successful;
+  this->CreateComponent(_child, components::ParentEntity(_parent));
+  return true;
 }
 
 /////////////////////////////////////////////////

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -1257,8 +1257,18 @@ bool EntityComponentManager::CreateComponentImplementation(
   // update the entities graph.
   if (_componentTypeId == components::ParentEntity::typeId)
   {
+    if (!_data)
+    {
+      gzerr << "Internal error: Invalid parent component detected, "
+            << "this should not happen." << std::endl;
+      return updateData;
+    }
     const auto *parent = static_cast<const components::ParentEntity *>(_data);
-    this->dataPtr->SetParentEntityGraph(_entity, parent->Data());
+    if (!this->dataPtr->SetParentEntityGraph(_entity, parent->Data()))
+    {
+      gzerr << "Failed setting parent for entity " << _entity << " to "
+            << parent->Data() << std::endl;
+    }
   }
 
   return updateData;

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -74,6 +74,15 @@ class gz::sim::EntityComponentManagerPrivate
   /// `AddEntityToMessage`.
   public: void CalculateStateThreadLoad();
 
+  /// \brief Helper function to only update the entity graph for a new
+  /// parent - child relation. This does not do any book-keeping on the
+  /// components::ParentEntity component, for which the EntityComponentManager
+  /// SetParentEntity function should be used.
+  /// \param[in] _parent the new parent of the entity, or kNullEntity if the
+  /// entity should be left parentless.
+  /// \param[in] _child the entity to update the parent for.
+  public: bool SetParentEntityGraph(const Entity _parent, const Entity _child);
+
   /// \brief Copies the contents of `_from` into this object.
   /// \note This is a member function instead of a copy constructor so that
   /// it can have additional parameters if the need arises in the future.
@@ -515,7 +524,6 @@ Entity EntityComponentManager::CloneImpl(Entity _entity, Entity _parent,
   if (_parent != kNullEntity)
   {
     this->SetParentEntity(clonedEntity, _parent);
-    this->CreateComponent(clonedEntity, components::ParentEntity(_parent));
   }
 
   // make sure that the cloned entity has a unique name
@@ -1072,24 +1080,39 @@ bool EntityComponentManager::HasEntity(const Entity _entity) const
 /////////////////////////////////////////////////
 Entity EntityComponentManager::ParentEntity(const Entity _entity) const
 {
-  auto parents = this->Entities().AdjacentsTo(_entity);
-  if (parents.empty())
+  const auto* parent = this->Component<components::ParentEntity>(_entity);
+  if (!parent)
     return kNullEntity;
-
-  // TODO(louise) Do we want to support multiple parents?
-  return parents.begin()->first;
+  return parent->Data();
 }
 
 /////////////////////////////////////////////////
 bool EntityComponentManager::SetParentEntity(const Entity _child,
     const Entity _parent)
 {
+  bool successful = this->dataPtr->SetParentEntityGraph(_child, _parent);
+  if (_parent == kNullEntity)
+  {
+    this->RemoveComponent<components::ParentEntity>(_child);
+    return true;
+  }
+  else if (successful)
+  {
+    this->CreateComponent(_child, components::ParentEntity(_parent));
+  }
+  return successful;
+}
+
+/////////////////////////////////////////////////
+bool EntityComponentManagerPrivate::SetParentEntityGraph(const Entity _child,
+    const Entity _parent)
+{
   // Remove current parent(s)
-  auto parents = this->Entities().AdjacentsTo(_child);
+  auto parents = this->entities.AdjacentsTo(_child);
   for (const auto &parent : parents)
   {
-    auto edge = this->dataPtr->entities.EdgeFromVertices(parent.first, _child);
-    this->dataPtr->entities.RemoveEdge(edge);
+    auto edge = this->entities.EdgeFromVertices(parent.first, _child);
+    this->entities.RemoveEdge(edge);
   }
 
   // Leave parent-less
@@ -1099,7 +1122,7 @@ bool EntityComponentManager::SetParentEntity(const Entity _child,
   }
 
   // Add edge
-  auto edge = this->dataPtr->entities.AddEdge({_parent, _child}, true);
+  auto edge = this->entities.AddEdge({_parent, _child}, true);
   return (math::graph::kNullId != edge.Id());
 }
 
@@ -1224,8 +1247,8 @@ bool EntityComponentManager::CreateComponentImplementation(
   // update the entities graph.
   if (_componentTypeId == components::ParentEntity::typeId)
   {
-    auto parentComp = this->Component<components::ParentEntity>(_entity);
-    this->SetParentEntity(_entity, parentComp->Data());
+    const auto *parent = static_cast<const components::ParentEntity *>(_data);
+    this->dataPtr->SetParentEntityGraph(_entity, parent->Data());
   }
 
   return updateData;
@@ -2317,7 +2340,6 @@ void EntityComponentManager::ApplyEntityDiff(
         this->dataPtr->entityCount = entity;
       }
       copyComponents(entity);
-      this->SetParentEntity(entity, _other.ParentEntity(entity));
     }
   }
 
@@ -2341,7 +2363,6 @@ void EntityComponentManager::ApplyEntityDiff(
         this->dataPtr->entityCount = entity;
       }
       copyComponents(entity);
-      this->SetParentEntity(entity, _other.ParentEntity(entity));
     }
 
     this->RequestRemoveEntity(entity, false);

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -78,10 +78,10 @@ class gz::sim::EntityComponentManagerPrivate
   /// parent - child relation. This does not do any book-keeping on the
   /// components::ParentEntity component, for which the EntityComponentManager
   /// SetParentEntity function should be used.
+  /// \param[in] _child the entity to update the parent for.
   /// \param[in] _parent the new parent of the entity, or kNullEntity if the
   /// entity should be left parentless.
-  /// \param[in] _child the entity to update the parent for.
-  public: bool SetParentEntityGraph(const Entity _parent, const Entity _child);
+  public: bool SetParentEntityGraph(const Entity _child, const Entity _parent);
 
   /// \brief Copies the contents of `_from` into this object.
   /// \note This is a member function instead of a copy constructor so that

--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -1292,8 +1292,7 @@ void SdfEntityCreator::RequestRemoveEntity(Entity _entity, bool _recursive)
         components::ParentEntity(_entity));
     for (const auto childEntity : childEntities)
     {
-      this->dataPtr->ecm->RemoveComponent<components::ParentEntity>(
-          childEntity);
+      this->dataPtr->ecm->SetParentEntity(childEntity, kNullEntity);
     }
   }
 

--- a/src/SdfEntityCreator.cc
+++ b/src/SdfEntityCreator.cc
@@ -1306,6 +1306,4 @@ void SdfEntityCreator::SetParent(Entity _child, Entity _parent)
   // TODO(louise) Figure out a way to avoid duplication while keeping all
   // state in components and also keeping a convenient graph in the ECM
   this->dataPtr->ecm->SetParentEntity(_child, _parent);
-  this->dataPtr->ecm->CreateComponent(_child,
-      components::ParentEntity(_parent));
 }

--- a/test/integration/physics_system.cc
+++ b/test/integration/physics_system.cc
@@ -538,7 +538,6 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(CreateRuntime))
   ecm->CreateComponent(modelEntity, components::Name("new_model"));
   ecm->CreateComponent(modelEntity, components::Static(false));
   ecm->SetParentEntity(modelEntity, worldEntity);
-  ecm->CreateComponent(modelEntity, components::ParentEntity(worldEntity));
 
   auto linkEntity = ecm->CreateEntity();
   ecm->CreateComponent(linkEntity, components::Link());
@@ -555,7 +554,6 @@ TEST_F(PhysicsSystemFixture, GZ_UTILS_TEST_DISABLED_ON_WIN32(CreateRuntime))
   ecm->CreateComponent(linkEntity, components::Inertial(inertia));
 
   ecm->SetParentEntity(linkEntity, modelEntity);
-  ecm->CreateComponent(linkEntity, components::ParentEntity(modelEntity));
 
   // Check we have a new model
   EXPECT_NE(kNullEntity, ecm->EntityByComponents(components::Model(),


### PR DESCRIPTION
Part of #3447, minor performance improvement in `EntityComponentManager::ParentEntity` that is somewhat in a hot path in physics, specifically in this snippet where we iterate over every single link and get its parent. https://github.com/gazebosim/gz-sim/blob/c017986be541e95f4398dfaa60ca718958d83002/src/systems/physics/Physics.cc#L3785-L3793

This is also a correctness improvement and future proofing, as explained below.

## Summary

With this change we always make sure the `components::ParentEntity` is kept in sync with the graph by changing the `SetParentEntity` API to also add the component.
There is a bit of duplication since now the function that updates the graph is private, but the graph won't exist anymore if #3447 lands so that function will be gone.
There are two main reasons for this change:

### Performance

A minor improvement since now getting the parent is a component lookup which is a fair bit more efficient than the gz-math call. Specifically this is a flamegraph for the jetty world

<img width="1200" height="1086" alt="jetty_bullet_new_main (1)" src="https://github.com/user-attachments/assets/9d907295-df3e-49d4-a79b-fc530e196132" />

Doing a lot of zooming into `UpdatePhysics` shows that quite a lot of time is taken in `ParentEntity` because it needs to do lookups in (ordered) maps + do a bunch of expensive API calls.
I don't have a flamegraph for this change but I can AI generate a micro benchmark if it's of interest.

### Correctness

Perhaps more important, previously we had two sources of truth for parent information. The `EntityComponentManager::ParentEntity(Entity)` API and reading the `components::ParentEntity` component via `EntityComponentManager::Component<components::parentEntity>(Entity)`.
Furthermore, setting the parent through `SetParentEntity` API required users to remember that they need to also create the component if they want the data to be consistent, which is prone to errors.

This is clear from the diff where there are a lot of places where users had to call `SetParentEntity` followed by `CreateComponent<components::ParentEntity>`. And this is even more obvious in the cases where this was not done and as such were not correct. For example, by grepping for `SetParentEntity` I found two cases in battery modeling where the user forgot to call `CreateComponent` so we had a discrepancy between the hierarchy saved in the components and the one saved in the graph:

https://github.com/gazebosim/gz-sim/blob/c017986be541e95f4398dfaa60ca718958d83002/src/systems/battery_plugin/LinearBatteryPlugin.cc#L297-L303

and

https://github.com/gazebosim/gz-sim/blob/c017986be541e95f4398dfaa60ca718958d83002/src/systems/thruster/Thruster.cc#L687-L692

### Future-proofing / Entt refactor

The entt refactor uses exactly this approach of being purely component based and deletes the graph altogether, so getting this in separately will reduce the diff / risk of regressions with the refactor.

## Backport Policy
I think this is safe since CI passes, performance is slightly improved and the code is slightly more correct (in the battery plugins I linked), but I might be unaware of some expectations of other parts of the code.
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [x] I am not sure
- [ ] Other (fill in yourself)
## Test it

Automated through CI

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.