### PR TITLE
doc: fix SceneBroadcaster typo in migration guide

### DIFF
--- a/tutorials/migration_world_api.md
+++ b/tutorials/migration_world_api.md
@@ -159,7 +159,7 @@ Classic | Gazebo
 -- | --
 EntityBelowPoint | Requires a system
 ModelBelowPoint | Requires a system
-SceneMsg | Use `gz::sim::systems::SceneBoradcaster`
+SceneMsg | Use `gz::sim::systems::SceneBroadcaster`
 WorldPoseMutex | N/A
 StripWorldName | N/A
 UniqueModelName | TODO


### PR DESCRIPTION
## Summary
- fix the SceneBroadcaster system name in the world API migration table

## Testing
- Not run (documentation typo only)