### PR TITLE
Add EcmGuard for thread-safe RAII access to the EntityComponentManager

### DIFF
--- a/include/gz/sim/Server.hh
+++ b/include/gz/sim/Server.hh
@@ -26,6 +26,9 @@
 #include <gz/sim/Export.hh>
 #include <gz/sim/ServerConfig.hh>
 #include <gz/sim/SystemPluginPtr.hh>
+#include <gz/sim/Types.hh>
+#include <gz/utils/ImplPtr.hh>
+
 #include <sdf/Element.hh>
 #include <sdf/Plugin.hh>
 
@@ -127,6 +130,76 @@ namespace gz
         STOPPED,
         /// \brief The server is currently running.
         RUNNING
+      };
+
+      /// \class EcmGuard Server.hh gz/sim/Server.hh
+      /// \brief RAII guard providing exclusive read-write access to the
+      /// EntityComponentManager.
+      public: class GZ_SIM_VISIBLE EcmGuard
+      {
+        /// \brief Default constructor creating an invalid guard.
+        public: EcmGuard();
+
+        /// \brief Destructor. Releases the exclusive lock on the ECM.
+        public: ~EcmGuard();
+
+        /// \brief Move constructor.
+        /// \param[in] _other Guard to move from.
+        public: EcmGuard(EcmGuard &&_other) noexcept;
+
+        /// \brief Move assignment operator.
+        /// \param[in] _other Guard to move from.
+        /// \return Reference to this guard.
+        public: EcmGuard &operator=(EcmGuard &&_other) noexcept;
+
+        /// \brief Deleted copy constructor.
+        public: EcmGuard(const EcmGuard &) = delete;
+
+        /// \brief Deleted copy assignment operator.
+        public: EcmGuard &operator=(const EcmGuard &) = delete;
+
+        /// \brief Boolean conversion operator to check validity.
+        /// \return True if the guard holds an active exclusive lock and valid
+        /// ECM.
+        public: explicit operator bool() const;
+
+        /// \brief Check whether the guard is valid and holds an active lock.
+        /// \return True if valid.
+        public: bool Valid() const;
+
+        /// \brief Member access operator for the underlying ECM.
+        /// \return Pointer to the EntityComponentManager.
+        public: EntityComponentManager *operator->();
+
+        /// \brief Const member access operator for the underlying ECM.
+        /// \return Const pointer to the EntityComponentManager.
+        public: const EntityComponentManager *operator->() const;
+
+        /// \brief Dereference operator for the underlying ECM.
+        /// \return Reference to the EntityComponentManager.
+        public: EntityComponentManager &operator*();
+
+        /// \brief Const dereference operator for the underlying ECM.
+        /// \return Const reference to the EntityComponentManager.
+        public: const EntityComponentManager &operator*() const;
+
+        /// \brief Get reference to the underlying ECM.
+        /// \return Reference to the EntityComponentManager.
+        public: EntityComponentManager &Ecm();
+
+        /// \brief Get const reference to the underlying ECM.
+        /// \return Const reference to the EntityComponentManager.
+        public: const EntityComponentManager &Ecm() const;
+
+        /// \brief Explicitly release the lock before destruction.
+        public: void Reset();
+
+        /// \internal
+        /// \brief Pointer to private data.
+        private: GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
+
+        /// \brief Befriend Server to allow construction with private lock.
+        friend class Server;
       };
 
       /// \brief Construct the server using the parameters specified in a
@@ -362,6 +435,19 @@ namespace gz
       /// \brief Get the current lifecycle status of the server.
       /// \return The current status (EXITED, STOPPED, or RUNNING).
       public: Status GetStatus() const;
