### PR TITLE
Reset wind velocity when WindEffects is disabled

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -35,6 +35,21 @@ release will remove the deprecated code.
     fluid interface now float and right themselves per hydrostatic theory;
     models tuned to compensate for the old behavior may need retuning.
 
+* **WindEffects**
+  * Disabling the wind through the `/world/<world>/wind` topic now sets the
+    wind entity's `WorldLinearVelocity` to zero and publishes it once on
+    `/world/<world>/wind_info`. Previously the velocity kept its last value,
+    so systems reading it (`LiftDrag`, `AdvancedLiftDrag`,
+    `MulticopterMotorModel`) saw the old wind after it was turned off.
+  * Re-enabling the wind now rises from zero in the direction of the current
+    seed, as at startup, instead of resuming the magnitude and direction the
+    wind had before being disabled.
+  * `/world/<world>/wind_info` messages now carry `enable_wind`; it was
+    always `false` before.
+  * When several wind commands are received before the next update, only the
+    newest one is applied. Previously the older ones were applied in later
+    updates.
+
 * **Entity wrapper classes (`Model`, `Link`, `World`)**
   * These now store their private data via `gz::utils::ImplPtr` (matching
     `Joint`, `Sensor`, `Light`, and `Actor`) instead of a hand-written

--- a/src/systems/wind_effects/WindEffects.cc
+++ b/src/systems/wind_effects/WindEffects.cc
@@ -236,6 +236,21 @@ class gz::sim::systems::WindEffectsPrivate
   public: void UpdateWindVelocity(const UpdateInfo &_info,
                                   EntityComponentManager &_ecm);
 
+  /// \brief Reset the wind: zero the wind entity's WorldLinearVelocity,
+  /// reset the low pass filters and publish the zero wind velocity.
+  /// Called when the wind gets disabled, so that systems reading that
+  /// component (e.g. LiftDrag) and subscribers of the wind information
+  /// topic see no wind, and so that the wind rises from zero in the
+  /// direction of the current seed when it is enabled again.
+  /// \param[in] _ecm Mutable reference to the EntityComponentManager.
+  public: void ResetWind(EntityComponentManager &_ecm);
+
+  /// \brief Publish the wind information (ENU) if there are subscribers.
+  /// \param[in] _windVel Current wind velocity.
+  /// \param[in] _enabled Whether the wind is enabled.
+  public: void PublishWindInfo(const math::Vector3d &_windVel,
+                               bool _enabled);
+
   /// \brief Calculate and apply forces on links affected by wind.
   /// \param[in] _info Simulation update info.
   /// \param[in] _ecm Mutable reference to the EntityComponentManager.
@@ -247,7 +262,8 @@ class gz::sim::systems::WindEffectsPrivate
   /// \param[in] _msg msgs::Wind message.
   public: void OnWindMsg(const msgs::Wind &_msg);
 
-  /// \brief Process commands received from transport
+  /// \brief Process commands received from transport. Only the newest
+  /// command is applied. If it disables the wind, the wind is reset.
   /// \param[in] _ecm Mutable reference to the EntityComponentManager.
   public: void ProcessCommandQueue(EntityComponentManager &_ecm);
 
@@ -571,15 +587,37 @@ void WindEffectsPrivate::UpdateWindVelocity(const UpdateInfo &_info,
   // Update component
   windLinVel->Data() = windVel;
 
-  // Publish wind information (ENU)
-  msgs::Wind windInfo_gz;
-  windInfo_gz.mutable_linear_velocity()->set_x(windVel.X());
-  windInfo_gz.mutable_linear_velocity()->set_y(windVel.Y());
-  windInfo_gz.mutable_linear_velocity()->set_z(windVel.Z());
-  if (this->windPub.HasConnections()){
-    this->windPub.Publish(windInfo_gz);
-  }
+  this->PublishWindInfo(windVel, true);
+}
 
