### PR TITLE
Build display-dependent tests without running them

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,26 +141,15 @@ set(tests_needing_display
   Server_Rendering_TEST.cc
 )
 
-# Add systems that need a valid display here.
-# \todo(anyone) Find a way to run these tests with a virtual display such Xvfb
-# or Xdummy instead of skipping them
-if(VALID_DISPLAY AND VALID_DRI_DISPLAY)
-  list(APPEND gtest_sources ${tests_needing_display})
-else()
-  message(STATUS
-    "Skipping these UNIT tests because a valid display was not found:")
-  foreach(test ${tests_needing_display})
-    message(STATUS " ${test}")
-  endforeach(test)
-endif()
-
 if (MSVC)
   # Warning #4251 is the "dll-interface" warning that tells you when types used
   # by a class are not being exported. These generated source files have private
   # members that don't get exported, so they trigger this warning. However, the
   # warning is not important since those members do not need to be interfaced
   # with.
-  set_source_files_properties(${sources} ${gtest_sources} COMPILE_FLAGS "/wd4251 /wd4146")
+  set_source_files_properties(
+    ${sources} ${gtest_sources} ${tests_needing_display}
+    COMPILE_FLAGS "/wd4251 /wd4146")
 endif()
 
 # Create the library target
@@ -236,6 +225,30 @@ gz_build_tests(TYPE UNIT
   ENVIRONMENT
     GZ_SIM_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
 )
+
+gz_build_tests(TYPE UNIT
+  SOURCES
+    ${tests_needing_display}
+  TEST_LIST display_test_targets
+  LIB_DEPS
+    ${PROJECT_LIBRARY_TARGET_NAME}
+    ${EXTRA_TEST_LIB_DEPS}
+    gz-sim
+  ENVIRONMENT
+    GZ_SIM_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+)
+
+if(BUILD_TESTING AND (NOT VALID_DISPLAY OR NOT VALID_DRI_DISPLAY))
+  message(STATUS
+    "Disabling these UNIT tests because a valid display was not found:")
+  foreach(test_target ${display_test_targets})
+    message(STATUS " ${test_target}")
+    set_tests_properties(${test_target} PROPERTIES DISABLED TRUE)
+    if(TEST check_${test_target})
+      set_tests_properties(check_${test_target} PROPERTIES DISABLED TRUE)
+    endif()
+  endforeach()
+endif()
 
 # Some server unit tests require rendering.
 if (TARGET UNIT_Server_Rendering_TEST)

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -79,15 +79,7 @@ endif()
 # Build the unit tests.
 set(test_sources gz_TEST.cc)
 
-# Add systems that need a valid display here.
-# \todo(anyone) Find a way to run these tests with a virtual display such Xvfb
-# or Xdummy instead of skipping them
-if(VALID_DISPLAY AND VALID_DRI_DISPLAY)
-  list(APPEND test_sources ModelCommandAPI_TEST.cc)
-else()
-  message(STATUS
-    "Skipping ModelCommandAPI tests because a valid display was not found")
-endif()
+set(tests_needing_display ModelCommandAPI_TEST.cc)
 
 # Build unit tests if Gazebo tools is installed
 if(BUILD_TESTING AND GZ_TOOLS_PROGRAM)
@@ -100,6 +92,29 @@ if(BUILD_TESTING AND GZ_TOOLS_PROGRAM)
     ENVIRONMENT
         GZ_SIM_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
   )
