### PR TITLE
[flaky-test] Fix Server::Run(non-blocking) hang when a short run finishes early

### DIFF
--- a/src/Server.cc
+++ b/src/Server.cc
@@ -15,6 +15,8 @@
  *
 */
 
+#include <future>
+#include <memory>
 #include <numeric>
 
 #ifdef HAVE_PYBIND11
@@ -188,15 +190,35 @@ bool Server::Run(const bool _blocking, const uint64_t _iterations,
   std::unique_lock<std::mutex> lock(this->dataPtr->runMutex);
   if (this->dataPtr->runThread.get_id() == std::thread::id())
   {
-    std::condition_variable cond;
-    this->dataPtr->runThread =
-      std::thread(&ServerPrivate::Run, this->dataPtr.get(), _iterations, &cond);
+    // Hand the run thread a promise it fulfills once it has published its
+    // startup state, and wait on the corresponding future, so the run state
+    // has been published before this function returns.
+    //
+    // The promise is shared rather than a stack local handed over by pointer,
+    // and it is created fresh for each spawn so no state can leak from a
+    // previous blocking Run() or RunOnce(), which go through
+    // ServerPrivate::Run too without ever creating a run thread.
+    auto startedP = std::make_shared<std::promise<bool>>();
+    std::future<bool> started = startedP->get_future();
 
-    // Wait for the thread to start. We do this to guarantee that the
-    // running variable gets updated before this function returns. With
-    // a small number of iterations it is possible that the run thread
-    // successfully completes before this function returns.
-    cond.wait(lock, [this]() -> bool {return this->dataPtr->running;});
+    this->dataPtr->runThread = std::thread(&ServerPrivate::Run,
+        this->dataPtr.get(), _iterations, startedP);
+
+    // Release runMutex before waiting: std::future::wait() does not drop it
+    // the way condition_variable::wait() does, and the run thread needs
+    // runMutex to publish the run state.
+    lock.unlock();
+
+    // The run thread aborts without running when a signal arrived first, and
+    // reports that through the promise. Pass it on rather than claiming a run
+    // was started.
+    if (!started.get())
+    {
+      gzwarn << "A stop signal was received before the run started. "
+             << "Simulation will not run.\n";
+      return false;
+    }
+
     return true;
   }
 

--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -153,20 +153,37 @@ void ServerPrivate::Stop()
 
 /////////////////////////////////////////////////
 bool ServerPrivate::Run(const uint64_t _iterations,
-    std::optional<std::condition_variable *> _cond)
+    std::shared_ptr<std::promise<bool>> _started)
 {
   // Return early if we've received a signal right before.
   // The ServerPrivate signal handler would set `running=false`,
   // but we immediately would set it to true here, which will essentially ignore
   // the signal. Since we can't reliably use the `running` variable, we return
   // if `signalReceived` is true
-  if (this->signalReceived)
+  const bool signalled = this->signalReceived;
+
+  {
+    // Publish the run state before releasing the waiter below, so that
+    // Server::Run cannot return before `running` is observable.
+    //
+    // Deliberately not written on the signalled path: `running` is already
+    // false there, and storing to it could clobber a concurrent run that
+    // slipped past the precondition check in Server::Run.
+    std::lock_guard<std::mutex> lock(this->runMutex);
+    if (!signalled)
+      this->running = true;
+  }
+
+  // Release the waiter exactly once, on both paths. Even when no run will
+  // happen the promise must be fulfilled, otherwise Server::Run waits forever
+  // for this thread's startup. The value carries whether a run actually
+  // started, so the waiter does not have to re-read `signalReceived` and
+  // mistake a signal arriving after a perfectly good start for a failed one.
+  if (_started)
+    _started->set_value(!signalled);
+
+  if (signalled)
     return false;
-  this->runMutex.lock();
-  this->running = true;
-  if (_cond)
-    _cond.value()->notify_all();
-  this->runMutex.unlock();
 
   bool result = true;
 

--- a/src/ServerPrivate.hh
+++ b/src/ServerPrivate.hh
@@ -24,6 +24,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <future>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -70,10 +71,20 @@ namespace gz
 
       /// \brief Run the server, and all the simulation runners.
       /// \param[in] _iterations Number of iterations.
-      /// \param[in] _cond Optional condition variable. This condition is
-      /// notified when the server has started running.
+      /// \param[in] _started Optional promise, fulfilled once this function
+      /// has published its startup state. Its value is true if a run actually
+      /// started and false if a pending signal aborted it before anything was
+      /// stepped. It is fulfilled on both paths: a caller waiting on the
+      /// corresponding future would otherwise block forever whenever no run
+      /// happens.
+      /// \note The promise is held through a shared_ptr rather than pointed at
+      /// a caller's stack object. Server::Run returns as soon as the future is
+      /// satisfied, which can be while this thread is still inside
+      /// set_value(); std::promise, unlike std::condition_variable, has no
+      /// destructor carve-out permitting that, so the run thread has to keep a
+      /// reference of its own.
       public: bool Run(const uint64_t _iterations,
-                 std::optional<std::condition_variable *> _cond = std::nullopt);
+                 std::shared_ptr<std::promise<bool>> _started = nullptr);
 
       /// \brief Add logging record plugin.
       /// \param[in] _config Server configuration parameters.
