### PR TITLE
Update Gazebo dependencies in Dockerfile

### DIFF
--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -14,7 +14,7 @@ RUN apt-get update \
     libgz-cmake-dev \
     libgz-common-dev \
     libgz-fuel-tools-dev \
-    libgz-math9-eigen-dev \
+    libgz-math-eigen3-dev \
     libgz-plugin-dev \
     libgz-physics-dev \
     libgz-rendering-dev \

--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -11,19 +11,20 @@ RUN scripts/enable_nightly.sh
 
 RUN apt-get update \
  && apt-get install -y \
-    libgz-cmake-dev \
-    libgz-common-dev \
-    libgz-fuel-tools-dev \
-    libgz-math-eigen3-dev \
-    libgz-plugin-dev \
-    libgz-physics-dev \
-    libgz-rendering-dev \
-    libgz-tools-dev \
-    libgz-transport-dev \
-    libgz-gui-dev \
-    libgz-msgs-dev \
-    libgz-sensors-dev \
-    libsdformat-dev \
+    libgz-rotary-cmake-dev \
+    libgz-rotary-common-dev \
+    libgz-rotary-fuel-tools-dev \
+    libgz-rotary-math-eigen3-dev \
+    libgz-rotary-plugin-dev \
+    libgz-rotary-physics-dev \
+    libgz-rotary-rendering-dev \
+    libgz-rotary-tools-dev \
+    libgz-rotary-transport-dev \
+    libgz-rotary-gui-dev \
+    libgz-rotary-msgs-dev \
+    libgz-rotary-sensors-dev \
+    libgz-rotary-utils-cli-dev \
+    libgz-rotary-sdformat-dev \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -11,19 +11,19 @@ RUN scripts/enable_nightly.sh
 
 RUN apt-get update \
  && apt-get install -y \
-    libgz-cmake5-dev \
-    libgz-common7-dev \
-    libgz-fuel-tools11-dev \
-    libgz-math9-eigen3-dev \
-    libgz-plugin4-dev \
-    libgz-physics9-dev \
-    libgz-rendering10-dev \
-    libgz-tools2-dev \
-    libgz-transport15-dev \
-    libgz-gui10-dev \
-    libgz-msgs12-dev \
-    libgz-sensors10-dev \
-    libsdformat16-dev \
+    libgz-cmake-dev \
+    libgz-common-dev \
+    libgz-fuel-tools-dev \
+    libgz-math9-eigen-dev \
+    libgz-plugin-dev \
+    libgz-physics-dev \
+    libgz-rendering-dev \
+    libgz-tools-dev \
+    libgz-transport-dev \
+    libgz-gui-dev \
+    libgz-msgs-dev \
+    libgz-sensors-dev \
+    libsdformat-dev \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
Our nightly github build images seem to have been failing for quite some time resulting in email spam to myself. I suspect the crux of the issue is that the docker files are using hard coded versions for jetty, but since we have moved to rotary, we have not updated these docker files.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [x] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.

