### PR TITLE
Use gz::utils::ImplPtr for Model, Link and World classes

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -14,6 +14,18 @@ release will remove the deprecated code.
     density. Existing SDF files that specify `<water_density>` will continue
     to load without error; the parameter is simply ignored.
 
+* **Entity wrapper classes (`Model`, `Link`, `World`)**
+  * These now store their private data via `gz::utils::ImplPtr` (matching
+    `Joint`, `Sensor`, `Light`, and `Actor`) instead of a hand-written
+    `std::unique_ptr` pimpl. This is an **ABI break** — the size and layout of
+    these classes changed — but the public API is unchanged: they remain
+    copyable and movable with the same value semantics.
+  * The `Model` and `World` destructors are **no longer `virtual`**. These are
+    lightweight value handles around an entity id and were never intended to be
+    used as polymorphic base classes (none of the sibling wrapper classes had a
+    virtual destructor). Deriving from `Model` or `World` and deleting through a
+    base pointer is no longer supported.
+
 * **Deprecations**
   * **Hydrodynamics**: Added mass via plugin parameters (`<xDotU>`,
     `<yDotV>`, `<zDotW>`, `<kDotP>`, `<mDotQ>`, `<nDotR>`, and all

--- a/include/gz/sim/Link.hh
+++ b/include/gz/sim/Link.hh
@@ -30,6 +30,8 @@
 #include <gz/math/Vector3.hh>
 #include <gz/math/AxisAlignedBox.hh>
 
+#include <gz/utils/ImplPtr.hh>
+
 #include <gz/sim/config.hh>
 #include <gz/sim/EntityComponentManager.hh>
 #include <gz/sim/Export.hh>
@@ -42,8 +44,6 @@ namespace gz
   {
     // Inline bracket to help doxygen filtering.
     inline namespace GZ_SIM_VERSION_NAMESPACE {
-    // Forward declarations.
-    class GZ_SIM_HIDDEN LinkPrivate;
     //
     /// \class Link Link.hh gz/sim/Link.hh
     /// \brief This class provides wrappers around entities and components
@@ -69,27 +69,6 @@ namespace gz
       /// \brief Constructor
       /// \param[in] _entity Link entity
       public: explicit Link(sim::Entity _entity = kNullEntity);
-
-      /// \brief Copy constructor
-      /// \param[in] _link Link to copy.
-      public: Link(const Link &_link);
-
-      /// \brief Move constructor
-      /// \param[in] _link Link to move.
-      public: Link(Link &&_link) noexcept;
-
-      /// \brief Move assignment operator.
-      /// \param[in] _link Link component to move.
-      /// \return Reference to this.
-      public: Link &operator=(Link &&_link) noexcept;
-
-      /// \brief Copy assignment operator.
-      /// \param[in] _link Link to copy.
-      /// \return Reference to this.
-      public: Link &operator=(const Link &_link);
-
-      /// \brief Destructor
-      public: ~Link();
 
       /// \brief Get the entity which this Link is related to.
       /// \return Link entity.
@@ -429,8 +408,8 @@ namespace gz
       public: std::optional<math::AxisAlignedBox> ComputeAxisAlignedBox(
         const EntityComponentManager &_ecm) const;
 
-      /// \brief Pointer to private data.
-      private: std::unique_ptr<LinkPrivate> dataPtr;
+      /// \brief Private data pointer.
+      GZ_UTILS_IMPL_PTR(dataPtr)
     };
     }
   }

--- a/include/gz/sim/Model.hh
+++ b/include/gz/sim/Model.hh
@@ -23,6 +23,8 @@
 
 #include <gz/math/Pose3.hh>
 
+#include <gz/utils/ImplPtr.hh>
+
 #include <gz/sim/config.hh>
 #include <gz/sim/EntityComponentManager.hh>
 #include <gz/sim/Export.hh>
