### PR TITLE
Fix Doxygen warnings in LED plugin documentation

### DIFF
--- a/src/systems/led_plugin/LedPlugin.hh
+++ b/src/systems/led_plugin/LedPlugin.hh
@@ -47,7 +47,7 @@ namespace systems
   ///
   /// ## System Parameters:
   ///
-  /// \code{.xml}
+  /// ```xml
   /// <plugin
   ///   filename="gz-sim-led-plugin-system"
   ///   name="gz::sim::systems::LedPlugin">
@@ -96,12 +96,10 @@ namespace systems
   ///     </step>
   ///   </mode>
   ///   <mode name="mode_name3">
-  ///   .
-  ///   .
-  ///   .
+  ///     <!-- Additional mode configuration omitted. -->
   ///   </mode>
   /// </plugin>
-  /// \endcode
+  /// ```
 
   class LedPlugin:
     public System,


### PR DESCRIPTION
# 🦟 Bug fix

Part of #3371.

## Summary

Fix the remaining Doxygen warnings emitted from `LedPlugin.hh` by:

- using the Markdown XML fence already used by neighboring system headers, so
  configuration elements are rendered as code instead of unsupported HTML;
- replacing three standalone dot lines, which Doxygen interprets as orphaned
  list markers, with an explicit XML omission comment.

The maintainer's latest Noble and Resolute warning artifacts list this file as
one coherent repository-owned warning group. This change is documentation-only
and does not alter the C++ token stream or plugin behavior.

## Test it

```sh
git diff --check
python3 - <<'PY'
from pathlib import Path
s = Path("src/systems/led_plugin/LedPlugin.hh").read_text()
assert s.count("/// ```xml") == 1
assert "/// \\code{.xml}" not in s
assert "/// \\endcode" not in s
assert "///   ." not in s
PY
```

The authoritative Doxygen matrix is provided by #3157 on Noble and Resolute;
the local environment does not include Gazebo's full documentation dependency
stack.

## Backport Policy

- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [x] I am not sure
- [ ] Other (fill in yourself)

## Checklist

- [x] Signed all commits for DCO
- [ ] Added a screen capture or video (not applicable: source documentation only)
- [ ] Added tests (not applicable: documentation-only change)
- [x] Updated documentation
- [ ] Updated migration guide (not applicable)
- [ ] Consider updating Python bindings (not applicable)
- [ ] `codecheck` passed (not available in the local dependency stack)
- [ ] All tests passed (runtime behavior is unchanged; full Doxygen validation is delegated to CI)
- [x] Updated Bazel files (not applicable: no files added)
- [ ] While waiting for a review, help review another open pull request
- [x] Was GenAI used to generate this PR? Yes; attribution is included below and in the commit.

Assisted-by: OpenAI Codex (GPT-5)
Generated-by: OpenAI Codex (GPT-5)

**Note to maintainers**: Please use **Squash-Merge** and retain the
`Signed-off-by`, `Assisted-by`, and `Generated-by` trailers.
