### PR TITLE
TrackedVehicle: read track_height from sdf

### DIFF
--- a/examples/worlds/tracked_vehicle_simple.sdf
+++ b/examples/worlds/tracked_vehicle_simple.sdf
@@ -1075,7 +1075,7 @@
                 <right_track><link>front_right_flipper</link></right_track>
                 <right_track><link>rear_right_flipper</link></right_track>
                 <tracks_separation>0.4</tracks_separation>
-                <tracks_height>0.18094</tracks_height>
+                <track_height>0.18094</track_height>
                 <steering_efficiency>0.5</steering_efficiency>
                 <!--debug>1</debug-->
             </plugin>

--- a/src/systems/tracked_vehicle/TrackedVehicle.cc
+++ b/src/systems/tracked_vehicle/TrackedVehicle.cc
@@ -275,6 +275,8 @@ void TrackedVehicle::Configure(const Entity &_entity,
       this->dataPtr->tracksSeparation).first;
   this->dataPtr->steeringEfficiency = _sdf->Get<double>("steering_efficiency",
       this->dataPtr->steeringEfficiency).first;
+  this->dataPtr->trackHeight = _sdf->Get<double>("track_height",
+      this->dataPtr->trackHeight).first;
 
   // Instantiate the speed limiters.
   this->dataPtr->limiterLin = std::make_unique<math::SpeedLimiter>();

--- a/src/systems/tracked_vehicle/TrackedVehicle.hh
+++ b/src/systems/tracked_vehicle/TrackedVehicle.hh
@@ -62,6 +62,10 @@ namespace systems
   ///     center of rotation commands (defaults to
   ///     `/model/${model_name}/link/${link_name}/track_cmd_center_of_rotation`)
   ///
+  /// - `<body_link>`: The name of the vehicle body link. Should be in between
+  ///   left and right tracks, center of this link will be the center of
+  ///   rotation. This element is optional, default is model's canonical link.
+  ///
   /// - `<tracks_separation>`: Distance between tracks, in meters. Required
   ///   parameter.
   ///

--- a/test/worlds/tracked_vehicle_simple.sdf
+++ b/test/worlds/tracked_vehicle_simple.sdf
@@ -1073,7 +1073,7 @@
                 <right_track><link>front_right_flipper</link></right_track>
                 <right_track><link>rear_right_flipper</link></right_track>
                 <tracks_separation>0.4</tracks_separation>
-                <tracks_height>0.18094</tracks_height>
+                <track_height>0.18094</track_height>
                 <steering_efficiency>0.5</steering_efficiency>
             </plugin>
             <plugin name='gz::sim::systems::TrackController' filename='gz-sim-track-controller-system'>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes N/A and #2309

## Summary
(re-target to main of https://github.com/gazebosim/gz-sim/pull/3883)

This change should fix missing read from sdf for `track_heigh`t value. Also fixed in examples and tests field was plural (expecting doxygen should have higher priority in this ambiguous case). Also fixed documentation for `body_link` value

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.