### PR TITLE
Support entity_namespace in user commands entity creation

### DIFF
--- a/include/gz/sim/EntityComponentManager.hh
+++ b/include/gz/sim/EntityComponentManager.hh
@@ -31,6 +31,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <optional>
 
 #include <gz/common/Console.hh>
 #include <gz/math/graph/Graph.hh>
@@ -111,6 +112,7 @@ namespace gz
       /// \param[in] _name The name that should be given to the cloned entity.
       /// Set this to an empty string if the cloned entity name should be
       /// auto-generated to something unique.
+      /// \param[in] _ns The namespace that should be given to the cloned entity.
       /// \param[in] _allowRename True if _name can be modified to be a unique
       /// name if it isn't already a unique name. False if _name cannot be
       /// modified to be a unique name. If _allowRename is set to False, and
@@ -123,7 +125,9 @@ namespace gz
       /// cloned.
       /// \sa Clone
       public: Entity Clone(Entity _entity, Entity _parent,
-                  const std::string &_name, bool _allowRename);
+                  const std::string &_name,
+                  const std::optional<std::string> &_ns,
+                  bool _allowRename);
 
       /// \brief Get the number of entities on the server.
       /// \return Entity count.
@@ -377,13 +381,16 @@ namespace gz
       /// \param[in] _entity The entity to clone.
       /// \param[in] _parent The parent of the cloned entity.
       /// \param[in] _name The name that should be given to the cloned entity.
+      /// \param[in] _ns The namespace that should be given to the cloned entity.
       /// \param[in] _allowRename True if _name can be modified to be a unique
       /// name if it isn't already a unique name. False if _name cannot be
       /// modified to be a unique name.
       /// \return The cloned entity. kNullEntity is returned if cloning failed.
       /// \sa Clone
       private: Entity CloneImpl(Entity _entity, Entity _parent,
-                  const std::string &_name, bool _allowRename);
+                  const std::string &_name,
+                  const std::optional<std::string> &_ns,
+                  bool _allowRename);
 
       /// \brief A version of Each() that doesn't use a cache. The cached
       /// version, Each(), is preferred.

--- a/include/gz/sim/EntityComponentManager.hh
+++ b/include/gz/sim/EntityComponentManager.hh
@@ -31,7 +31,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#include <optional>
 
 #include <gz/common/Console.hh>
 #include <gz/math/graph/Graph.hh>
@@ -125,8 +124,7 @@ namespace gz
       /// cloned.
       /// \sa Clone
       public: Entity Clone(Entity _entity, Entity _parent,
-                  const std::string &_name,
-                  const std::optional<std::string> &_ns,
+                  const std::string &_name, const std::string &_ns,
                   bool _allowRename);
 
       /// \brief Get the number of entities on the server.
@@ -388,8 +386,7 @@ namespace gz
       /// \return The cloned entity. kNullEntity is returned if cloning failed.
       /// \sa Clone
       private: Entity CloneImpl(Entity _entity, Entity _parent,
-                  const std::string &_name,
-                  const std::optional<std::string> &_ns,
+                  const std::string &_name, const std::string &_ns,
                   bool _allowRename);
 
       /// \brief A version of Each() that doesn't use a cache. The cached

--- a/include/gz/sim/EntityComponentManager.hh
+++ b/include/gz/sim/EntityComponentManager.hh
@@ -111,22 +111,22 @@ namespace gz
       /// \param[in] _name The name that should be given to the cloned entity.
       /// Set this to an empty string if the cloned entity name should be
       /// auto-generated to something unique.
-      /// \param[in] _ns The namespace that should be given to the cloned
-      /// entity.
       /// \param[in] _allowRename True if _name can be modified to be a unique
       /// name if it isn't already a unique name. False if _name cannot be
       /// modified to be a unique name. If _allowRename is set to False, and
       /// _name is not unique, _entity will not be cloned. If _name is an
       /// empty string, _allowRename is ignored since the cloned entity will
       /// have an auto-generated unique name.
+      /// \param[in] _ns The namespace that should be given to the cloned
+      /// entity.
       /// \return The cloned entity, which will have a unique name. kNullEntity
       /// is returned if cloning failed. Failure could occur if _entity does not
       /// exist, or if a unique name could not be generated for the entity to be
       /// cloned.
       /// \sa Clone
       public: Entity Clone(Entity _entity, Entity _parent,
-                  const std::string &_name, const std::string &_ns,
-                  bool _allowRename);
+                  const std::string &_name, bool _allowRename,
+                  const std::string &_ns = "");
 
       /// \brief Get the number of entities on the server.
       /// \return Entity count.
@@ -380,16 +380,16 @@ namespace gz
       /// \param[in] _entity The entity to clone.
       /// \param[in] _parent The parent of the cloned entity.
       /// \param[in] _name The name that should be given to the cloned entity.
-      /// \param[in] _ns The namespace that should be given to the cloned
-      /// entity.
       /// \param[in] _allowRename True if _name can be modified to be a unique
       /// name if it isn't already a unique name. False if _name cannot be
       /// modified to be a unique name.
+      /// \param[in] _ns The namespace that should be given to the cloned
+      /// entity.
       /// \return The cloned entity. kNullEntity is returned if cloning failed.
       /// \sa Clone
       private: Entity CloneImpl(Entity _entity, Entity _parent,
-                  const std::string &_name, const std::string &_ns,
-                  bool _allowRename);
+                  const std::string &_name, bool _allowRename,
+                  const std::string &_ns = "");
 
       /// \brief A version of Each() that doesn't use a cache. The cached
       /// version, Each(), is preferred.

--- a/include/gz/sim/EntityComponentManager.hh
+++ b/include/gz/sim/EntityComponentManager.hh
@@ -111,7 +111,8 @@ namespace gz
       /// \param[in] _name The name that should be given to the cloned entity.
       /// Set this to an empty string if the cloned entity name should be
       /// auto-generated to something unique.
-      /// \param[in] _ns The namespace that should be given to the cloned entity.
+      /// \param[in] _ns The namespace that should be given to the cloned
+      /// entity.
       /// \param[in] _allowRename True if _name can be modified to be a unique
       /// name if it isn't already a unique name. False if _name cannot be
       /// modified to be a unique name. If _allowRename is set to False, and
@@ -379,7 +380,8 @@ namespace gz
       /// \param[in] _entity The entity to clone.
       /// \param[in] _parent The parent of the cloned entity.
       /// \param[in] _name The name that should be given to the cloned entity.
