### PR TITLE
Stop TestFixture steps when the server has exited

### DIFF
--- a/test/helpers/TestFixture.hh
+++ b/test/helpers/TestFixture.hh
@@ -54,6 +54,14 @@ class TestFixture
     common::Console::SetVerbosity(4);
   }
 
+  /// Constructor.
+  /// \param[in] _config Server configuration.
+  public: TestFixture(const sim::ServerConfig &_config)
+    : fixture(_config)
+  {
+    common::Console::SetVerbosity(4);
+  }
+
   virtual ~TestFixture() = default;
 
   /// Pause the simulation in this fixture.
@@ -100,8 +108,7 @@ class TestFixture
   /// \return number of simulation steps taken.
   public: uint64_t Step()
   {
-    this->Simulator()->RunOnce(this->paused);
-    return 1u;
+    return this->Simulator()->RunOnce(this->paused) ? 1u : 0u;
   }
 
   /// Advance the simulation.
@@ -124,15 +131,28 @@ class TestFixture
     uint64_t iterations = 0u;
     // Fetch simulator early to ensure it is initialized
     auto simulator = this->Simulator();
+    if (this->maxStepSize <= 0.0 ||
+        simulator->GetStatus() == sim::Server::Status::EXITED)
+    {
+      return 0u;
+    }
+
     const auto deadline = this->info.simTime + _step;
     do {
       const double stepSize =
           std::chrono::duration<double>(deadline - this->info.simTime).count();
       uint64_t previous_iterations = this->Iterations();
-      simulator->Run(blocking,
+      if (!simulator->Run(blocking,
           static_cast<uint64_t>(std::ceil(stepSize / this->maxStepSize)),
-          this->paused);
-      iterations += this->Iterations() - previous_iterations;
+          this->paused))
+      {
+        break;
+      }
+
+      const auto steppedIterations = this->Iterations() - previous_iterations;
+      iterations += steppedIterations;
+      if (steppedIterations == 0u)
+        break;
     } while (this->info.simTime < deadline);
     return iterations;
   }
@@ -207,7 +227,7 @@ class TestFixture
 
   private: bool paused{false};
 
-  private: double maxStepSize;
+  private: double maxStepSize{0.0};
 
   private: sim::UpdateInfo info;
 

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -85,6 +85,7 @@ set(tests
   sdf_frame_semantics.cc
   sdf_include.cc
   sensor.cc
+  test_fixture.cc
   spherical_coordinates.cc
   swerve_drive_system.cc
   thruster.cc

--- a/test/integration/test_fixture.cc
+++ b/test/integration/test_fixture.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <string>
+
+#include <gz/sim/ServerConfig.hh>
+
+#include "helpers/TestFixture.hh"
+
+using namespace gz;
+using namespace std::literals::chrono_literals;
+
+//////////////////////////////////////////////////
+TEST(TestFixtureHelperTest, StepDurationStopsWhenServerExited)
+{
+  const std::string badSdf = R"(
+    <sdf version="1.12">
+      <world name="test">
+        <model name="bad_model_no_link" />
+      </world>
+    </sdf>)";
+
+  sim::ServerConfig serverConfig;
+  serverConfig.SetSdfString(badSdf);
+  serverConfig.SetWaitForAssets(true);
+  serverConfig.SetBehaviorOnSdfErrors(
+      sim::ServerConfig::SdfErrorBehavior::EXIT_IMMEDIATELY);
+
+  TestFixture fixture(serverConfig);
+  auto *server = fixture.Simulator();
+  ASSERT_NE(nullptr, server);
+  EXPECT_EQ(sim::Server::Status::EXITED, server->GetStatus());
+
+  const auto start = std::chrono::steady_clock::now();
+  EXPECT_EQ(0u, fixture.Step(100ms));
+  EXPECT_LT(std::chrono::steady_clock::now() - start, 1s);
+}


### PR DESCRIPTION
## Summary

- stop duration-based fixture stepping when the server is already `EXITED`
- stop when `Run` reports no progress, and initialize the step-size guard
- add a deterministic integration regression using an invalid SDF and immediate exit

## Why

When a test server exits with an error, simulation time no longer advances. `TestFixture::Step(duration)` nevertheless kept invoking `Run`, repeating the same server warning and producing excessive logs as reported in #3891.

## Verification

- checked behavior against `Server::Run` / `RunOnce` exit semantics
- registered deterministic integration regression in the existing test list
- `git diff --check`

A local CMake/CTest build was not available; compile and integration execution remain CI-bound.

Fixes #3891