### PR TITLE
test: build display-dependent unit tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,12 +143,10 @@ set(tests_needing_display
 
 # Add systems that need a valid display here.
 # \todo(anyone) Find a way to run these tests with a virtual display such Xvfb
-# or Xdummy instead of skipping them
-if(VALID_DISPLAY AND VALID_DRI_DISPLAY)
-  list(APPEND gtest_sources ${tests_needing_display})
-else()
+# or Xdummy instead of disabling them at test time
+if(NOT VALID_DISPLAY OR NOT VALID_DRI_DISPLAY)
   message(STATUS
-    "Skipping these UNIT tests because a valid display was not found:")
+    "Disabling these UNIT tests because a valid display was not found:")
   foreach(test ${tests_needing_display})
     message(STATUS " ${test}")
   endforeach(test)
@@ -160,7 +158,7 @@ if (MSVC)
   # members that don't get exported, so they trigger this warning. However, the
   # warning is not important since those members do not need to be interfaced
   # with.
-  set_source_files_properties(${sources} ${gtest_sources} COMPILE_FLAGS "/wd4251 /wd4146")
+  set_source_files_properties(${sources} ${gtest_sources} ${tests_needing_display} COMPILE_FLAGS "/wd4251 /wd4146")
 endif()
 
 # Create the library target
@@ -236,6 +234,32 @@ gz_build_tests(TYPE UNIT
   ENVIRONMENT
     GZ_SIM_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
 )
+
+gz_build_tests(TYPE UNIT
+  SOURCES
+    ${tests_needing_display}
+  LIB_DEPS
+    ${PROJECT_LIBRARY_TARGET_NAME}
+    ${EXTRA_TEST_LIB_DEPS}
+    gz-sim
+  TEST_LIST
+    tests_needing_display_targets
+  ENVIRONMENT
+    GZ_SIM_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+)
+
+if(NOT VALID_DISPLAY OR NOT VALID_DRI_DISPLAY)
+  set(disabled_display_tests ${tests_needing_display_targets})
+  if(Python3_Interpreter_FOUND)
+    foreach(test_target ${tests_needing_display_targets})
+      list(APPEND disabled_display_tests check_${test_target})
+    endforeach()
+  endif()
+
+  if(disabled_display_tests)
+    set_tests_properties(${disabled_display_tests} PROPERTIES DISABLED TRUE)
+  endif()
+endif()
 
 # Some server unit tests require rendering.
 if (TARGET UNIT_Server_Rendering_TEST)

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -79,14 +79,16 @@ endif()
 # Build the unit tests.
 set(test_sources gz_TEST.cc)
 
+set(cmd_tests_needing_display
+  ModelCommandAPI_TEST.cc
+)
+
 # Add systems that need a valid display here.
 # \todo(anyone) Find a way to run these tests with a virtual display such Xvfb
-# or Xdummy instead of skipping them
-if(VALID_DISPLAY AND VALID_DRI_DISPLAY)
-  list(APPEND test_sources ModelCommandAPI_TEST.cc)
-else()
+# or Xdummy instead of disabling them at test time
+if(NOT VALID_DISPLAY OR NOT VALID_DRI_DISPLAY)
   message(STATUS
-    "Skipping ModelCommandAPI tests because a valid display was not found")
+    "Disabling ModelCommandAPI tests because a valid display was not found")
 endif()
 
 # Build unit tests if Gazebo tools is installed
@@ -100,6 +102,31 @@ if(BUILD_TESTING AND GZ_TOOLS_PROGRAM)
     ENVIRONMENT
         GZ_SIM_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
   )
+
+  gz_build_tests(TYPE UNIT
+    SOURCES
+      ${cmd_tests_needing_display}
+    LIB_DEPS
+      gz-utils::gz-utils
+      ${PROJECT_LIBRARY_TARGET_NAME}
+    TEST_LIST
+      cmd_tests_needing_display_targets
+    ENVIRONMENT
+        GZ_SIM_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+  )
+
+  if(NOT VALID_DISPLAY OR NOT VALID_DRI_DISPLAY)
+    set(disabled_display_tests ${cmd_tests_needing_display_targets})
+    if(Python3_Interpreter_FOUND)
+      foreach(test_target ${cmd_tests_needing_display_targets})
+        list(APPEND disabled_display_tests check_${test_target})
+      endforeach()
+    endif()
+
+    if(disabled_display_tests)
+      set_tests_properties(${disabled_display_tests} PROPERTIES DISABLED TRUE)
+    endif()
+  endif()
 endif()
 
 foreach(CMD_TEST


### PR DESCRIPTION
## Summary
- Build display-dependent unit tests as separate `gz_build_tests` invocations instead of removing them from the source lists when no valid display is available.
- Disable their CTest entries when `VALID_DISPLAY` or `VALID_DRI_DISPLAY` is false, including the generated `check_` tests that would otherwise fail without XML output.
- Keep the existing target-specific setup for `UNIT_Server_Rendering_TEST` and `UNIT_ModelCommandAPI_TEST` intact.

Fixes #3496

## Testing
- `git diff --check origin/main..HEAD`
- Installed the Python-distributed CMake binary locally and ran `cmake -S . -B build\verify-display-tests -DBUILD_TESTING=ON -DENABLE_GUI=OFF`; configuration stopped at the expected missing local `gz-cmake` dependency before project CMake logic could run.
- Ran a temporary CMake/CTest harness that mocks `gz_build_tests(TEST_LIST ...)`; `ctest -C Debug --show-only=json-v1` confirmed these tests are registered and `DISABLED: true` when display detection is false:
  - `UNIT_Server_Rendering_TEST`
  - `check_UNIT_Server_Rendering_TEST`
  - `UNIT_ModelCommandAPI_TEST`
  - `check_UNIT_ModelCommandAPI_TEST`

Not run: full gz-sim configure/build/tests, because this Windows workspace does not have the Gazebo development dependencies such as `gz-cmake` installed.

## CI notes
- The current Jenkins build URL still reports `gz_sim-ci-pr_any-noble-amd64` failure, but `consoleText` returns HTTP 404 and `testReport/api/json` returns HTTP 503 as of 2026-07-10 14:42 CST.
- The last accessible failure evidence pointed to `UNIT_PeerTracker_TEST`, while this PR only changes display-dependent test registration for `UNIT_Server_Rendering_TEST` and `UNIT_ModelCommandAPI_TEST`; `network/PeerTracker_TEST.cc` is in the regular unit-test list, not `tests_needing_display`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests (not applicable; this changes test registration)
- [ ] Updated documentation (not needed)
- [ ] Updated migration guide (not needed)
- [ ] `codecheck` passed (not run; local Gazebo dependencies are unavailable)
- [ ] All tests passed (not run; local Gazebo dependencies are unavailable)
- [x] While waiting for a review on this PR, I have helped review another open pull request: #3745
- [x] GenAI was used; the commit includes `Generated-by: OpenAI Codex`