### PR TITLE
Rename Server::Ecm to Server::EcmScope and add usage examples

### DIFF
--- a/include/gz/sim/Server.hh
+++ b/include/gz/sim/Server.hh
@@ -135,6 +135,17 @@ namespace gz
       /// \class EcmGuard Server.hh gz/sim/Server.hh
       /// \brief RAII guard providing exclusive read-write access to the
       /// EntityComponentManager.
+      /// \details An instance of EcmGuard is obtained via Server::EcmScope().
+      /// The guard acquires the server's execution mutex upon construction and
+      /// releases it upon destruction or when Reset() is called.
+      ///
+      /// Example usage:
+      /// \code
+      /// if (auto guard = server.EcmScope(); guard)
+      /// {
+      ///   auto entity = guard->CreateEntity();
+      /// }
+      /// \endcode
       public: class GZ_SIM_VISIBLE EcmGuard
       {
         /// \brief Default constructor creating an invalid guard.
@@ -436,11 +447,24 @@ namespace gz
       /// \return The current status (EXITED, STOPPED, or RUNNING).
       public: Status GetStatus() const;
 
-      /// \brief Acquire an exclusive write lock on the ECM for modifications.
+      /// \brief Acquire an exclusive scope on the ECM for inspection or
+      /// modifications.
+      /// \details This returns an \ref EcmGuard RAII handle that acquires
+      /// the server's execution mutex, preventing simulation steps from
+      /// running while the ECM is being accessed.
+      ///
+      /// Example usage:
+      /// \code
+      /// if (auto guard = server.EcmScope(); guard)
+      /// {
+      ///   auto entity = guard->CreateEntity();
+      /// }
+      /// \endcode
       /// \param[in] _runnerId ID of the simulation runner (world index).
-      /// \return EcmGuard RAII handle. Evaluates to false if server is running,
-      /// out of bounds runner ID, or server in error state.
-      public: EcmGuard Ecm(const std::size_t _runnerId = 0);
+      /// \return EcmGuard RAII handle. Evaluates to false if the server is
+      /// running, the runner ID is out of bounds, or the server is in an error
+      /// state.
+      public: EcmGuard EcmScope(const std::size_t _runnerId = 0);
 
       /// \brief Get current simulation update info for a world.
       /// \param[in] _worldIndex Index of the world to query.

--- a/python/src/gz/sim/Server.cc
+++ b/python/src/gz/sim/Server.cc
@@ -36,8 +36,12 @@ void defineSimServer(pybind11::object module)
 {
   // EcmGuard
   pybind11::class_<gz::sim::Server::EcmGuard>(module, "EcmGuard",
-    "RAII guard for exclusive thread-safe access to the "
-      "EntityComponentManager.")
+    R"(RAII guard for exclusive thread-safe access to the
+EntityComponentManager.
+
+Example:
+    with server.ecm_scope() as ecm:
+        ecm.create_entity())")
     .def("__enter__", [](gz::sim::Server::EcmGuard &self)
         -> gz::sim::EntityComponentManager & {
       if (!self) {
@@ -88,11 +92,15 @@ void defineSimServer(pybind11::object module)
     "Resets all simulation runners under this server.")
   .def("reset", &gz::sim::Server::Reset,
     "Resets a specific simulation runner under this server.")
-  .def("ecm",
-    pybind11::overload_cast<const std::size_t>(&gz::sim::Server::Ecm),
+  .def("ecm_scope",
+    pybind11::overload_cast<const std::size_t>(&gz::sim::Server::EcmScope),
     pybind11::call_guard<pybind11::gil_scoped_release>(),
     pybind11::arg("runner_id") = 0,
-    "Acquire a thread-safe lock on the ECM as a context manager.")
+    R"(Acquire an exclusive scope on the ECM as a context manager.
+
+Example:
+    with server.ecm_scope() as ecm:
+        ecm.create_entity())")
   .def("iteration_count", &gz::sim::Server::IterationCount,
     pybind11::arg("world_index") = 0,
     "Get the number of iterations the server has executed.")

--- a/python/test/server_TEST.py
+++ b/python/test/server_TEST.py
@@ -27,7 +27,7 @@ class ServerTest(unittest.TestCase):
         self.assertFalse(server.is_running())
         self.assertEqual(3, server.entity_count(0))
 
-        with server.ecm() as ecm:
+        with server.ecm_scope() as ecm:
             self.assertIsInstance(ecm, EntityComponentManager)
             self.assertEqual(3, ecm.entity_count())
             self.assertTrue(ecm.has_entity(1))
@@ -37,14 +37,14 @@ class ServerTest(unittest.TestCase):
         server = Server(config)
         self.assertEqual(3, server.entity_count(0))
 
-        with server.ecm() as ecm:
+        with server.ecm_scope() as ecm:
             self.assertIsInstance(ecm, EntityComponentManager)
             e = ecm.create_entity()
             self.assertTrue(ecm.has_entity(e))
 
         # Confirm entity count reflects the mutation
         self.assertEqual(4, server.entity_count(0))
-        with server.ecm() as ecm:
+        with server.ecm_scope() as ecm:
             self.assertEqual(4, ecm.entity_count())
             self.assertTrue(ecm.has_entity(e))
 
@@ -54,12 +54,12 @@ class ServerTest(unittest.TestCase):
 
         # Verify exception is propagated (not swallowed by __exit__)
         with self.assertRaises(RuntimeError):
-            with server.ecm() as ecm:
+            with server.ecm_scope() as ecm:
                 ecm.create_entity()
                 raise RuntimeError('Test exception inside context manager')
 
         # Verify lock was released and subsequent operations work
-        with server.ecm() as ecm:
+        with server.ecm_scope() as ecm:
             self.assertIsInstance(ecm, EntityComponentManager)
 
     def test_invalid_runner_id(self):
@@ -68,7 +68,7 @@ class ServerTest(unittest.TestCase):
 
         # Out of bounds runner ID raises ValueError when entered
         with self.assertRaises(ValueError):
-            with server.ecm(999):
+            with server.ecm_scope(999):
                 pass
 
     def test_server_statistics(self):

--- a/src/Server.cc
+++ b/src/Server.cc
@@ -521,7 +521,7 @@ bool Server::Reset(const std::size_t _runnerId)
 }
 
 //////////////////////////////////////////////////
-Server::EcmGuard Server::Ecm(const std::size_t _runnerId)
+Server::EcmGuard Server::EcmScope(const std::size_t _runnerId)
 {
   EcmGuard guard;
   std::unique_lock<std::mutex> lock(this->dataPtr->runMutex);

--- a/src/Server_TEST.cc
+++ b/src/Server_TEST.cc
@@ -1393,7 +1393,7 @@ class ServerTest : public InternalFixture<::testing::Test>
 };
 
 /////////////////////////////////////////////////
-TEST_F(ServerTest, EcmContextManager)
+TEST_F(ServerTest, EcmScope)
 {
   ServerConfig serverConfig;
   serverConfig.SetSdfFile(
@@ -1401,9 +1401,9 @@ TEST_F(ServerTest, EcmContextManager)
   serverConfig.SetWaitForAssets(true);
   sim::Server server(serverConfig);
 
-  // 1. Basic reading
+  // 1. Basic reading (using C++17 if statement with initializer)
+  if (auto guard = server.EcmScope(); guard)
   {
-    auto guard = server.Ecm();
     EXPECT_TRUE(guard.Valid());
     EXPECT_TRUE(static_cast<bool>(guard));
     EXPECT_EQ(25u, guard->EntityCount());
@@ -1417,10 +1417,14 @@ TEST_F(ServerTest, EcmContextManager)
         });
     EXPECT_EQ(5u, modelCount);
   }
+  else
+  {
+    FAIL() << "Failed to acquire EcmScope";
+  }
 
   // 2. Entity Creation
   {
-    auto guard = server.Ecm();
+    auto guard = server.EcmScope();
     Entity newEntity = guard->CreateEntity();
     EXPECT_NE(kNullEntity, newEntity);
     EXPECT_EQ(26u, guard->EntityCount());
@@ -1428,7 +1432,7 @@ TEST_F(ServerTest, EcmContextManager)
 
   // 3. Move semantics & Reset
   {
-    auto g1 = server.Ecm();
+    auto g1 = server.EcmScope();
     Server::EcmGuard g2;
     g2 = std::move(g1);
     EXPECT_FALSE(g1.Valid());
@@ -1439,19 +1443,19 @@ TEST_F(ServerTest, EcmContextManager)
     EXPECT_NO_THROW(g2.Reset());  // Repeated reset is safe
 
     // Reset released lock, we can get another
-    auto g3 = server.Ecm();
+    auto g3 = server.EcmScope();
     EXPECT_TRUE(g3.Valid());
   }
 
   // 4. Invalid States
   {
-    EXPECT_FALSE(server.Ecm(999).Valid());  // Out of bounds runner
+    EXPECT_FALSE(server.EcmScope(999).Valid());  // Out of bounds runner
     server.Run(false, 0, false);
     EXPECT_TRUE(test::WaitUntil(1s, [&]() { return server.Running(); }));
-    EXPECT_FALSE(server.Ecm().Valid());  // Cannot access while running
+    EXPECT_FALSE(server.EcmScope().Valid());  // Cannot access while running
     server.Stop();
     EXPECT_TRUE(test::WaitUntil(1s, [&]() { return !server.Running(); }));
-    EXPECT_TRUE(server.Ecm().Valid());  // Valid again after stop
+    EXPECT_TRUE(server.EcmScope().Valid());  // Valid again after stop
   }
 }
 
@@ -1497,7 +1501,7 @@ TEST_F(ServerTest, GuardMutualExclusionWithRun)
   std::thread ecmThread(
       [&]()
       {
-        auto guard = server.Ecm();
+        auto guard = server.EcmScope();
         EXPECT_TRUE(guard.Valid());
         lockAcquired = true;
         EXPECT_TRUE(test::WaitUntil(5s, [&]() { return !holdLock.load(); }));


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

I got feedback from @iche033 and @shameekganguly that the API `Server::Ecm` does not inform the user that a mutex gets locked when `EcmGuard` is created and that users might unknowingly retain a long-lived instance of `EcmGuard` and block simulation execution. To mitigate that, this PR renames `Server::Ecm` to `Server::EcmScope` (C++) and `server.ecm` to `server.ecm_scope` (Python). I chose `EcmScope` over `EcmLock` because the locking is somewhat of an implementation detail. The main thing we want to point out is that this should be a short lived object. 

This also adds usage examples that use C++17 if-statements with initializers. The description in #3936 assigned and checked the guard in the same statement, which might cause a warning in some compilers.

### Usage Examples

#### C++ (C++17 if-statement with initializer)
```cpp
gz::sim::Server server(config);

if (auto guard = server.EcmScope(); guard)
{
  auto entity = guard->CreateEntity();
  // Safe mutation or inspection...
}
```

#### Python (Context Manager)
```python
server = gz.sim.Server(config)

with server.ecm_scope() as ecm:
    entity = ecm.create_entity()
    # Safe mutation or inspection...
```

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [x] Should be backported after all python API changes have landed and soaked.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.