### PR TITLE
Fix quaternion sign-flip causing angular velocity spikes

### DIFF
--- a/src/systems/odometry_publisher/OdometryPublisher.cc
+++ b/src/systems/odometry_publisher/OdometryPublisher.cc
@@ -339,8 +339,14 @@ math::Vector3d OdometryPublisherPrivate::CalculateAngularVelocity(
 {
   // Compute the first order finite difference between current and previous
   // rotation as quaternion.
+  math::Quaterniond currentRot = _currentPose.Rot();
+  if (currentRot.Dot(_lastPose.Rot()) < 0)
+  {
+    currentRot = -currentRot;
+  }
+
   const math::Quaterniond rotationDiff =
-    _currentPose.Rot() * _lastPose.Rot().Inverse();
+    currentRot * _lastPose.Rot().Inverse();
 
   math::Vector3d rotationAxis;
   double rotationAngle;

--- a/test/regression/3830_odometry_angular_velocity_continuity.cc
+++ b/test/regression/3830_odometry_angular_velocity_continuity.cc
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include <gz/msgs/odometry.pb.h>
+
+#include <gz/common/Console.hh>
+#include <gz/common/Util.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/transport/Node.hh>
+#include <gz/utils/ExtraTestMacros.hh>
+
+#include "gz/sim/components/AngularVelocityCmd.hh"
+#include "gz/sim/components/Model.hh"
+#include "gz/sim/components/Name.hh"
+#include "gz/sim/Server.hh"
+#include "gz/sim/SystemLoader.hh"
+#include "test_config.hh"
+
+#include "../helpers/Relay.hh"
+#include "../helpers/EnvTestFixture.hh"
+
+using namespace gz;
+using namespace sim;
+using namespace std::chrono_literals;
+
+/// \brief Regression test for https://github.com/gazebosim/gz-sim/issues/3830
+/// A unit quaternion q and its negation -q represent the same rotation. When
+/// the published world pose flips between these two representations,
+/// naively differencing consecutive orientations produces a spurious
+/// near-360-degree rotation for that tick, causing a large spike in the
+/// published angular velocity even though the model is rotating at a
+/// constant rate.
+class OdometryQuaternionContinuityTest
+  : public InternalFixture<::testing::TestWithParam<int>>
+{
+};
+
+/////////////////////////////////////////////////
+TEST_P(OdometryQuaternionContinuityTest,
+       GZ_UTILS_TEST_DISABLED_ON_WIN32(AngularVelocityHasNoSpikes))
+{
+  ServerConfig serverConfig;
+  serverConfig.SetSdfFile(gz::common::joinPaths(PROJECT_SOURCE_PATH,
+      "test", "worlds", "odometry_publisher.sdf"));
+
+  Server server(serverConfig);
+  EXPECT_FALSE(server.Running());
+  EXPECT_FALSE(*server.Running(0));
+
+  std::vector<math::Vector3d> odomAngVels;
+  std::function<void(const msgs::Odometry &)> odomCb =
+    [&](const msgs::Odometry &_msg)
+    {
+      odomAngVels.push_back(msgs::Convert(_msg.twist().angular()));
+    };
+  transport::Node node;
+  node.Subscribe("/model/vehicle/odometry", odomCb);
+
+  // Command a constant yaw rate. A rotation held long enough to sweep
+  // through several full turns will cross the quaternion sign-flip point
+  // multiple times, which is what triggers the bug.
+  test::Relay velocityRamp;
+  math::Vector3d angVelCmd(0.0, 0.0, 1.0);
+  velocityRamp.OnPreUpdate(
+      [&](const sim::UpdateInfo &, sim::EntityComponentManager &_ecm)
+      {
+        auto en = _ecm.EntityByComponents(
+          components::Model(),
+          components::Name("vehicle"));
+        EXPECT_NE(kNullEntity, en);
+
+        auto angVelCmdComp =
+          _ecm.Component<components::AngularVelocityCmd>(en);
+        if (!angVelCmdComp)
+        {
+          _ecm.CreateComponent(en,
+              components::AngularVelocityCmd(angVelCmd));
+        }
+        else
+        {
+          angVelCmdComp->Data() = angVelCmd;
+        }
+      });
+  server.AddSystem(velocityRamp.systemPtr);
+
+  // Run long enough to complete several full rotations at 1 rad/s.
+  server.Run(true, 6000, false);
+
+  int sleep = 0;
+  int maxSleep = 30;
+  for (; odomAngVels.size() < 200 && sleep < maxSleep; ++sleep)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  ASSERT_NE(maxSleep, sleep);
+  ASSERT_FALSE(odomAngVels.empty());
+
+  // Every reported yaw rate should stay close to the commanded 1 rad/s.
+  // Before the fix, a quaternion sign flip produces an angular velocity
+  // spike close to 2*pi divided by one publish period, orders of magnitude
+  // above the commanded rate.
+  for (const auto &angVel : odomAngVels)
+  {
+    EXPECT_NEAR(angVel.Z(), angVelCmd.Z(), 0.5)
+        << "Detected an angular velocity spike, likely from a "
+        << "non-continuous orientation quaternion.";
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(ServerRepeat, OdometryQuaternionContinuityTest,
+    ::testing::Range(1, 2));

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_TYPE "REGRESSION")
 
 set(tests
+  3830_odometry_angular_velocity_continuity.cc
 )
 
 link_directories(${PROJECT_BINARY_DIR}/test)


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #3830

## Summary
A unit quaternion q and its negation -q represent the same rotation. The
world pose published by OdometryPublisher can flip between these two
representations from one timestep to the next with no actual change in
orientation. `CalculateAngularVelocity` differenced consecutive poses
without accounting for this, so a sign flip produced a spurious ~360
degree rotation for that tick — causing large spikes in the published
angular velocity even during constant-rate rotation.

Fix: enforce that the current orientation quaternion lies in the same
hemisphere as the previous one (via dot product sign) before
differencing.

Reproduced and verified on gz-sim8 (Harmonic, 8.11.0). Added a
regression test that fails on unpatched code (~627 rad/s spike from a
commanded 1 rad/s) and passes with the fix.

This is my first contribution to Gazebo, so any guidance on style,
scope, or process is appreciated!

(Note: superseding #3831, which targeted gz-sim8 by mistake, this PR
is rebased cleanly onto main per current policy.)

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Claude (Anthropic)