### PR TITLE
Revert arm64 skip in ModelCommandAPI_TEST

### DIFF
--- a/src/cmd/ModelCommandAPI_TEST.cc
+++ b/src/cmd/ModelCommandAPI_TEST.cc
@@ -239,10 +239,7 @@ TEST_F(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_WIN32(Commands))
       "    - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "      [0.000000 0.000000 0.000000]\n"
       "      [0.000000 0.000000 0.000000]\n";
-    // Skip expectation on arm64 due to issue 3602
-#ifndef __aarch64__
     EXPECT_EQ(expectedOutput, output);
-#endif
   }
 
   // Tested command: gz model -m vehicle_blue --pose
@@ -391,10 +388,7 @@ TEST_F(ModelCommandAPI, GZ_UTILS_TEST_DISABLED_ON_WIN32(Commands))
       "  - Pose [ XYZ (m) ] [ RPY (rad) ]:\n"
       "    [0.000000 0.000000 0.000000]\n"
       "    [0.000000 0.000000 0.000000]\n";
-    // Skip expectation on arm64 due to issue 3602
-#ifndef __aarch64__
     EXPECT_EQ(expectedOutput, output);
-#endif
   }
 
   // Tested command: gz model -m vehicle_blue --joint caster_wheel


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/3602
Reverts https://github.com/gazebosim/gz-sim/pull/3603

## Summary

#3603 suppressed two `EXPECT_EQ` checks in `UNIT_ModelCommandAPI_TEST` behind `#ifndef __aarch64__`, because `gz model -m vehicle_blue` and `gz model -m vehicle_blue --joint` printed `- Axis unit vector [ XYZ ]: [0 1.26714e-17 1]` instead of `[0 0 1]` on macOS arm64.

The root cause was upstream in sdformat: `resolvePose` composed an edge chain with its own inverse when a frame was resolved against itself, which is the identity in real arithmetic but leaves a residual on the order of 2^-56 in floating point. `JointAxis::ResolveXyz` then rotated `(0, 0, 1)` by that near-identity quaternion. gazebosim/sdformat#1693 makes `resolvePose` return the identity directly for that case, and is merged to sdformat `main`.

This restores the two expectations. It is an exact revert of #3603 — three lines at each of two sites, one file, nothing else.

Only the joint axis line was ever affected. Every other numeric field in these two blocks — model pose, link poses, inertial poses, mass, inertia matrix — is formatted through `std::to_string`, i.e. six decimals, and is blind to a residual of this magnitude. The axis line is the only value in `ModelCommandAPI.cc` streamed straight to `std::cout`. That matches the diffs reported in #3602, where every differing hunk was an `- Axis unit vector` line.

## Testing

Verified on arm64 macOS before opening this:
https://github.com/samirbhattarai135/gz-sim/actions/runs/31436046216

`macos-15` runner (macOS 15.7.7, arm64, Apple clang 17.0.0 / clang-1700.0.13.5), this branch, dependencies from `brew install --HEAD --only-dependencies gz-rotary-sim` so sdformat is built from `main`:

```
installed gz-rotary-sdformat: HEAD-d08e88d
sdformat d08e88d contains d08e88d49415c6d6abba3114e8003d1b2ca6c8e9.
```

```
1/2 Test #85: UNIT_ModelCommandAPI_TEST .........   Passed   25.38 sec
2/2 Test #86: check_UNIT_ModelCommandAPI_TEST ...   Passed    0.07 sec
100% tests passed out of 2
```

A pass is only worth reporting if the runner is one where the residual can occur at all, so the job checks that first. It compiles a probe that composes the wheel-link pose from `static_diff_drive_vehicle.sdf` with its own inverse and rotates `UnitZ` by the result, and fails the job if the round trip cancels exactly:

```
residual -6.3357220245782474e-18 1.2671444049156495e-17
```

Those are the same values you measured locally on sdformat#1693, and the second is what #3602 prints as `1.26714e-17`. So the toolchain on that runner does produce the residual, and `UNIT_ModelCommandAPI_TEST` passes anyway once sdformat contains the fix. Because the restored expectation compares against a string containing `[0 0 1]`, this is also a direct observation that `gz model -m vehicle_blue --joint` now prints the declared axis exactly — previously only the sdformat unit test had been confirmed.

Two caveats on that run. It is GitHub Actions on my fork, not the OSRF builder, and it builds gz-sim from source against head-only brew formulas rather than through the packaging path. It also does not include a red baseline: I could not build the same tree against a pre-fix sdformat without pinning the formula, so the before/after pairing rests on your local revert of the `FrameSemantics.cc` hunk in sdformat#1693 rather than on this run.

`gz_sim-ci-pr_any-homebrew-arm64` is still the canonical check. If you trigger it, the two things worth reading in the console are that the formula line resolves to `gz-rotary-sdformat (HEAD-d08e88d)` or newer, and that `UNIT_ModelCommandAPI_TEST` passes. Recent runs of that job have also shown an unrelated `INTEGRATION_entity_system` failure (build 1738), which turns the GitHub status red without bearing on this change.

The verification workflow is not part of this PR — it lives on a scratch branch and will be deleted.

## Scope

`main` only. The same guard exists on `gz-sim10`, `gz-sim9` and `gz-sim8`, but sdformat#1693 is on sdformat `main` alone — `sdf16`, `sdf15` and `sdf14` do not have it — so reverting there would reintroduce the failure. Happy to open backports if and when the sdformat fix is backported.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage)) — `UNIT_ModelCommandAPI_TEST` only, on arm64 macOS; not the full suite
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

No tests added: this restores coverage that #3603 removed rather than adding any. `codecheck` and the full suite were not run — the change only deletes preprocessor lines.

**Note:** Assisted by Claude (Anthropic) per the GenAI disclosure policy; the commit carries an `Assisted-by:` trailer.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
