### PR TITLE
doc: fix JointController parameter markup

### DIFF
--- a/src/systems/joint_controller/JointController.hh
+++ b/src/systems/joint_controller/JointController.hh
@@ -48,7 +48,7 @@ namespace systems
   /// for velocity command. The actuator msg is an array of floats for
   /// position, velocity and normalized commands. Relies on
   /// `<actuator_number>` for the index of the velocity actuator and
-  /// defaults to topic "/actuators" when `topic` or `subtopic not set.
+  /// defaults to topic "/actuators" when `topic` or `sub_topic` is not set.
   ///
   /// - `<actuator_number>` used with `<use_actuator_msg>` to set
   /// the index of the velocity actuator.


### PR DESCRIPTION
## Summary
- Close the inline code span around `sub_topic` in the JointController documentation.
- Use the documented / implemented `sub_topic` parameter name in that sentence.

## Related issue
Part of #3371

## Testing
- `git diff --check`
- Verified the edited line now has balanced inline-code backticks.

I could not run the full Doxygen job locally because this Windows environment does not have the Gazebo documentation/build dependency stack installed.