+//////////////////////////////////////////////////
+void WindEffectsPrivate::ResetWind(EntityComponentManager &_ecm)
+{
+  this->magnitudeMean = 0.0;
+  this->magnitudeMeanVertical = 0.0;
+  this->directionMean.reset();
+
+  auto windLinVel =
+      _ecm.Component<components::WorldLinearVelocity>(this->windEntity);
+  if (!windLinVel)
+    return;
+
+  windLinVel->Data() = math::Vector3d::Zero;
+
+  this->PublishWindInfo(math::Vector3d::Zero, false);
+}
+
+//////////////////////////////////////////////////
+void WindEffectsPrivate::PublishWindInfo(const math::Vector3d &_windVel,
+                                         bool _enabled)
+{
+  if (!this->windPub.HasConnections())
+    return;
+
+  msgs::Wind windInfo;
+  msgs::Set(windInfo.mutable_linear_velocity(), _windVel);
+  windInfo.set_enable_wind(_enabled);
+  this->windPub.Publish(windInfo);
 }
 
 //////////////////////////////////////////////////
@@ -643,28 +681,28 @@ void WindEffectsPrivate::OnWindMsg(const msgs::Wind &_msg)
 //////////////////////////////////////////////////
 void WindEffectsPrivate::ProcessCommandQueue(EntityComponentManager &_ecm)
 {
-  std::lock_guard lock(this->windInfoMutex);
-  if (this->windCmdQueue.size() > 0)
+  bool disabled = false;
   {
-    this->currentWindInfo.CopyFrom(this->windCmdQueue.back());
-    this->windCmdQueue.pop_back();
-
-    // Also update the seed velocity component
-    auto windLinVelSeed =
-        _ecm.Component<components::WorldLinearVelocitySeed>(this->windEntity);
-
-    if (windLinVelSeed)
+    std::lock_guard lock(this->windInfoMutex);
+    if (this->windCmdQueue.size() > 0)
     {
-      windLinVelSeed->Data() =
-          msgs::Convert(this->currentWindInfo.linear_velocity());
-    }
-    else
-    {
-      _ecm.CreateComponent(this->windEntity,
-                           components::WorldLinearVelocitySeed(msgs::Convert(
-                               this->currentWindInfo.linear_velocity())));
+      const bool wasEnabled = this->currentWindInfo.enable_wind();
+
+      // Only the newest command matters, it carries the whole wind state
+      this->currentWindInfo.CopyFrom(this->windCmdQueue.back());
+      this->windCmdQueue.clear();
+
+      // Also update the seed velocity component
+      _ecm.SetComponentData<components::WorldLinearVelocitySeed>(
+          this->windEntity,
+          msgs::Convert(this->currentWindInfo.linear_velocity()));
+
+      disabled = wasEnabled && !this->currentWindInfo.enable_wind();
     }
   }
+
+  if (disabled)
+    this->ResetWind(_ecm);
 }
 
 //////////////////////////////////////////////////

--- a/src/systems/wind_effects/WindEffects.hh
+++ b/src/systems/wind_effects/WindEffects.hh
@@ -129,6 +129,23 @@ namespace systems
   /// ```
   /// Regions may not overlap.
   ///
+  /// ## Topics
+  ///
+  /// - `/world/<world_name>/wind` (gz.msgs.Wind): commands the wind. The
+  /// message replaces the whole wind state, so both fields must be set:
+  /// `linear_velocity` is the new seed velocity the low pass filters
+  /// converge to, and `enable_wind` turns the wind on or off. When the wind
+  /// gets disabled the forces are no longer applied and the wind entity's
+  /// `WorldLinearVelocity` is set to zero, so that systems reading that
+  /// component see no wind; the seed is kept. When it is enabled again, the
+  /// wind rises from zero in the direction of the current seed.
+  ///
+  /// - `/world/<world_name>/wind_info` (gz.msgs.Wind): publishes the
+  /// current wind velocity and whether the wind is enabled, at every update
+  /// while the wind is enabled and once, with a zero velocity, when the wind
+  /// gets disabled. A service with the same name returns the current seed
+  /// velocity and enable state.
+  ///
   class WindEffects final:
     public System,
     public ISystemConfigure,

--- a/test/integration/wind_effects.cc
+++ b/test/integration/wind_effects.cc
@@ -17,6 +17,9 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+#include <vector>
+
 #include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/entity_factory.pb.h>
 #include <gz/msgs/wind.pb.h>
@@ -37,10 +40,14 @@
 #include "gz/sim/components/Link.hh"
 #include "gz/sim/components/Name.hh"
 #include "gz/sim/components/Pose.hh"
+#include "gz/sim/components/Wind.hh"
 #include "gz/sim/components/WindMode.hh"
 
 #include "plugins/MockSystem.hh"
 #include "../helpers/EnvTestFixture.hh"
