### PR TITLE
Fix HasEqualityOperator trait for types with templated equality operators

### DIFF
--- a/include/gz/sim/detail/EntityComponentManager.hh
+++ b/include/gz/sim/detail/EntityComponentManager.hh
@@ -41,29 +41,15 @@ inline namespace GZ_SIM_VERSION_NAMESPACE {
 //////////////////////////////////////////////////
 namespace traits
 {
-  /// \brief Helper struct to determine if an equality operator is present.
-  struct TestEqualityOperator
-  {
-  };
-  template<typename T>
-  TestEqualityOperator operator == (const T&, const T&);
-
   /// \brief Type trait that determines if an operator== is defined for `T`.
-  template<typename T>
-  struct HasEqualityOperator
+  template <typename, typename = std::void_t<>>
+  struct HasEqualityOperator : std::false_type {};
+
+  template <typename T>
+  struct HasEqualityOperator<
+      T, std::void_t<decltype(std::declval<T>() == std::declval<T>())>>
+      : std::true_type
   {
-#if !defined(_MSC_VER)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnonnull"
-#endif
-    enum
-    {
-      // False positive codecheck "Using C-style cast"
-      value = !std::is_same<decltype(*(T*)(0) == *(T*)(0)), TestEqualityOperator>::value // NOLINT
-    };
-#if !defined(_MSC_VER)
-#pragma GCC diagnostic pop
-#endif
   };
 }
 

--- a/src/EntityComponentManager_TEST.cc
+++ b/src/EntityComponentManager_TEST.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <chrono>
 #include <optional>
 #include <gtest/gtest.h>
 
@@ -24,6 +25,7 @@
 #include <gz/math/Rand.hh>
 #include <gz/utils/ExtraTestMacros.hh>
 
+#include "gz/sim/components/Actor.hh"
 #include "gz/sim/components/CanonicalLink.hh"
 #include "gz/sim/components/ChildLinkName.hh"
 #include "gz/sim/components/Factory.hh"
@@ -3559,6 +3561,26 @@ TEST_P(EntityComponentManagerFixture, EntityByName)
   EXPECT_TRUE(entityByName);
   CompareEntityComponents<components::Name>(manager, entity,
     *entityByName, true);
+}
+
+//////////////////////////////////////////////////
+TEST_P(EntityComponentManagerFixture, HasEqualityOperator)
+{
+  EXPECT_TRUE(traits::HasEqualityOperator<int>::value);
+  EXPECT_TRUE(
+      traits::HasEqualityOperator<std::chrono::nanoseconds>::value);
+  EXPECT_FALSE(traits::HasEqualityOperator<Custom>::value);
+
+  Entity entity = manager.CreateEntity();
+  using namespace std::chrono_literals;
+  auto comp = manager.CreateComponent<AnimationTime>(entity,
+      AnimationTime(100ms));
+  ASSERT_NE(nullptr, comp);
+  EXPECT_EQ(100ms, comp->Data());
+
+  EXPECT_TRUE(manager.SetComponentData<AnimationTime>(entity, 200ms));
+  EXPECT_EQ(200ms, manager.ComponentData<AnimationTime>(entity));
+  EXPECT_FALSE(manager.SetComponentData<AnimationTime>(entity, 200ms));
 }
 
 // Run multiple times. We want to make sure that static globals don't cause


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fix compilation failure in `gz::sim::traits::HasEqualityOperator` when evaluated on types with templated `operator==` overloads in their own namespace (such as `std::chrono::duration`). I ran into this while working on a PR to expose ECS components to Python.

The previous implementation defined a dummy fallback overload `TestEqualityOperator operator==(const T&, const T&)` inside namespace `gz::sim::traits`. When evaluating `decltype(*(T*)(0) == *(T*)(0))` for types like `std::chrono::duration<...>`, unqualified lookup in `gz::sim::traits` and ADL in `std` both found templated `operator==` candidates without one being more specialized, resulting in ambiguous overload compiler errors.

```
error: use of overloaded operator '==' is ambiguous (with operand types 'std::chrono::duration<...>' and 'std::chrono::duration<...>')
note: candidate function: gz::sim::traits::operator==(const T&, const T&)
note: candidate function: std::chrono::operator==(const duration<_Rep1, _Period1>&, const duration<_Rep2, _Period2>&)
```

The fix in this PR replaces the fallback overload pattern with modern C++17 `std::void_t` SFINAE (`std::void_t<decltype(std::declval<T>() == std::declval<T>())>`), eliminating the need for a fallback `operator==` in `gz::sim::traits`.

9bb3d2f0f56e72f820003d48c7a74019d5ad36c6 adds a failing test to demonstrate the issue

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Gemini 3.7 Flash

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
