### PR TITLE
fix: Fixed data race for UI updates

### DIFF
--- a/src/gui/GuiRunner.cc
+++ b/src/gui/GuiRunner.cc
@@ -74,7 +74,7 @@ class gz::sim::GuiRunner::Implementation
   public: std::thread updateThread;
 
   /// \brief True if the initial state has been received and processed.
-  public: std::atomic<bool> receivedInitialState{false};
+  public: bool receivedInitialState{false};
 
   /// \brief Name of WorldControl service
   public: std::string controlService;
@@ -263,7 +263,8 @@ void GuiRunner::OnStateAsyncService(const msgs::SerializedStepMap &_res)
   // ensures that only one thread has access to the ecm and updateInfo
   // variables.
   QMetaObject::invokeMethod(this, "OnStateQt", Qt::QueuedConnection,
-                            Q_ARG(gz::msgs::SerializedStepMap, _res));
+                            Q_ARG(gz::msgs::SerializedStepMap, _res),
+                            Q_ARG(bool, true));
 
   // todo(anyone) store reqSrv string in a member variable and use it here
   // and in RequestState()
@@ -279,23 +280,27 @@ void GuiRunner::OnState(const msgs::SerializedStepMap &_msg)
   GZ_PROFILE_THREAD_NAME("GuiRunner::OnState");
   GZ_PROFILE("GuiRunner::Update");
 
-  // Only process state updates after initial state has been received.
-  if (!this->dataPtr->receivedInitialState)
-    return;
-
   // Since this function may be called from a transport thread, we push the
   // OnStateQt function to the queue so that its called from the Qt thread. This
   // ensures that only one thread has access to the ecm and updateInfo
   // variables.
   QMetaObject::invokeMethod(this, "OnStateQt", Qt::QueuedConnection,
-                            Q_ARG(gz::msgs::SerializedStepMap, _msg));
+                            Q_ARG(gz::msgs::SerializedStepMap, _msg),
+                            Q_ARG(bool, false));
 }
 
 /////////////////////////////////////////////////
-void GuiRunner::OnStateQt(const msgs::SerializedStepMap &_msg)
+void GuiRunner::OnStateQt(const msgs::SerializedStepMap &_msg, bool _fullState)
 {
   GZ_PROFILE_THREAD_NAME("Qt thread");
   GZ_PROFILE("GuiRunner::Update");
+
+  // Skip state updates until initial state is received
+  if (!_fullState && !this->dataPtr->receivedInitialState)
+  {
+    return;
+  }
+
   this->dataPtr->ecm.SetState(_msg.state());
 
   // Update all plugins

--- a/src/gui/GuiRunner.hh
+++ b/src/gui/GuiRunner.hh
@@ -67,7 +67,10 @@ class GZ_SIM_GUI_VISIBLE GuiRunner : public QObject
 
   /// \brief Called by the Qt thread to update the ECM with new state
   /// \param[in] _msg New state message.
-  private: Q_INVOKABLE void OnStateQt(const gz::msgs::SerializedStepMap &_msg);
+  /// \param[in] _fullState True if this is a full state update,
+  ///                       false if incremental.
+  private: Q_INVOKABLE void OnStateQt(const gz::msgs::SerializedStepMap &_msg,
+                                      bool _fullState);
 
   /// \brief Update the plugins.
   private: Q_INVOKABLE void UpdatePlugins();


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This fixes a data race that lead to objects not being shown in the GUI.

The data race happened in this scenario :
OnStateAsyncService called with full state -> State enqueued for QT thread
OnState called with updates, dropped as receivedInitialState is still false
OnState called with updates, dropped as receivedInitialState is still false

Qt Thread calls OnStateQt processes the full update, sets receivedInitialState to true.

The fix is to push all updates to the QT queue and discard them in the processing.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: SWE-1.6 Used for questioning about the code

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.

