### PR TITLE
Fix sensors.sdf example world

### DIFF
--- a/examples/worlds/sensors.sdf
+++ b/examples/worlds/sensors.sdf
@@ -210,9 +210,7 @@
     </model>
 
     <model name="force_torque_demo">
-      <link name="base_plate">
-        <static>true</static>
-      </link>
+      <link name="base_plate"/>
 
       <link name="link_1">
         <pose> 0 0 2.0 0 0 0</pose>

--- a/examples/worlds/sensors.sdf
+++ b/examples/worlds/sensors.sdf
@@ -24,6 +24,10 @@
       name="gz::sim::systems::AirPressure">
     </plugin>
     <plugin
+      filename="gz-sim-air-speed-system"
+      name="gz::sim::systems::AirSpeed">
+    </plugin>
+    <plugin
       filename="gz-sim-altimeter-system"
       name="gz::sim::systems::Altimeter">
     </plugin>
@@ -157,7 +161,7 @@
           <always_on>1</always_on>
           <update_rate>30</update_rate>
           <visualize>true</visualize>
-          <topic>air_pressure</topic>
+          <topic>air_speed</topic>
           <enable_metrics>true</enable_metrics>
           <air_speed>
             <pressure>


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

While looking through the example worlds for #3846 (A)I noticed that the sensors.sdf did not include the plugin for air speed and the topic name was set to air_pressure so I changed that in here.

Also, there were warnings that appeared because there was a `static` field in the sensors.sdf that is "not defined in SDF" (?) so I also removed that.

```shell
Warning [Utils.cc:132] [/sdf/world[@name="sensors"]/model[@name="force_torque_demo"]/link[@name="base_plate"]/static:/Users/cheriehu/rotary_gz11_ws/src/gz-sim/examples/worlds/sensors.sdf:L214]: XML Element[static], child of element[link], not defined in SDF. Copying[static] as children of [link].
Warning [Utils.cc:132] [/sdf/world[@name="sensors"]/model[@name="force_torque_demo"]/link[@name="base_plate"]/static:/Users/cheriehu/rotary_gz11_ws/src/gz-sim/examples/worlds/sensors.sdf:L214]: XML Element[static], child of element[link], not defined in SDF. Copying[static] as children of [link].
Warning [Utils.cc:132] [/sdf/model[@name="force_torque_demo"]/link[@name="base_plate"]/static:<data-string>:L3]: XML Element[static], child of element[link], not defined in SDF. Copying[static] as children of [link].
Warning [Utils.cc:132] [/sdf/model[@name="force_torque_demo"]/link[@name="base_plate"]/static:<data-string>:L3]: XML Element[static], child of element[link], not defined in SDF. Copying[static] as children of [link].
```

## Testing it
1. `gz sim -r c/gz-sim/examples/worlds/sensors.sdf`
2. Check that both the `/air_speed` and the `/air_pressure` topics have publishers
```
$ gz topic -i -t /air_pressure
Publishers [Address, Message Type]:
  tcp://10.190.241.6:50567, gz.msgs.FluidPressure
No subscribers on topic [/air_pressure]

$ gz topic -i -t /air_speed
Publishers [Address, Message Type]:
  tcp://10.190.241.6:50567, gz.msgs.AirSpeed
No subscribers on topic [/air_speed]
```
3. Also verify that there are no warnings printed when you launch that world in gz sim

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [X] This is safe to backport to the following versions:
    - [X] Jetty
    - [X] Ionic
    - [X] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [X] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [X] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Gemini 3.1 Pro

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
