### PR TITLE
doc: escape levels tutorial SDF headings

### DIFF
--- a/tutorials/levels.md
+++ b/tutorials/levels.md
@@ -148,7 +148,7 @@ tags will be added to a `<plugin name="gz::sim" filename="dummy">` tag.
 The plugin name `gz::sim` will be fixed so that a simulation runner
 would know to check for that name in each plugin tag.
 
-### <level>
+### `<level>`
 
 The `<level>` tag contains information about the volume occupied by the level
 and the entities inside the level. The volume is given by a `<box>` geometry
@@ -184,7 +184,7 @@ Example snippet:
 </level>
 ```
 
-### <performer>
+### `<performer>`
 
 \note See Runtime performers, the next section, for information about specifying performers without using the SDF `<performer>` tag.
 


### PR DESCRIPTION
## Summary
- Wrap `<level>` and `<performer>` in inline code in the levels tutorial headings.
- Avoid Doxygen parsing those heading labels as unsupported HTML/XML tags.

## Related issue
Part of #3371

## Testing
- `git diff --check`

I could not run the full Doxygen job locally because this Windows environment does not have the Gazebo documentation/build dependency stack installed.