### PR TITLE
Fix hierarchy inconsistency when serializing + deserializing state

### DIFF
--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -1264,7 +1264,11 @@ bool EntityComponentManager::CreateComponentImplementation(
       return updateData;
     }
     const auto *parent = static_cast<const components::ParentEntity *>(_data);
-    this->dataPtr->SetParentEntityGraph(_entity, parent->Data());
+    if (!this->dataPtr->SetParentEntityGraph(_entity, parent->Data()))
+    {
+      gzerr << "Failed setting parent for entity " << _entity << " to "
+            << parent->Data() << std::endl;
+    }
   }
 
   return updateData;

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -1898,8 +1898,20 @@ void EntityComponentManager::SetState(
     {
       this->dataPtr->CreateEntityImplementation(entity);
     }
+  }
 
-    // Create / remove / update components
+  // Create / remove / update components
+  for (int e = 0; e < _stateMsg.entities_size(); ++e)
+  {
+    const auto &entityMsg = _stateMsg.entities(e);
+
+    Entity entity{entityMsg.id()};
+
+    if (entityMsg.remove())
+    {
+      continue;
+    }
+
     for (int c = 0; c < entityMsg.components_size(); ++c)
     {
       const auto &compMsg = entityMsg.components(c);
@@ -1996,8 +2008,20 @@ void EntityComponentManager::SetState(
     {
       this->dataPtr->CreateEntityImplementation(entity);
     }
+  }
 
-    // Create / remove / update components
+  // Create / remove / update components
+  for (const auto &iter : _stateMsg.entities())
+  {
+    const auto &entityMsg = iter.second;
+
+    Entity entity{entityMsg.id()};
+
+    if (entityMsg.remove())
+    {
+      continue;
+    }
+
     for (const auto &compIter : iter.second.components())
     {
       const auto &compMsg = compIter.second;

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -3222,6 +3222,76 @@ TEST_P(EntityComponentManagerFixture,
 }
 
 //////////////////////////////////////////////////
+/// \brief Test that after serializing and deserializing state the hierarchy
+/// is preserved.
+TEST_P(EntityComponentManagerFixture,
+       GZ_UTILS_TEST_DISABLED_ON_WIN32(StateMsgHierarchy))
+{
+  static constexpr std::size_t NUM_ENTITIES = 100;
+  EntityComponentManager originalECMStateMap;
+  EntityComponentManager otherECMStateMap;
+
+  // A series of entities where half have no parent and half have the previous
+  // entity as a parent.
+  std::vector<Entity> entities;
+  entities.reserve(NUM_ENTITIES);
+  auto parentEntity = kNullEntity;
+  for (std::size_t i = 0; i < NUM_ENTITIES; ++i)
+  {
+    auto entity = originalECMStateMap.CreateEntity();
+    originalECMStateMap.CreateComponent(entity,
+        components::Name("entity_" + std::to_string(i)));
+    if (i % 2)
+    {
+      EXPECT_TRUE(originalECMStateMap.SetParentEntity(entity, parentEntity));
+    }
+    parentEntity = entity;
+    entities.push_back(entity);
+  }
+
+  // update the other ECM to have the new entity and component
+  msgs::SerializedStateMap stateMapMsg;
+  originalECMStateMap.State(stateMapMsg);
+  otherECMStateMap.SetState(stateMapMsg);
+
+  ASSERT_EQ(otherECMStateMap.EntityCount(), originalECMStateMap.EntityCount());
+  for (std::size_t i = 0; i < NUM_ENTITIES; ++i)
+  {
+    auto desc = otherECMStateMap.Descendants(entities[i]);
+    // Descendants includes self, remove it to simplify asserts
+    desc.erase(entities[i]);
+    if (i % 2 == 0)
+    {
+      // Entity with no descendents
+      ASSERT_EQ(desc.size(), 1);
+      EXPECT_EQ(*desc.begin(), entities[i + 1]);
+    } else {
+      EXPECT_EQ(desc.size(), 0);
+    }
+  }
+
+  EntityComponentManager otherECMState;
+  auto stateMsg = originalECMStateMap.State();
+  otherECMState.SetState(stateMsg);
+
+  ASSERT_EQ(otherECMState.EntityCount(), originalECMStateMap.EntityCount());
+  for (std::size_t i = 0; i < NUM_ENTITIES; ++i)
+  {
+    auto desc = otherECMState.Descendants(entities[i]);
+    // Descendants includes self, remove it to simplify asserts
+    desc.erase(entities[i]);
+    if (i % 2 == 0)
+    {
+      // Entity with no descendents
+      ASSERT_EQ(desc.size(), 1);
+      EXPECT_EQ(*desc.begin(), entities[i + 1]);
+    } else {
+      EXPECT_EQ(desc.size(), 0);
+    }
+  }
+}
+
+//////////////////////////////////////////////////
 TEST_P(EntityComponentManagerFixture, CopyEcm)
 {
   Entity entity = manager.CreateEntity();

--- a/src/cmd/ModelCommandAPI.cc
+++ b/src/cmd/ModelCommandAPI.cc
@@ -610,8 +610,8 @@ void printLinks(const uint64_t _modelEntity,
                 const std::string &_sensorName,
                 int _spaces)
 {
-  const auto links = _ecm.EntitiesByComponents(
-      components::ParentEntity(_modelEntity), components::Link());
+  const auto links = _ecm.ChildrenByComponents(
+      _modelEntity, components::Link());
   for (const auto &entity : links)
   {
     const auto nameComp = _ecm.Component<components::Name>(entity);
@@ -667,8 +667,8 @@ void printLinks(const uint64_t _modelEntity,
       spaces += 2;
     }
 
-    const auto sensors = _ecm.EntitiesByComponents(
-      components::ParentEntity(entity), components::Sensor());
+    const auto sensors = _ecm.ChildrenByComponents(
+      entity, components::Sensor());
     for (const auto &sensor : sensors)
     {
       const auto sensorNameComp = _ecm.Component<components::Name>(sensor);
@@ -719,8 +719,8 @@ void printJoints(const uint64_t _modelEntity,
     {sdf::JointType::UNIVERSAL, "universal"}
   };
 
-  const auto joints = _ecm.EntitiesByComponents(
-      components::ParentEntity(_modelEntity), components::Joint());
+  const auto joints = _ecm.ChildrenByComponents(
+      _modelEntity, components::Joint());
 
   for (const auto &entity : joints)
   {


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #3729 

## Summary

Add a pre-spawning step to the `SetState` functions so we are sure that entities are present when, afterwards, we try to add components to them.
Previously, since we spawned entities and their components in one go, we ended up in cases where an entity would be spawned before its parent, and updating the graph failed as a consequence.
I'm splitting this PR in three:

* The first commit https://github.com/gazebosim/gz-sim/pull/3750/commits/b27af72963eab05a0291aec830f12cef0a394ce8 adds a failing unit test, together with logging for failures in setting the hierarchy that will make the ModelCommandAPI unit test fail.
* The second commit https://github.com/gazebosim/gz-sim/pull/3750/commits/1de67aeaedc3cc4feb2e015f325c949c01e5dab7 will hopefully make CI green again by fixing the behavior.
* The third commit https://github.com/gazebosim/gz-sim/pull/3750/commits/ace4f90e0b4335ff989522c24d02324eb48c56b1 migrates the ModelCommandAPI to use ChildrenByComponents, which previously didn't work because of this bug as mentioned in #3729 

## Backport Policy
This is a fix and should be backported, BUT since it is based on the `ParentEntity` change the diff might become a bit gnarly if we decide to only backport this but not the ParentEntity change.
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.