+#include "../helpers/Relay.hh"
+#include "../helpers/Subscription.hh"
+#include "../helpers/Util.hh"
 
 using namespace gz;
 using namespace sim;
@@ -150,6 +157,7 @@ class BlockingPublisher
         : topic(std::move(_topic)), timeOut(_timeOut)
   {
     this->pub = this->node.template Advertise<T>(this->topic);
+    this->node.Subscribe(this->topic, &BlockingPublisher<T>::OnMsg, this);
   }
 
   public: bool Publish(const T &_msg)
@@ -158,7 +166,6 @@ class BlockingPublisher
       std::lock_guard<std::mutex> lock(this->onMsgMutex);
       this->onMsgCount = 0;
     }
-    this->node.Subscribe(this->topic, &BlockingPublisher<T>::OnMsg, this);
 
     this->pub.Publish(_msg);
     // Publish a second time
@@ -421,4 +428,138 @@ TEST_F(WindEffectsTest,
   // Now box_wind WorldLinearVelocity component should be added
   this->server->Run(true, 10, false);
   ASSERT_FALSE(linkVelocityComponent.values.empty());
+}
+
+/////////////////////////////////////////////////
+/// \brief Callback that records the wind entity's velocity at every
+/// iteration.
+/// \param[out] _values Recorded velocities.
+/// \return Callback to pass to test::Relay::OnPostUpdate.
+MockSystem::CallbackTypeConst windVelocityRecorder(
+    std::vector<math::Vector3d> &_values)
+{
+  return [&_values](const UpdateInfo &, const EntityComponentManager &_ecm)
+  {
+    auto windEntity = _ecm.EntityByComponents(components::Wind());
+    auto windVel =
+        _ecm.Component<components::WorldLinearVelocity>(windEntity);
+    if (windVel)
+      _values.push_back(windVel->Data());
+  };
+}
+
+/////////////////////////////////////////////////
+/// Check that disabling the wind zeroes the wind entity's velocity and
+/// publishes it, so systems that read the component (e.g. LiftDrag) or the
+/// wind information topic do not keep seeing the last wind, and that
+/// re-enabling the wind makes it rise from zero in the direction of the
+/// current seed.
+TEST_F(WindEffectsTest,
+       GZ_UTILS_TEST_DISABLED_ON_WIN32(DisableResetsWindVelocity))
+{
+  using namespace std::chrono_literals;
+
+  this->StartServer("/test/worlds/wind_effects.sdf");
+
+  std::vector<math::Vector3d> windVelocities;
+  test::Relay recorder;
+  recorder.OnPostUpdate(windVelocityRecorder(windVelocities));
+  this->server->AddSystem(recorder.systemPtr);
+  this->server->SetUpdatePeriod(0ns);
+
+  // Also follow the wind information published on the wind_info topic
+  transport::Node node;
+  Subscription<msgs::Wind> windInfo;
+  windInfo.Subscribe(node, "/world/wind_demo/wind_info");
+
+  // Let the wind rise from the seed specified in the SDF (+X), until both
+  // the wind entity and the wind information report it
+  ASSERT_TRUE(test::StepUntil(*this->server, 1000, [&]()
+  {
+    return !windVelocities.empty() && windVelocities.back().Length() > 0.1 &&
+        windInfo.Count() > 0 &&
+        msgs::Convert(windInfo.Last().linear_velocity()).Length() > 0.1;
+  }));
+  EXPECT_TRUE(windInfo.Last().enable_wind());
+
+  // Disable the wind and, at the same time, turn the seed towards +Y
+  msgs::Wind windCmd;
+  msgs::Set(windCmd.mutable_linear_velocity(),
+            math::Vector3d(0.0, 10.0, 10.0));
+  windCmd.set_enable_wind(false);
+  BlockingPublisher<msgs::Wind> pub("/world/wind_demo/wind", 5000ms);
+  ASSERT_TRUE(pub.Publish(windCmd));
+
+  // The wind velocity drops to zero on the next update and stays there
+  this->server->Run(true, 1, false);
+  EXPECT_EQ(math::Vector3d::Zero, windVelocities.back());
+  this->server->Run(true, 10, false);
+  EXPECT_EQ(math::Vector3d::Zero, windVelocities.back());
+
+  // The published wind information reports no wind and a disabled wind
+  ASSERT_TRUE(test::WaitUntil(5s, [&]()
+  {
+    return msgs::Convert(windInfo.Last().linear_velocity()) ==
+        math::Vector3d::Zero;
+  }));
+  EXPECT_FALSE(windInfo.Last().enable_wind());
+
+  // Re-enable the wind: it rises from zero, in the direction of the new
+  // seed, instead of jumping back to the velocity it had before being
+  // disabled
+  windCmd.set_enable_wind(true);
+  ASSERT_TRUE(pub.Publish(windCmd));
+  this->server->Run(true, 1, false);
+  const math::Vector3d firstWind = windVelocities.back();
+  EXPECT_GT(firstWind.Length(), 0.0);
+  EXPECT_LT(firstWind.Length(), 0.1);
+  EXPECT_LT(std::fabs(firstWind.X()), std::fabs(firstWind.Y()));
+}
+
+/////////////////////////////////////////////////
+/// Check that when several wind commands are received before the next
+/// update, only the newest one is applied.
+TEST_F(WindEffectsTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(LastCommandWins))
+{
+  using namespace std::chrono_literals;
+
+  this->StartServer("/test/worlds/wind_effects.sdf");
+
+  std::vector<math::Vector3d> windVelocities;
+  test::Relay recorder;
+  recorder.OnPostUpdate(windVelocityRecorder(windVelocities));
+  this->server->AddSystem(recorder.systemPtr);
+  this->server->SetUpdatePeriod(0ns);
+
+  // Let the wind rise from the seed specified in the SDF
+  this->server->Run(true, 100, false);
+  ASSERT_FALSE(windVelocities.empty());
+
+  // Disable and then re-enable the wind, with a new seed, without stepping
+  // in between
+  const math::Vector3d windVelSeed{5.0, 0.0, 5.0};
+  msgs::Wind windCmd;
+  msgs::Set(windCmd.mutable_linear_velocity(), windVelSeed);
+  BlockingPublisher<msgs::Wind> pub("/world/wind_demo/wind", 5000ms);
+  windCmd.set_enable_wind(false);
+  ASSERT_TRUE(pub.Publish(windCmd));
+  windCmd.set_enable_wind(true);
+  ASSERT_TRUE(pub.Publish(windCmd));
+
+  // Only the newest command is applied: the wind keeps rising, and the
+  // new seed is in place with the wind still enabled
+  this->server->Run(true, 20, false);
+  ASSERT_GE(windVelocities.size(), 2u);
+  EXPECT_GT(windVelocities.back().Length(),
+            windVelocities[windVelocities.size() - 2].Length());
+
+  transport::Node node;
+  const std::string windService{"/world/wind_demo/wind_info"};
+  ASSERT_TRUE(test::waitForService(node, windService));
+  msgs::Wind res;
+  bool executed{false};
+  node.Request(windService, 5000u, res, executed);
+  ASSERT_TRUE(executed);
+  EXPECT_EQ(windVelSeed, msgs::Convert(res.linear_velocity()));
+  EXPECT_TRUE(res.enable_wind());
 }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