+
+      /// \brief Acquire an exclusive write lock on the ECM for modifications.
+      /// \param[in] _runnerId ID of the simulation runner (world index).
+      /// \return EcmGuard RAII handle. Evaluates to false if server is running,
+      /// out of bounds runner ID, or server in error state.
+      public: EcmGuard Ecm(const std::size_t _runnerId = 0);
+
+      /// \brief Get current simulation update info for a world.
+      /// \param[in] _worldIndex Index of the world to query.
+      /// \return Current update info, or std::nullopt if _worldIndex
+      /// is invalid.
+      public: std::optional<UpdateInfo> CurrentInfo(
+                  const unsigned int _worldIndex = 0) const;
 
       /// \brief Private data
       private: std::unique_ptr<ServerPrivate> dataPtr;

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -81,6 +81,7 @@ if (BUILD_TESTING)
     link_TEST
     model_TEST
     sensor_TEST
+    server_TEST
     testFixture_TEST
     world_TEST
   )

--- a/python/src/gz/sim/EntityComponentManager.cc
+++ b/python/src/gz/sim/EntityComponentManager.cc
@@ -30,7 +30,15 @@ void defineSimEntityComponentManager(pybind11::object module)
       module, "EntityComponentManager",
     "The Entity Component Manager (ECM) manages entities and their components "
     "in the simulation.")
-  .def(pybind11::init<>());
+    .def(pybind11::init<>())
+    .def("entity_count", &gz::sim::EntityComponentManager::EntityCount,
+      "Get total number of entities.")
+    .def("create_entity",
+      pybind11::overload_cast<>(&gz::sim::EntityComponentManager::CreateEntity),
+      "Create a new entity.")
+    .def("has_entity", &gz::sim::EntityComponentManager::HasEntity,
+      pybind11::arg("entity"),
+      "Check if an entity exists.");
 }
 }  // namespace python
 }  // namespace sim

--- a/python/src/gz/sim/Server.cc
+++ b/python/src/gz/sim/Server.cc
@@ -90,6 +90,7 @@ void defineSimServer(pybind11::object module)
     "Resets a specific simulation runner under this server.")
   .def("ecm",
     pybind11::overload_cast<const std::size_t>(&gz::sim::Server::Ecm),
+    pybind11::call_guard<pybind11::gil_scoped_release>(),
     pybind11::arg("runner_id") = 0,
     "Acquire a thread-safe lock on the ECM as a context manager.")
   .def("iteration_count", &gz::sim::Server::IterationCount,

--- a/python/src/gz/sim/Server.cc
+++ b/python/src/gz/sim/Server.cc
@@ -15,10 +15,14 @@
  */
 
 
+#include <pybind11/chrono.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
+#include <gz/sim/EntityComponentManager.hh>
 #include <gz/sim/Server.hh>
 #include <gz/sim/ServerConfig.hh>
+#include <gz/sim/Types.hh>
 
 #include "Server.hh"
 
@@ -30,6 +34,36 @@ namespace python
 {
 void defineSimServer(pybind11::object module)
 {
+  // EcmGuard
+  pybind11::class_<gz::sim::Server::EcmGuard>(module, "EcmGuard",
+    "RAII guard for exclusive thread-safe access to the "
+      "EntityComponentManager.")
+    .def("__enter__", [](gz::sim::Server::EcmGuard &self)
+        -> gz::sim::EntityComponentManager & {
+      if (!self) {
+        throw pybind11::value_error(
+          "Cannot enter invalid EcmGuard (server is running or "
+          "runner_id is invalid)");
+      }
+      return *self;
+    }, pybind11::return_value_policy::reference_internal)
+    .def("__exit__", [](gz::sim::Server::EcmGuard &self,
+                        pybind11::object /*exc_type*/,
+                        pybind11::object /*exc_val*/,
+                        pybind11::object /*exc_tb*/) -> pybind11::bool_ {
+      self.Reset();
+      return pybind11::bool_(false);
+    })
+    .def("valid", &gz::sim::Server::EcmGuard::Valid,
+      "Check whether the guard holds an active lock.")
+    .def("__bool__", &gz::sim::Server::EcmGuard::operator bool)
+    .def("ecm", pybind11::overload_cast<>(&gz::sim::Server::EcmGuard::Ecm),
+      pybind11::return_value_policy::reference_internal,
+      "Get reference to the underlying EntityComponentManager.")
+    .def("reset", &gz::sim::Server::EcmGuard::Reset,
+      "Explicitly release the lock.");
+
+  // Server
   pybind11::class_<gz::sim::Server,
     std::shared_ptr<gz::sim::Server>>(module, "Server",
     "The main simuulation server class. This class manages the simulation "
@@ -53,7 +87,23 @@ void defineSimServer(pybind11::object module)
   .def("reset_all", &gz::sim::Server::ResetAll,
     "Resets all simulation runners under this server.")
   .def("reset", &gz::sim::Server::Reset,
-    "Resets a specific simulation runner under this server.");
+    "Resets a specific simulation runner under this server.")
+  .def("ecm",
+    pybind11::overload_cast<const std::size_t>(&gz::sim::Server::Ecm),
+    pybind11::arg("runner_id") = 0,
+    "Acquire a thread-safe lock on the ECM as a context manager.")
+  .def("iteration_count", &gz::sim::Server::IterationCount,
+    pybind11::arg("world_index") = 0,
+    "Get the number of iterations the server has executed.")
+  .def("current_info", &gz::sim::Server::CurrentInfo,
+    pybind11::arg("world_index") = 0,
+    "Get current simulation update info.")
+  .def("entity_count", &gz::sim::Server::EntityCount,
+    pybind11::arg("world_index") = 0,
+    "Get the number of entities on the server.")
+  .def("system_count", &gz::sim::Server::SystemCount,
+    pybind11::arg("world_index") = 0,
+    "Get the number of systems on the server.");
 }
 }  // namespace python
 }  // namespace sim