-      /// \param[in] _ns The namespace that should be given to the cloned entity.
+      /// \param[in] _ns The namespace that should be given to the cloned
+      /// entity.
       /// \param[in] _allowRename True if _name can be modified to be a unique
       /// name if it isn't already a unique name. False if _name cannot be
       /// modified to be a unique name.

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -412,8 +412,7 @@ Entity EntityComponentManagerPrivate::CreateEntityImplementation(Entity _entity)
 
 /////////////////////////////////////////////////
 Entity EntityComponentManager::Clone(Entity _entity, Entity _parent,
-    const std::string &_name, const std::string &_ns,
-    bool _allowRename)
+    const std::string &_name, bool _allowRename, const std::string &_ns)
 {
   // Clear maps so they're populated for the entity being cloned
   this->dataPtr->oldToClonedCanonicalLink.clear();
@@ -422,7 +421,7 @@ Entity EntityComponentManager::Clone(Entity _entity, Entity _parent,
   this->dataPtr->clonedToOriginalJointLinks.clear();
 
   auto clonedEntity =
-    this->CloneImpl(_entity, _parent, _name, _ns, _allowRename);
+    this->CloneImpl(_entity, _parent, _name, _allowRename, _ns);
 
   if (kNullEntity != clonedEntity)
   {
@@ -475,8 +474,7 @@ Entity EntityComponentManager::Clone(Entity _entity, Entity _parent,
 
 /////////////////////////////////////////////////
 Entity EntityComponentManager::CloneImpl(Entity _entity, Entity _parent,
-    const std::string &_name, const std::string &_ns,
-    bool _allowRename)
+    const std::string &_name, bool _allowRename, const std::string &_ns)
 {
   auto uniqueNameGenerated = false;
 
@@ -674,8 +672,8 @@ Entity EntityComponentManager::CloneImpl(Entity _entity, Entity _parent,
       }
     }
 
-    auto clonedChild = this->CloneImpl(childEntity, clonedEntity, name,
-        "", _allowRename);
+    auto clonedChild = this->CloneImpl(
+      childEntity, clonedEntity, name, _allowRename);
     if (kNullEntity == clonedChild)
     {
       gzerr << "Cloning child entity [" << childEntity << "] failed.\n";

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -28,7 +28,6 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
-#include <optional>
 
 #include <gz/common/Profiler.hh>
 #include <gz/math/graph/GraphAlgorithms.hh>
@@ -413,7 +412,7 @@ Entity EntityComponentManagerPrivate::CreateEntityImplementation(Entity _entity)
 
 /////////////////////////////////////////////////
 Entity EntityComponentManager::Clone(Entity _entity, Entity _parent,
-    const std::string &_name, const std::optional<std::string> &_ns,
+    const std::string &_name, const std::string &_ns,
     bool _allowRename)
 {
   // Clear maps so they're populated for the entity being cloned
@@ -475,7 +474,7 @@ Entity EntityComponentManager::Clone(Entity _entity, Entity _parent,
 
 /////////////////////////////////////////////////
 Entity EntityComponentManager::CloneImpl(Entity _entity, Entity _parent,
-    const std::string &_name, const std::optional<std::string> &_ns,
+    const std::string &_name, const std::string &_ns,
     bool _allowRename)
 {
   auto uniqueNameGenerated = false;
@@ -549,20 +548,18 @@ Entity EntityComponentManager::CloneImpl(Entity _entity, Entity _parent,
   }
   this->CreateComponent(clonedEntity, components::Name(clonedName));
 
-  if (nullptr != this->Component<components::Namespace>(_entity))
+  auto originalNsComp = this->Component<components::Namespace>(_entity);
+  if (nullptr != originalNsComp)
   {
     std::string ns;
-    if (_ns.has_value())
+    if (!_ns.empty())
     {
-      ns = _ns.value();
+      ns = _ns;
     }
     else
     {
-      // If the namespace is not provided, use the original entity's namespace
-      // if it exists. Otherwise, use an empty string as the namespace for the
-      // cloned entity.
-      auto originalNsComp = this->Component<components::Namespace>(_entity);
-      ns = originalNsComp ? originalNsComp->Data() : "";
+      // If the namespace is not provided, use the original entity's namespace.
+      ns = originalNsComp->Data();
     }
     this->CreateComponent(clonedEntity, components::Namespace(ns));
   }
@@ -682,7 +679,7 @@ Entity EntityComponentManager::CloneImpl(Entity _entity, Entity _parent,
     }
 
     auto clonedChild = this->CloneImpl(childEntity, clonedEntity, name,
-        std::nullopt, _allowRename);
+        "", _allowRename);
     if (kNullEntity == clonedChild)
     {
       gzerr << "Cloning child entity [" << childEntity << "] failed.\n";

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -549,19 +549,14 @@ Entity EntityComponentManager::CloneImpl(Entity _entity, Entity _parent,
   this->CreateComponent(clonedEntity, components::Name(clonedName));
 
   auto originalNsComp = this->Component<components::Namespace>(_entity);
-  if (nullptr != originalNsComp)
+  if (!_ns.empty())
   {
-    std::string ns;
-    if (!_ns.empty())
-    {
-      ns = _ns;
-    }
-    else
-    {
-      // If the namespace is not provided, use the original entity's namespace.
-      ns = originalNsComp->Data();
-    }
-    this->CreateComponent(clonedEntity, components::Namespace(ns));
+    this->CreateComponent(clonedEntity, components::Namespace(_ns));
+  }
+  else if (nullptr != originalNsComp && !originalNsComp->Data().empty())
+  {
+    this->CreateComponent(clonedEntity,
+      components::Namespace(originalNsComp->Data()));
   }
 
   // copy all components from _entity to clonedEntity

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -552,7 +552,7 @@ Entity EntityComponentManager::CloneImpl(Entity _entity, Entity _parent,
   {
     this->CreateComponent(clonedEntity, components::Namespace(_ns));
   }
-  else if (nullptr != originalNsComp && !originalNsComp->Data().empty())
+  else if (nullptr != originalNsComp)
   {
     this->CreateComponent(clonedEntity,
       components::Namespace(originalNsComp->Data()));

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -28,6 +28,7 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <optional>
 
 #include <gz/common/Profiler.hh>
 #include <gz/math/graph/GraphAlgorithms.hh>
@@ -39,7 +40,9 @@
 #include "gz/sim/components/Factory.hh"
 #include "gz/sim/components/Joint.hh"
 #include "gz/sim/components/Link.hh"
+#include "gz/sim/components/Model.hh"
 #include "gz/sim/components/Name.hh"
+#include "gz/sim/components/Namespace.hh"
 #include "gz/sim/components/ParentEntity.hh"
 #include "gz/sim/components/ParentLinkName.hh"
 #include "gz/sim/components/Recreate.hh"
@@ -410,7 +413,8 @@ Entity EntityComponentManagerPrivate::CreateEntityImplementation(Entity _entity)
 
 /////////////////////////////////////////////////
 Entity EntityComponentManager::Clone(Entity _entity, Entity _parent,
-    const std::string &_name, bool _allowRename)
+    const std::string &_name, const std::optional<std::string> &_ns,
+    bool _allowRename)
 {
   // Clear maps so they're populated for the entity being cloned
   this->dataPtr->oldToClonedCanonicalLink.clear();
@@ -418,7 +422,7 @@ Entity EntityComponentManager::Clone(Entity _entity, Entity _parent,
   this->dataPtr->originalToClonedLink.clear();
   this->dataPtr->clonedToOriginalJointLinks.clear();
 
-  auto clonedEntity = this->CloneImpl(_entity, _parent, _name, _allowRename);
+  auto clonedEntity = this->CloneImpl(_entity, _parent, _name, _ns, _allowRename);
 
   if (kNullEntity != clonedEntity)
   {
@@ -471,7 +475,8 @@ Entity EntityComponentManager::Clone(Entity _entity, Entity _parent,
 
 /////////////////////////////////////////////////
 Entity EntityComponentManager::CloneImpl(Entity _entity, Entity _parent,
-    const std::string &_name, bool _allowRename)
+    const std::string &_name, const std::optional<std::string> &_ns,
+    bool _allowRename)
 {
   auto uniqueNameGenerated = false;
 
@@ -544,13 +549,32 @@ Entity EntityComponentManager::CloneImpl(Entity _entity, Entity _parent,
   }
   this->CreateComponent(clonedEntity, components::Name(clonedName));
 
+  if (nullptr != this->Component<components::Namespace>(_entity))
+  {
+    std::string ns;
+    if (_ns.has_value())
+    {
+      ns = _ns.value();
+    }
+    else
+    {
+      // If the namespace is not provided, use the original entity's namespace
+      // if it exists. Otherwise, use an empty string as the namespace for the
+      // cloned entity.
+      auto originalNsComp = this->Component<components::Namespace>(_entity);
+      ns = originalNsComp ? originalNsComp->Data() : "";
+    }
+    this->CreateComponent(clonedEntity, components::Namespace(ns));
+  }
+
   // copy all components from _entity to clonedEntity
   for (const auto &type : this->ComponentTypes(_entity))
   {
-    // skip the Name and ParentEntity components since those were already
+    // skip the Name, Namespace and ParentEntity components since those were already
     // handled above
     if ((type == components::Name::typeId) ||
-        (type == components::ParentEntity::typeId))
+        (type == components::ParentEntity::typeId) ||
+        (type == components::Namespace::typeId))
       continue;
 
     auto originalComp = this->ComponentImplementation(_entity, type);
@@ -656,8 +680,9 @@ Entity EntityComponentManager::CloneImpl(Entity _entity, Entity _parent,
         name = nameComp->Data();
       }
     }
+
     auto clonedChild = this->CloneImpl(childEntity, clonedEntity, name,
-        _allowRename);
+        std::nullopt, _allowRename);
     if (kNullEntity == clonedChild)
     {
       gzerr << "Cloning child entity [" << childEntity << "] failed.\n";

--- a/src/EntityComponentManager.cc
+++ b/src/EntityComponentManager.cc
@@ -421,7 +421,8 @@ Entity EntityComponentManager::Clone(Entity _entity, Entity _parent,
   this->dataPtr->originalToClonedLink.clear();
   this->dataPtr->clonedToOriginalJointLinks.clear();
 
-  auto clonedEntity = this->CloneImpl(_entity, _parent, _name, _ns, _allowRename);
+  auto clonedEntity =
+    this->CloneImpl(_entity, _parent, _name, _ns, _allowRename);
 
   if (kNullEntity != clonedEntity)
   {
@@ -562,8 +563,8 @@ Entity EntityComponentManager::CloneImpl(Entity _entity, Entity _parent,
   // copy all components from _entity to clonedEntity
   for (const auto &type : this->ComponentTypes(_entity))
   {
-    // skip the Name, Namespace and ParentEntity components since those were already
-    // handled above
+    // skip the Name, Namespace and ParentEntity components since those were
+    // already handled above
     if ((type == components::Name::typeId) ||
         (type == components::ParentEntity::typeId) ||
         (type == components::Namespace::typeId))

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -2877,7 +2877,7 @@ TEST_P(EntityComponentManagerFixture,
 
   // clone the topLevelEntity
   auto clonedTopLevelEntity =
-    manager.Clone(topLevelEntity, kNullEntity, "", std::nullopt, allowRename);
+    manager.Clone(topLevelEntity, kNullEntity, "", "", allowRename);
   EXPECT_EQ(8u, manager.EntityCount());
   clonedEntities.insert(clonedTopLevelEntity);
   validateTopLevelClone(clonedTopLevelEntity);
@@ -2980,7 +2980,7 @@ TEST_P(EntityComponentManagerFixture,
   EXPECT_NE(kNullEntity,
       manager.EntityByComponents(components::Name(existingName)));
   auto renamedClonedEntity = manager.Clone(grandChildEntity1,
-      grandChildParentComp->Data(), existingName, std::nullopt, allowRename);
+      grandChildParentComp->Data(), existingName, "", allowRename);
   EXPECT_EQ(10u, manager.EntityCount());
   clonedEntities.insert(clonedGrandChildEntity);
   validateGrandChildClone(renamedClonedEntity, true, true);
@@ -2988,7 +2988,7 @@ TEST_P(EntityComponentManagerFixture,
   // Try cloning an entity with a name that already exists, without allowing
   // renaming. This should fail since entities should have unique names.
   auto failedClonedEntity = manager.Clone(grandChildEntity1,
-      grandChildParentComp->Data(), existingName, std::nullopt, noAllowRename);
+      grandChildParentComp->Data(), existingName, "", noAllowRename);
   EXPECT_EQ(10u, manager.EntityCount());
   EXPECT_EQ(kNullEntity, failedClonedEntity);
 
@@ -3024,7 +3024,7 @@ TEST_P(EntityComponentManagerFixture,
 
   // clone a joint that has a parent and child link.
   auto clonedParentModelEntity = manager.Clone(parentModelEntity, kNullEntity,
-      "", std::nullopt, true);
+      "", "", true);
   ASSERT_NE(kNullEntity, clonedParentModelEntity);
   // We just cloned a model with two links and a joint, a total of 4 new
   // entities.
@@ -3076,7 +3076,7 @@ TEST_P(EntityComponentManagerFixture,
 
   // try to clone an entity that does not exist
   EXPECT_EQ(kNullEntity, manager.Clone(kNullEntity, topLevelEntity, "",
-        std::nullopt, allowRename));
+        "", allowRename));
   EXPECT_EQ(18u, manager.EntityCount());
 }
 

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -30,6 +30,7 @@
 #include "gz/sim/components/Joint.hh"
 #include "gz/sim/components/Link.hh"
 #include "gz/sim/components/Name.hh"
+#include "gz/sim/components/Namespace.hh"
 #include "gz/sim/components/ParentEntity.hh"
 #include "gz/sim/components/ParentLinkName.hh"
 #include "gz/sim/components/Pose.hh"
@@ -2814,11 +2815,13 @@ TEST_P(EntityComponentManagerFixture,
 
   Entity topLevelEntity = manager.CreateEntity();
   manager.CreateComponent(topLevelEntity, components::Name("topLevelEntity"));
+  manager.CreateComponent(topLevelEntity, components::Namespace("topLevelNs"));
   manager.CreateComponent(topLevelEntity, IntComponent(123));
   manager.CreateComponent(topLevelEntity, StringComponent("string0"));
 
   Entity childEntity1 = manager.CreateEntity();
   manager.CreateComponent(childEntity1, components::Name("childEntity1"));
+  manager.CreateComponent(childEntity1, components::Namespace("childNs1"));
   manager.CreateComponent(childEntity1,
       components::ParentEntity(topLevelEntity));
   manager.CreateComponent(childEntity1, IntComponent(456));
@@ -2828,10 +2831,13 @@ TEST_P(EntityComponentManagerFixture,
   manager.CreateComponent(grandChildEntity1,
       components::Name("grandChildEntity1"));
   manager.CreateComponent(grandChildEntity1,
+      components::Namespace("grandChildNs1"));
+  manager.CreateComponent(grandChildEntity1,
       components::ParentEntity(childEntity1));
 
   Entity childEntity2 = manager.CreateEntity();
   manager.CreateComponent(childEntity2, components::Name("childEntity2"));
+  manager.CreateComponent(childEntity2, components::Namespace("childNs2"));
   manager.CreateComponent(childEntity2,
       components::ParentEntity(topLevelEntity));
   manager.CreateComponent(childEntity2, IntComponent(789));
@@ -2859,6 +2865,8 @@ TEST_P(EntityComponentManagerFixture,
             components::ParentEntity::typeId));
       CompareEntityComponents<components::Name>(manager, topLevelEntity,
           _clonedEntity, false);
+      CompareEntityComponents<components::Namespace>(manager, topLevelEntity,
+          _clonedEntity, true);
       CompareEntityComponents<IntComponent>(manager, topLevelEntity,
           _clonedEntity, true);
       CompareEntityComponents<StringComponent>(manager, topLevelEntity,
@@ -2869,7 +2877,7 @@ TEST_P(EntityComponentManagerFixture,
 
   // clone the topLevelEntity
   auto clonedTopLevelEntity =
-    manager.Clone(topLevelEntity, kNullEntity, "", allowRename);
+    manager.Clone(topLevelEntity, kNullEntity, "", std::nullopt, allowRename);
   EXPECT_EQ(8u, manager.EntityCount());
   clonedEntities.insert(clonedTopLevelEntity);
   validateTopLevelClone(clonedTopLevelEntity);
@@ -2887,6 +2895,8 @@ TEST_P(EntityComponentManagerFixture,
       EXPECT_EQ(clonedTopLevelEntity, parentComp->Data());
       CompareEntityComponents<components::Name>(manager, _clonedChild,
           _originalChild, false);
+      CompareEntityComponents<components::Namespace>(manager, _clonedChild,
+          _originalChild, true);
       CompareEntityComponents<IntComponent>(manager, _clonedChild,
           _originalChild, true);
       CompareEntityComponents<StringComponent>(manager, _clonedChild,
@@ -2894,13 +2904,15 @@ TEST_P(EntityComponentManagerFixture,
     };
 
   auto validateGrandChildClone =
-    [&](const Entity _clonedEntity, bool _sameParent)
+    [&](const Entity _clonedEntity, bool _sameNs, bool _sameParent)
     {
       EXPECT_NE(kNullEntity, _clonedEntity);
       EXPECT_EQ(manager.ComponentTypes(_clonedEntity),
           manager.ComponentTypes(grandChildEntity1));
       CompareEntityComponents<components::Name>(manager, _clonedEntity,
           grandChildEntity1, false);
+      CompareEntityComponents<components::Namespace>(manager, _clonedEntity,
+          grandChildEntity1, _sameNs);
       CompareEntityComponents<components::ParentEntity>(manager,
           _clonedEntity, grandChildEntity1, _sameParent);
       EXPECT_TRUE(manager.EntitiesByComponents(
@@ -2930,7 +2942,7 @@ TEST_P(EntityComponentManagerFixture,
 
       ASSERT_EQ(1u, clonedGrandChildren.size());
       clonedEntities.insert(clonedGrandChildren[0]);
-      validateGrandChildClone(clonedGrandChildren[0], false);
+      validateGrandChildClone(clonedGrandChildren[0], true, false);
       auto parentComp =
         manager.Component<components::ParentEntity>(clonedGrandChildren[0]);
       ASSERT_NE(nullptr, parentComp);
@@ -2950,31 +2962,33 @@ TEST_P(EntityComponentManagerFixture,
     EXPECT_TRUE(comparedToOriginalChild);
   }
 
-  // clone a child entity
+  // clone a child entity with a namespace provided
   auto grandChildParentComp =
     manager.Component<components::ParentEntity>(grandChildEntity1);
   ASSERT_NE(nullptr, grandChildParentComp);
   auto clonedGrandChildEntity = manager.Clone(grandChildEntity1,
-      grandChildParentComp->Data(), "", allowRename);
+      grandChildParentComp->Data(), "", "clonedGrandChildNs", allowRename);
   EXPECT_EQ(9u, manager.EntityCount());
   clonedEntities.insert(clonedGrandChildEntity);
-  validateGrandChildClone(clonedGrandChildEntity, true);
+  validateGrandChildClone(clonedGrandChildEntity, false, true);
 
-  // Try cloning an entity with a name that already exists, but allow renaming.
-  // This should succeed and generate a cloned entity with a unique name.
+  // Try cloning an entity with a name that already exists, but allow renaming
+  // and without a namespace provided.
+  // This should succeed and generate a cloned entity with a unique name
+  // and a same namespace.
   const auto existingName = "grandChildEntity1";
   EXPECT_NE(kNullEntity,
       manager.EntityByComponents(components::Name(existingName)));
   auto renamedClonedEntity = manager.Clone(grandChildEntity1,
-      grandChildParentComp->Data(), existingName, allowRename);
+      grandChildParentComp->Data(), existingName, std::nullopt, allowRename);
   EXPECT_EQ(10u, manager.EntityCount());
   clonedEntities.insert(clonedGrandChildEntity);
-  validateGrandChildClone(renamedClonedEntity, true);
+  validateGrandChildClone(renamedClonedEntity, true, true);
 
   // Try cloning an entity with a name that already exists, without allowing
   // renaming. This should fail since entities should have unique names.
   auto failedClonedEntity = manager.Clone(grandChildEntity1,
-      grandChildParentComp->Data(), existingName, noAllowRename);
+      grandChildParentComp->Data(), existingName, std::nullopt, noAllowRename);
   EXPECT_EQ(10u, manager.EntityCount());
   EXPECT_EQ(kNullEntity, failedClonedEntity);
 
@@ -3010,7 +3024,7 @@ TEST_P(EntityComponentManagerFixture,
 
   // clone a joint that has a parent and child link.
   auto clonedParentModelEntity = manager.Clone(parentModelEntity, kNullEntity,
-      "", true);
+      "", std::nullopt, true);
   ASSERT_NE(kNullEntity, clonedParentModelEntity);
   // We just cloned a model with two links and a joint, a total of 4 new
   // entities.
@@ -3062,7 +3076,7 @@ TEST_P(EntityComponentManagerFixture,
 
   // try to clone an entity that does not exist
   EXPECT_EQ(kNullEntity, manager.Clone(kNullEntity, topLevelEntity, "",
-        allowRename));
+        std::nullopt, allowRename));
   EXPECT_EQ(18u, manager.EntityCount());
 }
 

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -2877,7 +2877,7 @@ TEST_P(EntityComponentManagerFixture,
 
   // clone the topLevelEntity
   auto clonedTopLevelEntity =
-    manager.Clone(topLevelEntity, kNullEntity, "", "", allowRename);
+    manager.Clone(topLevelEntity, kNullEntity, "", allowRename);
   EXPECT_EQ(8u, manager.EntityCount());
   clonedEntities.insert(clonedTopLevelEntity);
   validateTopLevelClone(clonedTopLevelEntity);
@@ -2967,7 +2967,7 @@ TEST_P(EntityComponentManagerFixture,
     manager.Component<components::ParentEntity>(grandChildEntity1);
   ASSERT_NE(nullptr, grandChildParentComp);
   auto clonedGrandChildEntity = manager.Clone(grandChildEntity1,
-      grandChildParentComp->Data(), "", "clonedGrandChildNs", allowRename);
+      grandChildParentComp->Data(), "", allowRename, "clonedGrandChildNs");
   EXPECT_EQ(9u, manager.EntityCount());
   clonedEntities.insert(clonedGrandChildEntity);
   validateGrandChildClone(clonedGrandChildEntity, false, true);
@@ -2980,7 +2980,7 @@ TEST_P(EntityComponentManagerFixture,
   EXPECT_NE(kNullEntity,
       manager.EntityByComponents(components::Name(existingName)));
   auto renamedClonedEntity = manager.Clone(grandChildEntity1,
-      grandChildParentComp->Data(), existingName, "", allowRename);
+      grandChildParentComp->Data(), existingName, allowRename);
   EXPECT_EQ(10u, manager.EntityCount());
   clonedEntities.insert(clonedGrandChildEntity);
   validateGrandChildClone(renamedClonedEntity, true, true);
@@ -2988,7 +2988,7 @@ TEST_P(EntityComponentManagerFixture,
   // Try cloning an entity with a name that already exists, without allowing
   // renaming. This should fail since entities should have unique names.
   auto failedClonedEntity = manager.Clone(grandChildEntity1,
-      grandChildParentComp->Data(), existingName, "", noAllowRename);
+      grandChildParentComp->Data(), existingName, noAllowRename);
   EXPECT_EQ(10u, manager.EntityCount());
   EXPECT_EQ(kNullEntity, failedClonedEntity);
 
@@ -3024,7 +3024,7 @@ TEST_P(EntityComponentManagerFixture,
 
   // clone a joint that has a parent and child link.
   auto clonedParentModelEntity = manager.Clone(parentModelEntity, kNullEntity,
-      "", "", true);
+      "", true);
   ASSERT_NE(kNullEntity, clonedParentModelEntity);
   // We just cloned a model with two links and a joint, a total of 4 new
   // entities.
@@ -3075,8 +3075,8 @@ TEST_P(EntityComponentManagerFixture,
   }
 
   // try to clone an entity that does not exist
-  EXPECT_EQ(kNullEntity, manager.Clone(kNullEntity, topLevelEntity, "",
-        "", allowRename));
+  EXPECT_EQ(kNullEntity, manager.Clone(
+    kNullEntity, topLevelEntity, "", allowRename));
   EXPECT_EQ(18u, manager.EntityCount());
 }
 

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -1601,7 +1601,7 @@ void SimulationRunner::ProcessRecreateEntitiesCreate()
     {
       // set allowRenaming to false so the entities keep their original name
       Entity clonedEntity = this->entityCompMgr.Clone(ent,
-         parentComp->Data(), nameComp->Data(), "", false);
+         parentComp->Data(), nameComp->Data(), false);
 
       // remove the Recreate component so they do not get recreated again in the
       // next iteration

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -1601,7 +1601,7 @@ void SimulationRunner::ProcessRecreateEntitiesCreate()
     {
       // set allowRenaming to false so the entities keep their original name
       Entity clonedEntity = this->entityCompMgr.Clone(ent,
-         parentComp->Data(), nameComp->Data(), std::nullopt, false);
+         parentComp->Data(), nameComp->Data(), "", false);
 
       // remove the Recreate component so they do not get recreated again in the
       // next iteration

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -44,6 +44,7 @@
 #include "gz/sim/Constants.hh"
 #include "gz/sim/components/Model.hh"
 #include "gz/sim/components/Name.hh"
+#include "gz/sim/components/Namespace.hh"
 #include "gz/sim/components/Sensor.hh"
 #include "gz/sim/components/Visual.hh"
 #include "gz/sim/components/World.hh"
@@ -1600,7 +1601,7 @@ void SimulationRunner::ProcessRecreateEntitiesCreate()
     {
       // set allowRenaming to false so the entities keep their original name
       Entity clonedEntity = this->entityCompMgr.Clone(ent,
-         parentComp->Data(), nameComp->Data(), false);
+         parentComp->Data(), nameComp->Data(), std::nullopt, false);
 
       // remove the Recreate component so they do not get recreated again in the
       // next iteration

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -1186,7 +1186,11 @@ bool CreateCommand::CreateFromMsg(const msgs::EntityFactory &_createMsg,
 bool CreateCommand::CreateFromMsg(const msgs::EntityFactoryWithNs &_createMsg)
 {
   msgs::EntityFactory baseMsg;
-  baseMsg.ParseFromString(_createMsg.SerializeAsString());
+  if (!baseMsg.ParseFromString(_createMsg.SerializeAsString()))
+  {
+    gzerr << "Failed to parse EntityFactoryWithNs message" << std::endl;
+    return false;
+  }
 
   return this->CreateFromMsg(baseMsg, _createMsg.entity_namespace());
 }

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -1187,7 +1187,7 @@ bool CreateCommand::CreateFromMsg(const msgs::EntityFactoryWithNs &_createMsg)
   msgs::EntityFactory baseMsg;
   baseMsg.ParseFromString(_createMsg.SerializeAsString());
 
-  return this->CreateFromMsg(baseMsg, _createMsg.namespace_());
+  return this->CreateFromMsg(baseMsg, _createMsg.entity_namespace());
 }
 
 //////////////////////////////////////////////////

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -962,7 +962,7 @@ bool CreateCommand::CreateFromMsg(const msgs::EntityFactory &_createMsg,
           auto parentEntity = parentComp->Data();
           clonedEntity = this->iface->ecm->Clone(entityToClone,
               parentEntity, _createMsg.name(),
-              _ns, _createMsg.allow_renaming());
+              _createMsg.allow_renaming(), _ns);
           validClone = kNullEntity != clonedEntity;
         }
       }

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -893,10 +893,6 @@ bool CreateCommand::Execute()
   if (nullptr != createMsgWithNs)
   {
     // It could also be an EntityFactoryWithNs
-    gzwarn << "The EntityFactoryWithNs message and /create_with_ns service "
-           << "are deprecated and will be removed in a future version. "
-           << "Please use EntityFactory and /create instead."
-           << std::endl;
     return this->CreateFromMsg(*createMsgWithNs);
   }
 
@@ -905,10 +901,6 @@ bool CreateCommand::Execute()
   if (nullptr != createMsgWithNsV)
   {
     // It could also be an EntityFactoryWithNs_V
-    gzwarn << "The EntityFactoryWithNs_V message and create_with_ns_multiple "
-           << "service are deprecated and will be removed in a future version."
-           << " Please use EntityFactory_V and /create_multiple instead."
-           << std::endl;
     bool result = true;
     for (const auto &msgItem : createMsgWithNsV->data())
     {
@@ -925,17 +917,6 @@ bool CreateCommand::Execute()
 bool CreateCommand::CreateFromMsg(const msgs::EntityFactory &_createMsg,
   const std::string &_ns)
 {
-  // Load entity_namespace
-  std::string ns;
-  if (!_ns.empty())
-  {
-    ns = _ns;
-  }
-  else
-  {
-    ns = _createMsg.entity_namespace();
-  }
-
   // Load SDF
   sdf::Root root;
   sdf::Light lightSdf;
@@ -980,7 +961,7 @@ bool CreateCommand::CreateFromMsg(const msgs::EntityFactory &_createMsg,
         {
           auto parentEntity = parentComp->Data();
           clonedEntity = this->iface->ecm->Clone(entityToClone,
-              parentEntity, _createMsg.name(), ns, _createMsg.allow_renaming());
+              parentEntity, _createMsg.name(), _ns, _createMsg.allow_renaming());
           validClone = kNullEntity != clonedEntity;
         }
       }
@@ -1105,9 +1086,9 @@ bool CreateCommand::CreateFromMsg(const msgs::EntityFactory &_createMsg,
   {
     auto model = *root.Model();
     model.SetName(desiredName);
-    if (!ns.empty())
+    if (!_ns.empty())
     {
-      model.SetRawNamespace(ns);
+      model.SetRawNamespace(_ns);
     }
     entity = this->iface->creator->CreateEntitiesWithoutLoadingPlugins(&model);
   }

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -20,6 +20,7 @@
 #include "UserCommands.hh"
 #include <chrono>
 #include <future>
+#include <optional>
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -36,6 +37,8 @@
 #include <gz/msgs/entity.pb.h>
 #include <gz/msgs/entity_factory.pb.h>
 #include <gz/msgs/entity_factory_v.pb.h>
+#include <gz/msgs/entity_factory_with_ns.pb.h>
+#include <gz/msgs/entity_factory_with_ns_v.pb.h>
 #include <gz/msgs/light.pb.h>
 #include <gz/msgs/material_color.pb.h>
 #include <gz/msgs/physics.pb.h>
@@ -165,10 +168,22 @@ class CreateCommand : public UserCommandBase
   public: CreateCommand(msgs::EntityFactory *_msg,
       std::shared_ptr<UserCommandsInterface> &_iface);
 
+  /// \brief Constructor
+  /// \param[in] _msg Factory message.
+  /// \param[in] _iface Pointer to user commands interface with namespace.
+  public: CreateCommand(msgs::EntityFactoryWithNs *_msg,
+      std::shared_ptr<UserCommandsInterface> &_iface);
+
   /// \brief Constructor overload that takes a vector of Factory messages
   /// \param[in] _msg Vector of Factory message.
   /// \param[in] _iface Pointer to user commands interface.
   public: CreateCommand(msgs::EntityFactory_V *_msg,
+      std::shared_ptr<UserCommandsInterface> &_iface);
+
+  /// \brief Constructor overload that takes a vector of Factory messages
+  /// \param[in] _msg Vector of Factory message.
+  /// \param[in] _iface Pointer to user commands interface with namespace.
+  public: CreateCommand(msgs::EntityFactoryWithNs_V *_msg,
       std::shared_ptr<UserCommandsInterface> &_iface);
 
   // Documentation inherited
@@ -176,7 +191,20 @@ class CreateCommand : public UserCommandBase
 
   /// \brief Actual implementation that creates entities from message.
   /// \param[in] Factory message that specifies the entity to create.
-  private: bool CreateFromMsg(const msgs::EntityFactory &_createMsg);
+  /// \param[in] _ns Optional namespace to apply to the created entity.
+  private: bool CreateFromMsg(const msgs::EntityFactory &_createMsg,
+      const std::optional<std::string> &_ns = std::nullopt);
+
+  /// \brief Actual implementation that creates entities from message.
+  /// \param[in] Factory message that specifies the entity to create.
+  private: bool CreateFromMsg(const msgs::EntityFactoryWithNs &_createMsg);
+
+  /// \brief Helper function to copy data from EntityFactoryWithNs message to
+  /// EntityFactory message.
+  /// \param[in] _sourceMsg EntityFactoryWithNs message to copy data from.
+  /// \param[in] _targetMsg EntityFactory message to copy data to.
+  private: void CopyData(const msgs::EntityFactoryWithNs &_sourceMsg,
+      msgs::EntityFactory &_targetMsg);
 };
 
 /// \brief Command to remove an entity from simulation.
@@ -607,8 +635,12 @@ void UserCommands::Configure(const Entity &_entity,
   // Create service
   this->dataPtr->AdvertiseService<CreateCommand, msgs::EntityFactory>(
       "/world/" + validWorldName + "/create");
+  this->dataPtr->AdvertiseService<CreateCommand, msgs::EntityFactoryWithNs>(
+      "/world/" + validWorldName + "/create_with_ns");
   this->dataPtr->AdvertiseService<CreateCommand, msgs::EntityFactory_V>(
       "/world/" + validWorldName + "/create_multiple", "Create");
+  this->dataPtr->AdvertiseService<CreateCommand, msgs::EntityFactoryWithNs_V>(
+      "/world/" + validWorldName + "/create_with_ns_multiple", "Create");
 
   // Remove service
   this->dataPtr->AdvertiseService<RemoveCommand, msgs::Entity>(
@@ -821,11 +853,26 @@ CreateCommand::CreateCommand(msgs::EntityFactory *_msg,
 }
 
 //////////////////////////////////////////////////
+CreateCommand::CreateCommand(msgs::EntityFactoryWithNs *_msg,
+    std::shared_ptr<UserCommandsInterface> &_iface)
+    : UserCommandBase(_msg, _iface)
+{
+}
+
+//////////////////////////////////////////////////
 CreateCommand::CreateCommand(msgs::EntityFactory_V *_msg,
     std::shared_ptr<UserCommandsInterface> &_iface)
     : UserCommandBase(_msg, _iface)
 {
 }
+
+//////////////////////////////////////////////////
+CreateCommand::CreateCommand(msgs::EntityFactoryWithNs_V *_msg,
+    std::shared_ptr<UserCommandsInterface> &_iface)
+    : UserCommandBase(_msg, _iface)
+{
+}
+
 //////////////////////////////////////////////////
 bool CreateCommand::Execute()
 {
@@ -835,20 +882,39 @@ bool CreateCommand::Execute()
   {
     return this->CreateFromMsg(*createMsg);
   }
-  else
+  
+  auto createMsgV =
+      gz::msgs::DoDynamicCastMessage<msgs::EntityFactory_V>(this->msg);
+  if (nullptr != createMsgV)
   {
     // It could also be an EntityFactory_V
-    auto createMsgV =
-        gz::msgs::DoDynamicCastMessage<msgs::EntityFactory_V>(this->msg);
-    if (nullptr != createMsgV)
+    bool result = true;
+    for (const auto &msgItem : createMsgV->data())
     {
-      bool result = true;
-      for (const auto &msgItem : createMsgV->data())
-      {
-        result = result && this->CreateFromMsg(msgItem);
-      }
-      return result;
+      result = result && this->CreateFromMsg(msgItem);
     }
+    return result;
+  }
+
+  auto createMsgWithNs =
+      gz::msgs::DoDynamicCastMessage<msgs::EntityFactoryWithNs>(this->msg);
+  if (nullptr != createMsgWithNs)
+  {
+    // It could also be an EntityFactoryWithNs
+    return this->CreateFromMsg(*createMsgWithNs);
+  }
+
+  auto createMsgWithNsV =
+      gz::msgs::DoDynamicCastMessage<msgs::EntityFactoryWithNs_V>(this->msg);
+  if (nullptr != createMsgWithNsV)
+  {
+    // It could also be an EntityFactoryWithNs_V
+    bool result = true;
+    for (const auto &msgItem : createMsgWithNsV->data())
+    {
+      result = result && this->CreateFromMsg(msgItem);
+    }
+    return result;
   }
 
   gzerr << "Internal error, null create message" << std::endl;
@@ -856,7 +922,8 @@ bool CreateCommand::Execute()
 }
 
 //////////////////////////////////////////////////
-bool CreateCommand::CreateFromMsg(const msgs::EntityFactory &_createMsg)
+bool CreateCommand::CreateFromMsg(const msgs::EntityFactory &_createMsg,
+  const std::optional<std::string> &_ns)
 {
   // Load SDF
   sdf::Root root;
@@ -902,7 +969,7 @@ bool CreateCommand::CreateFromMsg(const msgs::EntityFactory &_createMsg)
         {
           auto parentEntity = parentComp->Data();
           clonedEntity = this->iface->ecm->Clone(entityToClone,
-              parentEntity, _createMsg.name(), _createMsg.allow_renaming());
+              parentEntity, _createMsg.name(), _ns, _createMsg.allow_renaming());
           validClone = kNullEntity != clonedEntity;
         }
       }
@@ -1027,6 +1094,10 @@ bool CreateCommand::CreateFromMsg(const msgs::EntityFactory &_createMsg)
   {
     auto model = *root.Model();
     model.SetName(desiredName);
+    if (_ns.has_value())
+    {
+      model.SetNamespace(_ns.value());
+    }
     entity = this->iface->creator->CreateEntitiesWithoutLoadingPlugins(&model);
   }
   else if (isLight && isRoot)
@@ -1116,6 +1187,75 @@ bool CreateCommand::CreateFromMsg(const msgs::EntityFactory &_createMsg)
          << std::endl;
 
   return true;
+}
+
+//////////////////////////////////////////////////
+bool CreateCommand::CreateFromMsg(const msgs::EntityFactoryWithNs &_createMsg)
+{
+  msgs::EntityFactory baseMsg;
+  this->CopyData(_createMsg, baseMsg);
+
+  std::optional<std::string> ns = std::nullopt;
+  if(_createMsg.has_ns())
+  {
+    ns = _createMsg.ns().data();
+  }
+
+  return this->CreateFromMsg(baseMsg, ns);
+}
+
+//////////////////////////////////////////////////
+void CreateCommand::CopyData(const msgs::EntityFactoryWithNs &_sourceMsg,
+    msgs::EntityFactory &_targetMsg)
+{
+  _targetMsg.Clear();
+
+  if (_sourceMsg.has_header())
+  {
+    _targetMsg.mutable_header()->CopyFrom(_sourceMsg.header());
+  }
+
+  switch (_sourceMsg.from_case())
+  {
+    case msgs::EntityFactoryWithNs::kSdf:
+      _targetMsg.set_sdf(_sourceMsg.sdf());
+      break;
+
+    case msgs::EntityFactoryWithNs::kSdfFilename:
+      _targetMsg.set_sdf_filename(_sourceMsg.sdf_filename());
+      break;
+
+    case msgs::EntityFactoryWithNs::kModel:
+      _targetMsg.mutable_model()->CopyFrom(_sourceMsg.model());
+      break;
+
+    case msgs::EntityFactoryWithNs::kLight:
+      _targetMsg.mutable_light()->CopyFrom(_sourceMsg.light());
+      break;
+
+    case msgs::EntityFactoryWithNs::kCloneName:
+      _targetMsg.set_clone_name(_sourceMsg.clone_name());
+      break;
+
+    case msgs::EntityFactoryWithNs::FROM_NOT_SET:
+    default:
+      break;
+  }
+
+  if (_sourceMsg.has_pose())
+  {
+    _targetMsg.mutable_pose()->CopyFrom(_sourceMsg.pose());
+  }
+
+  _targetMsg.set_name(_sourceMsg.name());
+  _targetMsg.set_allow_renaming(_sourceMsg.allow_renaming());
+  _targetMsg.set_relative_to(_sourceMsg.relative_to());
+
+  if (_sourceMsg.has_spherical_coordinates())
+  {
+    _targetMsg.mutable_spherical_coordinates()->CopyFrom(
+        _sourceMsg.spherical_coordinates());
+  }
 }
 
 //////////////////////////////////////////////////

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -198,13 +198,6 @@ class CreateCommand : public UserCommandBase
   /// \brief Actual implementation that creates entities from message.
   /// \param[in] Factory message that specifies the entity to create.
   private: bool CreateFromMsg(const msgs::EntityFactoryWithNs &_createMsg);
-
-  /// \brief Helper function to copy data from EntityFactoryWithNs message to
-  /// EntityFactory message.
-  /// \param[in] _sourceMsg EntityFactoryWithNs message to copy data from.
-  /// \param[in] _targetMsg EntityFactory message to copy data to.
-  private: void CopyData(const msgs::EntityFactoryWithNs &_sourceMsg,
-      msgs::EntityFactory &_targetMsg);
 };
 
 /// \brief Command to remove an entity from simulation.
@@ -1096,7 +1089,7 @@ bool CreateCommand::CreateFromMsg(const msgs::EntityFactory &_createMsg,
     model.SetName(desiredName);
     if (_ns.has_value())
     {
-      model.SetNamespace(_ns.value());
+      model.SetRawNamespace(_ns.value());
     }
     entity = this->iface->creator->CreateEntitiesWithoutLoadingPlugins(&model);
   }
@@ -1193,69 +1186,15 @@ bool CreateCommand::CreateFromMsg(const msgs::EntityFactory &_createMsg,
 bool CreateCommand::CreateFromMsg(const msgs::EntityFactoryWithNs &_createMsg)
 {
   msgs::EntityFactory baseMsg;
-  this->CopyData(_createMsg, baseMsg);
+  baseMsg.ParseFromString(_createMsg.SerializeAsString());
 
   std::optional<std::string> ns = std::nullopt;
-  if(_createMsg.has_ns())
+  if(_createMsg.has_namespace_())
   {
-    ns = _createMsg.ns().data();
+    ns = _createMsg.namespace_().data();
   }
 
   return this->CreateFromMsg(baseMsg, ns);
-}
-
-//////////////////////////////////////////////////
-void CreateCommand::CopyData(const msgs::EntityFactoryWithNs &_sourceMsg,
-    msgs::EntityFactory &_targetMsg)
-{
-  _targetMsg.Clear();
-
-  if (_sourceMsg.has_header())
-  {
-    _targetMsg.mutable_header()->CopyFrom(_sourceMsg.header());
-  }
-
-  switch (_sourceMsg.from_case())
-  {
-    case msgs::EntityFactoryWithNs::kSdf:
-      _targetMsg.set_sdf(_sourceMsg.sdf());
-      break;
-
-    case msgs::EntityFactoryWithNs::kSdfFilename:
-      _targetMsg.set_sdf_filename(_sourceMsg.sdf_filename());
-      break;
-
-    case msgs::EntityFactoryWithNs::kModel:
-      _targetMsg.mutable_model()->CopyFrom(_sourceMsg.model());
-      break;
-
-    case msgs::EntityFactoryWithNs::kLight:
-      _targetMsg.mutable_light()->CopyFrom(_sourceMsg.light());
-      break;
-
-    case msgs::EntityFactoryWithNs::kCloneName:
-      _targetMsg.set_clone_name(_sourceMsg.clone_name());
-      break;
-
-    case msgs::EntityFactoryWithNs::FROM_NOT_SET:
-    default:
-      break;
-  }
-
-  if (_sourceMsg.has_pose())
-  {
-    _targetMsg.mutable_pose()->CopyFrom(_sourceMsg.pose());
-  }
-
-  _targetMsg.set_name(_sourceMsg.name());
-  _targetMsg.set_allow_renaming(_sourceMsg.allow_renaming());
-  _targetMsg.set_relative_to(_sourceMsg.relative_to());
-
-  if (_sourceMsg.has_spherical_coordinates())
-  {
-    _targetMsg.mutable_spherical_coordinates()->CopyFrom(
-        _sourceMsg.spherical_coordinates());
-  }
 }
 
 //////////////////////////////////////////////////

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -893,6 +893,10 @@ bool CreateCommand::Execute()
   if (nullptr != createMsgWithNs)
   {
     // It could also be an EntityFactoryWithNs
+    gzwarn << "The EntityFactoryWithNs message and /create_with_ns service "
+           << "are deprecated and will be removed in a future version. "
+           << "Please use EntityFactory and /create instead."
+           << std::endl;
     return this->CreateFromMsg(*createMsgWithNs);
   }
 
@@ -901,6 +905,10 @@ bool CreateCommand::Execute()
   if (nullptr != createMsgWithNsV)
   {
     // It could also be an EntityFactoryWithNs_V
+    gzwarn << "The EntityFactoryWithNs_V message and create_with_ns_multiple "
+           << "service are deprecated and will be removed in a future version."
+           << " Please use EntityFactory_V and /create_multiple instead."
+           << std::endl;
     bool result = true;
     for (const auto &msgItem : createMsgWithNsV->data())
     {
@@ -917,6 +925,17 @@ bool CreateCommand::Execute()
 bool CreateCommand::CreateFromMsg(const msgs::EntityFactory &_createMsg,
   const std::string &_ns)
 {
+  // Load entity_namespace
+  std::string ns;
+  if (!_ns.empty())
+  {
+    ns = _ns;
+  }
+  else
+  {
+    ns = _createMsg.entity_namespace();
+  }
+
   // Load SDF
   sdf::Root root;
   sdf::Light lightSdf;
@@ -961,7 +980,7 @@ bool CreateCommand::CreateFromMsg(const msgs::EntityFactory &_createMsg,
         {
           auto parentEntity = parentComp->Data();
           clonedEntity = this->iface->ecm->Clone(entityToClone,
-              parentEntity, _createMsg.name(), _ns, _createMsg.allow_renaming());
+              parentEntity, _createMsg.name(), ns, _createMsg.allow_renaming());
           validClone = kNullEntity != clonedEntity;
         }
       }
@@ -1086,9 +1105,9 @@ bool CreateCommand::CreateFromMsg(const msgs::EntityFactory &_createMsg,
   {
     auto model = *root.Model();
     model.SetName(desiredName);
-    if (!_ns.empty())
+    if (!ns.empty())
     {
-      model.SetRawNamespace(_ns);
+      model.SetRawNamespace(ns);
     }
     entity = this->iface->creator->CreateEntitiesWithoutLoadingPlugins(&model);
   }

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -20,7 +20,6 @@
 #include "UserCommands.hh"
 #include <chrono>
 #include <future>
-#include <optional>
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -191,9 +190,9 @@ class CreateCommand : public UserCommandBase
 
   /// \brief Actual implementation that creates entities from message.
   /// \param[in] Factory message that specifies the entity to create.
-  /// \param[in] _ns Optional namespace to apply to the created entity.
+  /// \param[in] _ns Namespace to apply to the created entity.
   private: bool CreateFromMsg(const msgs::EntityFactory &_createMsg,
-      const std::optional<std::string> &_ns = std::nullopt);
+      const std::string &_ns);
 
   /// \brief Actual implementation that creates entities from message.
   /// \param[in] Factory message that specifies the entity to create.
@@ -873,7 +872,7 @@ bool CreateCommand::Execute()
       gz::msgs::DoDynamicCastMessage<msgs::EntityFactory>(this->msg);
   if (nullptr != createMsg)
   {
-    return this->CreateFromMsg(*createMsg);
+    return this->CreateFromMsg(*createMsg, "");
   }
   
   auto createMsgV =
@@ -884,7 +883,7 @@ bool CreateCommand::Execute()
     bool result = true;
     for (const auto &msgItem : createMsgV->data())
     {
-      result = result && this->CreateFromMsg(msgItem);
+      result = result && this->CreateFromMsg(msgItem, "");
     }
     return result;
   }
@@ -916,7 +915,7 @@ bool CreateCommand::Execute()
 
 //////////////////////////////////////////////////
 bool CreateCommand::CreateFromMsg(const msgs::EntityFactory &_createMsg,
-  const std::optional<std::string> &_ns)
+  const std::string &_ns)
 {
   // Load SDF
   sdf::Root root;
@@ -1087,9 +1086,9 @@ bool CreateCommand::CreateFromMsg(const msgs::EntityFactory &_createMsg,
   {
     auto model = *root.Model();
     model.SetName(desiredName);
-    if (_ns.has_value())
+    if (!_ns.empty())
     {
-      model.SetRawNamespace(_ns.value());
+      model.SetRawNamespace(_ns);
     }
     entity = this->iface->creator->CreateEntitiesWithoutLoadingPlugins(&model);
   }
@@ -1188,13 +1187,7 @@ bool CreateCommand::CreateFromMsg(const msgs::EntityFactoryWithNs &_createMsg)
   msgs::EntityFactory baseMsg;
   baseMsg.ParseFromString(_createMsg.SerializeAsString());
 
-  std::optional<std::string> ns = std::nullopt;
-  if(_createMsg.has_namespace_())
-  {
-    ns = _createMsg.namespace_().data();
-  }
-
-  return this->CreateFromMsg(baseMsg, ns);
+  return this->CreateFromMsg(baseMsg, _createMsg.namespace_());
 }
 
 //////////////////////////////////////////////////

--- a/src/systems/user_commands/UserCommands.cc
+++ b/src/systems/user_commands/UserCommands.cc
@@ -874,7 +874,7 @@ bool CreateCommand::Execute()
   {
     return this->CreateFromMsg(*createMsg, "");
   }
-  
+
   auto createMsgV =
       gz::msgs::DoDynamicCastMessage<msgs::EntityFactory_V>(this->msg);
   if (nullptr != createMsgV)
@@ -961,7 +961,8 @@ bool CreateCommand::CreateFromMsg(const msgs::EntityFactory &_createMsg,
         {
           auto parentEntity = parentComp->Data();
           clonedEntity = this->iface->ecm->Clone(entityToClone,
-              parentEntity, _createMsg.name(), _ns, _createMsg.allow_renaming());
+              parentEntity, _createMsg.name(),
+              _ns, _createMsg.allow_renaming());
           validClone = kNullEntity != clonedEntity;
         }
       }

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -24,6 +24,7 @@
 #include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/entity.pb.h>
 #include <gz/msgs/entity_factory.pb.h>
+#include <gz/msgs/entity_factory_with_ns.pb.h>
 #include <gz/msgs/light.pb.h>
 #include <gz/msgs/material_color.pb.h>
 #include <gz/msgs/physics.pb.h>
@@ -44,6 +45,7 @@
 #include "gz/sim/components/Material.hh"
 #include "gz/sim/components/Model.hh"
 #include "gz/sim/components/Name.hh"
+#include "gz/sim/components/Namespace.hh"
 #include "gz/sim/components/Physics.hh"
 #include "gz/sim/components/Pose.hh"
 #include "gz/sim/components/VisualCmd.hh"
@@ -130,7 +132,7 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   // SDF strings
   auto modelStr = std::string("<?xml version=\"1.0\" ?>") +
       "<sdf version='1.6'>" +
-      "<model name='spawned_model'>" +
+      "<model name='spawned_model' namespace='__name__/ns'>" +
       "<link name='link'>" +
       "<visual name='visual'>" +
       "<geometry><sphere><radius>1.0</radius></sphere></geometry>" +
@@ -172,7 +174,8 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
 
   // Check entity has not been created yet
   EXPECT_EQ(kNullEntity, ecm->EntityByComponents(components::Model(),
-      components::Name("spawned_model")));
+      components::Name("spawned_model"),
+      components::Namespace("spawned_model/ns")));
 
   // Run an iteration and check it was created
   server.Run(true, 1, false);
@@ -187,7 +190,8 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   entityCount = ecm->EntityCount();
 
   auto model = ecm->EntityByComponents(components::Model(),
-      components::Name("spawned_model"));
+      components::Name("spawned_model"),
+      components::Namespace("spawned_model/ns"));
   EXPECT_NE(kNullEntity, model);
 
   auto poseComp = ecm->Component<components::Pose>(model);
@@ -232,7 +236,8 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   entityCount = ecm->EntityCount();
 
   model = ecm->EntityByComponents(components::Model(),
-      components::Name("spawned_model_0"));
+      components::Name("spawned_model_0"),
+      components::Namespace("spawned_model_0/ns"));
   EXPECT_NE(kNullEntity, model);
 
   // Spawn with a different name
@@ -255,7 +260,7 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   entityCount = ecm->EntityCount();
 
   model = ecm->EntityByComponents(components::Model(),
-      components::Name("banana"));
+      components::Name("banana"), components::Namespace("banana/ns"));
   EXPECT_NE(kNullEntity, model);
 
   // Spawn a light
@@ -319,9 +324,9 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
 
   // Check neither exists yet
   EXPECT_EQ(kNullEntity, ecm->EntityByComponents(components::Model(),
-      components::Name("acerola")));
+      components::Name("acerola"), components::Namespace("acerola/ns")));
   EXPECT_EQ(kNullEntity, ecm->EntityByComponents(components::Model(),
-      components::Name("coconut")));
+      components::Name("coconut"), components::Namespace("coconut/ns")));
   EXPECT_EQ(entityCount, ecm->EntityCount());
 
   // Run an iteration and check both models were created
@@ -343,9 +348,9 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   entityCount = ecm->EntityCount();
 
   EXPECT_NE(kNullEntity, ecm->EntityByComponents(components::Model(),
-      components::Name("acerola")));
+      components::Name("acerola"), components::Namespace("acerola/ns")));
   EXPECT_NE(kNullEntity, ecm->EntityByComponents(components::Model(),
-      components::Name("coconut")));
+      components::Name("coconut"), components::Namespace("coconut/ns")));
 
   // Try to spawn 2 entities at once
   req.Clear();
@@ -407,9 +412,84 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
     EXPECT_TRUE(requestData.response.data());
   }
   EXPECT_EQ(entityCount + 4, ecm->EntityCount());
+  entityCount = ecm->EntityCount();
 
   EXPECT_NE(kNullEntity, ecm->EntityByComponents(components::Model(),
       components::Name("test_model")));
+
+  // Spawn a model with namespace
+  msgs::EntityFactoryWithNs reqWithNs;
+  reqWithNs.set_sdf(modelStr);
+  reqWithNs.set_name("spawned_model_with_ns");
+  reqWithNs.mutable_ns()->set_data("test_ns");
+
+  std::string serviceWithNs{"/world/empty/create_with_ns/blocking"};
+  auto requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
+
+  // Run an iteration and check it was created with namespace
+  server.Run(true, 1, false);
+  {
+    auto requestData = requestWithNsFuture.get();
+    EXPECT_TRUE(requestData.retval);
+    EXPECT_TRUE(requestData.result);
+    EXPECT_TRUE(requestData.response.data());
+  }
+
+  EXPECT_EQ(entityCount + 4, ecm->EntityCount());
+  entityCount = ecm->EntityCount();
+
+  model = ecm->EntityByComponents(components::Model(),
+      components::Name("spawned_model_with_ns"),
+      components::Namespace("test_ns"));
+  EXPECT_NE(kNullEntity, model);
+
+  // Spawn a model with empty namespace
+  reqWithNs.Clear();
+  reqWithNs.set_sdf(modelStr);
+  reqWithNs.set_name("spawned_model_with_empty_ns");
+  reqWithNs.mutable_ns()->set_data("");
+
+  requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
+
+  // Run an iteration and check it was created with namespace
+  server.Run(true, 1, false);
+  {
+    auto requestData = requestWithNsFuture.get();
+    EXPECT_TRUE(requestData.retval);
+    EXPECT_TRUE(requestData.result);
+    EXPECT_TRUE(requestData.response.data());
+  }
+
+  EXPECT_EQ(entityCount + 4, ecm->EntityCount());
+  entityCount = ecm->EntityCount();
+
+  model = ecm->EntityByComponents(components::Model(),
+      components::Name("spawned_model_with_empty_ns"),
+      components::Namespace(""));
+  EXPECT_NE(kNullEntity, model);
+
+  // Spawn a model without namespace provided
+  reqWithNs.Clear();
+  reqWithNs.set_sdf(modelStr);
+  reqWithNs.set_name("spawned_model_without_ns");
+
+  requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
+
+  // Run an iteration and check it was created with namespace
+  server.Run(true, 1, false);
+  {
+    auto requestData = requestWithNsFuture.get();
+    EXPECT_TRUE(requestData.retval);
+    EXPECT_TRUE(requestData.result);
+    EXPECT_TRUE(requestData.response.data());
+  }
+
+  EXPECT_EQ(entityCount + 4, ecm->EntityCount());
+
+  model = ecm->EntityByComponents(components::Model(),
+      components::Name("spawned_model_without_ns"),
+      components::Namespace("spawned_model_without_ns/ns"));
+  EXPECT_NE(kNullEntity, model);
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -277,7 +277,7 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
       components::Name("banana"), components::Namespace("banana/ns"));
   EXPECT_NE(kNullEntity, model);
 
-  // Spawn a model from SDF that doesn't define a namespace
+  // Spawn a model from SDF that doesn't set the namespace
   req.Clear();
   req.set_sdf(modelStrWithoutNs);
   req.set_name("orange");
@@ -297,9 +297,8 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   entityCount = ecm->EntityCount();
 
   model = ecm->EntityByComponents(components::Model(),
-      components::Name("orange"));
+      components::Name("orange"), components::Namespace(""));
   EXPECT_NE(kNullEntity, model);
-  EXPECT_EQ(nullptr, ecm->Component<components::Namespace>(model));
 
   // Spawn a light
   req.Clear();
@@ -460,7 +459,7 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   msgs::EntityFactoryWithNs reqWithNs;
   reqWithNs.set_sdf(modelStr);
   reqWithNs.set_name("spawned_model_with_ns");
-  reqWithNs.mutable_namespace_()->set_data("test_ns");
+  reqWithNs.set_namespace_("test_ns");
 
   std::string serviceWithNs{"/world/empty/create_with_ns/blocking"};
   auto requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
@@ -487,7 +486,7 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   reqWithNs.Clear();
   reqWithNs.set_sdf(modelStr);
   reqWithNs.set_name("spawned_model_with_empty_ns");
-  reqWithNs.mutable_namespace_()->set_data("");
+  reqWithNs.set_namespace_("");
 
   requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
 
@@ -505,7 +504,7 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
 
   model = ecm->EntityByComponents(components::Model(),
       components::Name("spawned_model_with_empty_ns"),
-      components::Namespace(""));
+      components::Namespace("spawned_model_with_empty_ns/ns"));
   EXPECT_NE(kNullEntity, model);
 
   // Spawn a model from SDF that defines a namespace through EntityFactoryWithNs
@@ -554,16 +553,15 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   entityCount = ecm->EntityCount();
 
   model = ecm->EntityByComponents(components::Model(),
-      components::Name("pineapple"));
+      components::Name("pineapple"), components::Namespace(""));
   EXPECT_NE(kNullEntity, model);
-  EXPECT_EQ(nullptr, ecm->Component<components::Namespace>(model));
 
   // Spawn a model from SDF that doesn't define a namespace through
   // EntityFactoryWithNs with a namespace override.
   reqWithNs.Clear();
   reqWithNs.set_sdf(modelStrWithoutNs );
   reqWithNs.set_name("grape");
-  reqWithNs.mutable_namespace_()->set_data("test_ns");
+  reqWithNs.set_namespace_("test_ns");
 
   requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
 

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -421,7 +421,7 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   msgs::EntityFactoryWithNs reqWithNs;
   reqWithNs.set_sdf(modelStr);
   reqWithNs.set_name("spawned_model_with_ns");
-  reqWithNs.mutable_ns()->set_data("test_ns");
+  reqWithNs.mutable_namespace_()->set_data("test_ns");
 
   std::string serviceWithNs{"/world/empty/create_with_ns/blocking"};
   auto requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
@@ -447,7 +447,7 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   reqWithNs.Clear();
   reqWithNs.set_sdf(modelStr);
   reqWithNs.set_name("spawned_model_with_empty_ns");
-  reqWithNs.mutable_ns()->set_data("");
+  reqWithNs.mutable_namespace_()->set_data("");
 
   requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
 

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -144,6 +144,20 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
       "</model>" +
       "</sdf>";
 
+  auto modelStrWithoutNs = std::string("<?xml version=\"1.0\" ?>") +
+      "<sdf version='1.6'>" +
+      "<model name='spawned_model'>" +
+      "<link name='link'>" +
+      "<visual name='visual'>" +
+      "<geometry><sphere><radius>1.0</radius></sphere></geometry>" +
+      "</visual>" +
+      "<collision name='visual'>" +
+      "<geometry><sphere><radius>1.0</radius></sphere></geometry>" +
+      "</collision>" +
+      "</link>" +
+      "</model>" +
+      "</sdf>";
+
   auto lightStr = std::string("<?xml version='1.0' ?>") +
       "<sdf version='1.6'>" +
       "<light name='spawned_light' type='directional'>" +
@@ -262,6 +276,30 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   model = ecm->EntityByComponents(components::Model(),
       components::Name("banana"), components::Namespace("banana/ns"));
   EXPECT_NE(kNullEntity, model);
+
+  // Spawn a model from SDF that doesn't define a namespace
+  req.Clear();
+  req.set_sdf(modelStrWithoutNs);
+  req.set_name("orange");
+
+  requestDataFuture = asyncRequest(node, service, req);
+
+  // Run an iteration and check it was created with given name
+  server.Run(true, 1, false);
+  {
+    auto requestData = requestDataFuture.get();
+    EXPECT_TRUE(requestData.retval);
+    EXPECT_TRUE(requestData.result);
+    EXPECT_TRUE(requestData.response.data());
+  }
+
+  EXPECT_EQ(entityCount + 4, ecm->EntityCount());
+  entityCount = ecm->EntityCount();
+
+  model = ecm->EntityByComponents(components::Model(),
+      components::Name("orange"));
+  EXPECT_NE(kNullEntity, model);
+  EXPECT_EQ(nullptr, ecm->Component<components::Namespace>(model));
 
   // Spawn a light
   req.Clear();
@@ -417,7 +455,8 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   EXPECT_NE(kNullEntity, ecm->EntityByComponents(components::Model(),
       components::Name("test_model")));
 
-  // Spawn a model with namespace
+  // Spawn a model from SDF that defines a namespace through EntityFactoryWithNs
+  // with a namespace override.  
   msgs::EntityFactoryWithNs reqWithNs;
   reqWithNs.set_sdf(modelStr);
   reqWithNs.set_name("spawned_model_with_ns");
@@ -443,7 +482,8 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
       components::Namespace("test_ns"));
   EXPECT_NE(kNullEntity, model);
 
