### PR TITLE
docs: consolidate wording corrections

### DIFF
--- a/examples/scripts/log_video_recorder/README.md
+++ b/examples/scripts/log_video_recorder/README.md
@@ -43,8 +43,8 @@ timestamped directory where the `record_one_run.bash` is in.
     A: Make sure you have all the fuel models downloaded in ~/.gz/fuel cache
 directory
 
-1. I see `tmp_record` dir, `tmp_recording.mp4` and other left over mp4 files
-in the directory where I ran `record_one_run.bash script.
+1. I see `tmp_record` dir, `tmp_recording.mp4` and other leftover mp4 files
+in the directory where I ran the `record_one_run.bash` script.
     A: The playback and recording process is probably interrupted and the
 script did not have the chance to clean up some of these intermediate files
 

--- a/examples/scripts/websocket_server/README.md
+++ b/examples/scripts/websocket_server/README.md
@@ -19,8 +19,8 @@ gz sim -v 4 -s websocket_server.sdf
     ```
       * The `index.html` web page is a simple demo that integrates a snapshot
         version of gzweb for communicating with the local websocket server.
-        It illustrates how gzweb connects to the websocket server
-        the events that it listens to in order to create the scene. It is
+        It illustrates how gzweb connects to the websocket server and
+        which events it listens to in order to create the scene. It is
         hardcoded to connect to the `websocket_server` world and has limited
         support for materials. For a more up-to-date gzweb visualization,
         see Option 2.
@@ -31,7 +31,7 @@ gz sim -v 4 -s websocket_server.sdf
 
 # Authorization
 
-The `websocket_server` plugin accepts to authentication keys:
+The `websocket_server` plugin accepts two authentication keys:
 
 * `<authorization_key>` : If this is set, then a connection must provide the matching key using an "auth" call on the websocket.
 If the `<admin_authorization_key>` is set, then the connection can provide that key.

--- a/include/gz/sim/Conversions.hh
+++ b/include/gz/sim/Conversions.hh
@@ -742,7 +742,7 @@ namespace gz
 
     /// \brief Specialized conversion from a projector SDF object to
     /// a projector message object.
-    /// \param[in] _in Projecotr SDF object.
+    /// \param[in] _in Projector SDF object.
     /// \return Projector message.
     template<>
     sdf::Projector convert(const msgs::Projector &_in);

--- a/include/gz/sim/ServerConfig.hh
+++ b/include/gz/sim/ServerConfig.hh
@@ -161,7 +161,7 @@ namespace gz
       ///
       /// \param[in] _file Full path to an SDF file.
       /// \return True if the file was set, false if the file was not set.
-      /// The file will not be set if the provide _file string is empty.
+      /// The file will not be set if the provided _file string is empty.
       public: bool SetSdfFile(const std::string &_file);
 
       /// \brief Get the SDF file that has been set. An empty string will be
@@ -173,7 +173,7 @@ namespace gz
       ///
       /// Setting the SDF string will override any value set by `SetSdfFile`.
       ///
-      /// \param[in] _sdfString Full path to an SDF file.
+      /// \param[in] _sdfString Full contents of the SDF string.
       /// \return (reserved for future use)
       public: bool SetSdfString(const std::string &_sdfString);
 

