### PR TITLE
A small change for the wayland support

### DIFF
--- a/src/gui/Gui.cc
+++ b/src/gui/Gui.cc
@@ -359,13 +359,28 @@ std::unique_ptr<gz::gui::Application> createGui(
     qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", "1");
   }
 
-  // check for wayland and force to use X for rendering
+  // check for wayland and force to use X for rendering, unless the user
+  // has explicitly opted in to (still-experimental) native Wayland
+  // rendering support.
   if (QString::fromLocal8Bit(qgetenv("XDG_SESSION_TYPE")) == "wayland")
   {
-    if (QString::fromLocal8Bit(qgetenv("QT_QPA_PLATFORM")).isEmpty())
+    bool nativeWaylandRequested =
+        QString::fromLocal8Bit(qgetenv("GZ_GUI_WAYLAND")) == "1";
+
+    if (nativeWaylandRequested)
+    {
+      gzmsg << "Detected Wayland with GZ_GUI_WAYLAND=1: using experimental "
+            << "native Wayland rendering instead of XWayland." << std::endl;
+      // Leave QT_QPA_PLATFORM unset (or as the user set it) so Qt picks
+      // its native wayland platform plugin. gz-gui's MinimalScene detects
+      // this at render-engine load time and routes rendering through
+      // OGRE-Next's native Wayland EGL backend instead of X11/GLX.
+    }
+    else if (QString::fromLocal8Bit(qgetenv("QT_QPA_PLATFORM")).isEmpty())
     {
       gzmsg << "Detected Wayland. Setting Qt to use the xcb plugin: "
-            << "'QT_QPA_PLATFORM=xcb'." << std::endl;
+            << "'QT_QPA_PLATFORM=xcb'. Set GZ_GUI_WAYLAND=1 to try "
+            << "experimental native Wayland rendering instead." << std::endl;
       qputenv("QT_QPA_PLATFORM", "xcb");
     }
   }


### PR DESCRIPTION
# 🎉 New feature

## Summary
Adds an opt-in `GZ_GUI_WAYLAND=1` environment variable to `src/gui/Gui.cc`. Today,
whenever `XDG_SESSION_TYPE=wayland` is detected, Gazebo unconditionally forces Qt onto
the `xcb` platform plugin (XWayland). Setting `GZ_GUI_WAYLAND=1` skips that override,
letting Qt use its native `wayland` platform plugin instead — which gz-gui's
`MinimalScene` plugin now detects at render-engine load time and routes through
gz-rendering's/OGRE-Next's native Wayland EGL backend instead of X11/GLX.

This is purely additive and off by default: without the env var, behavior is
byte-for-byte identical to today (still forces `xcb`). This is the "front door" flag
for the broader native-Wayland change spanning three repos:
- OGRECave/ogre-next#593
- gazebosim/gz-rendering#1325
- gazebosim/gz-gui#780

## Backport Policy
- [ ] I am not sure

## Test it
Requires the OGRE-Next/gz-rendering/gz-gui branches above built and installed together.

1. `unset QT_QPA_PLATFORM` (so nothing overrides Qt's platform selection ahead of time).
2. `GZ_GUI_WAYLAND=1 gz sim -v 4 examples/worlds/shapes.sdf`
3. Confirm the log shows "Detected Wayland with GZ_GUI_WAYLAND=1: using experimental
   native Wayland rendering instead of XWayland" and the GUI renders correctly with no
   crash (screenshot attached).
4. Without the env var set (same Wayland session), confirm it still logs "Detected
   Wayland. Setting Qt to use the xcb plugin" and behaves exactly as before.

## Checklist
- [x] Signed all commits for DCO
- [x] Added a screen capture or video to the PR description that demonstrates the fix
- [ ] Added tests — no gtest coverage added; the Wayland path needs a live compositor
      CI doesn't have, so verification is the manual run above
- [ ] Updated documentation (as needed) — the env var could use a mention in relevant
      GUI docs; flagging as a possible follow-up rather than doing it speculatively here
- [ ] Updated migration guide (as needed) — not needed, purely additive/opt-in
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed
- [x] All tests passed (See test coverage) — 223/280 pass; the 57 failures are a
      pre-existing environment gap (no gz-physics-dartsim-plugin built in this sandbox,
      unrelated to this change) plus two unrelated fake-home config-path test quirks in
      UNIT_Gui_TEST. Verified none touch the Wayland-detection code this PR adds.
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise. — N/A, no
      new files added, only `src/gui/Gui.cc` modified
- [ ] While waiting for a review on your PR, please help review another open pull request
- [x] Was GenAI used to generate this PR?

Assisted-by: Claude (Anthropic) — used for implementation and debugging assistance.