@@ -34,8 +36,6 @@ namespace gz
   {
     // Inline bracket to help doxygen filtering.
     inline namespace GZ_SIM_VERSION_NAMESPACE {
-    // Forward declarations.
-    class GZ_SIM_HIDDEN ModelPrivate;
     //
     /// \class Model Model.hh gz/sim/Model.hh
     /// \brief This class provides wrappers around entities and components
@@ -61,27 +61,6 @@ namespace gz
       /// \brief Constructor
       /// \param[in] _entity Model entity
       public: explicit Model(sim::Entity _entity = kNullEntity);
-
-      /// \brief Copy constructor
-      /// \param[in] _model Model to copy.
-      public: Model(const Model &_model);
-
-      /// \brief Move constructor
-      /// \param[in] _model Model to move.
-      public: Model(Model &&_model) noexcept;
-
-      /// \brief Move assignment operator.
-      /// \param[in] _model Model component to move.
-      /// \return Reference to this.
-      public: Model &operator=(Model &&_model) noexcept;
-
-      /// \brief Copy assignment operator.
-      /// \param[in] _model Model to copy.
-      /// \return Reference to this.
-      public: Model &operator=(const Model &_model);
-
-      /// \brief Destructor
-      public: virtual ~Model();
 
       /// \brief Get the entity which this Model is related to.
       /// \return Model entity.
@@ -224,8 +203,8 @@ namespace gz
       public: sim::Entity CanonicalLink(
           const EntityComponentManager &_ecm) const;
 
-      /// \brief Pointer to private data.
-      private: std::unique_ptr<ModelPrivate> dataPtr;
+      /// \brief Private data pointer.
+      GZ_UTILS_IMPL_PTR(dataPtr)
     };
     }
   }

--- a/include/gz/sim/World.hh
+++ b/include/gz/sim/World.hh
@@ -26,6 +26,8 @@
 #include <gz/math/Vector3.hh>
 #include <gz/math/SphericalCoordinates.hh>
 
+#include <gz/utils/ImplPtr.hh>
+
 #include "gz/sim/config.hh"
 #include "gz/sim/EntityComponentManager.hh"
 #include "gz/sim/Export.hh"
@@ -37,8 +39,6 @@ namespace gz
   {
     // Inline bracket to help doxygen filtering.
     inline namespace GZ_SIM_VERSION_NAMESPACE {
-    // Forward declarations.
-    class GZ_SIM_HIDDEN WorldPrivate;
     //
     /// \class World World.hh gz/sim/World.hh
     /// \brief This class provides wrappers around entities and components
@@ -62,27 +62,6 @@ namespace gz
       /// \brief Constructor
       /// \param[in] _entity World entity
       public: explicit World(sim::Entity _entity = kNullEntity);
-
-      /// \brief Copy constructor
-      /// \param[in] _world World to copy.
-      public: World(const World &_world);
-
-      /// \brief Move constructor
-      /// \param[in] _world World to move.
-      public: World(World &&_world) noexcept;
-
-      /// \brief Move assignment operator.
-      /// \param[in] _world World component to move.
-      /// \return Reference to this.
-      public: World &operator=(World &&_world) noexcept;
-
-      /// \brief Copy assignment operator.
-      /// \param[in] _world World to copy.
-      /// \return Reference to this.
-      public: World &operator=(const World &_world);
-
-      /// \brief Destructor
-      public: virtual ~World();
 
       /// \brief Get the entity which this World is related to.
       /// \return World entity.
@@ -195,8 +174,8 @@ namespace gz
       /// \return Number of models in this world.
       public: uint64_t ModelCount(const EntityComponentManager &_ecm) const;
 
-      /// \brief Pointer to private data.
-      private: std::unique_ptr<WorldPrivate> dataPtr;
+      /// \brief Private data pointer.
+      GZ_UTILS_IMPL_PTR(dataPtr)
     };
     }
   }

--- a/src/Link.cc
+++ b/src/Link.cc
@@ -46,10 +46,10 @@
 
 #include "gz/sim/Link.hh"
 
-class gz::sim::LinkPrivate
+class gz::sim::Link::Implementation
 {
   /// \brief Id of link entity.
-  public: Entity id{kNullEntity};
+  public: sim::Entity id{kNullEntity};
 };
 
 using namespace gz;
