### PR TITLE
doc: remove orphan details tag from HPC tutorial

### DIFF
--- a/tutorials/hpc_clusters.md
+++ b/tutorials/hpc_clusters.md
@@ -431,8 +431,6 @@ dependencies and so on. If your cluster uses e.g. the Lmod modules system, you
 can provide a part of the dependencies just by typing `module load X11`.
 If you can get this working, you would get the definitive answer to which files
 are needed inside the container. If not, you just have to guess.
-</details>
-
 **Explanation why this worked:** The list of files in `nvliblist.conf` is just
 a guess. Some might be missing, some
 [are there and shouldn't](https://github.com/apptainer/apptainer/issues/945#issuecomment-1374524681).


### PR DESCRIPTION
## Summary
- Remove an unmatched `</details>` tag from the HPC clusters tutorial.
- Avoid the Doxygen warning for a closing `details` tag without a matching opener.

## Related issue
Part of #3371

## Testing
- `git diff --check`
- Verified `tutorials/hpc_clusters.md` no longer contains `<details>` / `</details>` tags.

I could not run the full Doxygen job locally because this Windows environment does not have the Gazebo documentation/build dependency stack installed.