-  // Spawn a model with empty namespace
+  // Spawn a model from SDF that defines a namespace through EntityFactoryWithNs
+  // with an empty namespace override.
   reqWithNs.Clear();
   reqWithNs.set_sdf(modelStr);
   reqWithNs.set_name("spawned_model_with_empty_ns");
@@ -468,7 +508,8 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
       components::Namespace(""));
   EXPECT_NE(kNullEntity, model);
 
-  // Spawn a model without namespace provided
+  // Spawn a model from SDF that defines a namespace through EntityFactoryWithNs
+  // without a namespace override.
   reqWithNs.Clear();
   reqWithNs.set_sdf(modelStr);
   reqWithNs.set_name("spawned_model_without_ns");
@@ -485,10 +526,61 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   }
 
   EXPECT_EQ(entityCount + 4, ecm->EntityCount());
+  entityCount = ecm->EntityCount();
 
   model = ecm->EntityByComponents(components::Model(),
       components::Name("spawned_model_without_ns"),
       components::Namespace("spawned_model_without_ns/ns"));
+  EXPECT_NE(kNullEntity, model);
+
+  // Spawn a model from SDF that doesn't define a namespace through
+  // EntityFactoryWithNs without a namespace override.
+  reqWithNs.Clear();
+  reqWithNs.set_sdf(modelStrWithoutNs);
+  reqWithNs.set_name("pineapple");
+
+  requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
+
+  // Run an iteration and check it was created with namespace
+  server.Run(true, 1, false);
+  {
+    auto requestData = requestWithNsFuture.get();
+    EXPECT_TRUE(requestData.retval);
+    EXPECT_TRUE(requestData.result);
+    EXPECT_TRUE(requestData.response.data());
+  }
+
+  EXPECT_EQ(entityCount + 4, ecm->EntityCount());
+  entityCount = ecm->EntityCount();
+
+  model = ecm->EntityByComponents(components::Model(),
+      components::Name("pineapple"));
+  EXPECT_NE(kNullEntity, model);
+  EXPECT_EQ(nullptr, ecm->Component<components::Namespace>(model));
+
+  // Spawn a model from SDF that doesn't define a namespace through
+  // EntityFactoryWithNs with a namespace override.
+  reqWithNs.Clear();
+  reqWithNs.set_sdf(modelStrWithoutNs );
+  reqWithNs.set_name("grape");
+  reqWithNs.mutable_namespace_()->set_data("test_ns");
+
+  requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
+
+  // Run an iteration and check it was created with namespace
+  server.Run(true, 1, false);
+  {
+    auto requestData = requestWithNsFuture.get();
+    EXPECT_TRUE(requestData.retval);
+    EXPECT_TRUE(requestData.result);
+    EXPECT_TRUE(requestData.response.data());
+  }
+
+  EXPECT_EQ(entityCount + 4, ecm->EntityCount());
+
+  model = ecm->EntityByComponents(components::Model(),
+      components::Name("grape"),
+      components::Namespace("test_ns"));
   EXPECT_NE(kNullEntity, model);
 }
 

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -455,18 +455,20 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   EXPECT_NE(kNullEntity, ecm->EntityByComponents(components::Model(),
       components::Name("test_model")));
 
