### PR TITLE
Isolate acoustic comms parameter tests

### DIFF
--- a/test/integration/acoustic_comms.cc
+++ b/test/integration/acoustic_comms.cc
@@ -19,8 +19,10 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cstdlib>
 #include <functional>
 #include <mutex>
+#include <string>
 
 #include <gz/msgs.hh>
 #include <gz/transport/Node.hh>
@@ -53,8 +55,38 @@ public:
 
 /////////////////////////////////////////////////
 class AcousticCommsTestFixture :
-  public ::testing::TestWithParam<AcousticCommsTestDefinition>
+  public InternalFixture<::testing::TestWithParam<AcousticCommsTestDefinition>>
 {
+  protected: void SetUp() override
+  {
+    InternalFixture::SetUp();
+
+    // Keep one-way unbind requests from a destroyed server from reaching the
+    // next parameter case's broker.
+    const auto *previousPartition = std::getenv("GZ_PARTITION");
+    if (previousPartition != nullptr)
+    {
+      this->hadPartition = true;
+      this->oldPartition = previousPartition;
+    }
+
+    this->partition = gz::common::uuid();
+    EXPECT_TRUE(gz::common::setenv("GZ_PARTITION", this->partition));
+  }
+
+  protected: void TearDown() override
+  {
+    if (this->hadPartition)
+      EXPECT_TRUE(gz::common::setenv("GZ_PARTITION", this->oldPartition));
+    else
+      EXPECT_TRUE(gz::common::unsetenv("GZ_PARTITION"));
+
+    InternalFixture::TearDown();
+  }
+
+  private: bool hadPartition{false};
+  private: std::string oldPartition;
+  private: std::string partition;
 };
 
 TEST_P(AcousticCommsTestFixture,


### PR DESCRIPTION
## Summary

- run each acoustic-comms parameter case in a unique Gazebo Transport partition
- restore any incoming `GZ_PARTITION` value after each case
- use the repository's standard integration-test fixture so source-tree system
  plugins are loaded from the build directory

The comms endpoints send one-way unbind requests during server teardown. When
all six parameter cases share the default partition, those delayed requests can
reach the next case's newly created broker. In a representative pre-change
10.5.0 execution, this produced 20 `RemoveSubscriber()` errors: four before
each case after the first. Running the cases in distinct partitions removes
that cross-case transport traffic.

This relates to #3881. I did not reproduce the reporter's intermittent
zero-message assertion locally, so this PR does not claim an exact local
reproduction of that symptom.

## Testing

- Gazebo Sim 10.5.0 source at `2d3c7c7`, Noble, stable Jetty dependencies:
  - pre-change: 30/30 full executions passed, but every representative full
    execution emitted 20 stale-unbind errors
  - post-change: 30/30 full executions passed (180 parameter cases total) with
    zero stale-unbind errors
- current `main` at `e668c7a` with Rotary dependencies:
  - `INTEGRATION_acoustic_comms` passed
  - `check_INTEGRATION_acoustic_comms` passed
  - `codecheck` passed (cpplint and cppcheck)

The patch changes one integration-test source file only; production libraries,
worlds, and public interfaces are unchanged.

## Checklist

- [x] Added / strengthened test isolation
- [x] `codecheck` passed
- [x] Relevant tests passed
- [x] DCO sign-off included

Generated-by: OpenAI Codex (GPT-5; accessed 2026-08-17)
