### PR TITLE
Capture this explicitly in the component inspector editor callbacks

### DIFF
--- a/src/gui/plugins/component_inspector_editor/AirPressure.cc
+++ b/src/gui/plugins/component_inspector_editor/AirPressure.cc
@@ -65,7 +65,8 @@ Q_INVOKABLE void AirPressure::OnAirPressureNoise(
     double _dynamicBiasCorrelationTime)
 {
   gz::sim::UpdateCallback cb =
-      [=](EntityComponentManager &_ecm)
+      [this, _mean, _meanBias, _stdDev, _stdDevBias, _dynamicBiasStdDev,
+       _dynamicBiasCorrelationTime](EntityComponentManager &_ecm)
   {
     auto comp = _ecm.Component<components::AirPressureSensor>(
         this->inspector->GetEntity());
@@ -97,7 +98,7 @@ Q_INVOKABLE void AirPressure::OnAirPressureReferenceAltitude(
     double _referenceAltitude)
 {
   gz::sim::UpdateCallback cb =
-      [=](EntityComponentManager &_ecm)
+      [this, _referenceAltitude](EntityComponentManager &_ecm)
   {
     auto comp = _ecm.Component<components::AirPressureSensor>(
         this->inspector->GetEntity());

--- a/src/gui/plugins/component_inspector_editor/Altimeter.cc
+++ b/src/gui/plugins/component_inspector_editor/Altimeter.cc
@@ -69,7 +69,8 @@ Q_INVOKABLE void Altimeter::OnAltimeterPositionNoise(
     double _dynamicBiasCorrelationTime)
 {
   gz::sim::UpdateCallback cb =
-      [=](EntityComponentManager &_ecm)
+      [this, _mean, _meanBias, _stdDev, _stdDevBias, _dynamicBiasStdDev,
+       _dynamicBiasCorrelationTime](EntityComponentManager &_ecm)
   {
     auto comp = _ecm.Component<components::Altimeter>(
         this->inspector->GetEntity());
@@ -103,7 +104,8 @@ Q_INVOKABLE void Altimeter::OnAltimeterVelocityNoise(
     double _dynamicBiasCorrelationTime)
 {
   gz::sim::UpdateCallback cb =
-      [=](EntityComponentManager &_ecm)
+      [this, _mean, _meanBias, _stdDev, _stdDevBias, _dynamicBiasStdDev,
+       _dynamicBiasCorrelationTime](EntityComponentManager &_ecm)
   {
     auto comp = _ecm.Component<components::Altimeter>(
         this->inspector->GetEntity());

--- a/src/gui/plugins/component_inspector_editor/Imu.cc
+++ b/src/gui/plugins/component_inspector_editor/Imu.cc
@@ -100,7 +100,8 @@ Q_INVOKABLE void Imu::OnLinearAccelerationXNoise(
     double _dynamicBiasCorrelationTime)
 {
   gz::sim::UpdateCallback cb =
-      [=](EntityComponentManager &_ecm)
+      [this, _mean, _meanBias, _stdDev, _stdDevBias, _dynamicBiasStdDev,
+       _dynamicBiasCorrelationTime](EntityComponentManager &_ecm)
   {
     auto comp = _ecm.Component<components::Imu>(
         this->inspector->GetEntity());
@@ -134,7 +135,8 @@ Q_INVOKABLE void Imu::OnLinearAccelerationYNoise(
     double _dynamicBiasCorrelationTime)
 {
   gz::sim::UpdateCallback cb =
-      [=](EntityComponentManager &_ecm)
+      [this, _mean, _meanBias, _stdDev, _stdDevBias, _dynamicBiasStdDev,
+       _dynamicBiasCorrelationTime](EntityComponentManager &_ecm)
   {
     auto comp = _ecm.Component<components::Imu>(
         this->inspector->GetEntity());
@@ -168,7 +170,8 @@ Q_INVOKABLE void Imu::OnLinearAccelerationZNoise(
     double _dynamicBiasCorrelationTime)
 {
   gz::sim::UpdateCallback cb =
-      [=](EntityComponentManager &_ecm)
+      [this, _mean, _meanBias, _stdDev, _stdDevBias, _dynamicBiasStdDev,
+       _dynamicBiasCorrelationTime](EntityComponentManager &_ecm)
   {
     auto comp = _ecm.Component<components::Imu>(
         this->inspector->GetEntity());
@@ -202,7 +205,8 @@ Q_INVOKABLE void Imu::OnAngularVelocityXNoise(
     double _dynamicBiasCorrelationTime)
 {
   gz::sim::UpdateCallback cb =
-      [=](EntityComponentManager &_ecm)
+      [this, _mean, _meanBias, _stdDev, _stdDevBias, _dynamicBiasStdDev,
+       _dynamicBiasCorrelationTime](EntityComponentManager &_ecm)
   {
     auto comp = _ecm.Component<components::Imu>(
         this->inspector->GetEntity());
@@ -236,7 +240,8 @@ Q_INVOKABLE void Imu::OnAngularVelocityYNoise(
     double _dynamicBiasCorrelationTime)
 {
   gz::sim::UpdateCallback cb =
-      [=](EntityComponentManager &_ecm)
+      [this, _mean, _meanBias, _stdDev, _stdDevBias, _dynamicBiasStdDev,
+       _dynamicBiasCorrelationTime](EntityComponentManager &_ecm)
   {
     auto comp = _ecm.Component<components::Imu>(
         this->inspector->GetEntity());
@@ -270,7 +275,8 @@ Q_INVOKABLE void Imu::OnAngularVelocityZNoise(
     double _dynamicBiasCorrelationTime)
 {
   gz::sim::UpdateCallback cb =
-      [=](EntityComponentManager &_ecm)
+      [this, _mean, _meanBias, _stdDev, _stdDevBias, _dynamicBiasStdDev,
+       _dynamicBiasCorrelationTime](EntityComponentManager &_ecm)
   {
     auto comp = _ecm.Component<components::Imu>(
         this->inspector->GetEntity());

--- a/src/gui/plugins/component_inspector_editor/JointType.cc
+++ b/src/gui/plugins/component_inspector_editor/JointType.cc
@@ -78,7 +78,7 @@ JointType::JointType(ComponentInspectorEditor *_inspector)
 Q_INVOKABLE void JointType::OnJointType(QString _jointType)
 {
   gz::sim::UpdateCallback cb =
-      [=](EntityComponentManager &_ecm)
+      [this, _jointType](EntityComponentManager &_ecm)
   {
     components::JointType *comp =
       _ecm.Component<components::JointType>(this->inspector->GetEntity());

--- a/src/gui/plugins/component_inspector_editor/Lidar.cc
+++ b/src/gui/plugins/component_inspector_editor/Lidar.cc
@@ -79,7 +79,8 @@ Q_INVOKABLE void Lidar::OnLidarNoise(
     double _dynamicBiasCorrelationTime)
 {
   gz::sim::UpdateCallback cb =
-      [=](EntityComponentManager &_ecm)
+      [this, _mean, _meanBias, _stdDev, _stdDevBias, _dynamicBiasStdDev,
+       _dynamicBiasCorrelationTime](EntityComponentManager &_ecm)
   {
     auto comp = _ecm.Component<components::GpuLidar>(
         this->inspector->GetEntity());
@@ -117,7 +118,11 @@ Q_INVOKABLE void Lidar::OnLidarChange(
     double _verticalScanMaxAngle)
 {
   gz::sim::UpdateCallback cb =
-      [=](EntityComponentManager &_ecm)
+      [this, _rangeMin, _rangeMax, _rangeResolution, _horizontalScanSamples,
+       _horizontalScanResolution, _horizontalScanMinAngle,
+       _horizontalScanMaxAngle, _verticalScanSamples, _verticalScanResolution,
+       _verticalScanMinAngle,
+       _verticalScanMaxAngle](EntityComponentManager &_ecm)
   {
     auto comp = _ecm.Component<components::GpuLidar>(
         this->inspector->GetEntity());

--- a/src/gui/plugins/component_inspector_editor/Magnetometer.cc
+++ b/src/gui/plugins/component_inspector_editor/Magnetometer.cc
@@ -78,7 +78,8 @@ Q_INVOKABLE void Magnetometer::OnMagnetometerXNoise(
       double _dynamicBiasCorrelationTime)
 {
   UpdateCallback cb =
-      [=](EntityComponentManager &_ecm)
+      [this, _mean, _meanBias, _stdDev, _stdDevBias, _dynamicBiasStdDev,
+       _dynamicBiasCorrelationTime](EntityComponentManager &_ecm)
   {
     auto comp = _ecm.Component<components::Magnetometer>(
         this->inspector->GetEntity());
@@ -112,7 +113,8 @@ Q_INVOKABLE void Magnetometer::OnMagnetometerYNoise(
       double _dynamicBiasCorrelationTime)
 {
   UpdateCallback cb =
-      [=](EntityComponentManager &_ecm)
+      [this, _mean, _meanBias, _stdDev, _stdDevBias, _dynamicBiasStdDev,
+       _dynamicBiasCorrelationTime](EntityComponentManager &_ecm)
   {
     auto comp = _ecm.Component<components::Magnetometer>(
         this->inspector->GetEntity());
@@ -146,7 +148,8 @@ Q_INVOKABLE void Magnetometer::OnMagnetometerZNoise(
       double _dynamicBiasCorrelationTime)
 {
   UpdateCallback cb =
-      [=](EntityComponentManager &_ecm)
+      [this, _mean, _meanBias, _stdDev, _stdDevBias, _dynamicBiasStdDev,
+       _dynamicBiasCorrelationTime](EntityComponentManager &_ecm)
   {
     auto comp = _ecm.Component<components::Magnetometer>(
         this->inspector->GetEntity());

--- a/src/gui/plugins/component_inspector_editor/Pose3d.cc
+++ b/src/gui/plugins/component_inspector_editor/Pose3d.cc
@@ -36,7 +36,7 @@ Pose3d::Pose3d(ComponentInspectorEditor *_inspector)
   this->inspector = _inspector;
 
   ComponentCreator creator =
-    [=](EntityComponentManager &_ecm, Entity _entity, QStandardItem *_item)
+    [this](EntityComponentManager &_ecm, Entity _entity, QStandardItem *_item)
   {
     auto comp = _ecm.Component<components::Pose>(_entity);
     if (nullptr == _item || nullptr == comp)
@@ -71,7 +71,7 @@ Q_INVOKABLE void Pose3d::PoseUpdate(
     double _x, double _y, double _z, double _roll, double _pitch, double _yaw)
 {
   gz::sim::UpdateCallback cb =
-      [=](EntityComponentManager &_ecm)
+      [this, _x, _y, _z, _roll, _pitch, _yaw](EntityComponentManager &_ecm)
   {
     auto comp = _ecm.Component<components::Pose>(this->inspector->GetEntity());
     if (comp)


### PR DESCRIPTION
# 🦟 Bug fix

Part of gazebosim/gz-cmake#580

## Summary

`[=]` implicitly captured `this`, which is deprecated in C++20. This affects lambdas in `component_inspector_editor`, all of the same shape: an `UpdateCallback` that uses `this->inspector` plus the enclosing setter's parameters.

Before:
```
src/gui/plugins/component_inspector_editor/Imu.cc:103:7: warning: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Wdeprecated]
```
plus 17 more in `AirPressure.cc`, `Altimeter.cc`, `Imu.cc`, `JointType.cc`, `Lidar.cc`, `Magnetometer.cc` and `Pose3d.cc`.

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Claude Opus 5

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