-  // Spawn a model from SDF that defines a namespace with a namespace override.
-  req.Clear();
-  req.set_sdf(modelStr);
-  req.set_name("spawned_model_with_ns");
-  req.set_entity_namespace("test_ns");
+  // Spawn a model from SDF that defines a namespace through EntityFactoryWithNs
+  // with a namespace override.  
+  msgs::EntityFactoryWithNs reqWithNs;
+  reqWithNs.set_sdf(modelStr);
+  reqWithNs.set_name("spawned_model_with_ns");
+  reqWithNs.set_entity_namespace("test_ns");
 
-  requestDataFuture = asyncRequest(node, service, req);
+  std::string serviceWithNs{"/world/empty/create_with_ns/blocking"};
+  auto requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
 
   // Run an iteration and check it was created with namespace
   server.Run(true, 1, false);
   {
-    auto requestData = requestDataFuture.get();
+    auto requestData = requestWithNsFuture.get();
     EXPECT_TRUE(requestData.retval);
     EXPECT_TRUE(requestData.result);
     EXPECT_TRUE(requestData.response.data());
@@ -480,19 +482,19 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
       components::Namespace("test_ns"));
   EXPECT_NE(kNullEntity, model);
 
-  // Spawn a model from SDF that defines a namespace with an empty
-  // namespace override.
-  req.Clear();
-  req.set_sdf(modelStr);
-  req.set_name("spawned_model_with_empty_ns");
-  req.set_entity_namespace("");
+  // Spawn a model from SDF that defines a namespace through EntityFactoryWithNs
+  // with an empty namespace override.
+  reqWithNs.Clear();
+  reqWithNs.set_sdf(modelStr);
+  reqWithNs.set_name("spawned_model_with_empty_ns");
+  reqWithNs.set_entity_namespace("");
 