+
+  gz_build_tests(TYPE UNIT
+    SOURCES
+      ${tests_needing_display}
+    TEST_LIST display_test_targets
+    LIB_DEPS
+      gz-utils::gz-utils
+      ${PROJECT_LIBRARY_TARGET_NAME}
+    ENVIRONMENT
+        GZ_SIM_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+  )
+
+  if(NOT VALID_DISPLAY OR NOT VALID_DRI_DISPLAY)
+    message(STATUS
+      "Disabling these UNIT tests because a valid display was not found:")
+    foreach(test_target ${display_test_targets})
+      message(STATUS " ${test_target}")
+      set_tests_properties(${test_target} PROPERTIES DISABLED TRUE)
+      if(TEST check_${test_target})
+        set_tests_properties(check_${test_target} PROPERTIES DISABLED TRUE)
+      endif()
+    endforeach()
+  endif()
 endif()
 
 foreach(CMD_TEST

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -143,19 +143,6 @@ if (MSVC OR NOT GZ_TOOLS_PROGRAM)
   list(REMOVE_ITEM tests log_system.cc)
 endif()
 
-# Add systems that need a valid display here.
-# \todo(anyone) Find a way to run these tests with a virtual display such Xvfb
-# or Xdummy instead of skipping them
-if(VALID_DISPLAY AND VALID_DRI_DISPLAY)
-  list(APPEND tests ${tests_needing_display})
-else()
-  message(STATUS
-    "Skipping these INTEGRATION tests because a valid display was not found:")
-  foreach(test ${tests_needing_display})
-    message(STATUS " ${test}")
-  endforeach(test)
-endif()
-
 # Add tests that need pybind11
 if (${pybind11_FOUND})
   list(APPEND tests python_system_loader.cc)
@@ -167,7 +154,9 @@ if (MSVC)
   # members that don't get exported, so they trigger this warning. However, the
   # warning is not important since those members do not need to be interfaced
   # with.
-  set_source_files_properties(${tests} COMPILE_FLAGS "/wd4251 /wd4146")
+  set_source_files_properties(
+    ${tests} ${tests_needing_display}
+    COMPILE_FLAGS "/wd4251 /wd4146")
 endif()
 
 link_directories(${PROJECT_BINARY_DIR}/test)
@@ -183,6 +172,30 @@ gz_build_tests(TYPE INTEGRATION
     GZ_SIM_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
     GZ_IP=127.0.0.1
 )
+
+gz_build_tests(TYPE INTEGRATION
+  SOURCES
+    ${tests_needing_display}
+  TEST_LIST display_test_targets
+  LIB_DEPS
+    ${EXTRA_TEST_LIB_DEPS}
+    ${PROJECT_LIBRARY_TARGET_NAME}-rendering
+  ENVIRONMENT
+    GZ_SIM_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+    GZ_IP=127.0.0.1
+)
+
+if(BUILD_TESTING AND (NOT VALID_DISPLAY OR NOT VALID_DRI_DISPLAY))
+  message(STATUS
+    "Disabling these INTEGRATION tests because a valid display was not found:")
+  foreach(test_target ${display_test_targets})
+    message(STATUS " ${test_target}")
+    set_tests_properties(${test_target} PROPERTIES DISABLED TRUE)
+    if(TEST check_${test_target})
+      set_tests_properties(check_${test_target} PROPERTIES DISABLED TRUE)
+    endif()
+  endforeach()
+endif()
 
 
 # For INTEGRATION_physics_system, we need to check what version of DART is
@@ -284,10 +297,13 @@ if(TARGET INTEGRATION_examples_build)
   set_tests_properties(INTEGRATION_examples_build PROPERTIES TIMEOUT 320)
 endif()
 
-if(VALID_DISPLAY AND VALID_DRI_DISPLAY AND TARGET INTEGRATION_sensors_system)
+if(TARGET INTEGRATION_sensors_system)
   target_link_libraries(INTEGRATION_sensors_system
     gz-rendering::gz-rendering
   )
+endif()
+
+if(TARGET INTEGRATION_actor_trajectory)
   target_link_libraries(INTEGRATION_actor_trajectory
     gz-rendering::gz-rendering
   )

--- a/test/performance/CMakeLists.txt
+++ b/test/performance/CMakeLists.txt
@@ -9,17 +9,6 @@ set(tests_needing_display
   sensors_system.cc
 )
 
-# Add systems that need a valid display here.
-if(VALID_DISPLAY AND VALID_DRI_DISPLAY)
-  list(APPEND tests ${tests_needing_display})
-else()
-  message(STATUS
-    "Skipping these PERFORMANCE tests because a valid display was not found:")
-  foreach(test ${tests_needing_display})
-    message(STATUS " ${test}")
-  endforeach(test)
-endif()
-
 set(exec
   sdf_runner
 )
@@ -32,7 +21,9 @@ if (MSVC)
   # members that don't get exported, so they trigger this warning. However, the
   # warning is not important since those members do not need to be interfaced
   # with.
-  set_source_files_properties(${tests} COMPILE_FLAGS "/wd4251 /wd4146")
+  set_source_files_properties(
+    ${tests} ${tests_needing_display}
+    COMPILE_FLAGS "/wd4251 /wd4146")
   set_source_files_properties(${exec}.cc COMPILE_FLAGS "/wd4251 /wd4146")
 endif()
 
@@ -45,6 +36,28 @@ gz_build_tests(TYPE PERFORMANCE
     GZ_SIM_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
 )
 
+gz_build_tests(TYPE PERFORMANCE
+  SOURCES
+    ${tests_needing_display}
+  TEST_LIST display_test_targets
+  LIB_DEPS
+    ${EXTRA_TEST_LIB_DEPS}
+  ENVIRONMENT
+    GZ_SIM_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+)
+
+if(BUILD_TESTING AND (NOT VALID_DISPLAY OR NOT VALID_DRI_DISPLAY))
+  message(STATUS
+    "Disabling these PERFORMANCE tests because a valid display was not found:")
+  foreach(test_target ${display_test_targets})
+    message(STATUS " ${test_target}")
+    set_tests_properties(${test_target} PROPERTIES DISABLED TRUE)
+    if(TEST check_${test_target})
+      set_tests_properties(check_${test_target} PROPERTIES DISABLED TRUE)
+    endif()
+  endforeach()
+endif()
+
 add_executable(
   PERFORMANCE_${exec}
   ${exec}.cc
@@ -56,7 +69,7 @@ target_link_libraries(
     gz-sim
 )
 
-if(VALID_DISPLAY AND VALID_DRI_DISPLAY AND TARGET PERFORMANCE_sensors_system)
+if(TARGET PERFORMANCE_sensors_system)
   target_link_libraries(PERFORMANCE_sensors_system
     gz-rendering::gz-rendering
   )


### PR DESCRIPTION
# 🎉 New feature

Closes #3496

## Summary

Display-dependent unit, command, integration, and performance tests are now
always registered and compiled. When CMake cannot find a valid display or DRI
display, CTest disables both each generated test and its `check_` companion.
This lets headless and macOS CI catch compile regressions without attempting to
run rendering tests or validate result files that were never produced.

The existing rendering links and MSVC compile flags now also apply when these
tests are built on a machine without a display.

Some portions of this pull request were generated using OpenAI Codex (GPT-5).

## Backport Policy

- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [x] I am not sure
- [ ] Other (fill in yourself)

## Test it

Configure on a machine without a display:

```sh
unset DISPLAY WAYLAND_DISPLAY
cmake -S . -B build -DBUILD_TESTING=ON -DSKIP_PYBIND11=ON
cmake --build build
ctest --test-dir build -N
```

The display-dependent executables should be built, while their runtime tests
and `check_` companion tests should be listed as disabled.

Locally validated on macOS against the Rotary dependency stack:

- all 28 display-dependent executables compiled and linked
- all 56 runtime and result-check CTest entries were disabled
- `codecheck` completed successfully

## Checklist

- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature (not applicable: build-system-only change)
- [x] Added tests (existing display-dependent tests now cover headless compilation)
- [ ] Added example and/or tutorial (not applicable)
- [ ] Updated documentation (not applicable)
- [ ] Updated migration guide (not applicable)
- [ ] Consider updating Python bindings (not applicable)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage)) (targeted build and CTest validation passed; full matrix is delegated to CI)
- [x] Updated Bazel files (if adding new files). Created an issue otherwise. (not applicable: no files added)
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: OpenAI Codex (GPT-5)
Generated-by: OpenAI Codex (GPT-5)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