--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -1189,8 +1189,8 @@ rendering::LightPtr SceneManager::CreateLight(Entity _id,
 
   if (this->HasEntity(_id))
   {
-    gzerr << "Light with Id: [" << _id << "] can not be create there is "
-              "another entity with the same entity number" << std::endl;
+    gzerr << "Light with Id: [" << _id << "] cannot be created because "
+              "another entity has the same entity number" << std::endl;
     return nullptr;
   }
 

--- a/src/systems/ackermann_steering/AckermannSteering.hh
+++ b/src/systems/ackermann_steering/AckermannSteering.hh
@@ -44,11 +44,11 @@ namespace systems
   /// `/model/{name_of_model}/steer_angle`. Automatically set True when
   /// `<use_actuator_msg>` is True, uses defaults topic name "/actuators".
   ///
-  /// - `<use_actuator_msg>` True to enable the use of actutor message
+  /// - `<use_actuator_msg>` True to enable the use of actuator message
   /// for steering angle command. Relies on `<actuator_number>` for the
   /// index of the position actuator and defaults to topic "/actuators".
   ///
-  /// - `<actuator_number>` used with `<use_actuator_commands>` to set
+  /// - `<actuator_number>` used with `<use_actuator_msg>` to set
   /// the index of the steering angle position actuator.
   ///
   /// - `<steer_p_gain>`: Float used to control the steering angle P gain.

--- a/src/systems/joint_position_controller/JointPositionController.hh
+++ b/src/systems/joint_position_controller/JointPositionController.hh
@@ -52,11 +52,11 @@ namespace systems
   /// - `<joint_index>` Axis of the joint to control. Optional parameter.
   /// The default value is 0.
   ///
-  /// - `<use_actuator_msg>` True to enable the use of actutor message
+  /// - `<use_actuator_msg>` True to enable the use of actuator message
   /// for position command. Relies on `<actuator_number>` for the
   /// index of the position actuator and defaults to topic "/actuators".
   ///
-  /// - `<actuator_number>` used with `<use_actuator_commands>` to set
+  /// - `<actuator_number>` used with `<use_actuator_msg>` to set
   /// the index of the position actuator.
   ///
   /// - `<p_gain>` The proportional gain of the PID. Optional parameter.

--- a/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
+++ b/src/systems/multicopter_motor_model/MulticopterMotorModel.cc
@@ -297,7 +297,7 @@ void MulticopterMotorModel::Configure(const Entity &_entity,
   }
   else
   {
-    gzerr << "Please specify a actuator_number.\n";
+    gzerr << "Please specify an actuator_number.\n";
   }
 
   if (sdfClone->HasElement("turningDirection"))

--- a/src/systems/spacecraft_thruster_model/SpacecraftThrusterModel.cc
+++ b/src/systems/spacecraft_thruster_model/SpacecraftThrusterModel.cc
@@ -167,7 +167,7 @@ void SpacecraftThrusterModel::Configure(const Entity &_entity,
   }
   else
   {
-    gzerr << "Please specify a actuator_number.\n";
+    gzerr << "Please specify an actuator_number.\n";
   }
 
   if (sdfClone->HasElement("max_thrust"))

--- a/tutorials/hpc_clusters.md
+++ b/tutorials/hpc_clusters.md
@@ -431,8 +431,6 @@ dependencies and so on. If your cluster uses e.g. the Lmod modules system, you
 can provide a part of the dependencies just by typing `module load X11`.
 If you can get this working, you would get the definitive answer to which files
 are needed inside the container. If not, you just have to guess.
-</details>
-
 **Explanation why this worked:** The list of files in `nvliblist.conf` is just
 a guess. Some might be missing, some
 [are there and shouldn't](https://github.com/apptainer/apptainer/issues/945#issuecomment-1374524681).


### PR DESCRIPTION
# Bug fix

## Summary
- Consolidate the small, non-behavior-changing documentation and diagnostic wording corrections previously split across #3762, #3768, #3769, #3770, #3771, #3772, and #3774.
- Correct malformed or inaccurate text in the HPC tutorial, script examples, conversion documentation, server configuration documentation, and actuator parameter documentation.
- Improve grammar in existing light and actuator diagnostic messages without changing control flow or runtime behavior.

Related issue: #3371

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Testing
- `git diff --check`
- Targeted old/new text assertions for all seven source changes
- DCO, package validation, Bazel, Ubuntu Noble, Ubuntu Noble GUI-disabled, Ubuntu Resolute, and Windows `gz_sim-pr-cnlwin` passed on the consolidated head

## CI notes
- `Ubuntu Resolute CI (GUI disabled)` failed in the existing `TrackedVehicleTest.PublishCmd` at `test/integration/tracked_vehicle_system.cc:366`: `poses.back().Pos().Z()` was `0.599049`, just below the `> 0.6` threshold. The consolidated diff does not touch that test, tracked-vehicle behavior, physics code, or its world files.
- Windows `gz_sim-pr-cnlwin` build 1358 passed for the consolidated head.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description (not applicable: text-only changes)
- [ ] Added tests (not applicable: documentation and diagnostic text only)
- [x] Updated documentation
- [ ] Updated migration guide (not applicable)
- [ ] Consider updating Python bindings (not applicable)
- [ ] `codecheck` passed (no separate codecheck context was reported)
- [ ] All tests passed (one unrelated integration failure remains)
- [ ] Updated Bazel files (not applicable: no files added)
- [ ] While waiting for a review on this PR, please help review another open pull request
- [x] Was GenAI used to generate this PR? The required commit attribution is included below.

Assisted-by: OpenAI Codex