-  requestDataFuture = asyncRequest(node, service, req);
+  requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
 
   // Run an iteration and check it was created with namespace
   server.Run(true, 1, false);
   {
-    auto requestData = requestDataFuture.get();
+    auto requestData = requestWithNsFuture.get();
     EXPECT_TRUE(requestData.retval);
     EXPECT_TRUE(requestData.result);
     EXPECT_TRUE(requestData.response.data());
@@ -506,19 +508,18 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
       components::Namespace("spawned_model_with_empty_ns/ns"));
   EXPECT_NE(kNullEntity, model);
 
-  // Spawn a model from SDF that doesn't define a namespace with a
-  // namespace override.
-  req.Clear();
-  req.set_sdf(modelStrWithoutNs);
-  req.set_name("grape");
-  req.set_entity_namespace("test_ns");
+  // Spawn a model from SDF that defines a namespace through EntityFactoryWithNs
+  // without a namespace override.
+  reqWithNs.Clear();
+  reqWithNs.set_sdf(modelStr);
+  reqWithNs.set_name("spawned_model_without_ns");
 
-  requestDataFuture = asyncRequest(node, service, req);
+  requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
 
   // Run an iteration and check it was created with namespace
   server.Run(true, 1, false);
   {
-    auto requestData = requestDataFuture.get();
+    auto requestData = requestWithNsFuture.get();
     EXPECT_TRUE(requestData.retval);
     EXPECT_TRUE(requestData.result);
     EXPECT_TRUE(requestData.response.data());
@@ -528,23 +529,47 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   entityCount = ecm->EntityCount();
 
   model = ecm->EntityByComponents(components::Model(),
-      components::Name("grape"),
-      components::Namespace("test_ns"));
+      components::Name("spawned_model_without_ns"),
+      components::Namespace("spawned_model_without_ns/ns"));
   EXPECT_NE(kNullEntity, model);
 
