### PR TITLE
doc: fix Projector typo in conversion docs

### DIFF
--- a/include/gz/sim/Conversions.hh
+++ b/include/gz/sim/Conversions.hh
@@ -742,7 +742,7 @@ namespace gz
 
     /// \brief Specialized conversion from a projector SDF object to
     /// a projector message object.
-    /// \param[in] _in Projecotr SDF object.
+    /// \param[in] _in Projector SDF object.
     /// \return Projector message.
     template<>
     sdf::Projector convert(const msgs::Projector &_in);


### PR DESCRIPTION
## Summary
- fix a Projector spelling typo in the conversion API documentation

## Testing
- `git diff --check`