### PR TITLE
Use transport::Node::Subscriber RAII in test helper Subscription

### DIFF
--- a/test/helpers/Subscription.hh
+++ b/test/helpers/Subscription.hh
@@ -41,26 +41,8 @@ class Subscription
   /// \brief Default constructor.
   public: Subscription() = default;
 
-  /// \brief Destructor. Unsubscribes from the topic before this object is
-  /// destroyed so that the transport's asynchronous delivery thread cannot
-  /// invoke OnMessage() on an already-destroyed instance. Node::Unsubscribe
-  /// removes the handler and drains any in-flight callback, which prevents a
-  /// use-after-free on the members below (e.g. messageHistory) when messages
-  /// are still being delivered at teardown.
-  public: ~Subscription()
-  {
-    if (this->subscribed)
-    {
-      this->node->Unsubscribe(this->topicName);
-    }
-  }
-
   /// \brief Subscribe to a topic.
-  /// \param[in] _node Node to use to subscribe. It must outlive this
-  /// Subscription: the destructor unsubscribes through this node, so the
-  /// node has to still be alive when the Subscription is destroyed.
-  /// Declare the node before the Subscription so the latter is destroyed
-  /// first.
+  /// \param[in] _node Node to use to subscribe.
   /// \param[in] _topicName Name of the topic to subscribe.
   /// \param[in] _messageHistoryDepth Maximum size for
   /// message history buffer. Buffer grows indefinitely
@@ -76,12 +58,11 @@ class Subscription
     }
     std::lock_guard<std::mutex> lock(this->mutex);
     const auto callback = &Subscription::OnMessage;
-    if (!_node.Subscribe(_topicName, callback, this))
+    this->subscriber = _node.CreateSubscriber(_topicName, callback, this);
+    if (!this->subscriber)
     {
       throw std::runtime_error("Cannot subscribe to " + _topicName);
     }
-    this->node = &_node;
-    this->topicName = _topicName;
     this->messageHistoryDepth = _messageHistoryDepth;
     this->subscribed = true;
   }
@@ -197,12 +178,8 @@ class Subscription
     this->messageArrival.notify_all();
   }
 
-  /// \brief Node used to subscribe, needed to unsubscribe on destruction.
-  /// Not owned; must outlive this object (the standard transport contract).
-  private: transport::Node *node{nullptr};
-
-  /// \brief Name of the subscribed topic, needed to unsubscribe.
-  private: std::string topicName;
+  /// \brief Transport subscriber object.
+  private: transport::Node::Subscriber subscriber;
 
   /// \brief Flag to indicate if topic is subscribed or not
   private: bool subscribed{false};


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Use Node::CreateSubscriber to obtain a Node::Subscriber RAII handle instead of manually managing unsubscription via a raw transport::Node pointer in ~Subscription. This decouples the lifetime of Subscription from the declaration and destruction order of transport::Node in test fixtures.

This would alleviate issues like https://github.com/gazebosim/gz-sim/pull/3854#issuecomment-5459050109 where a segfault occured because the order of declaration `Subscription<msgs::LaserScan>` and `transport::Node` was incorrect.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Gemini 3.7 Flash

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
