### PR TITLE
Fix issue #3754. Solution is to resolve the correct Fuel model SDF vi…

### DIFF
--- a/src/gui/plugins/resource_spawner/ResourceSpawner.cc
+++ b/src/gui/plugins/resource_spawner/ResourceSpawner.cc
@@ -103,6 +103,16 @@ namespace {
 
 // Default owner to be fetched from Fuel. This owner cannot be removed.
 constexpr const char *kDefaultOwner = "openrobotics";
+
+/////////////////////////////////////////////////
+std::string modelSdfPath(const std::string &_modelPath)
+{
+  auto sdfPath = sdf::getModelFilePath(_modelPath);
+  if (sdfPath.empty()) {
+    sdfPath = gz::common::joinPaths(_modelPath, "model.sdf");
+  }
+  return sdfPath;
+}
 }
 using namespace gz;
 using namespace sim;
@@ -577,7 +587,7 @@ void ResourceSpawner::OnDownloadFuelResource(const QString &_path,
     std::string thumbnailPath = common::joinPaths(localPath, "thumbnails");
     this->SetThumbnail(thumbnailPath, modelResource);
     modelResource.isDownloaded = true;
-    modelResource.sdfPath = common::joinPaths(localPath, "model.sdf");
+    modelResource.sdfPath = modelSdfPath(localPath);
     modelResource.isFuel = true;
     // Update the current grid of resources
     this->dataPtr->resourceModel.UpdateResourceModel(index, modelResource);
@@ -677,7 +687,7 @@ void ResourceSpawner::UpdateOwnerListModel(Resource _resource)
         common::URI(_resource.sdfPath), path))
   {
     _resource.isDownloaded = true;
-    _resource.sdfPath = common::joinPaths(path, "model.sdf");
+    _resource.sdfPath = modelSdfPath(path);
     std::string thumbnailPath = common::joinPaths(path, "thumbnails");
     this->SetThumbnail(thumbnailPath, _resource);
   }

--- a/src/gui/plugins/spawn/Spawn.cc
+++ b/src/gui/plugins/spawn/Spawn.cc
@@ -28,9 +28,12 @@
 #include <QQmlProperty>
 
 #include <gz/common/Console.hh>
+#include <gz/common/Filesystem.hh>
 #include <gz/common/MeshManager.hh>
 #include <gz/common/Profiler.hh>
 #include <gz/common/Uuid.hh>
+#include <gz/fuel_tools/FuelClient.hh>
+#include <gz/fuel_tools/Interface.hh>
 
 #include <gz/gui/Application.hh>
 #include <gz/gui/GuiEvents.hh>
@@ -53,6 +56,7 @@
 #include <gz/transport/Publisher.hh>
 
 #include <sdf/Root.hh>
+#include <sdf/ParserConfig.hh>
 
 #include "gz/sim/rendering/RenderUtil.hh"
 #include "gz/sim/rendering/SceneManager.hh"
@@ -80,8 +84,15 @@ namespace gz::sim
     /// \brief Handle placement requests
     public: void HandlePlacement();
 
+    /// \brief Create a parser config that resolves resources for previews.
+    /// \return Parser configuration with Fuel and local file resolution.
+    public: sdf::ParserConfig ParserConfigWithFuelFindFile();
+
     /// \brief Gazebo communication node.
     public: transport::Node node;
+
+    /// \brief Client used to resolve Fuel resources while loading previews.
+    public: fuel_tools::FuelClient fuelClient;
 
     /// \brief Flag for indicating whether the preview needs to be generated.
     public: bool generatePreview = false;
@@ -282,6 +293,30 @@ void SpawnPrivate::HandlePlacement()
 }
 
 /////////////////////////////////////////////////
+sdf::ParserConfig SpawnPrivate::ParserConfigWithFuelFindFile()
+{
+  sdf::ParserConfig config = sdf::ParserConfig::GlobalConfig();
+  auto existingCallback = config.FindFileCallback();
+  config.SetFindCallback(
+      [this, existingCallback](const std::string &_uri) -> std::string
+      {
+        if (existingCallback)
+        {
+          auto path = existingCallback(_uri);
+          if (!path.empty())
+            return path;
+        }
+
+        auto path = common::findFile(_uri);
+        if (!path.empty())
+          return path;
+
+        return fuel_tools::fetchResourceWithClient(_uri, this->fuelClient);
+      });
+  return config;
+}
+
+/////////////////////////////////////////////////
 void SpawnPrivate::OnRender()
 {
   if (nullptr == this->scene)
@@ -321,13 +356,14 @@ void SpawnPrivate::OnRender()
     // Generate spawn preview
     rendering::VisualPtr rootVis = this->scene->RootVisual();
     sdf::Root root;
+    sdf::ParserConfig parserConfig = this->ParserConfigWithFuelFindFile();
     if (!this->spawnSdfString.empty())
     {
-      root.LoadSdfString(this->spawnSdfString);
+      root.LoadSdfString(this->spawnSdfString, parserConfig);
     }
     else if (!this->spawnSdfPath.empty())
     {
-      root.Load(this->spawnSdfPath);
+      root.Load(this->spawnSdfPath, parserConfig);
     }
     else if (!this->spawnCloneName.empty())
     {


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #3754 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
The cause of the issue is the GUI Resource Spawner and Spawn plugins did not resolve Fuel model files correctly: Resource Spawner assumed every cached model uses `model.sdf` instead of the path from `model.config`, and Spawn loaded spawn previews without resolving embedded Fuel URIs, so models such as Spectrum Plane failed with an empty `sdf::findFile()` callback.

Checking development history, it can be deemed that developers are already aware of related issue, see below.
The server has long registered a Fuel/resource resolver at startup:
```
// Server.cc
sdf::setFindCallback(std::bind(&ServerPrivate::FetchResource, ...));
common::addFindFileURICallback(std::bind(&ServerPrivate::FetchResourceUri, ...));
```
Test side too:
```
    auto fuelCb = [&](const std::string &_uri)
    {
      auto out =
          fuel_tools::fetchResourceWithClient(_uri, *this->fuelClient.get());
      ...
      return out;
    };
    sdf::setFindCallback(fuelCb);
```

This fix applies a similar solution as the server side but scoped by `sdf::ParserConfig` (a per-load `findFile` callback that falls back to `gz::common::findFile()` and `gz::fuel_tools::fetchResourceWithClient())`, rather than a global `sdf::setFindCallback()`. 
This scoping ensures much better safety than process-global way that server-side does, otherwise we would be risking at silently replacing that process-wide state.

After the code change, log no longer shows error message. Below is a screen recording helps demonstrate fix:

https://github.com/user-attachments/assets/9e8c9485-5ed0-444a-ab66-77829fea3174



## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [x] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [x] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.