### PR TITLE
Fix graded buoyancy for rotated collision shapes

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -14,6 +14,16 @@ release will remove the deprecated code.
     density. Existing SDF files that specify `<water_density>` will continue
     to load without error; the parameter is simply ignored.
 
+* **Buoyancy**
+  * The graded buoyancy mode now accounts for the orientation of each
+    collision when slicing it against a fluid interface. Previously the
+    slicing plane was always axis aligned in the shape's own frame, so a
+    rolled or pitched shape displaced the wrong volume at the wrong
+    centroid, and a heeled floating body could receive a capsizing moment
+    instead of a righting moment. Bodies at nonzero roll or pitch near a
+    fluid interface now float and right themselves per hydrostatic theory;
+    models tuned to compensate for the old behavior may need retuning.
+
 * **Entity wrapper classes (`Model`, `Link`, `World`)**
   * These now store their private data via `gz::utils::ImplPtr` (matching
     `Joint`, `Sensor`, `Light`, and `Actor`) instead of a hand-written

--- a/src/systems/buoyancy/Buoyancy.cc
+++ b/src/systems/buoyancy/Buoyancy.cc
@@ -180,10 +180,17 @@ void BuoyancyPrivate::GradedFluidDensity(
   auto prevLayerVol = 0.0;
   auto centerOfBuoyancy = math::Vector3d{0, 0, 0};
 
+  // Express the fluid interface plane (world z = height) in the shape frame,
+  // where VolumeBelow evaluates. A shape frame point x lies on it when
+  // (p + R x) . z = height, i.e. x . (R^T z) = height - p.Z(): rotated
+  // normal, unchanged offset. An axis aligned plane here erases the
+  // restoring moment of inclined hulls.
+  const math::Vector3d planeNormal =
+      _pose.Rot().RotateVectorReverse(math::Vector3d::UnitZ);
+
   for (const auto &[height, currFluidDensity] : this->layers)
   {
-    // TODO(arjo): Transform plane and slice the shape
-    math::Planed plane{math::Vector3d{0, 0, 1}, height - _pose.Pos().Z()};
+    math::Planed plane{planeNormal, height - _pose.Pos().Z()};
     auto vol = _shape.VolumeBelow(plane);
 
     // Short circuit.

--- a/test/integration/buoyancy.cc
+++ b/test/integration/buoyancy.cc
@@ -172,6 +172,56 @@ TEST_F(BuoyancyTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(RestoringMoments))
 }
 
 /////////////////////////////////////////////////
+// A surface piercing vessel with positive metacentric height must right
+// itself. Only a surface piercing case exercises the interface plane
+// orientation: with the plane fixed to the shape frame axes the buoyancy
+// centroid rotates rigidly with the hull and the vessel capsizes.
+TEST_F(BuoyancyTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(SurfaceRighting))
+{
+  ServerConfig serverConfig;
+  const auto sdfFile = common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+    "test", "worlds", "buoyancy_graded_surface_righting.sdf");
+  serverConfig.SetSdfFile(sdfFile);
+
+  std::vector<math::Pose3d> poses;
+  test::Relay testSystem;
+  testSystem.OnPostUpdate([&](const sim::UpdateInfo &,
+                            const sim::EntityComponentManager &_ecm)
+  {
+    Entity vessel = _ecm.EntityByComponents(
+      components::Model(), components::Name("box_vessel"));
+    auto pose = _ecm.Component<components::Pose>(vessel);
+    ASSERT_NE(pose, nullptr);
+    poses.push_back(pose->Data());
+  });
+
+  Server server(serverConfig);
+  server.AddSystem(testSystem.systemPtr);
+
+  // Several natural roll periods (about 1.4 s each).
+  const std::size_t iterations{4000};
+  server.Run(true, iterations, false);
+  ASSERT_EQ(poses.size(), iterations);
+
+  const double initialRoll{0.3};
+  double minRoll{initialRoll}, maxAbsRoll{0.0};
+  for (const auto &pose : poses)
+  {
+    const double roll = pose.Rot().Euler().X();
+    minRoll = std::min(minRoll, roll);
+    maxAbsRoll = std::max(maxAbsRoll, std::abs(roll));
+
+    // A capsizing vessel passes this bound within the first second.
+    EXPECT_LT(std::abs(roll), initialRoll + 0.15);
+    EXPECT_NEAR(pose.Pos().Z(), 0.0, 0.25);
+  }
+
+  // The moment must drive the roll through upright, not hold the heel.
+  EXPECT_LT(minRoll, 0.0);
+  EXPECT_GT(maxAbsRoll, 0.05);
+}
+
+/////////////////////////////////////////////////
 // See https://github.com/gazebosim/gz-sim/issues/1175
 TEST_F(BuoyancyTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(UniformWorldMovement))
 {

--- a/test/worlds/buoyancy_graded_surface_righting.sdf
+++ b/test/worlds/buoyancy_graded_surface_righting.sdf
@@ -1,0 +1,63 @@
+<?xml version="1.0" ?>
+<!--
+  Regression world for graded buoyancy at attitude: a box vessel floating
+  half submerged with an initial heel. Its positive transverse metacentric
+  height (+0.2083 m; Fossen 2011, eq. 4.32) must right it; the old axis
+  aligned slicing capsized it.
+-->
+<sdf version="1.6">
+  <world name="buoyancy_surface_righting">
+    <physics name="1ms" type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>0</real_time_factor>
+    </physics>
+    <plugin
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+    <plugin
+      filename="gz-sim-buoyancy-system"
+      name="gz::sim::systems::Buoyancy">
+      <graded_buoyancy>
+        <default_density>1000</default_density>
+        <density_change>
+          <above_depth>0</above_depth>
+          <density>1</density>
+        </density_change>
+      </graded_buoyancy>
+    </plugin>
+
+    <!-- 2 x 1 x 0.5 box, mass = half its displacement (500 kg), so the
+         waterline passes through its centre. Heeled 0.3 rad. -->
+    <model name="box_vessel">
+      <pose>0 0 0 0.3 0 0</pose>
+      <link name="body">
+        <inertial>
+          <mass>500</mass>
+          <inertia>
+            <ixx>52.083</ixx>
+            <iyy>177.083</iyy>
+            <izz>208.333</izz>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyz>0</iyz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box><size>2 1 0.5</size></box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box><size>2 1 0.5</size></box>
+          </geometry>
+        </visual>
+      </link>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

When computing graded buoyancy, the water surface plane was expressed in the collision shape's own frame, ignoring its rotation (as if the waterline tilted along with the hull). The fix rotates the plane into the shape frame before slicing. This resolves the existing TODO.

<img width="919" height="420" alt="buoyancy_attitude_fix" src="https://github.com/user-attachments/assets/61b4bd0d-2b64-4130-b916-f3602de8e84d" />

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Claude Fable 5
**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.