--- a/python/test/server_TEST.py
+++ b/python/test/server_TEST.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import unittest
+
+from gz.sim import EntityComponentManager, Server, ServerConfig, UpdateInfo
+
+
+class ServerTest(unittest.TestCase):
+
+    def test_ecm_context_manager_read(self):
+        config = ServerConfig()
+        server = Server(config)
+        self.assertFalse(server.is_running())
+        self.assertEqual(3, server.entity_count(0))
+
+        with server.ecm() as ecm:
+            self.assertIsInstance(ecm, EntityComponentManager)
+            self.assertEqual(3, ecm.entity_count())
+            self.assertTrue(ecm.has_entity(1))
+
+    def test_ecm_context_manager_write(self):
+        config = ServerConfig()
+        server = Server(config)
+        self.assertEqual(3, server.entity_count(0))
+
+        with server.ecm() as ecm:
+            self.assertIsInstance(ecm, EntityComponentManager)
+            e = ecm.create_entity()
+            self.assertTrue(ecm.has_entity(e))
+
+        # Confirm entity count reflects the mutation
+        self.assertEqual(4, server.entity_count(0))
+        with server.ecm() as ecm:
+            self.assertEqual(4, ecm.entity_count())
+            self.assertTrue(ecm.has_entity(e))
+
+    def test_guard_exception_safety(self):
+        config = ServerConfig()
+        server = Server(config)
+
+        # Verify exception is propagated (not swallowed by __exit__)
+        with self.assertRaises(RuntimeError):
+            with server.ecm() as ecm:
+                ecm.create_entity()
+                raise RuntimeError('Test exception inside context manager')
+
+        # Verify lock was released and subsequent operations work
+        with server.ecm() as ecm:
+            self.assertIsInstance(ecm, EntityComponentManager)
+
+    def test_invalid_runner_id(self):
+        config = ServerConfig()
+        server = Server(config)
+
+        # Out of bounds runner ID raises ValueError when entered
+        with self.assertRaises(ValueError):
+            with server.ecm(999):
+                pass
+
+    def test_server_statistics(self):
+        config = ServerConfig()
+        server = Server(config)
+
+        self.assertEqual(0, server.iteration_count(0))
+        self.assertEqual(3, server.entity_count(0))
+        self.assertEqual(3, server.system_count(0))
+
+        info = server.current_info(0)
+        self.assertIsInstance(info, UpdateInfo)
+        self.assertEqual(0, info.iterations)
+        self.assertEqual(datetime.timedelta(0), info.sim_time)
+        self.assertTrue(info.paused)
+
+        self.assertIsNone(server.current_info(999))
+
+        # Step simulation
+        self.assertTrue(server.run(True, 10, False))
+        self.assertEqual(10, server.iteration_count(0))
+        info_after = server.current_info(0)
+        self.assertIsInstance(info_after, UpdateInfo)
+        self.assertEqual(10, info_after.iterations)
+        self.assertGreater(info_after.sim_time, datetime.timedelta(0))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -39,6 +39,93 @@
 using namespace gz;
 using namespace sim;
 
