### PR TITLE
Allow gltf and glb files to be read as animations in SceneManager

### DIFF
--- a/src/rendering/SceneManager.cc
+++ b/src/rendering/SceneManager.cc
@@ -2378,7 +2378,7 @@ SceneManager::LoadAnimations(const sdf::Actor &_actor)
       }
       mapAnimNameId[animName] = numAnims++;
     }
-    else if (extension == "dae")
+    else if (extension == "dae" || extension == "gltf" || extension == "glb")
     {
       // Load the mesh if it has not been loaded before
       const common::Mesh *animMesh = nullptr;


### PR DESCRIPTION
Assisted by: Gemini 3.1 Pro

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Related to https://github.com/gazebosim/gz-common/pull/891

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Previously animations in gltf and glb files were not loaded as animations in the SceneManager, so the `interpolate_x` field in the sdf file would be ignored if the mesh was a GLTF/GLB.

## Testing
This is with a modified version of the actor.sdf example world where the `actor_walking` mesh was using a GLB file instead of a Collada file. (Meshes were converted using [COLLADA2GLTF](https://github.com/KhronosGroup/COLLADA2GLTF)). Notice that before the change, the speed of the animation is slow and the actor's foot appears to slip on the ground.

Before this change

https://github.com/user-attachments/assets/7961872b-a3e5-406e-a919-a55b3b3efabb



After this change


https://github.com/user-attachments/assets/6f68632b-04fc-48af-bc4d-887c8ff23094

### To replicate
1. Checkout to https://github.com/gazebosim/gz-common/pull/891 branch on gz-common (otherwise the GLB meshes will be distorted)
2. Checkout this PR on gz-sim
3. Build the workspace
4. Replace the collada file in the actor.sdf example world with a converted GLB file

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [X] This is safe to backport to the following versions:
    - [X] Jetty
    - [X] Ionic
    - [X] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [X] Signed all commits for DCO
- [X] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [X] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Gemini 3.1 Pro

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
