### PR TITLE
test: relax PeerTracker stale count assertion

### DIFF
--- a/src/network/PeerTracker_TEST.cc
+++ b/src/network/PeerTracker_TEST.cc
@@ -192,7 +192,10 @@ TEST(PeerTracker, GZ_UTILS_TEST_DISABLED_ON_MAC(PeerTrackerStale))
   }
   EXPECT_LT(sleep, maxSleep);
 
-  EXPECT_EQ(1, stalePeers);
+  // tracker2 keeps publishing slower heartbeats, so tracker1 can rediscover
+  // and mark it stale again before this timing-based wait observes the first
+  // stale event.
+  EXPECT_GE(stalePeers.load(), 1);
 
   // Expect while tracker1 can see tracker2, the opposite is
   // not true.


### PR DESCRIPTION
## Summary
- Relax the `PeerTracker.PeerTrackerStale` assertion from exactly one stale callback to at least one stale callback.
- Document why the test can observe more than one stale event with its intentionally mismatched heartbeat periods.

## Why
This showed up in https://github.com/gazebosim/gz-sim/pull/3759 on noble amd64: `PeerTracker.PeerTrackerStale` expected `stalePeers == 1` but observed `2`.

The test sets tracker1 to a 10 ms stale threshold while tracker2 keeps publishing heartbeats every 100 ms. After tracker1 removes tracker2 as stale, a later tracker2 heartbeat can add it again and let tracker1 mark it stale a second time before the polling loop wakes up.

## Testing
- `git diff --check HEAD~1..HEAD`

I could not run the unit test locally because this Windows environment does not have the Gazebo build dependency stack installed.

## CI notes
- Current `Ubuntu Noble CI` and `Ubuntu Resolute CI (GUI disabled)` logs show `UNIT_PeerTracker_TEST` and `check_UNIT_PeerTracker_TEST` passing.
- The current failing test is `INTEGRATION_tracked_vehicle_system` / `TrackedVehicleTest.PublishCmd` at `test/integration/tracked_vehicle_system.cc:366`: `poses.back().Pos().Z()` was `0.599049` versus the `> 0.6` expectation. That path is outside this PR's `src/network/PeerTracker_TEST.cc` diff.