### PR TITLE
Return early from EachNew and EachRemoved when nothing is new or marked for removal

### DIFF
--- a/include/gz/sim/detail/EntityComponentManager.hh
+++ b/include/gz/sim/detail/EntityComponentManager.hh
@@ -421,6 +421,11 @@ template <typename... ComponentTypeTs>
 void EntityComponentManager::EachNew(typename identity<std::function<
     bool(const Entity &_entity, ComponentTypeTs *...)>>::type _f)
 {
+  // Nothing to do if no entity was created since the last
+  // ClearNewlyCreatedEntities call: skip the view lookup entirely.
+  if (!this->HasNewEntities())
+    return;
+
   // Get the view. This will create a new view if one does not already
   // exist.
   auto view = this->FindView<ComponentTypeTs...>();
@@ -443,6 +448,11 @@ template <typename... ComponentTypeTs>
 void EntityComponentManager::EachNew(typename identity<std::function<
     bool(const Entity &_entity, const ComponentTypeTs *...)>>::type _f) const
 {
+  // Nothing to do if no entity was created since the last
+  // ClearNewlyCreatedEntities call: skip the view lookup entirely.
+  if (!this->HasNewEntities())
+    return;
+
   // Get the view. This will create a new view if one does not already
   // exist.
   auto view = this->FindView<ComponentTypeTs...>();
@@ -465,13 +475,17 @@ template<typename ...ComponentTypeTs>
 void EntityComponentManager::EachRemoved(typename identity<std::function<
     bool(const Entity &_entity, const ComponentTypeTs *...)>>::type _f) const
 {
+  // Nothing to do if no entity is marked for removal: skip the view lookup
+  // entirely.
+  if (!this->HasEntitiesMarkedForRemoval())
+    return;
+
   // Get the view. This will create a new view if one does not already
   // exist.
   auto view = this->FindView<ComponentTypeTs...>();
 
-  // Iterate over the entities in the view and in the newly created
-  // entities list, and invoke the callback
-  // function.
+  // Iterate over the entities in the view that are marked for removal, and
+  // invoke the callback function.
   for (const Entity entity : view->ToRemoveEntities())
   {
     const auto &data = view->EntityComponentData(entity);


### PR DESCRIPTION
# 🎉 New feature

## Summary

Every system calls `EachNew<...>` on every step, and many also call `EachRemoved<...>`. Each call looks up (or creates) the matching view before iterating: it allocates the component type key, takes the views mutex, probes the view map, and applies any pending additions to that view. In steady state almost nothing is new and nothing is being removed, so all of that work ends with an empty loop.

This PR checks `HasNewEntities()` / `HasEntitiesMarkedForRemoval()` first and returns right away when there is nothing to visit. The check is exact: `ClearNewlyCreatedEntities` clears every view's new entity set and flags pending additions as not new, and views only hold entities marked for removal while the ECM's own removal list is non empty. When something is new or marked for removal, the code path is the same as before.

The finding comes from the server profiling report at https://caguero.github.io/gz-profiling/2026-09-01/ (Priority 5 in [findings_report.md](https://github.com/caguero/gz-profiling/blob/main/2026-09-01/findings_report.md)).

Benchmark on this branch vs. main (a2164ed22), headless server, steady state steps per second, interleaved A/B runs pinned to one core:

| World | steps/s before | steps/s after | change | CPU per step before (us) | after (us) | CPU change | runs each |
|---|---:|---:|---:|---:|---:|---:|---:|
| sensors (non rendering sensors) | 45,517 | 46,654 | **+2.5%** | 22.0 | 21.4 | -2.5% | 6 |
| gpu_lidar_sensor (one GPU lidar) | 31,761 | 37,274 | **+17.4%** | 31.5 | 26.8 | -14.8% | 6 |
| moving_robots_and_sensors (two driven robots, cameras and lidar) | 1,702 | 1,735 | **+2.0%** | 587.1 | 575.1 | -2.0% | 3 |
| sensors_demo (six rendering sensors) | 3,324 | 3,342 | **+0.5%** | 302.1 | 299.2 | -1.0% | 3 |
| jetty (warehouse scene, 4 ms step) | 481 | 493 | **+2.6%** | 2,078.2 | 2,025.6 | -2.5% | 3 |
| 3k_shapes_static (3000 static models) | 422 | 418 | **-0.9%** | 2,370.1 | 2,386.4 | +0.7% | 3 |
| 3k_shapes (3000 dynamic models) | 13.7 | 13.7 | **+0.0%** | 72,897.5 | 72,791.5 | -0.1% | 3 |

The gpu_lidar_sensor gain is larger than the others and also the noisiest measurement: the six before runs span 29.5k to 34.8k steps/s and the six after runs 33.9k to 37.7k, so the real gain is somewhere between +10% and +20%. A plausible reason for it being larger than the sensors world: the sensors system runs its `PostUpdate` in a separate thread, and every `EachNew` there used to take the same views mutex as the main update thread, so the early return also removes lock contention.

The fast worlds (tens of thousands of steps per second) benefit the most because the per call overhead is a visible share of a very short step. Physics or GPU bound worlds are within run to run noise.

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests (the existing `EachNew*` and `EachRemoved` cases cover both the empty and the non empty case)
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Claude Fable 5.1

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
