### PR TITLE
[flaky test] Fix lost stop request when Server teardown races SimulationRunner startup

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1601,6 +1601,7 @@ gz_sim_system_libraries(
         "@com_google_protobuf//:protobuf_lite",
         "@gz-common//profiler",
         "@gz-math",
+        "@gz-msgs",
         "@gz-msgs//:gzmsgs_cc_proto",
         "@gz-plugin//:register",
         "@gz-transport",

--- a/examples/worlds/sensors.sdf
+++ b/examples/worlds/sensors.sdf
@@ -24,6 +24,10 @@
       name="gz::sim::systems::AirPressure">
     </plugin>
     <plugin
+      filename="gz-sim-air-speed-system"
+      name="gz::sim::systems::AirSpeed">
+    </plugin>
+    <plugin
       filename="gz-sim-altimeter-system"
       name="gz::sim::systems::Altimeter">
     </plugin>
@@ -157,7 +161,7 @@
           <always_on>1</always_on>
           <update_rate>30</update_rate>
           <visualize>true</visualize>
-          <topic>air_pressure</topic>
+          <topic>air_speed</topic>
           <enable_metrics>true</enable_metrics>
           <air_speed>
             <pressure>
@@ -206,9 +210,7 @@
     </model>
 
     <model name="force_torque_demo">
-      <link name="base_plate">
-        <static>true</static>
-      </link>
+      <link name="base_plate"/>
 
       <link name="link_1">
         <pose> 0 0 2.0 0 0 0</pose>

--- a/include/gz/sim/Server.hh
+++ b/include/gz/sim/Server.hh
@@ -350,6 +350,9 @@ namespace gz
                                       const unsigned int _worldIndex = 0);
 
       /// \brief Stop the server. This will stop all running simulations.
+      /// \note Stopping is permanent for this Server instance: subsequent
+      /// calls to Run() and RunOnce() return without stepping simulation and
+      /// report failure. Construct a new Server to run again.
       public: void Stop();
 
       /// \brief Reset all runners in this simulation

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <mutex>
 #include <ostream>
 #include <unordered_set>
 #ifdef HAVE_PYBIND11
@@ -777,6 +778,7 @@ void SimulationRunner::Stop()
 /////////////////////////////////////////////////
 void SimulationRunner::OnStop()
 {
+  std::lock_guard<std::mutex> lock(this->runStateMutex);
   this->stopReceived = true;
   this->running = false;
 }
@@ -841,7 +843,20 @@ bool SimulationRunner::Run(const uint64_t _iterations)
   if (!this->currentInfo.paused)
     this->realTimeWatch.Start();
 
-  this->running = true;
+  // A stop request may arrive while this thread is still starting up, e.g.
+  // the Server being destroyed right after a non-blocking Run(). Checking
+  // `stopReceived` and setting `running` under runStateMutex keeps such a
+  // stop from being overwritten (issues #2609 and #3829).
+  {
+    std::lock_guard<std::mutex> lock(this->runStateMutex);
+    if (this->stopReceived)
+    {
+      gzdbg << "SimulationRunner::Run: a stop request arrived before the run "
+            << "loop started; no iterations will be executed." << std::endl;
+      return false;
+    }
+    this->running = true;
+  }
 
   // Create the world statistics publisher.
   if (!this->statsPub.Valid())
@@ -931,7 +946,7 @@ bool SimulationRunner::Run(const uint64_t _iterations)
   if (_iterations > 0)
   {
     bool created = this->entitiesCreated;
-    while(!created && this->running)
+    while (!created && this->running)
     {
       {
         std::unique_lock<std::mutex> createLock(this->assetCreationMutex);
@@ -1083,7 +1098,10 @@ bool SimulationRunner::Run(const uint64_t _iterations)
     }
   }
 
-  this->running = false;
+  {
+    std::lock_guard<std::mutex> lock(this->runStateMutex);
+    this->running = false;
+  }
 
   return true;
 }

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -30,6 +30,7 @@
 #include <functional>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <set>
 #include <string>