+
+class Server::EcmGuard::Implementation
+{
+  public: std::unique_lock<std::mutex> lock;
+  public: EntityComponentManager *ecm{nullptr};
+};
+
+
+//////////////////////////////////////////////////
+Server::EcmGuard::EcmGuard()
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
+{
+}
+
+//////////////////////////////////////////////////
+Server::EcmGuard::~EcmGuard() = default;
+
+//////////////////////////////////////////////////
+Server::EcmGuard::EcmGuard(EcmGuard &&_other) noexcept = default;
+
+//////////////////////////////////////////////////
+Server::EcmGuard &Server::EcmGuard::operator=(
+    EcmGuard &&_other) noexcept = default;
+
+//////////////////////////////////////////////////
+Server::EcmGuard::operator bool() const
+{
+  return this->Valid();
+}
+
+//////////////////////////////////////////////////
+bool Server::EcmGuard::Valid() const
+{
+  return this->dataPtr != nullptr &&
+         this->dataPtr->ecm != nullptr &&
+         this->dataPtr->lock.owns_lock();
+}
+
+//////////////////////////////////////////////////
+EntityComponentManager *Server::EcmGuard::operator->()
+{
+  return this->dataPtr ? this->dataPtr->ecm : nullptr;
+}
+
+//////////////////////////////////////////////////
+const EntityComponentManager *Server::EcmGuard::operator->() const
+{
+  return this->dataPtr ? this->dataPtr->ecm : nullptr;
+}
+
+//////////////////////////////////////////////////
+EntityComponentManager &Server::EcmGuard::operator*()
+{
+  return *this->dataPtr->ecm;
+}
+
+//////////////////////////////////////////////////
+const EntityComponentManager &Server::EcmGuard::operator*() const
+{
+  return *this->dataPtr->ecm;
+}
+
+//////////////////////////////////////////////////
+EntityComponentManager &Server::EcmGuard::Ecm()
+{
+  return *this->dataPtr->ecm;
+}
+
+//////////////////////////////////////////////////
+const EntityComponentManager &Server::EcmGuard::Ecm() const
+{
+  return *this->dataPtr->ecm;
+}
+
+//////////////////////////////////////////////////
+void Server::EcmGuard::Reset()
+{
+  if (this->dataPtr)
+  {
+    if (this->dataPtr->lock.owns_lock())
+    {
+      this->dataPtr->lock.unlock();
+    }
+    this->dataPtr->ecm = nullptr;
+  }
+}
+
 /////////////////////////////////////////////////
 Server::Server(const ServerConfig &_config)
   : dataPtr(new ServerPrivate)
@@ -431,6 +518,45 @@ bool Server::Reset(const std::size_t _runnerId)
   }
   this->dataPtr->simRunners[_runnerId]->Reset(true, false, false);
   return true;
