### PR TITLE
fix: skip light visual lookup when Sensors path has no mapping (#3862)

### DIFF
--- a/src/rendering/RenderUtil.cc
+++ b/src/rendering/RenderUtil.cc
@@ -2481,9 +2481,12 @@ void RenderUtilPrivate::RemoveRenderingEntities(
       [&](const Entity &_entity, const components::Light *)->bool
       {
         this->removeEntities[_entity] = _info.iterations;
-        this->removeEntities[matchLightWithVisuals[_entity]] =
-          _info.iterations;
-        matchLightWithVisuals.erase(_entity);
+        auto visualIt = this->matchLightWithVisuals.find(_entity);
+        if (visualIt != this->matchLightWithVisuals.end())
+        {
+          this->removeEntities[visualIt->second] = _info.iterations;
+          this->matchLightWithVisuals.erase(visualIt);
+        }
         return true;
       });
 
@@ -3009,11 +3012,15 @@ void RenderUtilPrivate::UpdateLights(
     auto l = std::dynamic_pointer_cast<rendering::Light>(node);
     if (l)
     {
-      rendering::VisualPtr lightVisual =
-          this->sceneManager.VisualById(
-            this->matchLightWithVisuals[light.first]);
-      if (lightVisual)
-        lightVisual->SetVisible(light.second.visualize_visual());
+      // Light visuals exist only when enableSensors is false (see Create path).
+      auto visualIt = this->matchLightWithVisuals.find(light.first);
+      if (visualIt != this->matchLightWithVisuals.end())
+      {
+        rendering::VisualPtr lightVisual =
+            this->sceneManager.VisualById(visualIt->second);
+        if (lightVisual)
+          lightVisual->SetVisible(light.second.visualize_visual());
+      }
 
       if (!light.second.is_light_off())
       {


### PR DESCRIPTION
# Bug fix

Fixes #3862

## Summary
Sensors-enabled `RenderUtil` never populates `matchLightWithVisuals`, but `UpdateLights` used `operator[]`, which inserted entity `0` and made `SceneManager::VisualById(0)` log a spurious Err. Light updates still worked.

Use `find()` in `UpdateLights` and `RemoveRenderingEntities` so missing mappings are skipped.

## Backport Policy
- [x] I am not sure

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] `codecheck` / full suite (not run locally on Windows)
- [x] Was GenAI used to generate this PR? If so, make sure to add Assisted-by to your commits.

Assisted-by: Cursor (Composer)

**Note to maintainers**: Squash-Merge and retain `Signed-off-by` / `Assisted-by`.