### PR TITLE
Fix assumptions for tracked vehicle test

### DIFF
--- a/test/integration/tracked_vehicle_system.cc
+++ b/test/integration/tracked_vehicle_system.cc
@@ -362,8 +362,8 @@ class TrackedVehicleTest : public InternalFixture<::testing::Test>
     server.Run(true, 3500, false);
 
     EXPECT_NEAR(poses.back().Pos().X(), beforeStairsPose.X() + 3.4, 0.15);
-    EXPECT_LE(poses.back().Pos().Y(), 0.7);
-    EXPECT_GT(poses.back().Pos().Z(), 0.6);
+    EXPECT_NEAR(poses.back().Pos().Y(), 0.0, 1e-1);
+    EXPECT_GT(poses.back().Pos().Z(), 0.55);
     EXPECT_ANGLE_NEAR(poses.back().Rot().Roll(), 0.0, 1e-1);
     EXPECT_ANGLE_NEAR(poses.back().Rot().Pitch(), -0.4, 1e-1);
     EXPECT_ANGLE_NEAR(


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #3723 

## Summary

Relax the threshold for Z a bit, have an actual threshold that makes sense for Y.
Specifically, I ran the test manually (run the demo world, wait 300 steps, send a command, wait 3500 steps) and this was the result:

<img width="1920" height="1032" alt="Screenshot From 2026-08-25 20-31-11" src="https://github.com/user-attachments/assets/301df1fb-2c6f-4e0d-87e9-d5e5e2f7c0fc" />

Since we are moving purely in X, the Y should really be almost 0 so made that check stricter, the Z is a bit lower, but anyway it seems the _intention_ of the test is to make sure that the vehicle climbs the stairs so a few millimeters won't make a difference.

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.