### PR TITLE
fix: correct actuator_number error message grammar

### DIFF
--- a/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
+++ b/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
@@ -297,7 +297,7 @@ void MulticopterMotorModel::Configure(const Entity &_entity,
   }
   else
   {
-    gzerr << "Please specify a actuator_number.\n";
+    gzerr << "Please specify an actuator_number.\n";
   }
 
   if (sdfClone->HasElement("turningDirection"))

--- a/src/systems/spacecraft_thruster_model/SpacecraftThrusterModel.cc
+++ b/src/systems/spacecraft_thruster_model/SpacecraftThrusterModel.cc
@@ -167,7 +167,7 @@ void SpacecraftThrusterModel::Configure(const Entity &_entity,
   }
   else
   {
-    gzerr << "Please specify a actuator_number.\n";
+    gzerr << "Please specify an actuator_number.\n";
   }
 
   if (sdfClone->HasElement("max_thrust"))


### PR DESCRIPTION
## Summary
- correct the missing actuator_number error message grammar in multicopter and spacecraft actuator systems

## Testing
- `git diff --check`