### PR TITLE
Get clock cpu load

### DIFF
--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -599,9 +599,16 @@ void SimulationRunner::PublishStats()
     clockMsg.mutable_real()->set_nsec(realTimeSecNsec.second);
     clockMsg.mutable_sim()->set_sec(simTimeSecNsec.first);
     clockMsg.mutable_sim()->set_nsec(simTimeSecNsec.second);
-    clockMsg.mutable_system()->set_sec(GZ_SYSTEM_TIME_S());
+
+    auto curTime = std::chrono::system_clock::now();
+    auto seconds = std::chrono::duration_cast<std::chrono::seconds>(
+      curTime.time_since_epoch()).count();
+    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+      curTime.time_since_epoch()).count();
+    clockMsg.mutable_system()->set_sec(seconds);
     clockMsg.mutable_system()->set_nsec(
-        GZ_SYSTEM_TIME_NS() - GZ_SYSTEM_TIME_S() * GZ_SEC_TO_NANO);
+      ns - seconds * GZ_SEC_TO_NANO);
+
     this->clockPub.Publish(clockMsg);
 
     // Only publish to root topic if no others are.

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -600,7 +600,7 @@ void SimulationRunner::PublishStats()
     clockMsg.mutable_sim()->set_sec(simTimeSecNsec.first);
     clockMsg.mutable_sim()->set_nsec(simTimeSecNsec.second);
 
-    auto curTime = std::chrono::system_clock::now();
+    auto curTime = GZ_SYSTEM_TIME();
     auto seconds = std::chrono::duration_cast<std::chrono::seconds>(
       curTime.time_since_epoch()).count();
     auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(

--- a/src/systems/sensors/Sensors.cc
+++ b/src/systems/sensors/Sensors.cc
@@ -396,7 +396,7 @@ void SensorsPrivate::RunOnce()
 {
   {
     std::unique_lock<std::mutex> cvLock(this->renderMutex);
-    this->renderCv.wait_for(cvLock, std::chrono::microseconds(1000), [this]()
+    this->renderCv.wait_for(cvLock, std::chrono::milliseconds(100), [this]()
     {
       return !this->running || this->updateAvailable;
     });


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

    fix: Don't wake render thread without reason
    
    The sensor thread was awakened for no reason ever ms.
    This lead to a high cpu load on clock_gettime.

    fix: Fixed broken system timestamp
    
    The timestamp was computed from multiple calls to
    std::chrono::system_clock::now(). This was a inefficient
    and b broken in case the second flipped between calls.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [x] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.

