### PR TITLE
Fix potentially uninitialized variables

### DIFF
--- a/src/gui/plugins/apply_force_torque/ApplyForceTorque.cc
+++ b/src/gui/plugins/apply_force_torque/ApplyForceTorque.cc
@@ -332,7 +332,7 @@ void ApplyForceTorque::Update(const UpdateInfo &/*_info*/,
     const std::string innerxml{"<verbose>0</verbose>"};
 
     // Get world entity
-    Entity worldEntity;
+    Entity worldEntity = kNullEntity;
     _ecm.Each<components::World, components::Name>(
       [&](const Entity &_entity,
         const components::World */*_world*/,

--- a/src/gui/plugins/mouse_drag/MouseDrag.cc
+++ b/src/gui/plugins/mouse_drag/MouseDrag.cc
@@ -344,7 +344,7 @@ void MouseDrag::Update(const UpdateInfo &_info,
     const std::string innerxml{"<verbose>0</verbose>"};
 
     // Get world entity
-    Entity worldEntity;
+    Entity worldEntity = kNullEntity;
     _ecm.Each<components::World, components::Name>(
       [&](const Entity &_entity,
         const components::World */*_world*/,

--- a/src/systems/thruster/Thruster.cc
+++ b/src/systems/thruster/Thruster.cc
@@ -653,7 +653,7 @@ void Thruster::PreUpdate(
     this->dataPtr->batteryInitialized = true;
 
     // Check that a battery exists with the specified name
-    Entity batteryEntity;
+    Entity batteryEntity = kNullEntity;
     int numBatteriesWithName = 0;
     _ecm.Each<components::BatterySoC, components::Name>(
       [&](const Entity &_entity,

--- a/test/integration/reset_detachable_joint.cc
+++ b/test/integration/reset_detachable_joint.cc
@@ -132,7 +132,7 @@ void TestPlugin::Configure(const Entity &,
                const std::shared_ptr<const sdf::Element>&,
                EntityComponentManager &_ecm, EventManager&) {
 
-  Entity simpleArmEntity;
+  Entity simpleArmEntity = kNullEntity;
 
   _ecm.Each<components::Model, components::Name>(
       [&](const Entity &_entityIt,


### PR DESCRIPTION
# 🦟 Bug fix

Surfaced in #3447 and made my CI runs there red! Ref CI run [here](https://build.osrfoundation.org/job/gz_sim-ci-pr_any-noble-amd64/2356/consoleText), example snippet:

```
[01m[K/home/jenkins/workspace/gz_sim-ci-pr_any-noble-amd64/gz-sim/test/integration/reset_detachable_joint.cc:[m[K In member function ‘[01m[Kvirtual void TestPlugin::[01;32m[KConfigure[m[K(const gz::sim::v11::Entity&, const std::shared_ptr<const sdf::v17::Element>&, gz::sim::v11::EntityComponentManager&, gz::sim::v11::EventManager&)[m[K’:
[01m[K/home/jenkins/workspace/gz_sim-ci-pr_any-noble-amd64/gz-sim/test/integration/reset_detachable_joint.cc:150:37:[m[K [01;35m[Kwarning: [m[K‘[01m[KsimpleArmEntity[m[K’ may be used uninitialized [[01;35m[K]8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wmaybe-uninitialized-Wmaybe-uninitialized]8;;[m[K]
  150 |   auto model = Model(simpleArmEntity[01;35m[K)[m[K;
      |                                     [01;35m[K^[m[K
[01m[K/home/jenkins/workspace/gz_sim-ci-pr_any-noble-amd64/gz-sim/test/integration/reset_detachable_joint.cc:135:10:[m[K [01;36m[Knote: [m[K‘[01m[KsimpleArmEntity[m[K’ was declared here
  135 |   Entity [01;36m[KsimpleArmEntity[m[K;
      |          [01;36m[K^~~~~~~~~~~~~~~[m[K
```

## Summary

The compiler in #3447 was complaining of using potentially uninitialized variables and it was generally correct, we have these instances where declare an Entity, assign a value only in an `Each` call and if _for some reason_ that `Each` call didn't match any entity we would be in undefined behavior land.
I suspect the compiler actually catches this after #3447 because it inlines the calls rather than going through the `std::function` indirection (which is also why performance is much better), but I'm not 100% sure.
This PR just initializes all to kNullEntity.

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.