+}
+
+//////////////////////////////////////////////////
+Server::EcmGuard Server::Ecm(const std::size_t _runnerId)
+{
+  EcmGuard guard;
+  std::unique_lock<std::mutex> lock(this->dataPtr->runMutex);
+
+  if (this->dataPtr->running)
+  {
+    gzerr << "Cannot access ECM while the server is running.\n";
+    return guard;
+  }
+  if (_runnerId >= this->dataPtr->simRunners.size())
+  {
+    gzerr << "Runner id " << _runnerId << " out of bounds.\n";
+    return guard;
+  }
+  if (this->dataPtr->exitedWithErrors)
+  {
+    gzerr << "Cannot access ECM because server exited with errors.\n";
+    return guard;
+  }
+
+  guard.dataPtr->lock = std::move(lock);
+  guard.dataPtr->ecm =
+      &this->dataPtr->simRunners[_runnerId]->EntityCompMgr();
+  return guard;
+}
+
+//////////////////////////////////////////////////
+std::optional<UpdateInfo> Server::CurrentInfo(
+    const unsigned int _worldIndex) const
+{
+  if (_worldIndex < this->dataPtr->simRunners.size())
+  {
+    return this->dataPtr->simRunners[_worldIndex]->CurrentInfo();
+  }
+  return std::nullopt;
 }
 
 //////////////////////////////////////////////////

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -23,7 +23,9 @@
 #include <gz/msgs/stringmsg_v.pb.h>
 #include <gz/msgs/world_control.pb.h>
 
+#include <atomic>
 #include <csignal>
+#include <thread>
 #include <vector>
 #include <gz/common/StringUtils.hh>
 #include <gz/common/Util.hh>
@@ -1384,3 +1386,154 @@ TEST_P(ServerFixture, WorldControlIgnoredOnExit)
 // Run multiple times. We want to make sure that static globals don't cause
 // problems.
 INSTANTIATE_TEST_SUITE_P(ServerRepeat, ServerFixture, ::testing::Range(1, 2));
