### PR TITLE
Use marker array visualize contacts

### DIFF
--- a/src/gui/plugins/visualize_contacts/VisualizeContacts.cc
+++ b/src/gui/plugins/visualize_contacts/VisualizeContacts.cc
@@ -22,6 +22,7 @@
 #include <gz/msgs/contacts.pb.h>
 #include <gz/msgs/entity.pb.h>
 #include <gz/msgs/marker.pb.h>
+#include <gz/msgs/marker_v.pb.h>
 
 #include <string>
 #include <vector>
@@ -57,6 +58,14 @@ namespace sim
 {
 inline namespace GZ_SIM_VERSION_NAMESPACE
 {
+namespace
+{
+//////////////////////////////////////////////////
+void OnMarkerArrayResponse(const gz::msgs::Boolean &, const bool)
+{
+}
+}  // namespace
+
   /// \brief Private data class for VisualizeContacts
   class VisualizeContactsPrivate
   {
@@ -223,6 +232,7 @@ void VisualizeContacts::Update(const UpdateInfo &_info,
   // Get the contacts and publish them
   // Since we are setting a lifetime for the markers, we get all the
   // contacts instead of getting new and removed ones
+  gz::msgs::Marker_V markerMsgs;
 
   // Variable for setting the markers id through the iteration
   int markerID = 1;
@@ -234,19 +244,25 @@ void VisualizeContacts::Update(const UpdateInfo &_info,
       {
         for (int i = 0; i < contact.position_size(); ++i)
         {
-          // Set marker id, poses and request service
-          this->dataPtr->positionMarkerMsg.set_id(markerID++);
-          gz::msgs::Set(this->dataPtr->positionMarkerMsg.mutable_pose(),
+          // Add marker id and pose to the marker array
+          auto markerMsg = markerMsgs.add_marker();
+          markerMsg->CopyFrom(this->dataPtr->positionMarkerMsg);
+
+          markerMsg->set_id(markerID++);
+          gz::msgs::Set(markerMsg->mutable_pose(),
             gz::math::Pose3d(contact.position(i).x(),
               contact.position(i).y(), contact.position(i).z(),
               0, 0, 0));
-
-          this->dataPtr->node.Request(
-            "/marker", this->dataPtr->positionMarkerMsg);
         }
       }
       return true;
     });
+
+  if (markerMsgs.marker_size() > 0)
+  {
+    this->dataPtr->node.Request(
+        "/marker_array", markerMsgs, &OnMarkerArrayResponse);
+  }
 }
 
 //////////////////////////////////////////////////

--- a/test/integration/markers.cc
+++ b/test/integration/markers.cc
@@ -16,7 +16,9 @@
  */
 
 #include <gtest/gtest.h>
+#include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/marker.pb.h>
+#include <gz/msgs/marker_v.pb.h>
 
 #include <gz/common/Console.hh>
 #include <gz/common/Util.hh>
@@ -50,6 +52,11 @@ void markerCb(const msgs::Marker &_msg)
   mutex.lock();
   markerMsgs.push_back(_msg);
   mutex.unlock();
+}
+
+/////////////////////////////////////////////////
+void markerArrayCb(const gz::msgs::Boolean &, const bool)
+{
 }
 
 /////////////////////////////////////////////////
@@ -112,4 +119,75 @@ TEST_F(MarkersTest, MarkerPublisher)
   node.Request("/marker", markerMsg);
   markerManager.Update();
   wait(2, markerMsg);
+}
+
+/////////////////////////////////////////////////
+TEST_F(MarkersTest, MarkerArrayPublisher)
+{
+  std::map<std::string, std::string> params;
+  auto engine = gz::rendering::engine("ogre2", params);
+  auto scene = engine->CreateScene("testscene_marker_array");
+
+  // Clear messages received by previous tests.
+  mutex.lock();
+  markerMsgs.clear();
+  mutex.unlock();
+
+  MarkerManager markerManager;
+  markerManager.Init(scene);
+
+  // Function that Waits for messages to be received
+  auto wait = [&](std::size_t _size) {
+    for (int sleep = 0; sleep < 30; ++sleep)
+    {
+      // The service request is asynchronous, so keep processing messages.
+      markerManager.Update();
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+      mutex.lock();
+      bool received = markerMsgs.size() == _size;
+      mutex.unlock();
+
+      if (received)
+        break;
+    }
+
+    mutex.lock();
+    EXPECT_EQ(markerMsgs.size(), _size);
+    mutex.unlock();
+  };
+
+  // subscribe to marker topic
+  transport::Node node;
+  node.Subscribe("/marker", &markerCb);
+
+  gz::msgs::Marker_V markerArrayMsg;
+
+  auto markerMsg0 = markerArrayMsg.add_marker();
+  markerMsg0->set_ns("array");
+  markerMsg0->set_id(0);
+  markerMsg0->set_action(gz::msgs::Marker::ADD_MODIFY);
+  markerMsg0->set_type(gz::msgs::Marker::SPHERE);
+  markerMsg0->set_visibility(gz::msgs::Marker::GUI);
+
+  auto markerMsg1 = markerArrayMsg.add_marker();
+  markerMsg1->set_ns("array");
+  markerMsg1->set_id(1);
+  markerMsg1->set_action(gz::msgs::Marker::ADD_MODIFY);
+  markerMsg1->set_type(gz::msgs::Marker::BOX);
+  markerMsg1->set_visibility(gz::msgs::Marker::GUI);
+
+  // Send an asynchronous marker array request.
+  EXPECT_TRUE(node.Request(
+      "/marker_array", markerArrayMsg, &markerArrayCb));
+
+  wait(2);
+
+  mutex.lock();
+  auto receivedMsgs = markerMsgs;
+  mutex.unlock();
+
+  ASSERT_EQ(receivedMsgs.size(), 2u);
+  EXPECT_EQ(markerMsg0->DebugString(), receivedMsgs[0].DebugString());
+  EXPECT_EQ(markerMsg1->DebugString(), receivedMsgs[1].DebugString());
 }

--- a/test/integration/markers.cc
+++ b/test/integration/markers.cc
@@ -128,51 +128,23 @@ TEST_F(MarkersTest, MarkerArrayPublisher)
   auto engine = gz::rendering::engine("ogre2", params);
   auto scene = engine->CreateScene("testscene_marker_array");
 
-  // Clear messages received by previous tests.
-  mutex.lock();
-  markerMsgs.clear();
-  mutex.unlock();
-
   MarkerManager markerManager;
   markerManager.Init(scene);
 
-  // Function that Waits for messages to be received
-  auto wait = [&](std::size_t _size) {
-    for (int sleep = 0; sleep < 30; ++sleep)
-    {
-      // The service request is asynchronous, so keep processing messages.
-      markerManager.Update();
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-      mutex.lock();
-      bool received = markerMsgs.size() == _size;
-      mutex.unlock();
-
-      if (received)
-        break;
-    }
-
-    mutex.lock();
-    EXPECT_EQ(markerMsgs.size(), _size);
-    mutex.unlock();
-  };
-
-  // subscribe to marker topic
   transport::Node node;
-  node.Subscribe("/marker", &markerCb);
 
   gz::msgs::Marker_V markerArrayMsg;
 
   auto markerMsg0 = markerArrayMsg.add_marker();
   markerMsg0->set_ns("array");
-  markerMsg0->set_id(0);
+  markerMsg0->set_id(1);
   markerMsg0->set_action(gz::msgs::Marker::ADD_MODIFY);
   markerMsg0->set_type(gz::msgs::Marker::SPHERE);
   markerMsg0->set_visibility(gz::msgs::Marker::GUI);
 
   auto markerMsg1 = markerArrayMsg.add_marker();
   markerMsg1->set_ns("array");
-  markerMsg1->set_id(1);
+  markerMsg1->set_id(2);
   markerMsg1->set_action(gz::msgs::Marker::ADD_MODIFY);
   markerMsg1->set_type(gz::msgs::Marker::BOX);
   markerMsg1->set_visibility(gz::msgs::Marker::GUI);
@@ -181,13 +153,24 @@ TEST_F(MarkersTest, MarkerArrayPublisher)
   EXPECT_TRUE(node.Request(
       "/marker_array", markerArrayMsg, &markerArrayCb));
 
-  wait(2);
+  rendering::VisualPtr visual0;
+  rendering::VisualPtr visual1;
 
-  mutex.lock();
-  auto receivedMsgs = markerMsgs;
-  mutex.unlock();
+  for (int sleep = 0; sleep < 30; ++sleep)
+  {
+    // The service request is asynchronous, so keep processing messages.
+    markerManager.Update();
 
-  ASSERT_EQ(receivedMsgs.size(), 2u);
-  EXPECT_EQ(markerMsg0->DebugString(), receivedMsgs[0].DebugString());
-  EXPECT_EQ(markerMsg1->DebugString(), receivedMsgs[1].DebugString());
+    visual0 = scene->VisualByName("__GZ_MARKER_VISUAL_array_1");
+    visual1 = scene->VisualByName("__GZ_MARKER_VISUAL_array_2");
+
+    if (visual0 && visual1){
+      break;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  ASSERT_NE(nullptr, visual0);
+  ASSERT_NE(nullptr, visual1);
 }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #3730.

## Summary
This updates `VisualizeContacts` to batch contact position markers into a single `Marker_V` request, then send it through `/marker_array` once per update. Previously, one `/marker` request was sent per contact position.
The request remains non-blocking, matching the existing behavior.

Also adds behavioral coverage for the `/marker_array` path in `test/integration/markers.cc`: the test sends a `Marker_V` with multiple markers, updates `MarkerManager`, and verifies that each marker is received.

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated by: GPT5.5, used for local test commands and finding build tools.
**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.

## Notes 
Relying on CI for an initial check so keeping this as draft