-  // Spawn a model through EntityFactoryWithNs to verify the
-  // compatibility service still works during the deprecation cycle.
-  msgs::EntityFactoryWithNs reqWithNs;
-  reqWithNs.set_sdf(modelStr);
-  reqWithNs.set_name("spawned_model_with_ns_deprecated");
-  reqWithNs.set_entity_namespace("test_ns_deprecated");
+  // Spawn a model from SDF that doesn't define a namespace through
+  // EntityFactoryWithNs without a namespace override.
+  reqWithNs.Clear();
+  reqWithNs.set_sdf(modelStrWithoutNs);
+  reqWithNs.set_name("pineapple");
 
-  std::string serviceWithNs{"/world/empty/create_with_ns/blocking"};
-  auto requestDataWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
+  requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
+
   // Run an iteration and check it was created with namespace
   server.Run(true, 1, false);
   {
-    auto requestData = requestDataWithNsFuture.get();
+    auto requestData = requestWithNsFuture.get();
+    EXPECT_TRUE(requestData.retval);
+    EXPECT_TRUE(requestData.result);
+    EXPECT_TRUE(requestData.response.data());
+  }
+
+  EXPECT_EQ(entityCount + 4, ecm->EntityCount());
+  entityCount = ecm->EntityCount();
+
+  model = ecm->EntityByComponents(components::Model(),
+      components::Name("pineapple"), components::Namespace(""));
+  EXPECT_NE(kNullEntity, model);
+
+  // Spawn a model from SDF that doesn't define a namespace through
+  // EntityFactoryWithNs with a namespace override.
+  reqWithNs.Clear();
+  reqWithNs.set_sdf(modelStrWithoutNs );
+  reqWithNs.set_name("grape");
+  reqWithNs.set_entity_namespace("test_ns");
+
+  requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
+
+  // Run an iteration and check it was created with namespace
+  server.Run(true, 1, false);
+  {
+    auto requestData = requestWithNsFuture.get();
     EXPECT_TRUE(requestData.retval);
     EXPECT_TRUE(requestData.result);
     EXPECT_TRUE(requestData.response.data());
@@ -553,7 +578,7 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   EXPECT_EQ(entityCount + 4, ecm->EntityCount());
 
   model = ecm->EntityByComponents(components::Model(),
-      components::Name("spawned_model_with_ns"),
+      components::Name("grape"),
       components::Namespace("test_ns"));
   EXPECT_NE(kNullEntity, model);
 }

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -297,8 +297,9 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   entityCount = ecm->EntityCount();
 
   model = ecm->EntityByComponents(components::Model(),
-      components::Name("orange"), components::Namespace(""));
+      components::Name("orange"));
   EXPECT_NE(kNullEntity, model);