When the wind is disabled through the `/world/<world>/wind` topic, `WindEffects` returns early from `PreUpdate`, so the wind entity's `WorldLinearVelocity` keeps its last filtered value and `/world/<world>/wind_info` stops publishing. Systems that read the component (`LiftDrag`, `AdvancedLiftDrag`, `MulticopterMotorModel`) and subscribers of `wind_info` keep seeing the old wind after it was turned off.

When a command disables the wind, this PR zeroes the wind entity velocity, resets the low pass filters and publishes the zero wind once, so re-enabling the wind rises from zero in the direction of the current seed, as at startup. Two related issues in the same command path are fixed as well: only the newest queued command is applied (older ones were applied in later updates), and `wind_info` messages now carry `enable_wind`. The topics are documented in the header and the behavior changes in `Migration.md`.

The two added tests fail before this PR and pass after it. `AirSpeed` reads the seed rather than the filtered velocity, so it is not affected by this change and is left for a follow-up.

## Backport Policy
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [x] I am not sure
- [x] Other (fill in yourself)

The patch applies and the `wind_effects` tests pass on `gz-sim10` and `gz-sim9`, but it changes behavior (re-enabling now ramps from zero and `wind_info` carries `enable_wind`), so I leave the decision to the maintainers. Harmonic does not have the `wind_info` publishing, so a backport there would need a manual patch.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Claude Fable 5.1