### PR TITLE
doc: fix example README typos

### DIFF
--- a/examples/scripts/log_video_recorder/README.md
+++ b/examples/scripts/log_video_recorder/README.md
@@ -43,8 +43,8 @@ timestamped directory where the `record_one_run.bash` is in.
     A: Make sure you have all the fuel models downloaded in ~/.gz/fuel cache
 directory
 
-1. I see `tmp_record` dir, `tmp_recording.mp4` and other left over mp4 files
-in the directory where I ran `record_one_run.bash script.
+1. I see `tmp_record` dir, `tmp_recording.mp4` and other leftover mp4 files
+in the directory where I ran the `record_one_run.bash` script.
     A: The playback and recording process is probably interrupted and the
 script did not have the chance to clean up some of these intermediate files
 

--- a/examples/scripts/websocket_server/README.md
+++ b/examples/scripts/websocket_server/README.md
@@ -19,8 +19,8 @@ gz sim -v 4 -s websocket_server.sdf
     ```
       * The `index.html` web page is a simple demo that integrates a snapshot
         version of gzweb for communicating with the local websocket server.
-        It illustrates how gzweb connects to the websocket server
-        the events that it listens to in order to create the scene. It is
+        It illustrates how gzweb connects to the websocket server and
+        which events it listens to in order to create the scene. It is
         hardcoded to connect to the `websocket_server` world and has limited
         support for materials. For a more up-to-date gzweb visualization,
         see Option 2.
@@ -31,7 +31,7 @@ gz sim -v 4 -s websocket_server.sdf
 
 # Authorization
 
-The `websocket_server` plugin accepts to authentication keys:
+The `websocket_server` plugin accepts two authentication keys:
 
 * `<authorization_key>` : If this is set, then a connection must provide the matching key using an "auth" call on the websocket.
 If the `<admin_authorization_key>` is set, then the connection can provide that key.


### PR DESCRIPTION
## Summary
- fix wording in the websocket server example README
- close a missing inline-code backtick in the log video recorder README

## Testing
- `git diff --check`