@@ -184,7 +195,9 @@ namespace gz
       public: std::mutex runMutex;
 
       /// \brief This is used to indicate that Run has been called, and the
-      /// server is in the run state.
+      /// server is in the run state. This is a level, not an edge: it is false
+      /// again once a run completes, so it must not be used to observe that a
+      /// run has started. See the `_started` promise of Run() for that.
       public: std::atomic<bool> running{false};
 
       /// \brief Thread that executes systems.

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -23,8 +23,10 @@
 #include <gz/msgs/stringmsg_v.pb.h>
 #include <gz/msgs/world_control.pb.h>
 
+#include <atomic>
 #include <csignal>
 #include <vector>
+#include <gz/common/SignalHandler.hh>
 #include <gz/common/StringUtils.hh>
 #include <gz/common/Util.hh>
 #include <gz/math/Rand.hh>
@@ -597,6 +599,111 @@ TEST_P(ServerFixture, RunNonBlockingPaused)
   EXPECT_EQ(100u, *server.IterationCount());
   EXPECT_FALSE(server.Running());
   EXPECT_FALSE(*server.Running(0));
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, RunNonBlockingShortMultiple)
+{
+  // Regression test for the second of the two hangs behind the flaky timeouts
+  // reported in https://github.com/gazebosim/gz-sim/issues/2609 and
+  // https://github.com/gazebosim/gz-sim/issues/3829: Server::Run(false, ...)
+  // waited on `running`, which is false again once a short run completes, so
+  // a run that started and finished before the waiter woke up made
+  // Server::Run wait forever. Short runs maximize that window.
+  //
+  // This is a stress test: it reproduces probabilistically, so the repetition
+  // count is what gives it teeth. Every wait below is bounded so that a
+  // regression fails with a diagnosable message rather than hanging until the
+  // CTest timeout -- which is the very symptom #3829 reports.
+  for (int i = 0; i < 100; ++i)
+  {
+    sim::Server server;
+    server.SetUpdatePeriod(1ns);
+    EXPECT_TRUE(server.Run(false, 1, false)) << "iteration " << i;
+
+    ASSERT_NE(std::nullopt, server.IterationCount());
+    int sleep = 0;
+    const int maxSleep = 5000;
+    while (*server.IterationCount() < 1 && sleep < maxSleep)
+    {
+      GZ_SLEEP_MS(1);
+      ++sleep;
+    }
+    EXPECT_LT(sleep, maxSleep) << "run never executed on iteration " << i;
+    EXPECT_EQ(1u, *server.IterationCount()) << "iteration " << i;
+  }
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, RunNonBlockingAfterBlockingRun)
+{
+  // A blocking Run() goes through ServerPrivate::Run without ever creating the
+  // run thread. Any state left behind by that call must not be mistaken by the
+  // next non-blocking Run() for its own run thread having started, or the wait
+  // below returns immediately and the caller races the run thread it just
+  // spawned. Server::Run creates the startup handshake fresh for each spawn.
+  sim::Server server;
+  server.SetUpdatePeriod(1ns);
+
+  EXPECT_TRUE(server.Run(true, 1, false));
+  ASSERT_NE(std::nullopt, server.IterationCount());
+  EXPECT_EQ(1u, *server.IterationCount());
+  EXPECT_FALSE(server.Running());
+
+  // Now a non-blocking run on the same Server. The wait must actually block
+  // until this run thread has started.
+  EXPECT_TRUE(server.Run(false, 1, false));
+
+  int sleep = 0;
+  const int maxSleep = 5000;
+  while (*server.IterationCount() < 2 && sleep < maxSleep)
+  {
+    GZ_SLEEP_MS(1);
+    ++sleep;
+  }
+  EXPECT_LT(sleep, maxSleep) << "second run never executed";
+  EXPECT_EQ(2u, *server.IterationCount());
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, RunAfterSignal)
+{
+  // A signal delivered before Run() aborts the run: ServerPrivate::Run returns
+  // early without stepping anything. Before the fix behind #3829 that early
+  // return never released the startup handshake, so the non-blocking
+  // Server::Run below waited forever. It must now return, and must report the
+  // failure rather than claiming a run was started.
+  sim::Server server;
+  server.SetUpdatePeriod(1ns);
+
+  // gz-common dispatches signals on its own thread, invoking the registered
+  // handlers in registration order. A handler registered after the Server's is
+  // therefore invoked once the Server has finished processing the signal, so
+  // waiting on it beats guessing at a sleep.
+  std::atomic<bool> signalHandled{false};
+  common::SignalHandler testHandler;
+  ASSERT_TRUE(testHandler.Initialized());
+  ASSERT_TRUE(testHandler.AddCallback(
+        [&signalHandled](int) { signalHandled = true; }));
+
+  ASSERT_EQ(0, std::raise(SIGINT));
+
+  int sleep = 0;
+  const int maxSleep = 5000;
+  while (!signalHandled && sleep < maxSleep)
+  {
+    GZ_SLEEP_MS(1);
+    ++sleep;
+  }
+  ASSERT_TRUE(signalHandled) << "the signal was never dispatched";
+
+  // Neither form of Run may claim success, and neither may step the world.
+  EXPECT_FALSE(server.Run(false, 1, false));
+  EXPECT_FALSE(server.Run(true, 1, false));
+
+  ASSERT_NE(std::nullopt, server.IterationCount());
+  EXPECT_EQ(0u, *server.IterationCount());
+  EXPECT_FALSE(server.Running());
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

Part of #3829 

## Summary

Server::Run spawned the run thread and then waited on the 'running' flag with no timeout. 'running' is a level on/off flag, not an event. ServerPrivate::Run sets it back to false when the run completes, so a short run (few iterations, fast world) that started and finished before the waiting thread woke up left Server::Run waiting forever.

<img width="2591" height="1320" alt="image" src="https://github.com/user-attachments/assets/1d7e253c-94e6-4dc7-8ce4-a89d95f5fe62" />

## Fix

Hand the run thread a std::promise instead, created fresh for each spawn, and wait on the corresponding future. A **satisfied future stays satisfied**, so a run that finished early cannot be missed. 

Promise ownership: the promise is passed as a std::shared_ptr, so the calling thread and run thread independently keep it alive. This matters because the caller may return as soon as the shared state becomes ready while the producer is still completing set_value().

Happens-before relationship: completion of promise::set_value() synchronizes with a successful wait or retrieval from the associated future. Because the run thread writes running = true before set_value(true), the caller cannot complete started.get() before that startup publication.

Signal path: the early-return path now fulfills the promise with false. Previously it returned without notifying the caller, guaranteeing a hang for a non-blocking run attempted after a signal. Capturing signalReceived once also prevents a signal arriving after a valid startup from retroactively changing the startup result. 

## Tests

Add three regression tests: RunNonBlockingShortMultiple for the short-run race itself, RunNonBlockingAfterBlockingRun for the blocking-then-non- blocking sequence, and RunAfterSignal for the signal-before-Run path, the one path that had no coverage at all and where the non-blocking Run() hung forever.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-By: Claude Fable 5, Opus 5

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.