### PR TITLE
Replace run flags with a single RunState and drop the Server::Run startup handshake

### DIFF
--- a/src/Server.cc
+++ b/src/Server.cc
@@ -179,6 +179,13 @@ bool Server::Run(const bool _blocking, const uint64_t _iterations,
       gzwarn << "The server is already runnnng.\n";
       return false;
     }
+
+    if (this->dataPtr->signalReceived)
+    {
+      gzwarn << "A stop signal was received before the run started. "
+             << "Simulation will not run.\n";
+      return false;
+    }
   }
 
   if (_blocking)
@@ -188,15 +195,13 @@ bool Server::Run(const bool _blocking, const uint64_t _iterations,
   std::unique_lock<std::mutex> lock(this->dataPtr->runMutex);
   if (this->dataPtr->runThread.get_id() == std::thread::id())
   {
-    std::condition_variable cond;
+    // Publish the run state from this thread rather than waiting for the run
+    // thread to do it. `running` is a level, not an edge: a short run could
+    // start and finish, clearing it again, before a waiter here ever
+    // observed it, which left Server::Run waiting forever (issue #3829).
+    this->dataPtr->running = true;
     this->dataPtr->runThread =
-      std::thread(&ServerPrivate::Run, this->dataPtr.get(), _iterations, &cond);
-
-    // Wait for the thread to start. We do this to guarantee that the
-    // running variable gets updated before this function returns. With
-    // a small number of iterations it is possible that the run thread
-    // successfully completes before this function returns.
-    cond.wait(lock, [this]() -> bool {return this->dataPtr->running;});
+      std::thread(&ServerPrivate::Run, this->dataPtr.get(), _iterations);
     return true;
   }
 

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -195,10 +195,8 @@ bool Server::Run(const bool _blocking, const uint64_t _iterations,
   std::unique_lock<std::mutex> lock(this->dataPtr->runMutex);
   if (this->dataPtr->runThread.get_id() == std::thread::id())
   {
-    // Publish the run state from this thread rather than waiting for the run
-    // thread to do it. `running` is a level, not an edge: a short run could
-    // start and finish, clearing it again, before a waiter here ever
-    // observed it, which left Server::Run waiting forever (issue #3829).
+    // Set `running` here instead of waiting for the run thread: a short run
+    // could finish and clear it before the wait ever saw it (issue #3829).
     this->dataPtr->running = true;
     this->dataPtr->runThread =
       std::thread(&ServerPrivate::Run, this->dataPtr.get(), _iterations);

--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -156,8 +156,8 @@ bool ServerPrivate::Run(const uint64_t _iterations)
 {
   std::unique_lock<std::mutex> startLock(this->runMutex);
 
-  // Return early if we've received a signal right before. Clear `running`,
-  // which a non-blocking Server::Run publishes ahead of this thread.
+  // A signal arrived before the run started. Clear `running`, which a
+  // non-blocking Server::Run has already set.
   if (this->signalReceived)
   {
     this->running = false;

--- a/src/ServerPrivate.cc
+++ b/src/ServerPrivate.cc
@@ -152,21 +152,19 @@ void ServerPrivate::Stop()
 }
 
 /////////////////////////////////////////////////
-bool ServerPrivate::Run(const uint64_t _iterations,
-    std::optional<std::condition_variable *> _cond)
+bool ServerPrivate::Run(const uint64_t _iterations)
 {
-  // Return early if we've received a signal right before.
-  // The ServerPrivate signal handler would set `running=false`,
-  // but we immediately would set it to true here, which will essentially ignore
-  // the signal. Since we can't reliably use the `running` variable, we return
-  // if `signalReceived` is true
+  std::unique_lock<std::mutex> startLock(this->runMutex);
+
+  // Return early if we've received a signal right before. Clear `running`,
+  // which a non-blocking Server::Run publishes ahead of this thread.
   if (this->signalReceived)
+  {
+    this->running = false;
     return false;
-  this->runMutex.lock();
+  }
   this->running = true;
-  if (_cond)
-    _cond.value()->notify_all();
-  this->runMutex.unlock();
+  startLock.unlock();
 
   bool result = true;
 

--- a/src/ServerPrivate.hh
+++ b/src/ServerPrivate.hh
@@ -181,9 +181,7 @@ namespace gz
       public: std::mutex runMutex;
 
       /// \brief This is used to indicate that Run has been called, and the
-      /// server is in the run state. This is a level, not an edge: it is false
-      /// again once a run completes, so it must not be used to observe that a
-      /// run has started.
+      /// server is in the run state. It is cleared again when the run ends.
       public: std::atomic<bool> running{false};
 
       /// \brief Thread that executes systems.

--- a/src/ServerPrivate.hh
+++ b/src/ServerPrivate.hh
@@ -70,10 +70,7 @@ namespace gz
 
       /// \brief Run the server, and all the simulation runners.
       /// \param[in] _iterations Number of iterations.
-      /// \param[in] _cond Optional condition variable. This condition is
-      /// notified when the server has started running.
-      public: bool Run(const uint64_t _iterations,
-                 std::optional<std::condition_variable *> _cond = std::nullopt);
+      public: bool Run(const uint64_t _iterations);
 
       /// \brief Add logging record plugin.
       /// \param[in] _config Server configuration parameters.
@@ -184,7 +181,9 @@ namespace gz
       public: std::mutex runMutex;
 
       /// \brief This is used to indicate that Run has been called, and the
-      /// server is in the run state.
+      /// server is in the run state. This is a level, not an edge: it is false
+      /// again once a run completes, so it must not be used to observe that a
+      /// run has started.
       public: std::atomic<bool> running{false};
 
       /// \brief Thread that executes systems.

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -23,8 +23,10 @@
 #include <gz/msgs/stringmsg_v.pb.h>
 #include <gz/msgs/world_control.pb.h>
 
+#include <atomic>
 #include <csignal>
 #include <vector>
+#include <gz/common/SignalHandler.hh>
 #include <gz/common/StringUtils.hh>
 #include <gz/common/Util.hh>
 #include <gz/math/Rand.hh>
@@ -597,6 +599,98 @@ TEST_P(ServerFixture, RunNonBlockingPaused)
   EXPECT_EQ(100u, *server.IterationCount());
   EXPECT_FALSE(server.Running());
   EXPECT_FALSE(*server.Running(0));
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, RunNonBlockingThenDestroy)
+{
+  // Regression test for https://github.com/gazebosim/gz-sim/issues/3829:
+  // destroying a Server right after a non-blocking Run() emits the stop
+  // request while the run thread may still be starting up. With that stop
+  // lost the run loop never terminates and the destructor blocks forever
+  // joining the run thread. This is the exact shape of the flaky teardown
+  // timeouts in this file, so it is repeated to widen the race window.
+  ServerConfig serverConfig;
+  serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
+      "test", "worlds", "shapes.sdf"));
+
+  for (int i = 0; i < 50; ++i)
+  {
+    sim::Server server(serverConfig);
+    EXPECT_TRUE(server.Run(false, 0, false)) << "iteration " << i;
+  }
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, RunNonBlockingAfterBlockingRun)
+{
+  // A blocking Run() goes through ServerPrivate::Run without ever creating the
+  // run thread. Any state left behind by that call must not be mistaken by the
+  // next non-blocking Run() for its own run thread having started, or the wait
+  // below returns immediately and the caller races the run thread it just
+  // spawned. Server::Run creates the startup handshake fresh for each spawn.
+  sim::Server server;
+  server.SetUpdatePeriod(1ns);
+
+  EXPECT_TRUE(server.Run(true, 1, false));
+  ASSERT_NE(std::nullopt, server.IterationCount());
+  EXPECT_EQ(1u, *server.IterationCount());
+  EXPECT_FALSE(server.Running());
+
+  // Now a non-blocking run on the same Server. The wait must actually block
+  // until this run thread has started.
+  EXPECT_TRUE(server.Run(false, 1, false));
+
+  int sleep = 0;
+  const int maxSleep = 5000;
+  while (*server.IterationCount() < 2 && sleep < maxSleep)
+  {
+    GZ_SLEEP_MS(1);
+    ++sleep;
+  }
+  EXPECT_LT(sleep, maxSleep) << "second run never executed";
+  EXPECT_EQ(2u, *server.IterationCount());
+}
+
+/////////////////////////////////////////////////
+TEST_P(ServerFixture, RunAfterSignal)
+{
+  // A signal delivered before Run() aborts the run: ServerPrivate::Run returns
+  // early without stepping anything. Before the fix behind #3829 that early
+  // return never released the startup handshake, so the non-blocking
+  // Server::Run below waited forever. It must now return, and must report the
+  // failure rather than claiming a run was started.
+  sim::Server server;
+  server.SetUpdatePeriod(1ns);
+
+  // gz-common dispatches signals on its own thread, invoking the registered
+  // handlers in registration order. A handler registered after the Server's is
+  // therefore invoked once the Server has finished processing the signal, so
+  // waiting on it beats guessing at a sleep.
+  std::atomic<bool> signalHandled{false};
+  common::SignalHandler testHandler;
+  ASSERT_TRUE(testHandler.Initialized());
+  ASSERT_TRUE(testHandler.AddCallback(
+        [&signalHandled](int) { signalHandled = true; }));
+
+  ASSERT_EQ(0, std::raise(SIGINT));
+
+  int sleep = 0;
+  const int maxSleep = 5000;
+  while (!signalHandled && sleep < maxSleep)
+  {
+    GZ_SLEEP_MS(1);
+    ++sleep;
+  }
+  ASSERT_TRUE(signalHandled) << "the signal was never dispatched";
+
+  // Neither form of Run may claim success, and neither may step the world.
+  EXPECT_FALSE(server.Run(false, 1, false));
+  EXPECT_FALSE(server.Run(true, 1, false));
+
+  ASSERT_NE(std::nullopt, server.IterationCount());
+  EXPECT_EQ(0u, *server.IterationCount());
+  EXPECT_FALSE(server.Running());
 }
 
 /////////////////////////////////////////////////

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -604,12 +604,10 @@ TEST_P(ServerFixture, RunNonBlockingPaused)
 /////////////////////////////////////////////////
 TEST_P(ServerFixture, RunNonBlockingThenDestroy)
 {
-  // Regression test for https://github.com/gazebosim/gz-sim/issues/3829:
-  // destroying a Server right after a non-blocking Run() emits the stop
-  // request while the run thread may still be starting up. With that stop
-  // lost the run loop never terminates and the destructor blocks forever
-  // joining the run thread. This is the exact shape of the flaky teardown
-  // timeouts in this file, so it is repeated to widen the race window.
+  // Destroying a Server right after a non-blocking Run() sends the stop while
+  // the run thread may still be starting. If that stop is lost the destructor
+  // blocks forever joining the thread (issue #3829). Repeated to widen the
+  // race window.
   ServerConfig serverConfig;
   serverConfig.SetSdfFile(common::joinPaths(PROJECT_SOURCE_PATH,
       "test", "worlds", "shapes.sdf"));
@@ -624,11 +622,8 @@ TEST_P(ServerFixture, RunNonBlockingThenDestroy)
 /////////////////////////////////////////////////
 TEST_P(ServerFixture, RunNonBlockingAfterBlockingRun)
 {
-  // A blocking Run() goes through ServerPrivate::Run without ever creating the
-  // run thread. Any state left behind by that call must not be mistaken by the
-  // next non-blocking Run() for its own run thread having started, or the wait
-  // below returns immediately and the caller races the run thread it just
-  // spawned. Server::Run creates the startup handshake fresh for each spawn.
+  // A blocking Run() never creates the run thread. State it leaves behind
+  // must not confuse the next non-blocking Run() on the same Server.
   sim::Server server;
   server.SetUpdatePeriod(1ns);
 
@@ -637,8 +632,7 @@ TEST_P(ServerFixture, RunNonBlockingAfterBlockingRun)
   EXPECT_EQ(1u, *server.IterationCount());
   EXPECT_FALSE(server.Running());
 
-  // Now a non-blocking run on the same Server. The wait must actually block
-  // until this run thread has started.
+  // Now a non-blocking run on the same Server.
   EXPECT_TRUE(server.Run(false, 1, false));
 
   int sleep = 0;
@@ -655,18 +649,13 @@ TEST_P(ServerFixture, RunNonBlockingAfterBlockingRun)
 /////////////////////////////////////////////////
 TEST_P(ServerFixture, RunAfterSignal)
 {
-  // A signal delivered before Run() aborts the run: ServerPrivate::Run returns
-  // early without stepping anything. Before the fix behind #3829 that early
-  // return never released the startup handshake, so the non-blocking
-  // Server::Run below waited forever. It must now return, and must report the
-  // failure rather than claiming a run was started.
+  // A signal before Run() aborts the run. The non-blocking Run() below used
+  // to hang forever (issue #3829); it must return and report failure.
   sim::Server server;
   server.SetUpdatePeriod(1ns);
 
-  // gz-common dispatches signals on its own thread, invoking the registered
-  // handlers in registration order. A handler registered after the Server's is
-  // therefore invoked once the Server has finished processing the signal, so
-  // waiting on it beats guessing at a sleep.
+  // Signal handlers run in registration order on the gz-common signal thread,
+  // so a handler registered after the Server's runs once the Server is done.
   std::atomic<bool> signalHandled{false};
   common::SignalHandler testHandler;
   ASSERT_TRUE(testHandler.Initialized());
@@ -684,7 +673,7 @@ TEST_P(ServerFixture, RunAfterSignal)
   }
   ASSERT_TRUE(signalHandled) << "the signal was never dispatched";
 
-  // Neither form of Run may claim success, and neither may step the world.
+  // Neither form of Run may succeed or step the world.
   EXPECT_FALSE(server.Run(false, 1, false));
   EXPECT_FALSE(server.Run(true, 1, false));
 

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -840,10 +840,8 @@ bool SimulationRunner::Run(const uint64_t _iterations)
   if (!this->currentInfo.paused)
     this->realTimeWatch.Start();
 
-  // A stop request may arrive while this thread is still starting up, e.g.
-  // the Server being destroyed right after a non-blocking Run(). Only an
-  // IDLE runner may transition to RUNNING, so such a stop is never
-  // overwritten (issues #2609 and #3829).
+  // A stop may have arrived while this thread was starting up, e.g. the
+  // Server being destroyed right after a non-blocking Run() (issue #3829).
   if (!this->runState.TryStart())
   {
     gzdbg << "SimulationRunner::Run: a stop request arrived before the run "

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -19,7 +19,6 @@
 
 #include <algorithm>
 #include <memory>
-#include <mutex>
 #include <ostream>
 #include <unordered_set>
 #ifdef HAVE_PYBIND11
@@ -778,9 +777,7 @@ void SimulationRunner::Stop()
 /////////////////////////////////////////////////
 void SimulationRunner::OnStop()
 {
-  std::lock_guard<std::mutex> lock(this->runStateMutex);
-  this->stopReceived = true;
-  this->running = false;
+  this->runState.Stop();
 }
 
 /////////////////////////////////////////////////
@@ -830,7 +827,7 @@ bool SimulationRunner::Run(const uint64_t _iterations)
     if (this->networkMgr->IsSecondary())
     {
       gzdbg << "Secondary running." << std::endl;
-      while (!this->stopReceived)
+      while (!this->StopReceived())
       {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
       }
@@ -844,18 +841,14 @@ bool SimulationRunner::Run(const uint64_t _iterations)
     this->realTimeWatch.Start();
 
   // A stop request may arrive while this thread is still starting up, e.g.
-  // the Server being destroyed right after a non-blocking Run(). Checking
-  // `stopReceived` and setting `running` under runStateMutex keeps such a
-  // stop from being overwritten (issues #2609 and #3829).
+  // the Server being destroyed right after a non-blocking Run(). Only an
+  // IDLE runner may transition to RUNNING, so such a stop is never
+  // overwritten (issues #2609 and #3829).
+  if (!this->runState.TryStart())
   {
-    std::lock_guard<std::mutex> lock(this->runStateMutex);
-    if (this->stopReceived)
-    {
-      gzdbg << "SimulationRunner::Run: a stop request arrived before the run "
-            << "loop started; no iterations will be executed." << std::endl;
-      return false;
-    }
-    this->running = true;
+    gzdbg << "SimulationRunner::Run: a stop request arrived before the run "
+          << "loop started; no iterations will be executed." << std::endl;
+    return false;
   }
 
   // Create the world statistics publisher.
@@ -946,7 +939,7 @@ bool SimulationRunner::Run(const uint64_t _iterations)
   if (_iterations > 0)
   {
     bool created = this->entitiesCreated;
-    while (!created && this->running)
+    while (!created && this->Running())
     {
       {
         std::unique_lock<std::mutex> createLock(this->assetCreationMutex);
@@ -963,7 +956,7 @@ bool SimulationRunner::Run(const uint64_t _iterations)
   // Execute all the systems until we are told to stop, or the number of
   // iterations is reached.
   auto nextUpdateTime = std::chrono::steady_clock::now() + this->updatePeriod;
-  while (this->running && (_iterations == 0 ||
+  while (this->Running() && (_iterations == 0 ||
        processedIterations < _iterations))
   {
     // Create entities if set. This needs to be called before updating
@@ -1098,10 +1091,7 @@ bool SimulationRunner::Run(const uint64_t _iterations)
     }
   }
 
-  {
-    std::lock_guard<std::mutex> lock(this->runStateMutex);
-    this->running = false;
-  }
+  this->runState.Finish();
 
   return true;
 }
@@ -1326,7 +1316,7 @@ void SimulationRunner::LoadPlugins(const Entity _entity,
 /////////////////////////////////////////////////
 bool SimulationRunner::Running() const
 {
-  return this->running;
+  return this->runState.Running();
 }
 
 /////////////////////////////////////////////////
@@ -1338,7 +1328,7 @@ bool SimulationRunner::ParallelPostUpdates() const
 /////////////////////////////////////////////////
 bool SimulationRunner::StopReceived() const
 {
-  return this->stopReceived;
+  return this->runState.Stopped();
 }
 
 /////////////////////////////////////////////////
@@ -1381,7 +1371,7 @@ void SimulationRunner::SetUpdatePeriod(
 void SimulationRunner::SetPaused(const bool _paused)
 {
   // Only update the realtime clock if Run() has been called.
-  if (this->running)
+  if (this->Running())
   {
     // Start or stop the realtime stopwatch based on _paused. We don't need to
     // check the stopwatch state here since the stopwatch class checks its

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -424,41 +424,39 @@ namespace gz
       /// See the newWorldControlState variable below.
       private: void ProcessNewWorldControlState();
 
-      /// \brief Lifecycle of the run loop: IDLE to RUNNING to IDLE, or
-      /// STOPPED from any state. STOPPED is terminal, so stopping a runner is
-      /// permanent. A single atomic makes the transition into RUNNING a
-      /// compare and exchange from IDLE, so a stop request that arrives while
-      /// Run() is starting up can never be overwritten.
+      /// \brief State of the run loop: IDLE to RUNNING to IDLE, or STOPPED
+      /// from any state. STOPPED is permanent. Entering RUNNING is a compare
+      /// and exchange from IDLE, so a stop request can never be overwritten.
       private: class RunState
       {
         /// \brief Try to enter RUNNING.
-        /// \return False if a stop was already received.
+        /// \return False if a stop was received.
         public: bool TryStart()
         {
           auto expected = Value::IDLE;
           return this->value.compare_exchange_strong(expected, Value::RUNNING);
         }
 
-        /// \brief Leave RUNNING. A STOPPED state is left untouched.
+        /// \brief Leave RUNNING. STOPPED is left untouched.
         public: void Finish()
         {
           auto expected = Value::RUNNING;
           this->value.compare_exchange_strong(expected, Value::IDLE);
         }
 
-        /// \brief Record a stop request. Permanent.
+        /// \brief Record a stop request.
         public: void Stop()
         {
           this->value = Value::STOPPED;
         }
 
-        /// \return True while Run() is stepping simulation.
+        /// \return True while running.
         public: bool Running() const
         {
           return this->value == Value::RUNNING;
         }
 
-        /// \return True once a stop request has been received.
+        /// \return True once a stop was received.
         public: bool Stopped() const
         {
           return this->value == Value::STOPPED;

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -30,7 +30,6 @@
 #include <functional>
 #include <list>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <set>
 #include <string>
@@ -425,19 +424,60 @@ namespace gz
       /// See the newWorldControlState variable below.
       private: void ProcessNewWorldControlState();
 
-      /// \brief This is used to indicate that a stop event has been received.
-      /// The latch is monotonic — nothing ever clears it — so stopping is
-      /// permanent: once set, Run() returns immediately without stepping.
-      private: std::atomic<bool> stopReceived{false};
+      /// \brief Lifecycle of the run loop: IDLE to RUNNING to IDLE, or
+      /// STOPPED from any state. STOPPED is terminal, so stopping a runner is
+      /// permanent. A single atomic makes the transition into RUNNING a
+      /// compare and exchange from IDLE, so a stop request that arrives while
+      /// Run() is starting up can never be overwritten.
+      private: class RunState
+      {
+        /// \brief Try to enter RUNNING.
+        /// \return False if a stop was already received.
+        public: bool TryStart()
+        {
+          auto expected = Value::IDLE;
+          return this->value.compare_exchange_strong(expected, Value::RUNNING);
+        }
 
-      /// \brief This is used to indicate that Run has been called, and the
-      /// server is in the run state.
-      private: std::atomic<bool> running{false};
+        /// \brief Leave RUNNING. A STOPPED state is left untouched.
+        public: void Finish()
+        {
+          auto expected = Value::RUNNING;
+          this->value.compare_exchange_strong(expected, Value::IDLE);
+        }
 
-      /// \brief Guards every write to `running` and `stopReceived`, making
-      /// Run()'s startup check-then-set atomic with respect to OnStop() so a
-      /// racing stop request cannot be overwritten. Reads stay lock-free.
-      private: std::mutex runStateMutex;
+        /// \brief Record a stop request. Permanent.
+        public: void Stop()
+        {
+          this->value = Value::STOPPED;
+        }
+
+        /// \return True while Run() is stepping simulation.
+        public: bool Running() const
+        {
+          return this->value == Value::RUNNING;
+        }
+
+        /// \return True once a stop request has been received.
+        public: bool Stopped() const
+        {
+          return this->value == Value::STOPPED;
+        }
+
+        /// \brief The states of the run loop.
+        private: enum class Value
+        {
+          IDLE,
+          RUNNING,
+          STOPPED
+        };
+
+        /// \brief Current state.
+        private: std::atomic<Value> value{Value::IDLE};
+      };
+
+      /// \brief Current run state.
+      private: RunState runState;
 
       /// \brief Manager of all systems.
       /// Note: must be before EntityComponentManager

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -18,9 +18,8 @@
 #include <gtest/gtest.h>
 #include <tinyxml2.h>
 
-#include <atomic>
 #include <chrono>
-#include <thread>
+#include <future>
 
 #include <gz/msgs/clock.pb.h>
 #include <gz/msgs/gui.pb.h>
@@ -1760,30 +1759,24 @@ TEST_P(SimulationRunnerTest, StopBeforeRun)
   // run thread's startup.
   runner.Stop();
 
-  std::atomic<bool> returned{false};
-  std::atomic<bool> runResult{true};
-  std::thread runThread([&]()
+  // Run indefinitely on another thread: with the stop request lost this
+  // never returns, so bound the wait instead of hanging until the CTest
+  // timeout.
+  auto run = std::async(std::launch::async, [&runner]()
   {
-    // Run indefinitely: with the stop request lost this never returns.
-    runResult = runner.Run(0);
-    returned = true;
+    return runner.Run(0);
   });
-
-  // Bound the wait at 10s so a regression fails fast instead of hanging.
-  for (int sleep = 0; sleep < 100 && !returned; ++sleep)
-  {
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  }
-  EXPECT_TRUE(returned);
+  const bool returned =
+    run.wait_for(std::chrono::seconds(10)) == std::future_status::ready;
+  EXPECT_TRUE(returned) << "Run() did not return: the stop request was lost";
 
   // On regression the runner is spinning in the run loop; a second stop lets
-  // it exit so join() returns and the test fails instead of hanging.
+  // it exit so the future's destructor can join the thread.
   if (!returned)
     runner.Stop();
-  runThread.join();
 
   // The stop must prevent any stepping and be reported as failure.
-  EXPECT_FALSE(runResult);
+  EXPECT_FALSE(run.get());
   EXPECT_FALSE(runner.Running());
   EXPECT_TRUE(runner.StopReceived());
   EXPECT_EQ(0u, runner.IterationCount());

--- a/src/SimulationRunner_TEST.cc
+++ b/src/SimulationRunner_TEST.cc
@@ -1759,9 +1759,8 @@ TEST_P(SimulationRunnerTest, StopBeforeRun)
   // run thread's startup.
   runner.Stop();
 
-  // Run indefinitely on another thread: with the stop request lost this
-  // never returns, so bound the wait instead of hanging until the CTest
-  // timeout.
+  // Run on another thread with a bounded wait: with the stop lost this
+  // would never return.
   auto run = std::async(std::launch::async, [&runner]()
   {
     return runner.Run(0);
@@ -1770,8 +1769,7 @@ TEST_P(SimulationRunnerTest, StopBeforeRun)
     run.wait_for(std::chrono::seconds(10)) == std::future_status::ready;
   EXPECT_TRUE(returned) << "Run() did not return: the stop request was lost";
 
-  // On regression the runner is spinning in the run loop; a second stop lets
-  // it exit so the future's destructor can join the thread.
+  // On regression a second stop lets the run loop exit so the thread joins.
   if (!returned)
     runner.Stop();
 


### PR DESCRIPTION
# 🦟 Bug fix

Part of #3829

## Summary

Suggestion for #3855 that also covers #3858.

Both hangs in #3829 have the same cause: a flag set at startup can either overwrite a stop request or be cleared before another thread sees it.

This PR replaces the `running` and `stopReceived` flags in `SimulationRunner` with a single `RunState`. The only way to enter the running state is an atomic compare and exchange from idle, so a stop request can no longer be lost. Because of that, `Server::Run` no longer needs to wait for the run thread to start. It sets `running` itself before creating the thread, which removes the condition variable and the promise proposed in #3858.

Tests: keeps `StopBeforeRun`, `RunAfterSignal` and `RunNonBlockingAfterBlockingRun`, and adds `RunNonBlockingThenDestroy`, which reproduces the reported teardown hang. `RunNonBlockingShortMultiple` is left out because it never reproduced the race locally.

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Claude Fable 5

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
