### PR TITLE
Disable 24.04 CI on Rotary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,41 +15,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  noble-ci:
-    runs-on: ubuntu-latest
-    name: Ubuntu Noble CI
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
-      - uses: pre-commit/action@v3.0.1
-        with:
-          extra_args: --all-files
-      - name: Compile and test
-        id: ci
-        uses: gazebo-tooling/action-gz-ci@noble
-        with:
-          gzdev-project-name: rotary
-          # per bug https://github.com/gazebosim/gz-sim/issues/1409
-          cmake-args: '-DCMAKE_INSTALL_PREFIX=/usr -DBUILD_DOCS=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo'
-
-  noble-ci-disable-gui:
-    runs-on: ubuntu-latest
-    name: Ubuntu Noble CI (GUI disabled)
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
-      - name: Compile and test
-        id: ci
-        uses: gazebo-tooling/action-gz-ci@noble
-        with:
-          gzdev-project-name: rotary
-          # per bug https://github.com/gazebosim/gz-sim/issues/1409
-          cmake-args: '-DCMAKE_INSTALL_PREFIX=/usr -DBUILD_DOCS=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_GUI=OFF'
-          cppcheck-enabled: true
-          cpplint-enabled: true
-
   resolute-ci:
     runs-on: ubuntu-latest
     name: Ubuntu Resolute CI


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebo-tooling/release-tools/issues/1515.

## Summary

Disable the Ubuntu Noble (24.04) CI jobs for Rotary per https://github.com/gazebo-tooling/release-tools/issues/1515, since CI is fully working on Resolute (26.04) and 26.04.1 has been released, so now is a good time to drop Noble. This should hopefully speed up CI.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [x] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Test it

Confirm that CI passes

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
