### PR TITLE
Report protobuf serialization errors

### DIFF
--- a/include/gz/sim/components/SemanticDescription.hh
+++ b/include/gz/sim/components/SemanticDescription.hh
@@ -44,8 +44,10 @@ class SemanticDescriptionSerializer
   {
     msgs::StringMsg msg;
     msg.set_data(_desc);
-    auto result = msg.SerializeToOstream(&_out);
-    (void)result;
+    if (!msg.SerializeToOstream(&_out))
+    {
+      _out.setstate(std::ios_base::failbit);
+    }
     return _out;
   }
 
@@ -53,10 +55,13 @@ class SemanticDescriptionSerializer
   static std::istream &Deserialize(std::istream &_in, std::string &_desc)
   {
     msgs::StringMsg msg;
-    if(msg.ParsePartialFromIstream(&_in))
+    if (!msg.ParsePartialFromIstream(&_in))
     {
-      _desc = msg.data();
+      _in.setstate(std::ios_base::failbit);
+      return _in;
     }
+
+    _desc = msg.data();
     return _in;
   }
 };

--- a/include/gz/sim/components/SemanticTags.hh
+++ b/include/gz/sim/components/SemanticTags.hh
@@ -48,8 +48,10 @@ class SemanticTagsSerializer
     {
       msg.add_data(tag);
     }
-    auto result = msg.SerializeToOstream(&_out);
-    (void)result;
+    if (!msg.SerializeToOstream(&_out))
+    {
+      _out.setstate(std::ios_base::failbit);
+    }
     return _out;
   }
 
@@ -58,8 +60,9 @@ class SemanticTagsSerializer
                                    std::vector<std::string> &_tags)
   {
     msgs::StringMsg_V msg;
-    if(!msg.ParsePartialFromIstream(&_in))
+    if (!msg.ParsePartialFromIstream(&_in))
     {
+      _in.setstate(std::ios_base::failbit);
       return _in;
     }
     _tags.clear();

--- a/include/gz/sim/components/Serialization.hh
+++ b/include/gz/sim/components/Serialization.hh
@@ -22,7 +22,7 @@
 #pragma warning(disable: 4251)
 #endif
 
-#include <google/protobuf/message_lite.h>
+#include <google/protobuf/message.h>
 
 #ifdef _MSC_VER
 #pragma warning(pop)
@@ -30,6 +30,8 @@
 
 #include <gz/msgs/double_v.pb.h>
 
+#include <ios>
+#include <memory>
 #include <string>
 #include <vector>
 #include <sdf/Sensor.hh>
@@ -125,8 +127,10 @@ namespace serializers
         msg = gz::msgs::Convert(_data);
       }
 
-      auto result = msg.SerializeToOstream(&_out);
-      (void)result;
+      if (!msg.SerializeToOstream(&_out))
+      {
+        _out.setstate(std::ios_base::failbit);
+      }
       return _out;
     }
 
@@ -140,6 +144,7 @@ namespace serializers
       MsgType msg;
       if (!msg.ParseFromIstream(&_in))
       {
+        _in.setstate(std::ios_base::failbit);
         return _in;
       }
 
@@ -170,8 +175,10 @@ namespace serializers
     {
       gz::msgs::Double_V msg;
       *msg.mutable_data() = {_vec.begin(), _vec.end()};
-      auto result = msg.SerializeToOstream(&_out);
-      (void)result;
+      if (!msg.SerializeToOstream(&_out))
+      {
+        _out.setstate(std::ios_base::failbit);
+      }
       return _out;
     }
 
@@ -185,6 +192,7 @@ namespace serializers
       gz::msgs::Double_V msg;
       if (!msg.ParseFromIstream(&_in))
       {
+        _in.setstate(std::ios_base::failbit);
         return _in;
       }
 
@@ -203,8 +211,10 @@ namespace serializers
     public: static std::ostream &Serialize(std::ostream &_out,
         const google::protobuf::Message &_msg)
     {
-      auto result = _msg.SerializeToOstream(&_out);
-      (void)result;
+      if (!_msg.SerializeToOstream(&_out))
+      {
+        _out.setstate(std::ios_base::failbit);
+      }
       return _out;
     }
 
@@ -215,8 +225,16 @@ namespace serializers
     public: static std::istream &Deserialize(std::istream &_in,
         google::protobuf::Message &_msg)
     {
-      auto result = _msg.ParseFromIstream(&_in);
-      (void)result;
+      // Parse into a temporary message so malformed data can't leave the
+      // component partially updated.
+      std::unique_ptr<google::protobuf::Message> parsed(_msg.New());
+      if (!parsed->ParseFromIstream(&_in))
+      {
+        _in.setstate(std::ios_base::failbit);
+        return _in;
+      }
+
+      _msg.CopyFrom(*parsed);
       return _in;
     }
   };

--- a/src/Component_TEST.cc
+++ b/src/Component_TEST.cc
@@ -20,14 +20,20 @@
 #include <gz/utils/ExtraTestMacros.hh>
 
 #include <memory>
+#include <sstream>
+#include <streambuf>
 
 #include <sdf/Element.hh>
 #include <gz/common/Console.hh>
 #include <gz/math/Inertial.hh>
 
 #include "gz/sim/components/Component.hh"