+  EXPECT_EQ(nullptr, ecm->Component<components::Namespace>(model));
 
   // Spawn a light
   req.Clear();

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -554,8 +554,9 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   entityCount = ecm->EntityCount();
 
   model = ecm->EntityByComponents(components::Model(),
-      components::Name("pineapple"), components::Namespace(""));
+      components::Name("pineapple"));
   EXPECT_NE(kNullEntity, model);
+  EXPECT_EQ(nullptr, ecm->Component<components::Namespace>(model));
 
   // Spawn a model from SDF that doesn't define a namespace through
   // EntityFactoryWithNs with a namespace override.

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -132,7 +132,7 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   // SDF strings
   auto modelStr = std::string("<?xml version=\"1.0\" ?>") +
       "<sdf version='1.6'>" +
-      "<model name='spawned_model' namespace='__name__/ns'>" +
+      "<model name='spawned_model' namespace='{name}/ns'>" +
       "<link name='link'>" +
       "<visual name='visual'>" +
       "<geometry><sphere><radius>1.0</radius></sphere></geometry>" +

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -456,7 +456,7 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
       components::Name("test_model")));
 
   // Spawn a model from SDF that defines a namespace through EntityFactoryWithNs
-  // with a namespace override.  
+  // with a namespace override.
   msgs::EntityFactoryWithNs reqWithNs;
   reqWithNs.set_sdf(modelStr);
   reqWithNs.set_name("spawned_model_with_ns");

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -459,7 +459,7 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   msgs::EntityFactoryWithNs reqWithNs;
   reqWithNs.set_sdf(modelStr);
   reqWithNs.set_name("spawned_model_with_ns");