+
+/////////////////////////////////////////////////
+class ServerTest : public InternalFixture<::testing::Test>
+{
+};
+
+/////////////////////////////////////////////////
+TEST_F(ServerTest, EcmContextManager)
+{
+  ServerConfig serverConfig;
+  serverConfig.SetSdfFile(
+      common::joinPaths(PROJECT_SOURCE_PATH, "test", "worlds", "shapes.sdf"));
+  serverConfig.SetWaitForAssets(true);
+  sim::Server server(serverConfig);
+
+  // 1. Basic reading
+  {
+    auto guard = server.Ecm();
+    EXPECT_TRUE(guard.Valid());
+    EXPECT_TRUE(static_cast<bool>(guard));
+    EXPECT_EQ(25u, guard->EntityCount());
+
+    std::size_t modelCount = 0;
+    guard->Each<components::Model>(
+        [&](const Entity &, const components::Model *)
+        {
+          modelCount++;
+          return true;
+        });
+    EXPECT_EQ(5u, modelCount);
+  }
+
+  // 2. Entity Creation
+  {
+    auto guard = server.Ecm();
+    Entity newEntity = guard->CreateEntity();
+    EXPECT_NE(kNullEntity, newEntity);
+    EXPECT_EQ(26u, guard->EntityCount());
+  }
+
+  // 3. Move semantics & Reset
+  {
+    auto g1 = server.Ecm();
+    Server::EcmGuard g2;
+    g2 = std::move(g1);
+    EXPECT_FALSE(g1.Valid());
+    EXPECT_TRUE(g2.Valid());
+
+    g2.Reset();
+    EXPECT_FALSE(g2.Valid());
+    EXPECT_NO_THROW(g2.Reset());  // Repeated reset is safe
+
+    // Reset released lock, we can get another
+    auto g3 = server.Ecm();
+    EXPECT_TRUE(g3.Valid());
+  }
+
+  // 4. Invalid States
+  {
+    EXPECT_FALSE(server.Ecm(999).Valid());  // Out of bounds runner
+
+    server.Run(false, 0, false);
+    while (!server.Running()) GZ_SLEEP_MS(10);
+    EXPECT_FALSE(server.Ecm().Valid());  // Cannot access while running
+
+    server.Stop();
+    while (server.Running()) GZ_SLEEP_MS(10);
+    EXPECT_TRUE(server.Ecm().Valid());  // Valid again after stop
+  }
+}
+
+/////////////////////////////////////////////////
+TEST_F(ServerTest, ServerCurrentInfo)
+{
+  ServerConfig serverConfig;
+  serverConfig.SetWaitForAssets(true);
+
+  sim::Server server(serverConfig);
+
+  // Initial update info
+  auto initialInfo = server.CurrentInfo(0);
+  ASSERT_TRUE(initialInfo.has_value());
+  EXPECT_EQ(0u, initialInfo->iterations);
+  EXPECT_EQ(std::chrono::steady_clock::duration::zero(), initialInfo->simTime);
+  EXPECT_TRUE(initialInfo->paused);
+
+  // Invalid runner / world ID returns nullopt
+  EXPECT_FALSE(server.CurrentInfo(999).has_value());
+
+  // Run simulation for 10 steps (unpaused)
+  EXPECT_TRUE(server.Run(true, 10, false));
+
+  auto updatedInfo = server.CurrentInfo(0);
+  ASSERT_TRUE(updatedInfo.has_value());
+  EXPECT_EQ(10u, updatedInfo->iterations);
+  EXPECT_GT(updatedInfo->simTime, std::chrono::steady_clock::duration::zero());
+}
+
+/////////////////////////////////////////////////
+TEST_F(ServerTest, GuardMutualExclusionWithRun)
+{
+  ServerConfig serverConfig;
+  serverConfig.SetWaitForAssets(true);
+
+  sim::Server server(serverConfig);
+
+  std::atomic<bool> holdLock{true};
+  std::atomic<bool> lockAcquired{false};
+  std::atomic<bool> runFinished{false};
+
+  std::thread ecmThread(
+      [&]()
+      {
+        auto guard = server.Ecm();
+        EXPECT_TRUE(guard.Valid());
+        lockAcquired = true;
+        while (holdLock.load())
+        {
+          std::this_thread::sleep_for(10ms);
+        }
+        guard.Reset();
+      });
+
+  // Wait until the ECM thread acquires the lock
+  while (!lockAcquired.load())
+  {
+    std::this_thread::sleep_for(5ms);
+  }
+
+  // Start server.Run in a background thread to verify it blocks
+  std::thread runThread(
+      [&]()
+      {
+        server.Run(true, 1, false);
+        runFinished = true;
+      });
+
+  // Give runThread time to attempt running and block on runMutex
+  std::this_thread::sleep_for(100ms);
+  EXPECT_FALSE(runFinished.load());
+
+  // Release the ECM guard lock
+  holdLock = false;
+
+  // Now runThread should unblock and complete
+  runThread.join();
+  ecmThread.join();
+
+  EXPECT_TRUE(runFinished.load());
+  EXPECT_EQ(1u, *server.IterationCount());
+}

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -1446,13 +1446,11 @@ TEST_F(ServerTest, EcmContextManager)
   // 4. Invalid States
   {
     EXPECT_FALSE(server.Ecm(999).Valid());  // Out of bounds runner
-
     server.Run(false, 0, false);
-    while (!server.Running()) GZ_SLEEP_MS(10);
+    EXPECT_TRUE(test::WaitUntil(1s, [&]() { return server.Running(); }));
     EXPECT_FALSE(server.Ecm().Valid());  // Cannot access while running
-
     server.Stop();
-    while (server.Running()) GZ_SLEEP_MS(10);
+    EXPECT_TRUE(test::WaitUntil(1s, [&]() { return !server.Running(); }));
     EXPECT_TRUE(server.Ecm().Valid());  // Valid again after stop
   }
 }