@@ -57,32 +57,10 @@ using namespace sim;
 
 //////////////////////////////////////////////////
 Link::Link(sim::Entity _entity)
-  : dataPtr(std::make_unique<LinkPrivate>())
+  : dataPtr(utils::MakeImpl<Implementation>())
 {
   this->dataPtr->id = _entity;
 }
-
-/////////////////////////////////////////////////
-Link::Link(const Link &_link)
-  : dataPtr(std::make_unique<LinkPrivate>(*_link.dataPtr))
-{
-}
-
-/////////////////////////////////////////////////
-Link::Link(Link &&_link) noexcept = default;
-
-//////////////////////////////////////////////////
-Link::~Link() = default;
-
-/////////////////////////////////////////////////
-Link &Link::operator=(const Link &_link)
-{
-  *this->dataPtr = (*_link.dataPtr);
-  return *this;
-}
-
-/////////////////////////////////////////////////
-Link &Link::operator=(Link &&_link) noexcept = default;
 
 //////////////////////////////////////////////////
 Entity Link::Entity() const

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -30,10 +30,10 @@
 #include "gz/sim/components/WindMode.hh"
 #include "gz/sim/Model.hh"
 
-class gz::sim::ModelPrivate
+class gz::sim::Model::Implementation
 {
   /// \brief Id of model entity.
-  public: Entity id{kNullEntity};
+  public: sim::Entity id{kNullEntity};
 };
 
 using namespace gz;
@@ -41,32 +41,10 @@ using namespace sim;
 
 //////////////////////////////////////////////////
 Model::Model(sim::Entity _entity)
-  : dataPtr(std::make_unique<ModelPrivate>())
+  : dataPtr(utils::MakeImpl<Implementation>())
 {
   this->dataPtr->id = _entity;
 }
-
-/////////////////////////////////////////////////
-Model::Model(const Model &_model)
-  : dataPtr(std::make_unique<ModelPrivate>(*_model.dataPtr))
-{
-}
-
-/////////////////////////////////////////////////
-Model::Model(Model &&_model) noexcept = default;
-
-//////////////////////////////////////////////////
-Model::~Model() = default;
-
-/////////////////////////////////////////////////
-Model &Model::operator=(const Model &_model)
-{
-  *this->dataPtr = (*_model.dataPtr);
-  return *this;
-}
-
-/////////////////////////////////////////////////
-Model &Model::operator=(Model &&_model) noexcept = default;
 
 //////////////////////////////////////////////////
 Entity Model::Entity() const

--- a/src/World.cc
+++ b/src/World.cc
@@ -30,10 +30,10 @@
 #include "gz/sim/components/World.hh"
 #include "gz/sim/World.hh"
 
-class gz::sim::WorldPrivate
+class gz::sim::World::Implementation
 {
   /// \brief Id of world entity.
-  public: Entity id{kNullEntity};
+  public: sim::Entity id{kNullEntity};
 };
 
 using namespace gz;
@@ -41,32 +41,10 @@ using namespace sim;
 
 //////////////////////////////////////////////////
 World::World(sim::Entity _entity)
-  : dataPtr(std::make_unique<WorldPrivate>())
+  : dataPtr(utils::MakeImpl<Implementation>())
 {
   this->dataPtr->id = _entity;
 }
-
-/////////////////////////////////////////////////
-World::World(const World &_world)
-  : dataPtr(std::make_unique<WorldPrivate>(*_world.dataPtr))
-{
-}
-
-/////////////////////////////////////////////////
-World::World(World &&_world) noexcept = default;
-
-//////////////////////////////////////////////////
-World::~World() = default;
-
-/////////////////////////////////////////////////
-World &World::operator=(const World &_world)
-{
-  *this->dataPtr = (*_world.dataPtr);
-  return *this;
-}
-
-/////////////////////////////////////////////////
-World &World::operator=(World &&_world) noexcept = default;
 
 //////////////////////////////////////////////////
 Entity World::Entity() const


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# Clean :broom: 

This patch uses `ImplPtr` for Model, Link and World classes for consistency. 

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [x] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Opus 4.8

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.