+#include "gz/sim/components/Inertial.hh"
+#include "gz/sim/components/JointPosition.hh"
 #include "gz/sim/components/Serialization.hh"
 #include "gz/sim/components/Name.hh"
+#include "gz/sim/components/SemanticDescription.hh"
+#include "gz/sim/components/SemanticTags.hh"
 #include "gz/sim/EntityComponentManager.hh"
 
 #include "../test/helpers/EnvTestFixture.hh"
@@ -42,6 +48,20 @@ struct SimpleOperator
 };
 
 struct Simple {};
+
+/// \brief A stream buffer which rejects every write.
+class FailingOutputBuffer : public std::streambuf
+{
+  protected: int_type overflow(int_type) override
+  {
+    return traits_type::eof();
+  }
+
+  protected: std::streamsize xsputn(const char *, std::streamsize) override
+  {
+    return 0;
+  }
+};
 
 using CustomComponent =
       components::Component<std::shared_ptr<int>, class CustomComponentTag>;
@@ -530,6 +550,93 @@ TEST_F(ComponentTest, IStream)
     std::istringstream istr("not used");
     comp.Deserialize(istr);
   }
+}
+
+//////////////////////////////////////////////////
+// See https://github.com/gazebosim/gz-sim/issues/3385
+TEST_F(ComponentTest, ProtobufStreamErrors)
+{
+  const std::string invalidProto(1, static_cast<char>(0x80));
+
+  // Parsing failures should set failbit and leave component data unchanged.
+  {
+    msgs::Int32 data;
+    data.set_data(482);
+    CustomMsg comp(data);
+    std::istringstream istr(invalidProto);
+    comp.Deserialize(istr);
+    EXPECT_TRUE(istr.fail());
+    EXPECT_EQ(482, comp.Data().data());
+  }
+
+  {
+    components::JointPosition comp(std::vector<double>{1.0, 2.0});
+    std::istringstream istr(invalidProto);
+    comp.Deserialize(istr);
+    EXPECT_TRUE(istr.fail());
+    EXPECT_EQ((std::vector<double>{1.0, 2.0}), comp.Data());
+  }
+
+  {
+    math::Inertiald inertial;
+    auto massMatrix = inertial.MassMatrix();
+    massMatrix.SetMass(42.0);
+    inertial.SetMassMatrix(massMatrix);
+    components::Inertial comp(inertial);
+    std::istringstream istr(invalidProto);
+    comp.Deserialize(istr);
+    EXPECT_TRUE(istr.fail());
+    EXPECT_DOUBLE_EQ(42.0, comp.Data().MassMatrix().Mass());
+  }
+
+  {
+    std::string description = "original";
+    std::istringstream istr(invalidProto);
+    serializers::SemanticDescriptionSerializer::Deserialize(
+        istr, description);
+    EXPECT_TRUE(istr.fail());
+    EXPECT_EQ("original", description);
+  }
+
+  {
+    components::SemanticTags comp(
+        std::vector<std::string>{"one", "two"});
+    std::istringstream istr(invalidProto);
+    comp.Deserialize(istr);
+    EXPECT_TRUE(istr.fail());
+    EXPECT_EQ((std::vector<std::string>{"one", "two"}), comp.Data());
+  }
+
+  // Serialization failures should be observable through the output stream.
+  auto expectSerializationFailure = [](const auto &_component)
+  {
+    FailingOutputBuffer buffer;
+    std::ostream out(&buffer);
+    EXPECT_TRUE(out.good());
+    _component.Serialize(out);
+    EXPECT_TRUE(out.fail());
+  };
+
+  msgs::Int32 msg;
+  msg.set_data(482);
+  expectSerializationFailure(CustomMsg(msg));
+  expectSerializationFailure(
+      components::JointPosition(std::vector<double>{1.0, 2.0}));
+
+  math::Inertiald inertial;
+  auto massMatrix = inertial.MassMatrix();
+  massMatrix.SetMass(42.0);
+  inertial.SetMassMatrix(massMatrix);
+  expectSerializationFailure(components::Inertial(inertial));
+  {
+    FailingOutputBuffer buffer;
+    std::ostream out(&buffer);
+    EXPECT_TRUE(out.good());
+    serializers::SemanticDescriptionSerializer::Serialize(out, "description");
+    EXPECT_TRUE(out.fail());
+  }
+  expectSerializationFailure(
+      components::SemanticTags(std::vector<std::string>{"one", "two"}));
 }
 
 namespace test_components


### PR DESCRIPTION
## Summary

- propagate protobuf serialization and deserialization failures through the stream state
- parse generic protobuf messages into a temporary object before updating component data
- cover message, vector, converted-component, semantic-description, and semantic-tags serializers

## Root cause

The protobuf APIs return `false` on failure, but the serializers discarded those results. Callers therefore could not observe malformed input or failed output, and the generic message serializer could leave component data partially updated after a failed parse.

## Testing

- `git diff --check`
- `cppcheck --enable=warning,performance,portability --std=c++17 --language=c++ --suppress=missingIncludeSystem --suppress=missingInclude -Iinclude ...`
- `bazel test //:Component_TEST` was attempted locally, but the macOS Bazel toolchain failed in the unchanged external `tinyxml2` dependency because it could not locate `<cctype>`, before this target compiled

Fixes #3385