@@ -1502,18 +1500,11 @@ TEST_F(ServerTest, GuardMutualExclusionWithRun)
         auto guard = server.Ecm();
         EXPECT_TRUE(guard.Valid());
         lockAcquired = true;
-        while (holdLock.load())
-        {
-          std::this_thread::sleep_for(10ms);
-        }
+        EXPECT_TRUE(test::WaitUntil(5s, [&]() { return !holdLock.load(); }));
         guard.Reset();
       });
-
   // Wait until the ECM thread acquires the lock
-  while (!lockAcquired.load())
-  {
-    std::this_thread::sleep_for(5ms);
-  }
+  EXPECT_TRUE(test::WaitUntil(1s, [&]() { return lockAcquired.load(); }));
 
   // Start server.Run in a background thread to verify it blocks
   std::thread runThread(

--- a/src/SimulationRunner.cc
+++ b/src/SimulationRunner.cc
@@ -1654,6 +1654,12 @@ const EntityComponentManager &SimulationRunner::EntityCompMgr() const
 }
 
 /////////////////////////////////////////////////
+EntityComponentManager &SimulationRunner::EntityCompMgr()
+{
+  return this->entityCompMgr;
+}
+
+/////////////////////////////////////////////////
 EventManager &SimulationRunner::EventMgr()
 {
   return this->eventMgr;

--- a/src/SimulationRunner.hh
+++ b/src/SimulationRunner.hh
@@ -240,6 +240,10 @@ namespace gz
       /// \return Reference to the entity component manager.
       public: const EntityComponentManager &EntityCompMgr() const;
 
+      /// \brief Get a mutable reference to the EntityComponentManager.
+      /// \return Mutable reference to the entity component manager.
+      public: EntityComponentManager &EntityCompMgr();
+
       /// \brief Return an entity with the provided name.
       /// \details If multiple entities with the same name exist, the first
       /// entity found will be returned.


### PR DESCRIPTION
# 🎉 New feature

Alternative to https://github.com/gazebosim/gz-sim/pull/3446/

## Summary
This PR introduces `Server::Ecm()`, which returns an `EcmGuard` to provide safe, synchronous read and write access to the EntityComponentManager.

In C++, `EcmGuard` uses the RAII pattern to acquire the server's `runMutex`. This naturally blocks the simulation from starting while the ECM is being inspected or mutated. Conversely, if the simulation is actively stepping, it safely rejects access to prevent race conditions.

In Python, this exposes `server.ecm()` as a native context manager. This enables clean, linear scripting without the need for asynchronous callbacks—making it especially powerful for driving synchronous Reinforcement Learning (Gym) environments.

### Usage Examples

**C++ Usage:**
```cpp
// Safely acquire the ECM lock
if (auto ecmGuard = server.Ecm()) 
{
    // Mutate or read from the ECM safely
    Entity newEntity = ecmGuard->CreateEntity();
    
    // The lock is automatically released when 'ecmGuard' goes out of scope,
    // allowing the simulation to resume safely.
}
```

**Python Usage (RL Gym Loop Example):**
```python
# The context manager provides flat, synchronous access
for _ in range(5):
    with server.ecm() as ecm:
        # Inject forces or manipulate entities
        chassis.add_world_force(ecm, action_force)
    
    # Step the simulation forward
    server.run(True, 1, False)

# Safely extract the final observation state
with server.ecm() as ecm:
    obs = chassis.world_pose(ecm)
```

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Test it
1. Build the branch
2. Run the C++ server tests: `ctest -R UNIT_Server_TEST`
3. Run the Python server tests: `ctest -R server_TEST`
4. Use the new API in a Python script via `with server.ecm() as ecm:` and verify it behaves correctly.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Gemini 3.1 Pro

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