-  reqWithNs.set_namespace_("test_ns");
+  reqWithNs.set_entity_namespace("test_ns");
 
   std::string serviceWithNs{"/world/empty/create_with_ns/blocking"};
   auto requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
@@ -486,7 +486,7 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   reqWithNs.Clear();
   reqWithNs.set_sdf(modelStr);
   reqWithNs.set_name("spawned_model_with_empty_ns");
-  reqWithNs.set_namespace_("");
+  reqWithNs.set_entity_namespace("");
 
   requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
 
@@ -561,7 +561,7 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   reqWithNs.Clear();
   reqWithNs.set_sdf(modelStrWithoutNs );
   reqWithNs.set_name("grape");
-  reqWithNs.set_namespace_("test_ns");
+  reqWithNs.set_entity_namespace("test_ns");
 
   requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
 

--- a/test/integration/user_commands.cc
+++ b/test/integration/user_commands.cc
@@ -454,20 +454,18 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
   EXPECT_NE(kNullEntity, ecm->EntityByComponents(components::Model(),
       components::Name("test_model")));
 
-  // Spawn a model from SDF that defines a namespace through EntityFactoryWithNs
-  // with a namespace override.  
-  msgs::EntityFactoryWithNs reqWithNs;
-  reqWithNs.set_sdf(modelStr);
-  reqWithNs.set_name("spawned_model_with_ns");
-  reqWithNs.set_entity_namespace("test_ns");
+  // Spawn a model from SDF that defines a namespace with a namespace override.
+  req.Clear();
+  req.set_sdf(modelStr);
+  req.set_name("spawned_model_with_ns");
+  req.set_entity_namespace("test_ns");
 
-  std::string serviceWithNs{"/world/empty/create_with_ns/blocking"};
-  auto requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
+  requestDataFuture = asyncRequest(node, service, req);
 
   // Run an iteration and check it was created with namespace
   server.Run(true, 1, false);
   {
-    auto requestData = requestWithNsFuture.get();
+    auto requestData = requestDataFuture.get();
     EXPECT_TRUE(requestData.retval);
     EXPECT_TRUE(requestData.result);
     EXPECT_TRUE(requestData.response.data());
@@ -481,19 +479,19 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
       components::Namespace("test_ns"));
   EXPECT_NE(kNullEntity, model);
 
-  // Spawn a model from SDF that defines a namespace through EntityFactoryWithNs
-  // with an empty namespace override.
-  reqWithNs.Clear();
-  reqWithNs.set_sdf(modelStr);
-  reqWithNs.set_name("spawned_model_with_empty_ns");
-  reqWithNs.set_entity_namespace("");
+  // Spawn a model from SDF that defines a namespace with an empty
+  // namespace override.
+  req.Clear();
+  req.set_sdf(modelStr);
+  req.set_name("spawned_model_with_empty_ns");
+  req.set_entity_namespace("");
 
-  requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
+  requestDataFuture = asyncRequest(node, service, req);
 
   // Run an iteration and check it was created with namespace
   server.Run(true, 1, false);
   {
-    auto requestData = requestWithNsFuture.get();
+    auto requestData = requestDataFuture.get();
     EXPECT_TRUE(requestData.retval);
     EXPECT_TRUE(requestData.result);
     EXPECT_TRUE(requestData.response.data());
@@ -507,18 +505,19 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
       components::Namespace("spawned_model_with_empty_ns/ns"));
   EXPECT_NE(kNullEntity, model);
 
-  // Spawn a model from SDF that defines a namespace through EntityFactoryWithNs
-  // without a namespace override.
-  reqWithNs.Clear();
-  reqWithNs.set_sdf(modelStr);
-  reqWithNs.set_name("spawned_model_without_ns");
+  // Spawn a model from SDF that doesn't define a namespace with a
+  // namespace override.
+  req.Clear();
+  req.set_sdf(modelStrWithoutNs);
+  req.set_name("grape");
+  req.set_entity_namespace("test_ns");
 
-  requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
+  requestDataFuture = asyncRequest(node, service, req);
 
   // Run an iteration and check it was created with namespace
   server.Run(true, 1, false);
   {
-    auto requestData = requestWithNsFuture.get();
+    auto requestData = requestDataFuture.get();
     EXPECT_TRUE(requestData.retval);
     EXPECT_TRUE(requestData.result);
     EXPECT_TRUE(requestData.response.data());
@@ -526,58 +525,34 @@ TEST_F(UserCommandsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Create))
 
   EXPECT_EQ(entityCount + 4, ecm->EntityCount());
   entityCount = ecm->EntityCount();
-
-  model = ecm->EntityByComponents(components::Model(),
-      components::Name("spawned_model_without_ns"),
-      components::Namespace("spawned_model_without_ns/ns"));
-  EXPECT_NE(kNullEntity, model);
-
-  // Spawn a model from SDF that doesn't define a namespace through
-  // EntityFactoryWithNs without a namespace override.
-  reqWithNs.Clear();
-  reqWithNs.set_sdf(modelStrWithoutNs);
-  reqWithNs.set_name("pineapple");
-
-  requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
-
-  // Run an iteration and check it was created with namespace
-  server.Run(true, 1, false);
-  {
-    auto requestData = requestWithNsFuture.get();
-    EXPECT_TRUE(requestData.retval);
-    EXPECT_TRUE(requestData.result);
-    EXPECT_TRUE(requestData.response.data());
-  }
-
-  EXPECT_EQ(entityCount + 4, ecm->EntityCount());
-  entityCount = ecm->EntityCount();
-
-  model = ecm->EntityByComponents(components::Model(),
-      components::Name("pineapple"), components::Namespace(""));
-  EXPECT_NE(kNullEntity, model);
-
-  // Spawn a model from SDF that doesn't define a namespace through
-  // EntityFactoryWithNs with a namespace override.
-  reqWithNs.Clear();
-  reqWithNs.set_sdf(modelStrWithoutNs );
-  reqWithNs.set_name("grape");
-  reqWithNs.set_entity_namespace("test_ns");
-
-  requestWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
-
-  // Run an iteration and check it was created with namespace
-  server.Run(true, 1, false);
-  {
-    auto requestData = requestWithNsFuture.get();
-    EXPECT_TRUE(requestData.retval);
-    EXPECT_TRUE(requestData.result);
-    EXPECT_TRUE(requestData.response.data());
-  }
-
-  EXPECT_EQ(entityCount + 4, ecm->EntityCount());
 
   model = ecm->EntityByComponents(components::Model(),
       components::Name("grape"),
+      components::Namespace("test_ns"));
+  EXPECT_NE(kNullEntity, model);
+
+  // Spawn a model through EntityFactoryWithNs to verify the
+  // compatibility service still works during the deprecation cycle.
+  msgs::EntityFactoryWithNs reqWithNs;
+  reqWithNs.set_sdf(modelStr);
+  reqWithNs.set_name("spawned_model_with_ns_deprecated");
+  reqWithNs.set_entity_namespace("test_ns_deprecated");
+
+  std::string serviceWithNs{"/world/empty/create_with_ns/blocking"};
+  auto requestDataWithNsFuture = asyncRequest(node, serviceWithNs, reqWithNs);
+  // Run an iteration and check it was created with namespace
+  server.Run(true, 1, false);
+  {
+    auto requestData = requestDataWithNsFuture.get();
+    EXPECT_TRUE(requestData.retval);
+    EXPECT_TRUE(requestData.result);
+    EXPECT_TRUE(requestData.response.data());
+  }
+
+  EXPECT_EQ(entityCount + 4, ecm->EntityCount());
+
+  model = ecm->EntityByComponents(components::Model(),
+      components::Name("spawned_model_with_ns"),
       components::Namespace("test_ns"));
   EXPECT_NE(kNullEntity, model);
 }


### PR DESCRIPTION
# 🎉 New feature

## Summary

This PR adds new services for creating entities with a namespace:
  - `/world/<world>/create_with_ns`
  - `/world/<world>/create_with_ns_multiple`

The new services use `EntityFactoryWithNs` messages. When a namespace is provided, it is applied to the created model. When no namespace is provided, the model keeps the namespace from the SDF if one exists.

This also updates entity cloning so cloned entities can either:
  - use a namespace passed by the caller
  - keep the original entity namespace when no new namespace is passed

Tests were updated to cover entity creation with and without namespaces, namespace overrides, and namespace handling during cloning.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Test it
 Build the project, then run the related tests:

```bash
ctest -R "EntityComponentManager|user_commands"
 ```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
