### PR TITLE
Add CI for Bazel - Clang, Fix layering failure

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -23,19 +23,4 @@ jobs:
           {"folder": ".", "bzlmodEnabled": false},
         ]
       exclude_windows: true
-      bazel_test_command: "bazel test --test_output=errors //..."
-
-  test-clang:
-    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v7.2.2
-    with:
-      folders: |
-        [
-          ".",
-        ]
-      exclude: |
-        [
-          {"folder": ".", "bzlmodEnabled": false},
-          {"folder": ".", "os": "macos-latest"},
-        ]
-      exclude_windows: true
       bazel_test_command: "bazel test --repo_env=CC=clang --repo_env=CXX=clang++ --test_output=errors //..."

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -24,3 +24,18 @@ jobs:
         ]
       exclude_windows: true
       bazel_test_command: "bazel test --test_output=errors //..."
+
+  test-clang:
+    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v7.2.2
+    with:
+      folders: |
+        [
+          ".",
+        ]
+      exclude: |
+        [
+          {"folder": ".", "bzlmodEnabled": false},
+          {"folder": ".", "os": "macos-latest"},
+        ]
+      exclude_windows: true
+      bazel_test_command: "bazel test --repo_env=CC=clang --repo_env=CXX=clang++ --test_output=errors //..."

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -590,6 +590,7 @@ gz_sim_system_libraries(
     visibility = ["//visibility:public"],
     deps = [
         ":gz-sim",
+        "@com_google_protobuf//:protobuf_lite",
         "@gz-common//profiler",
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-plugin//:register",
@@ -978,6 +979,8 @@ gz_sim_system_libraries(
     visibility = ["//visibility:public"],
     deps = [
         ":gz-sim",
+        "@com_google_protobuf//:protobuf_lite",
+        "@gz-common//profiler",
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-plugin//:register",
         "@gz-transport",
@@ -1552,6 +1555,7 @@ gz_sim_system_libraries(
     visibility = ["//visibility:public"],
     deps = [
         ":gz-sim",
+        "@com_google_protobuf//:protobuf_lite",
         "@gz-common//profiler",
         "@gz-math",
         "@gz-msgs//:gzmsgs_cc_proto",
@@ -1594,6 +1598,7 @@ gz_sim_system_libraries(
     visibility = ["//visibility:public"],
     deps = [
         ":gz-sim",
+        "@com_google_protobuf//:protobuf_lite",
         "@gz-common//profiler",
         "@gz-math",
         "@gz-msgs//:gzmsgs_cc_proto",


### PR DESCRIPTION
# 🦟 Bug fix

Fix compiles on Bazel / Clang + add a CI step to find future regressions.

## Summary

#3481 broke Bazel + Clang builds where the layering step reports errors such as:

```
bazel-out/haswell-opt/bin/external/gz-sim+/src/systems/pose_publisher/PosePublisher_static_plugin.cc:20:10: error: module gz-sim+//:gz-sim-pose-publisher-system-static does not depend on a module exporting 'google/protobuf/arena.h'
   20 | #include <google/protobuf/arena.h>
```

It seems this wasn't caught by CI because we don't test Bazel + Clang, so this PR also adds a step to the Bazel CI builds to make sure we test that combination.
The first commit only adds the CI, you can find a failure in its new Bazel + Clang step https://github.com/gazebosim/gz-sim/actions/runs/27944359735/job/82685279109.
The second commit adds the actual fix. Here is a run for it showing green Bazel builds https://github.com/gazebosim/gz-sim/actions/runs/27949882252/job/82703886503?pr=3712.

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.