### PR TITLE
Fix: graded bouyancy for rotated collision shapes

### DIFF
--- a/src/systems/buoyancy/Buoyancy.cc
+++ b/src/systems/buoyancy/Buoyancy.cc
@@ -178,8 +178,10 @@ void BuoyancyPrivate::GradedFluidDensity(
 
   for (const auto &[height, currFluidDensity] : this->layers)
   {
-    // TODO(arjo): Transform plane and slice the shape
-    math::Planed plane{math::Vector3d{0, 0, 1}, height - _pose.Pos().Z()};
+    // VolumeBelow and CenterOfVolumeBelow expect the plane in the shape frame.
+    math::Planed plane{
+      _pose.Rot().RotateVectorReverse(math::Vector3d::UnitZ),
+      height - _pose.Pos().Z()};
     auto vol = _shape.VolumeBelow(plane);
 
     // Short circuit.

--- a/test/integration/buoyancy.cc
+++ b/test/integration/buoyancy.cc
@@ -399,6 +399,39 @@ TEST_F(BuoyancyTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(GradedBuoyancy))
 
 
 /////////////////////////////////////////////////
+TEST_F(BuoyancyTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(GradedBuoyancyRotatedCollision))
+{
+  TestFixture fixture(common::joinPaths(std::string(PROJECT_SOURCE_PATH),
+    "test", "worlds", "graded_buoyancy_rotated_collision.sdf"));
+
+  std::size_t iterations{0};
+  fixture.OnPostUpdate([&](
+      const sim::UpdateInfo &,
+      const sim::EntityComponentManager &_ecm)
+  {
+    auto links = entitiesFromScopedName("horizontal_cylinder::link", _ecm);
+    ASSERT_EQ(1u, links.size());
+    auto link = *links.begin();
+    EXPECT_NE(kNullEntity, link);
+
+    // The cylinder floats half-submerged: it must not translate or rotate.
+    auto pose = worldPose(link, _ecm);
+    EXPECT_NEAR(0.0, pose.Pos().X(), 1e-2);
+    EXPECT_NEAR(0.0, pose.Pos().Y(), 1e-2);
+    EXPECT_NEAR(0.0, pose.Pos().Z(), 1e-2);
+    EXPECT_NEAR(0.0, pose.Rot().Euler().X(), 1e-2);
+    EXPECT_NEAR(0.0, pose.Rot().Euler().Y(), 1e-2);
+    EXPECT_NEAR(0.0, pose.Rot().Euler().Z(), 1e-2);
+
+    iterations++;
+  }).Finalize();
+
+  std::size_t targetIterations{1000};
+  fixture.Server()->Run(true, targetIterations, false);
+  EXPECT_EQ(targetIterations, iterations);
+}
+
+/////////////////////////////////////////////////
 TEST_F(BuoyancyTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(OffsetAndRotationGraded))
 {
   TestFixture fixture(common::joinPaths(std::string(PROJECT_SOURCE_PATH),

--- a/test/worlds/graded_buoyancy_rotated_collision.sdf
+++ b/test/worlds/graded_buoyancy_rotated_collision.sdf
@@ -1,0 +1,70 @@
+<?xml version="1.0" ?>
+<!--
+  A floating cylinder whose collision is rotated 90 degrees about Y, so its
+  axis lies along world X. Mass is half the displaced water mass, so it
+  floats half-submerged at the surface and must stay level and in place.
+-->
+<sdf version="1.6">
+  <world name="buoyancy_rotated_collision">
+
+    <physics name="1ms" type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>0</real_time_factor>
+    </physics>
+    <plugin
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+    <plugin
+      filename="gz-sim-buoyancy-system"
+      name="gz::sim::systems::Buoyancy">
+      <graded_buoyancy>
+        <default_density>1000</default_density>
+        <density_change>
+          <above_depth>0</above_depth>
+          <density>1</density>
+        </density_change>
+      </graded_buoyancy>
+    </plugin>
+
+    <!-- mass = 500 * volume = 500 * pi * 0.2^2 * 2, so it floats half-submerged -->
+    <model name="horizontal_cylinder">
+      <pose>0 0 0 0 0 0</pose>
+      <link name="link">
+        <inertial>
+          <mass>125.66</mass>
+          <inertia>
+            <ixx>2.51</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>43.14</iyy>
+            <iyz>0</iyz>
+            <izz>43.14</izz>
+          </inertia>
+        </inertial>
+        <visual name="visual">
+          <pose>0 0 0 0 1.5707963267948966 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>2.0</length>
+            </cylinder>
+          </geometry>
+        </visual>
+        <collision name="collision">
+          <pose>0 0 0 0 1.5707963267948966 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>2.0</length>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #3892

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
Graded buoyancy ignores collision orientation. `GradedFluidDensity` builds the fluid layer plane with a world-Z normal and never rotates it into the collision frame (the existing `TODO(arjo)`), but the shape's `VolumeBelow` / `CenterOfVolumeBelow` expect the plane in the shape frame. Any rotated collision therefore gets a wrong submerged volume and center of buoyancy.

Symptom: a cylinder collision rotated 90° (axis horizontal, e.g. an submarine hull) pitch-flips at the water surface, because its center of buoyancy is computed up to L/4 away along the hull axis. Capsule, ellipsoid, cone, and rotated box collisions are affected too; axis-aligned shapes are not.

Fix: rotate the plane normal into the collision frame. The new `GradedBuoyancyRotatedCollision` test floats a rotated cylinder half-submerged at the surface; it fails before the fix and passes after.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [x] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Claude Code

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.