@@ -425,11 +426,18 @@ namespace gz
       private: void ProcessNewWorldControlState();
 
       /// \brief This is used to indicate that a stop event has been received.
+      /// The latch is monotonic — nothing ever clears it — so stopping is
+      /// permanent: once set, Run() returns immediately without stepping.
       private: std::atomic<bool> stopReceived{false};
 
       /// \brief This is used to indicate that Run has been called, and the
       /// server is in the run state.
       private: std::atomic<bool> running{false};
+
+      /// \brief Guards every write to `running` and `stopReceived`, making
+      /// Run()'s startup check-then-set atomic with respect to OnStop() so a
+      /// racing stop request cannot be overwritten. Reads stay lock-free.
+      private: std::mutex runStateMutex;
 
       /// \brief Manager of all systems.
       /// Note: must be before EntityComponentManager

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -18,6 +18,10 @@
 #include <gtest/gtest.h>
 #include <tinyxml2.h>
 
+#include <atomic>
+#include <chrono>
+#include <thread>
+
 #include <gz/msgs/clock.pb.h>
 #include <gz/msgs/gui.pb.h>
 #include <gz/msgs/sdf_generator_config.pb.h>
@@ -1733,6 +1737,56 @@ TEST_P(SimulationRunnerTest, ParallelPostUpdatesPolicy)
 
     EXPECT_FALSE(runner.ParallelPostUpdates());
   }
+}
+
+/////////////////////////////////////////////////
+// A stop request arriving before Run() starts executing must not be lost,
+// otherwise Run() loops forever and Server's destructor blocks joining the
+// run thread (issues #2609 and #3829).
+TEST_P(SimulationRunnerTest, StopBeforeRun)
+{
+  // Load SDF file
+  sdf::Root root;
+  root.Load(common::joinPaths(PROJECT_SOURCE_PATH,
+      "test", "worlds", "shapes.sdf"));
+
+  ASSERT_EQ(1u, root.WorldCount());
+
+  // Create simulation runner
+  auto systemLoader = std::make_shared<SystemLoader>();
+  SimulationRunner runner(*root.WorldByIndex(0), systemLoader);
+
+  // Emit the stop request before Run, mimicking Server teardown racing the
+  // run thread's startup.
+  runner.Stop();
+
+  std::atomic<bool> returned{false};
+  std::atomic<bool> runResult{true};
+  std::thread runThread([&]()
+  {
+    // Run indefinitely: with the stop request lost this never returns.
+    runResult = runner.Run(0);
+    returned = true;
+  });
+
+  // Bound the wait at 10s so a regression fails fast instead of hanging.
+  for (int sleep = 0; sleep < 100 && !returned; ++sleep)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  EXPECT_TRUE(returned);
+
+  // On regression the runner is spinning in the run loop; a second stop lets
+  // it exit so join() returns and the test fails instead of hanging.
+  if (!returned)
+    runner.Stop();
+  runThread.join();
+
+  // The stop must prevent any stepping and be reported as failure.
+  EXPECT_FALSE(runResult);
+  EXPECT_FALSE(runner.Running());
+  EXPECT_TRUE(runner.StopReceived());
+  EXPECT_EQ(0u, runner.IterationCount());
 }
 
 // Run multiple times. We want to make sure that static globals don't cause

--- a/src/systems/led_plugin/LedPlugin.hh
+++ b/src/systems/led_plugin/LedPlugin.hh
@@ -47,7 +47,7 @@ namespace systems
   ///
   /// ## System Parameters:
   ///
-  /// \code{.xml}
+  /// ```xml
   /// <plugin
   ///   filename="gz-sim-led-plugin-system"
   ///   name="gz::sim::systems::LedPlugin">
@@ -96,12 +96,10 @@ namespace systems
   ///     </step>
   ///   </mode>
   ///   <mode name="mode_name3">
-  ///   .
-  ///   .
-  ///   .
+  ///     <!-- Additional mode configuration omitted. -->
   ///   </mode>
   /// </plugin>
-  /// \endcode
+  /// ```
 
   class LedPlugin:
     public System,

