### PR TITLE
Preserve plugin path in Python loader integration test

### DIFF
--- a/test/integration/python_system_loader.cc
+++ b/test/integration/python_system_loader.cc
@@ -21,6 +21,7 @@
 
 #include <chrono>
 #include <gz/common/Filesystem.hh>
+#include <gz/common/SystemPaths.hh>
 #include <gz/transport/Node.hh>
 #include <gz/utils/ExtraTestMacros.hh>
 #include <optional>
@@ -63,9 +64,15 @@ void worldReset()
 TEST_F(PythonSystemLoaderTest,
        GZ_UTILS_TEST_DISABLED_ON_WIN32(LoadMultipleSystems))
 {
-  common::setenv("GZ_SIM_SYSTEM_PLUGIN_PATH",
-                 common::joinPaths(std::string(PROJECT_SOURCE_PATH), "python",
-                                   "test", "plugins"));
+  // Keep the native plugin path set by InternalFixture while adding the
+  // directory that contains the Python test systems. Both use the same
+  // environment variable.
+  std::string pluginPath;
+  ASSERT_TRUE(common::env("GZ_SIM_SYSTEM_PLUGIN_PATH", pluginPath));
+  pluginPath = common::joinPaths(std::string(PROJECT_SOURCE_PATH), "python",
+                                "test", "plugins") +
+               common::SystemPaths::Delimiter() + pluginPath;
+  ASSERT_TRUE(common::setenv("GZ_SIM_SYSTEM_PLUGIN_PATH", pluginPath));
 
   sim::ServerConfig serverConfig;
   serverConfig.SetSdfFile(common::joinPaths(std::string(PROJECT_SOURCE_PATH),


### PR DESCRIPTION
## Summary

- preserve the native build-plugin path established by `InternalFixture`
- prepend the Python test-system directory with the platform path delimiter
- fail explicitly if reading or updating the test environment fails

`PythonSystemLoaderTest` currently replaces `GZ_SIM_SYSTEM_PLUGIN_PATH` with
the directory that contains its Python modules. That discards the build
directory installed by the common fixture, so package-style test runs can
accidentally depend on a system-installed Python loader plugin.

Preserving the fixture path lets the native loader come from the build under
test while still making the Python systems importable.

Fixes #3886.

## Testing

- Gazebo Sim 10.5.0 source at `2d3c7c7`, Noble, Jetty dependencies:
  - with the system-installed Python loader hidden, the unmodified integration
    test reproduced the reported `Could not find shared library` failure
  - the patched test passed 1/1 under the identical negative control
- current `main` at `e668c7a`, Rotary dependencies, exact commit `29119b6`:
  - `INTEGRATION_python_system_loader` and its native loader target built
  - with the system-installed loader hidden, the integration test passed 1/1
  - `codecheck` passed, including cpplint and cppcheck
- `git diff --check` passed

The patch changes one integration-test source file only; production libraries,
worlds, and public interfaces are unchanged.

## Checklist

- [x] Reproduced the reported failure mechanism
- [x] Verified the fix without a system-installed loader fallback
- [x] `codecheck` passed
- [x] Relevant integration test passed
- [x] DCO sign-off included

Generated-by: OpenAI Codex (GPT-5; accessed 2026-08-17)
