### PR TITLE
doc: fix actuator parameter docs

### DIFF
--- a/src/systems/ackermann_steering/AckermannSteering.hh
+++ b/src/systems/ackermann_steering/AckermannSteering.hh
@@ -44,11 +44,11 @@ namespace systems
   /// `/model/{name_of_model}/steer_angle`. Automatically set True when
   /// `<use_actuator_msg>` is True, uses defaults topic name "/actuators".
   ///
-  /// - `<use_actuator_msg>` True to enable the use of actutor message
+  /// - `<use_actuator_msg>` True to enable the use of actuator message
   /// for steering angle command. Relies on `<actuator_number>` for the
   /// index of the position actuator and defaults to topic "/actuators".
   ///
-  /// - `<actuator_number>` used with `<use_actuator_commands>` to set
+  /// - `<actuator_number>` used with `<use_actuator_msg>` to set
   /// the index of the steering angle position actuator.
   ///
   /// - `<steer_p_gain>`: Float used to control the steering angle P gain.

--- a/src/systems/joint_position_controller/JointPositionController.hh
+++ b/src/systems/joint_position_controller/JointPositionController.hh
@@ -52,11 +52,11 @@ namespace systems
   /// - `<joint_index>` Axis of the joint to control. Optional parameter.
   /// The default value is 0.
   ///
-  /// - `<use_actuator_msg>` True to enable the use of actutor message
+  /// - `<use_actuator_msg>` True to enable the use of actuator message
   /// for position command. Relies on `<actuator_number>` for the
   /// index of the position actuator and defaults to topic "/actuators".
   ///
-  /// - `<actuator_number>` used with `<use_actuator_commands>` to set
+  /// - `<actuator_number>` used with `<use_actuator_msg>` to set
   /// the index of the position actuator.
   ///
   /// - `<p_gain>` The proportional gain of the PID. Optional parameter.


### PR DESCRIPTION
## Summary
- fix the actuator message spelling in AckermannSteering and JointPositionController docs
- correct the actuator_number reference to the actual `<use_actuator_msg>` SDF parameter

## Testing
- `git diff --check`