--- a/src/systems/scene_broadcaster/SceneBroadcaster.cc
+++ b/src/systems/scene_broadcaster/SceneBroadcaster.cc
@@ -34,6 +34,7 @@
 #include <gz/msgs/sensor_noise.pb.h>
 #include <gz/msgs/serialized_map.pb.h>
 #include <gz/msgs/stringmsg.pb.h>
+#include <gz/msgs/Utility.hh>
 #include <gz/msgs/uint32_v.pb.h>
 #include <gz/msgs/visual.pb.h>
 
@@ -1264,8 +1265,8 @@ void SceneBroadcasterPrivate::AddModels(T *_msg, const Entity _entity,
 {
   for (const auto &vertex : _graph.AdjacentsFrom(_entity))
   {
-    auto modelMsg = std::dynamic_pointer_cast<msgs::Model>(
-        vertex.second.get().Data());
+    auto modelMsg =
+        gz::msgs::DoDynamicCastMessage<msgs::Model>(vertex.second.get().Data());
     if (!modelMsg)
       continue;
 
@@ -1290,8 +1291,8 @@ void SceneBroadcasterPrivate::AddLights(T *_msg, const Entity _entity,
 
   for (const auto &vertex : _graph.AdjacentsFrom(_entity))
   {
-    auto lightMsg = std::dynamic_pointer_cast<msgs::Light>(
-        vertex.second.get().Data());
+    auto lightMsg =
+        gz::msgs::DoDynamicCastMessage<msgs::Light>(vertex.second.get().Data());
     if (!lightMsg)
       continue;
 
@@ -1308,7 +1309,7 @@ void SceneBroadcasterPrivate::AddVisuals(msgs::Link *_msg, const Entity _entity,
 
   for (const auto &vertex : _graph.AdjacentsFrom(_entity))
   {
-    auto visualMsg = std::dynamic_pointer_cast<msgs::Visual>(
+    auto visualMsg = gz::msgs::DoDynamicCastMessage<msgs::Visual>(
         vertex.second.get().Data());
     if (!visualMsg)
       continue;
@@ -1326,7 +1327,7 @@ void SceneBroadcasterPrivate::AddSensors(msgs::Link *_msg, const Entity _entity,
 
   for (const auto &vertex : _graph.AdjacentsFrom(_entity))
   {
-    auto sensorMsg = std::dynamic_pointer_cast<msgs::Sensor>(
+    auto sensorMsg = gz::msgs::DoDynamicCastMessage<msgs::Sensor>(
         vertex.second.get().Data());
     if (!sensorMsg)
       continue;
@@ -1344,7 +1345,7 @@ void SceneBroadcasterPrivate::AddParticleEmitters(msgs::Link *_msg,
 
   for (const auto &vertex : _graph.AdjacentsFrom(_entity))
   {
-    auto emitterMsg = std::dynamic_pointer_cast<msgs::ParticleEmitter>(
+    auto emitterMsg = gz::msgs::DoDynamicCastMessage<msgs::ParticleEmitter>(
         vertex.second.get().Data());
     if (!emitterMsg)
       continue;
@@ -1362,7 +1363,7 @@ void SceneBroadcasterPrivate::AddProjectors(msgs::Link *_msg,
 
   for (const auto &vertex : _graph.AdjacentsFrom(_entity))
   {
-    auto projectorMsg = std::dynamic_pointer_cast<msgs::Projector>(
+    auto projectorMsg = gz::msgs::DoDynamicCastMessage<msgs::Projector>(
         vertex.second.get().Data());
     if (!projectorMsg)
       continue;
@@ -1380,8 +1381,8 @@ void SceneBroadcasterPrivate::AddLinks(msgs::Model *_msg, const Entity _entity,
 
   for (const auto &vertex : _graph.AdjacentsFrom(_entity))
   {
-    auto linkMsg = std::dynamic_pointer_cast<msgs::Link>(
-        vertex.second.get().Data());
+    auto linkMsg =
+        gz::msgs::DoDynamicCastMessage<msgs::Link>(vertex.second.get().Data());
     if (!linkMsg)
       continue;
 

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -829,7 +829,8 @@ CreateCommand::CreateCommand(msgs::EntityFactory_V *_msg,
 //////////////////////////////////////////////////
 bool CreateCommand::Execute()
 {
-  auto createMsg = dynamic_cast<const msgs::EntityFactory *>(this->msg);
+  auto createMsg =
+      gz::msgs::DoDynamicCastMessage<msgs::EntityFactory>(this->msg);
   if (nullptr != createMsg)
   {
     return this->CreateFromMsg(*createMsg);
@@ -837,7 +838,8 @@ bool CreateCommand::Execute()
   else
   {
     // It could also be an EntityFactory_V
-    auto createMsgV = dynamic_cast<const msgs::EntityFactory_V *>(this->msg);
+    auto createMsgV =
+        gz::msgs::DoDynamicCastMessage<msgs::EntityFactory_V>(this->msg);
     if (nullptr != createMsgV)
     {
       bool result = true;
@@ -1126,7 +1128,7 @@ RemoveCommand::RemoveCommand(msgs::Entity *_msg,
 //////////////////////////////////////////////////
 bool RemoveCommand::Execute()
 {
-  auto removeMsg = dynamic_cast<const msgs::Entity *>(this->msg);
+  auto removeMsg = gz::msgs::DoDynamicCastMessage<msgs::Entity>(this->msg);
   if (nullptr == removeMsg)
   {
     gzerr << "Internal error, null remove message" << std::endl;
@@ -1175,7 +1177,7 @@ LightCommand::LightCommand(msgs::Light *_msg,
 //////////////////////////////////////////////////
 bool LightCommand::Execute()
 {
-  auto lightMsg = dynamic_cast<msgs::Light *>(this->msg);
+  auto lightMsg = gz::msgs::DoDynamicCastMessage<msgs::Light>(this->msg);
   if (nullptr == lightMsg)
   {
     gzerr << "Internal error, null light message" << std::endl;
@@ -1369,7 +1371,7 @@ PoseCommand::PoseCommand(msgs::Pose *_msg,
 //////////////////////////////////////////////////
 bool PoseCommand::Execute()
 {
-  auto poseMsg = dynamic_cast<const msgs::Pose *>(this->msg);
+  auto poseMsg = gz::msgs::DoDynamicCastMessage<msgs::Pose>(this->msg);
   if (nullptr == poseMsg)
   {
     gzerr << "Internal error, null create message" << std::endl;
@@ -1389,7 +1391,7 @@ PoseVectorCommand::PoseVectorCommand(msgs::Pose_V *_msg,
 //////////////////////////////////////////////////
 bool PoseVectorCommand::Execute()
 {
-  auto poseVectorMsg = dynamic_cast<const msgs::Pose_V *>(this->msg);
+  auto poseVectorMsg = gz::msgs::DoDynamicCastMessage<msgs::Pose_V>(this->msg);
   if (nullptr == poseVectorMsg)
   {
     gzerr << "Internal error, null create message" << std::endl;
@@ -1417,7 +1419,7 @@ PhysicsCommand::PhysicsCommand(msgs::Physics *_msg,
 //////////////////////////////////////////////////
 bool PhysicsCommand::Execute()
 {
-  auto physicsMsg = dynamic_cast<const msgs::Physics *>(this->msg);
+  auto physicsMsg = gz::msgs::DoDynamicCastMessage<msgs::Physics>(this->msg);
   if (nullptr == physicsMsg)
   {
     gzerr << "Internal error, null physics message" << std::endl;
@@ -1453,7 +1455,7 @@ SphericalCoordinatesCommand::SphericalCoordinatesCommand(
 bool SphericalCoordinatesCommand::Execute()
 {
   auto sphericalCoordinatesMsg =
-      dynamic_cast<const msgs::SphericalCoordinates *>(this->msg);
+      gz::msgs::DoDynamicCastMessage<msgs::SphericalCoordinates>(this->msg);
   if (nullptr == sphericalCoordinatesMsg)
   {
     gzerr << "Internal error, null SphericalCoordinates message" << std::endl;
@@ -1536,7 +1538,7 @@ EnableCollisionCommand::EnableCollisionCommand(msgs::Entity *_msg,
 //////////////////////////////////////////////////
 bool EnableCollisionCommand::Execute()
 {
-  auto entityMsg = dynamic_cast<const msgs::Entity *>(this->msg);
+  auto entityMsg = gz::msgs::DoDynamicCastMessage<msgs::Entity>(this->msg);
   if (nullptr == entityMsg)
   {
     gzerr << "Internal error, null create message" << std::endl;
@@ -1586,7 +1588,7 @@ DisableCollisionCommand::DisableCollisionCommand(msgs::Entity *_msg,
 //////////////////////////////////////////////////
 bool DisableCollisionCommand::Execute()
 {
-  auto entityMsg = dynamic_cast<const msgs::Entity *>(this->msg);
+  auto entityMsg = gz::msgs::DoDynamicCastMessage<msgs::Entity>(this->msg);
   if (nullptr == entityMsg)
   {
     gzerr << "Internal error, null create message" << std::endl;
@@ -1645,8 +1647,9 @@ VisualCommand::VisualCommand(msgs::MaterialColor *_msg,
 //////////////////////////////////////////////////
 bool VisualCommand::Execute()
 {
-  auto visualMsg = dynamic_cast<const msgs::Visual *>(this->msg);
-  auto materialColorMsg = dynamic_cast<const msgs::MaterialColor *>(this->msg);
+  auto visualMsg = gz::msgs::DoDynamicCastMessage<msgs::Visual>(this->msg);
+  auto materialColorMsg =
+      gz::msgs::DoDynamicCastMessage<msgs::MaterialColor>(this->msg);
   if (visualMsg != nullptr)
   {
     Entity visualEntity = kNullEntity;
@@ -1771,8 +1774,8 @@ WheelSlipCommand::WheelSlipCommand(msgs::WheelSlipParametersCmd *_msg,
 //////////////////////////////////////////////////
 bool WheelSlipCommand::Execute()
 {
-  auto wheelSlipMsg = dynamic_cast<const msgs::WheelSlipParametersCmd *>(
-      this->msg);
+  auto wheelSlipMsg =
+      gz::msgs::DoDynamicCastMessage<msgs::WheelSlipParametersCmd>(this->msg);
   if (nullptr == wheelSlipMsg)
   {
     gzerr << "Internal error, null wheel slip message" << std::endl;


### PR DESCRIPTION
# 🦟 Bug fix

Part of gazebosim/gz-sim#3829


## Summary

A stop request emitted while SimulationRunner::Run was still starting up (e.g. Server destroyed right after a non-blocking Run) was overwritten by the unconditional 'running = true' assignment, so the run loop never terminated and ServerPrivate's destructor blocked forever joining the run thread. This is the cause of the long-standing UNIT_Server_TEST timeout flakiness (ServerConfigSensorPlugin and siblings): the test's service request is answered by the transport thread, so the test can reach teardown while the run thread is still in startup.

More info in https://github.com/gazebosim/gz-sim/issues/3829#issuecomment-5072087361

## Fix

Honor the pending stop by making the startup transition atomic: a new runStateMutex guards every write to the running/stopReceived pair, and Run() checks 'stopReceived' and sets 'running' under that lock. Either OnStop() wins and Run() returns without stepping, or Run() wins and the stop's 'running = false' necessarily lands afterwards and sticks. Reads stay lock-free — both flags remain atomics and the run loop conditions are untouched — so there is no per-iteration cost.

Run() now returns false instead of true when it does not step, so an aborted run is reported to the caller rather than looking like a successful zero-iteration run. Document that 'stopReceived' is monotonic and that stopping is therefore permanent: a Server cannot be run again once stopped, which was already relied upon by the SdfErrorBehavior EXIT_IMMEDIATELY path but was never stated in the public API docs.

Add a deterministic regression test (StopBeforeRun) that stops the runner before Run() and asserts it returns failure without stepping.

## Backport Policy

- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-By: Claude Fable 5, Opus 5

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.