### PR TITLE
Extend VisualizeContacts gui plugin to display force arrows

### DIFF
--- a/src/gui/plugins/visualize_contacts/VisualizeContacts.cc
+++ b/src/gui/plugins/visualize_contacts/VisualizeContacts.cc
@@ -161,7 +161,7 @@ void AddForceArrowMarkers(
     public: bool showForcesState{false};
 
     /// brief Scale of force vectors in m/N
-    public: double forceScale{0.01};
+    public: double forceScale{0.1};
 
     /// \brief Radius of the force arrow in meters
     public: double arrowRadius{0.01};

--- a/src/gui/plugins/visualize_contacts/VisualizeContacts.cc
+++ b/src/gui/plugins/visualize_contacts/VisualizeContacts.cc
@@ -24,6 +24,7 @@
 #include <gz/msgs/marker.pb.h>
 #include <gz/msgs/marker_v.pb.h>
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -64,6 +65,78 @@ namespace
 void OnMarkerArrayResponse(const gz::msgs::Boolean &, const bool)
 {
 }
+
+constexpr gz::math::Color kContactColor =
+    gz::math::Color::UnclampedColor(0.0f, 0.0f, 1.0f, 1.0f);
+
+constexpr gz::math::Color kForceArrowAmbient =
+    gz::math::Color::UnclampedColor(1.0f, 0.8f, 0.0f, 1.0f);
+constexpr gz::math::Color kForceArrowDiffuse =
+    gz::math::Color::UnclampedColor(1.0f, 0.9f, 0.1f, 1.0f);
+constexpr gz::math::Color kForceArrowEmissive =
+    gz::math::Color::UnclampedColor(0.9f, 0.5f, 0.0f, 1.0f);
+
+constexpr double kMinimumForceToVisualize = 1e-2;
+
+//////////////////////////////////////////////////
+/// \brief Helper function to add force arrow body and head markers to a marker
+/// array
+/// \param[out] _markerMsgs Marker array to append markers to
+/// \param[in] _forceMarkerId ID for the force arrow markers
+/// \param[in] _pos Contact position in world coordinates
+/// \param[in] _force Contact force vector in world coordinates
+/// \param[in] _forceScale Scale factor to convert force magnitude to arrow length
+/// \param[in] _arrowRadius Radius of the arrow body cylinder
+/// \param[in] _bodyMarkerMsg Template marker message for arrow body
+/// \param[in] _headMarkerMsg Template marker message for arrow head
+void AddForceArrowMarkers(
+    gz::msgs::Marker_V &_markerMsgs,
+    int _forceMarkerId,
+    const gz::math::Vector3d &_pos,
+    const gz::math::Vector3d &_force,
+    double _forceScale,
+    double _arrowRadius,
+    const gz::msgs::Marker &_bodyMarkerMsg,
+    const gz::msgs::Marker &_headMarkerMsg)
+{
+  double fNorm = _force.Length();
+  if (fNorm <= kMinimumForceToVisualize)
+    return;
+
+  double L = fNorm * _forceScale;
+  gz::math::Vector3d u = _force / fNorm;
+
+  double bodyDiam = 2.0 * _arrowRadius;
+  double headDiam = 2.2 * bodyDiam;
+  // Clamp head and body lens to prevent small scale rendering artifacts.
+  double headLen = std::min(0.4 * L, std::max(0.01, 2.5 * bodyDiam));
+  double bodyLen = std::max(0.001, L - headLen);
+
+  // Default cylinder and cone marker shapes are aligned with +Z.
+  // Compute rotation from +Z to the unit force direction vector u.
+  gz::math::Quaterniond rot;
+  rot.SetFrom2Axes(gz::math::Vector3d::UnitZ, u);
+
+  // 1. Body (Cylinder)
+  gz::math::Vector3d pBody = _pos + (0.5 * bodyLen) * u;
+  auto bodyMarker = _markerMsgs.add_marker();
+  bodyMarker->CopyFrom(_bodyMarkerMsg);
+  bodyMarker->set_id(_forceMarkerId);
+  gz::msgs::Set(bodyMarker->mutable_pose(),
+    gz::math::Pose3d(pBody, rot));
+  gz::msgs::Set(bodyMarker->mutable_scale(),
+    gz::math::Vector3d(bodyDiam, bodyDiam, bodyLen));
+
+  // 2. Head (Cone)
+  gz::math::Vector3d pHead = _pos + (bodyLen + 0.5 * headLen) * u;
+  auto headMarker = _markerMsgs.add_marker();
+  headMarker->CopyFrom(_headMarkerMsg);
+  headMarker->set_id(_forceMarkerId);
+  gz::msgs::Set(headMarker->mutable_pose(),
+    gz::math::Pose3d(pHead, rot));
+  gz::msgs::Set(headMarker->mutable_scale(),
+    gz::math::Vector3d(headDiam, headDiam, headLen));
+}
 }  // namespace
 
   /// \brief Private data class for VisualizeContacts
@@ -84,35 +157,35 @@ void OnMarkerArrayResponse(const gz::msgs::Boolean &, const bool)
     public: bool checkboxPrevState{false};
 
     /// \brief State of the show forces checkbox
-    public: bool showForcesState{true};
+    public: bool showForcesState{false};
 
     /// brief Scale of force vectors in m/N
-    public: double forceScale{0.002};
+    public: double forceScale{0.01};
 
-    /// \brief Radius of the force arrow shaft in meters
-    public: double arrowRadius{0.008};
+    /// \brief Radius of the force arrow in meters
+    public: double arrowRadius{0.01};
 
     /// \brief Message template for contact positions (spheres)
     public: gz::msgs::Marker positionMarkerMsg;
 
-    /// \brief Message template for cylinder shafts of force arrows
-    public: gz::msgs::Marker shaftMarkerMsg;
+    /// \brief Message template for cylinder of force arrows
+    public: gz::msgs::Marker arrowBodyMarkerMsg;
 
     /// \brief Message template for cone heads of force arrows
-    public: gz::msgs::Marker headMarkerMsg;
+    public: gz::msgs::Marker arrowHeadMarkerMsg;
 
-    /// \brief Radius of the visualized contact sphere
-    public: double contactRadius{0.03};
+    /// \brief Radius of the visualized contact sphere in meters
+    public: double sphereRadius{0.10};
 
     /// \brief Update time of the markers in milliseconds
-    public: int64_t markerLifetime{100};
+    public: int64_t markerLifetime{200};
 
     /// \brief Simulation time for the last markers update
     public: std::chrono::steady_clock::duration lastMarkersUpdateTime{0};
 
     /// \brief Mutex for variable mutated by the checkbox and spinboxes
     /// callbacks.
-    /// The variables are: checkboxState, showForcesState, contactRadius,
+    /// The variables are: checkboxState, showForcesState, sphereRadius,
     /// forceScale and markerLifetime
     public: std::mutex serviceMutex;
 
@@ -144,9 +217,11 @@ void VisualizeContacts::LoadConfig(const tinyxml2::XMLElement *)
   if (this->title.empty())
     this->title = "Visualize contacts";
 
-  // Configure Marker messages for position and forces of contacts
+  // Configure Marker messages for position and forces of contacts.
+  // Spheres for contact positions, cylinders for force arrow body and
+  // cone for force arrow head.
 
-  // Bright glowing cyan spheres for contact positions
+  // Create the contact sphere marker message
   this->dataPtr->positionMarkerMsg.set_ns("positions");
   this->dataPtr->positionMarkerMsg.set_action(
     gz::msgs::Marker::ADD_MODIFY);
@@ -161,71 +236,65 @@ void VisualizeContacts::LoadConfig(const tinyxml2::XMLElement *)
     positionMarkerMsg.mutable_lifetime()->
       set_nsec(this->dataPtr->markerLifetime * 1000000);
 
+  // Set material properties
   gz::msgs::Set(
     this->dataPtr->positionMarkerMsg.mutable_material()->mutable_ambient(),
-    gz::math::Color(0.0, 0.85, 1.0, 1.0));
+    kContactColor);
   gz::msgs::Set(
     this->dataPtr->positionMarkerMsg.mutable_material()->mutable_diffuse(),
-    gz::math::Color(0.0, 1.0, 1.0, 1.0));
-  gz::msgs::Set(
-    this->dataPtr->positionMarkerMsg.mutable_material()->mutable_emissive(),
-    gz::math::Color(0.0, 0.6, 0.9, 1.0));
+    kContactColor);
 
   // Set contact position scale
   gz::msgs::Set(this->dataPtr->positionMarkerMsg.mutable_scale(),
-    gz::math::Vector3d(this->dataPtr->contactRadius,
-    this->dataPtr->contactRadius,
-    this->dataPtr->contactRadius));
+    gz::math::Vector3d(this->dataPtr->sphereRadius,
+    this->dataPtr->sphereRadius,
+    this->dataPtr->sphereRadius));
 
-  // Bright glowing amber/gold cylinder shaft for 3D force arrows
-  this->dataPtr->shaftMarkerMsg.set_ns("force_shafts");
-  this->dataPtr->shaftMarkerMsg.set_action(
+  // Create the force arrow body marker message.
+  // Scale is not assigned here, it is updated dynamically in `Update`.
+  this->dataPtr->arrowBodyMarkerMsg.set_ns("force_arrow_bodies");
+  this->dataPtr->arrowBodyMarkerMsg.set_action(
     gz::msgs::Marker::ADD_MODIFY);
-  this->dataPtr->shaftMarkerMsg.set_type(
+  this->dataPtr->arrowBodyMarkerMsg.set_type(
     gz::msgs::Marker::CYLINDER);
-  this->dataPtr->shaftMarkerMsg.set_visibility(
+  this->dataPtr->arrowBodyMarkerMsg.set_visibility(
     gz::msgs::Marker::GUI);
   this->dataPtr->
-    shaftMarkerMsg.mutable_lifetime()->
+    arrowBodyMarkerMsg.mutable_lifetime()->
       set_sec(0);
   this->dataPtr->
-    shaftMarkerMsg.mutable_lifetime()->
+    arrowBodyMarkerMsg.mutable_lifetime()->
       set_nsec(this->dataPtr->markerLifetime * 1000000);
 
+  // Set material properties
   gz::msgs::Set(
-    this->dataPtr->shaftMarkerMsg.mutable_material()->mutable_ambient(),
-    gz::math::Color(1.0, 0.8, 0.0, 1.0));
+    this->dataPtr->arrowBodyMarkerMsg.mutable_material()->mutable_ambient(),
+    kForceArrowAmbient);
   gz::msgs::Set(
-    this->dataPtr->shaftMarkerMsg.mutable_material()->mutable_diffuse(),
-    gz::math::Color(1.0, 0.9, 0.1, 1.0));
+    this->dataPtr->arrowBodyMarkerMsg.mutable_material()->mutable_diffuse(),
+    kForceArrowDiffuse);
   gz::msgs::Set(
-    this->dataPtr->shaftMarkerMsg.mutable_material()->mutable_emissive(),
-    gz::math::Color(0.9, 0.5, 0.0, 1.0));
+    this->dataPtr->arrowBodyMarkerMsg.mutable_material()->mutable_emissive(),
+    kForceArrowEmissive);
 
-  // Bright glowing amber/gold cone head for 3D force arrows
-  this->dataPtr->headMarkerMsg.set_ns("force_heads");
-  this->dataPtr->headMarkerMsg.set_action(
+  // Create the force arrow head marker message.
+  // Scale is not assigned here, it is updated dynamically in `Update`.
+  this->dataPtr->arrowHeadMarkerMsg.set_ns("force_arrow_heads");
+  this->dataPtr->arrowHeadMarkerMsg.set_action(
     gz::msgs::Marker::ADD_MODIFY);
-  this->dataPtr->headMarkerMsg.set_type(
+  this->dataPtr->arrowHeadMarkerMsg.set_type(
     gz::msgs::Marker::CONE);
-  this->dataPtr->headMarkerMsg.set_visibility(
+  this->dataPtr->arrowHeadMarkerMsg.set_visibility(
     gz::msgs::Marker::GUI);
   this->dataPtr->
-    headMarkerMsg.mutable_lifetime()->
+    arrowHeadMarkerMsg.mutable_lifetime()->
       set_sec(0);
   this->dataPtr->
-    headMarkerMsg.mutable_lifetime()->
+    arrowHeadMarkerMsg.mutable_lifetime()->
       set_nsec(this->dataPtr->markerLifetime * 1000000);
 
-  gz::msgs::Set(
-    this->dataPtr->headMarkerMsg.mutable_material()->mutable_ambient(),
-    gz::math::Color(1.0, 0.8, 0.0, 1.0));
-  gz::msgs::Set(
-    this->dataPtr->headMarkerMsg.mutable_material()->mutable_diffuse(),
-    gz::math::Color(1.0, 0.9, 0.1, 1.0));
-  gz::msgs::Set(
-    this->dataPtr->headMarkerMsg.mutable_material()->mutable_emissive(),
-    gz::math::Color(0.9, 0.5, 0.0, 1.0));
+  this->dataPtr->arrowHeadMarkerMsg.mutable_material()->CopyFrom(
+    this->dataPtr->arrowBodyMarkerMsg.material());
 }
 
 /////////////////////////////////////////////////
@@ -285,28 +354,32 @@ void VisualizeContacts::Update(const UpdateInfo &_info,
     }
     else if (this->dataPtr->checkboxPrevState && !this->dataPtr->checkboxState)
     {
+      gzdbg << "Removing markers..." << std::endl;
+
       // Remove position markers
       this->dataPtr->positionMarkerMsg.set_action(
         gz::msgs::Marker::DELETE_ALL);
       this->dataPtr->node.Request(
         "/marker", this->dataPtr->positionMarkerMsg);
+
+      // Change action in case checkbox is checked again
       this->dataPtr->positionMarkerMsg.set_action(
         gz::msgs::Marker::ADD_MODIFY);
 
-      // Remove force shaft markers
-      this->dataPtr->shaftMarkerMsg.set_action(
+      // Remove force arrow body markers
+      this->dataPtr->arrowBodyMarkerMsg.set_action(
         gz::msgs::Marker::DELETE_ALL);
       this->dataPtr->node.Request(
-        "/marker", this->dataPtr->shaftMarkerMsg);
-      this->dataPtr->shaftMarkerMsg.set_action(
+        "/marker", this->dataPtr->arrowBodyMarkerMsg);
+      this->dataPtr->arrowBodyMarkerMsg.set_action(
         gz::msgs::Marker::ADD_MODIFY);
 
-      // Remove force head markers
-      this->dataPtr->headMarkerMsg.set_action(
+      // Remove force arrow head markers
+      this->dataPtr->arrowHeadMarkerMsg.set_action(
         gz::msgs::Marker::DELETE_ALL);
       this->dataPtr->node.Request(
-        "/marker", this->dataPtr->headMarkerMsg);
-      this->dataPtr->headMarkerMsg.set_action(
+        "/marker", this->dataPtr->arrowHeadMarkerMsg);
+      this->dataPtr->arrowHeadMarkerMsg.set_action(
         gz::msgs::Marker::ADD_MODIFY);
     }
 
@@ -331,6 +404,9 @@ void VisualizeContacts::Update(const UpdateInfo &_info,
   // contacts instead of getting new and removed ones
   gz::msgs::Marker_V markerMsgs;
 
+  // Marker ID for position spheres and force arrows.
+  // Note that the position spheres, arrow bodies and arrow heads 
+  // are in separate marker namespaces.
   int posMarkerID = 1;
   int forceMarkerID = 1;
 
@@ -358,45 +434,17 @@ void VisualizeContacts::Update(const UpdateInfo &_info,
           {
             const auto &forceMsg = contact.wrench(i).body_1_wrench().force();
             gz::math::Vector3d force(forceMsg.x(), forceMsg.y(), forceMsg.z());
-            double fNorm = force.Length();
-            if (fNorm > 1e-2)
+            if (force.Length() > kMinimumForceToVisualize)
             {
-              double L = fNorm * this->dataPtr->forceScale;
-              gz::math::Vector3d u = force / fNorm;
-
-              double shaftDiam = 2.0 * this->dataPtr->arrowRadius;
-              double headDiam = 2.2 * shaftDiam;
-              double headLen = std::max(0.01, 2.5 * shaftDiam);
-              if (headLen > 0.4 * L)
-              {
-                headLen = 0.4 * L;
-              }
-              double shaftLen = std::max(0.001, L - headLen);
-
-              gz::math::Quaterniond rot;
-              rot.SetFrom2Axes(gz::math::Vector3d::UnitZ, u);
-
-              // 1. Shaft (Cylinder)
-              gz::math::Vector3d pShaft = p + (0.5 * shaftLen) * u;
-              auto shaftMarker = markerMsgs.add_marker();
-              shaftMarker->CopyFrom(this->dataPtr->shaftMarkerMsg);
-              shaftMarker->set_id(forceMarkerID);
-              gz::msgs::Set(shaftMarker->mutable_pose(),
-                gz::math::Pose3d(pShaft, rot));
-              gz::msgs::Set(shaftMarker->mutable_scale(),
-                gz::math::Vector3d(shaftDiam, shaftDiam, shaftLen));
-
-              // 2. Head (Cone)
-              gz::math::Vector3d pHead = p + (shaftLen + 0.5 * headLen) * u;
-              auto headMarker = markerMsgs.add_marker();
-              headMarker->CopyFrom(this->dataPtr->headMarkerMsg);
-              headMarker->set_id(forceMarkerID);
-              gz::msgs::Set(headMarker->mutable_pose(),
-                gz::math::Pose3d(pHead, rot));
-              gz::msgs::Set(headMarker->mutable_scale(),
-                gz::math::Vector3d(headDiam, headDiam, headLen));
-
-              forceMarkerID++;
+              AddForceArrowMarkers(
+                  markerMsgs,
+                  forceMarkerID++,
+                  p,
+                  force,
+                  this->dataPtr->forceScale,
+                  this->dataPtr->arrowRadius,
+                  this->dataPtr->arrowBodyMarkerMsg,
+                  this->dataPtr->arrowHeadMarkerMsg);
             }
           }
         }
@@ -451,16 +499,16 @@ void VisualizeContactsPrivate::CreateCollisionData(
 }
 
 //////////////////////////////////////////////////
-void VisualizeContacts::UpdateRadius(double _radius)
+void VisualizeContacts::UpdateSphereRadius(double _radius)
 {
   std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
-  this->dataPtr->contactRadius = _radius;
+  this->dataPtr->sphereRadius = _radius;
 
   // Set scale
   gz::msgs::Set(this->dataPtr->positionMarkerMsg.mutable_scale(),
-    gz::math::Vector3d(this->dataPtr->contactRadius,
-    this->dataPtr->contactRadius,
-    this->dataPtr->contactRadius));
+    gz::math::Vector3d(this->dataPtr->sphereRadius,
+    this->dataPtr->sphereRadius,
+    this->dataPtr->sphereRadius));
 }
 
 //////////////////////////////////////////////////
@@ -480,9 +528,9 @@ void VisualizeContacts::UpdatePeriod(double _period)
   this->dataPtr->
     positionMarkerMsg.mutable_lifetime()->set_nsec(_period * 1000000);
   this->dataPtr->
-    shaftMarkerMsg.mutable_lifetime()->set_nsec(_period * 1000000);
+    arrowBodyMarkerMsg.mutable_lifetime()->set_nsec(_period * 1000000);
   this->dataPtr->
-    headMarkerMsg.mutable_lifetime()->set_nsec(_period * 1000000);
+    arrowHeadMarkerMsg.mutable_lifetime()->set_nsec(_period * 1000000);
 }
 
 // Register this plugin

--- a/src/gui/plugins/visualize_contacts/VisualizeContacts.cc
+++ b/src/gui/plugins/visualize_contacts/VisualizeContacts.cc
@@ -83,21 +83,37 @@ void OnMarkerArrayResponse(const gz::msgs::Boolean &, const bool)
     /// \brief Previous state of the checkbox
     public: bool checkboxPrevState{false};
 
-    /// \brief Message for visualizing contact positions
+    /// \brief State of the show forces checkbox
+    public: bool showForcesState{true};
+
+    /// brief Scale of force vectors in m/N
+    public: double forceScale{0.002};
+
+    /// \brief Radius of the force arrow shaft in meters
+    public: double arrowRadius{0.008};
+
+    /// \brief Message template for contact positions (spheres)
     public: gz::msgs::Marker positionMarkerMsg;
 
+    /// \brief Message template for cylinder shafts of force arrows
+    public: gz::msgs::Marker shaftMarkerMsg;
+
+    /// \brief Message template for cone heads of force arrows
+    public: gz::msgs::Marker headMarkerMsg;
+
     /// \brief Radius of the visualized contact sphere
-    public: double contactRadius{0.10};
+    public: double contactRadius{0.03};
 
     /// \brief Update time of the markers in milliseconds
-    public: int64_t markerLifetime{200};
+    public: int64_t markerLifetime{100};
 
     /// \brief Simulation time for the last markers update
     public: std::chrono::steady_clock::duration lastMarkersUpdateTime{0};
 
     /// \brief Mutex for variable mutated by the checkbox and spinboxes
     /// callbacks.
-    /// The variables are: checkboxState, contactRadius and markerLifetime
+    /// The variables are: checkboxState, showForcesState, contactRadius,
+    /// forceScale and markerLifetime
     public: std::mutex serviceMutex;
 
     /// \brief Initialization flag
@@ -128,11 +144,9 @@ void VisualizeContacts::LoadConfig(const tinyxml2::XMLElement *)
   if (this->title.empty())
     this->title = "Visualize contacts";
 
-  // Configure Marker messages for position of the contacts
+  // Configure Marker messages for position and forces of contacts
 
-  // Blue spheres for positions
-
-  // Create the marker message
+  // Bright glowing cyan spheres for contact positions
   this->dataPtr->positionMarkerMsg.set_ns("positions");
   this->dataPtr->positionMarkerMsg.set_action(
     gz::msgs::Marker::ADD_MODIFY);
@@ -147,19 +161,71 @@ void VisualizeContacts::LoadConfig(const tinyxml2::XMLElement *)
     positionMarkerMsg.mutable_lifetime()->
       set_nsec(this->dataPtr->markerLifetime * 1000000);
 
-  // Set material properties
   gz::msgs::Set(
     this->dataPtr->positionMarkerMsg.mutable_material()->mutable_ambient(),
-    gz::math::Color(0, 0, 1, 1));
+    gz::math::Color(0.0, 0.85, 1.0, 1.0));
   gz::msgs::Set(
     this->dataPtr->positionMarkerMsg.mutable_material()->mutable_diffuse(),
-    gz::math::Color(0, 0, 1, 1));
+    gz::math::Color(0.0, 1.0, 1.0, 1.0));
+  gz::msgs::Set(
+    this->dataPtr->positionMarkerMsg.mutable_material()->mutable_emissive(),
+    gz::math::Color(0.0, 0.6, 0.9, 1.0));
 
   // Set contact position scale
   gz::msgs::Set(this->dataPtr->positionMarkerMsg.mutable_scale(),
     gz::math::Vector3d(this->dataPtr->contactRadius,
     this->dataPtr->contactRadius,
     this->dataPtr->contactRadius));
+
+  // Bright glowing amber/gold cylinder shaft for 3D force arrows
+  this->dataPtr->shaftMarkerMsg.set_ns("force_shafts");
+  this->dataPtr->shaftMarkerMsg.set_action(
+    gz::msgs::Marker::ADD_MODIFY);
+  this->dataPtr->shaftMarkerMsg.set_type(
+    gz::msgs::Marker::CYLINDER);
+  this->dataPtr->shaftMarkerMsg.set_visibility(
+    gz::msgs::Marker::GUI);
+  this->dataPtr->
+    shaftMarkerMsg.mutable_lifetime()->
+      set_sec(0);
+  this->dataPtr->
+    shaftMarkerMsg.mutable_lifetime()->
+      set_nsec(this->dataPtr->markerLifetime * 1000000);
+
+  gz::msgs::Set(
+    this->dataPtr->shaftMarkerMsg.mutable_material()->mutable_ambient(),
+    gz::math::Color(1.0, 0.8, 0.0, 1.0));
+  gz::msgs::Set(
+    this->dataPtr->shaftMarkerMsg.mutable_material()->mutable_diffuse(),
+    gz::math::Color(1.0, 0.9, 0.1, 1.0));
+  gz::msgs::Set(
+    this->dataPtr->shaftMarkerMsg.mutable_material()->mutable_emissive(),
+    gz::math::Color(0.9, 0.5, 0.0, 1.0));
+
+  // Bright glowing amber/gold cone head for 3D force arrows
+  this->dataPtr->headMarkerMsg.set_ns("force_heads");
+  this->dataPtr->headMarkerMsg.set_action(
+    gz::msgs::Marker::ADD_MODIFY);
+  this->dataPtr->headMarkerMsg.set_type(
+    gz::msgs::Marker::CONE);
+  this->dataPtr->headMarkerMsg.set_visibility(
+    gz::msgs::Marker::GUI);
+  this->dataPtr->
+    headMarkerMsg.mutable_lifetime()->
+      set_sec(0);
+  this->dataPtr->
+    headMarkerMsg.mutable_lifetime()->
+      set_nsec(this->dataPtr->markerLifetime * 1000000);
+
+  gz::msgs::Set(
+    this->dataPtr->headMarkerMsg.mutable_material()->mutable_ambient(),
+    gz::math::Color(1.0, 0.8, 0.0, 1.0));
+  gz::msgs::Set(
+    this->dataPtr->headMarkerMsg.mutable_material()->mutable_diffuse(),
+    gz::math::Color(1.0, 0.9, 0.1, 1.0));
+  gz::msgs::Set(
+    this->dataPtr->headMarkerMsg.mutable_material()->mutable_emissive(),
+    gz::math::Color(0.9, 0.5, 0.0, 1.0));
 }
 
 /////////////////////////////////////////////////
@@ -167,6 +233,20 @@ void VisualizeContacts::OnVisualize(bool _checked)
 {
   std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
   this->dataPtr->checkboxState = _checked;
+}
+
+/////////////////////////////////////////////////
+void VisualizeContacts::OnVisualizeForces(bool _checked)
+{
+  std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
+  this->dataPtr->showForcesState = _checked;
+}
+
+/////////////////////////////////////////////////
+void VisualizeContacts::UpdateForceScale(double _scale)
+{
+  std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
+  this->dataPtr->forceScale = _scale;
 }
 
 //////////////////////////////////////////////////
@@ -198,18 +278,35 @@ void VisualizeContacts::Update(const UpdateInfo &_info,
 
   {
     std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
-    if (this->dataPtr->checkboxPrevState && !this->dataPtr->checkboxState)
+    if (this->dataPtr->checkboxState && !this->dataPtr->checkboxPrevState)
     {
-      // Remove the markers
+      // Re-scan collisions to ensure any newly added models are enabled
+      this->dataPtr->CreateCollisionData(_ecm);
+    }
+    else if (this->dataPtr->checkboxPrevState && !this->dataPtr->checkboxState)
+    {
+      // Remove position markers
       this->dataPtr->positionMarkerMsg.set_action(
         gz::msgs::Marker::DELETE_ALL);
-
-      gzdbg << "Removing markers..." << std::endl;
       this->dataPtr->node.Request(
         "/marker", this->dataPtr->positionMarkerMsg);
-
-      // Change action in case checkbox is checked again
       this->dataPtr->positionMarkerMsg.set_action(
+        gz::msgs::Marker::ADD_MODIFY);
+
+      // Remove force shaft markers
+      this->dataPtr->shaftMarkerMsg.set_action(
+        gz::msgs::Marker::DELETE_ALL);
+      this->dataPtr->node.Request(
+        "/marker", this->dataPtr->shaftMarkerMsg);
+      this->dataPtr->shaftMarkerMsg.set_action(
+        gz::msgs::Marker::ADD_MODIFY);
+
+      // Remove force head markers
+      this->dataPtr->headMarkerMsg.set_action(
+        gz::msgs::Marker::DELETE_ALL);
+      this->dataPtr->node.Request(
+        "/marker", this->dataPtr->headMarkerMsg);
+      this->dataPtr->headMarkerMsg.set_action(
         gz::msgs::Marker::ADD_MODIFY);
     }
 
@@ -234,8 +331,9 @@ void VisualizeContacts::Update(const UpdateInfo &_info,
   // contacts instead of getting new and removed ones
   gz::msgs::Marker_V markerMsgs;
 
-  // Variable for setting the markers id through the iteration
-  int markerID = 1;
+  int posMarkerID = 1;
+  int forceMarkerID = 1;
+
   _ecm.Each<components::ContactSensorData>(
     [&](const Entity &,
         const components::ContactSensorData *_contacts) -> bool
@@ -244,15 +342,63 @@ void VisualizeContacts::Update(const UpdateInfo &_info,
       {
         for (int i = 0; i < contact.position_size(); ++i)
         {
-          // Add marker id and pose to the marker array
+          const auto &pos = contact.position(i);
+          gz::math::Vector3d p(pos.x(), pos.y(), pos.z());
+
+          // Add contact point position sphere marker
           auto markerMsg = markerMsgs.add_marker();
           markerMsg->CopyFrom(this->dataPtr->positionMarkerMsg);
 
-          markerMsg->set_id(markerID++);
+          markerMsg->set_id(posMarkerID++);
           gz::msgs::Set(markerMsg->mutable_pose(),
-            gz::math::Pose3d(contact.position(i).x(),
-              contact.position(i).y(), contact.position(i).z(),
-              0, 0, 0));
+            gz::math::Pose3d(p, gz::math::Quaterniond::Identity));
+
+          // If 3D force arrows are enabled and wrench data is available
+          if (this->dataPtr->showForcesState && i < contact.wrench_size())
+          {
+            const auto &forceMsg = contact.wrench(i).body_1_wrench().force();
+            gz::math::Vector3d force(forceMsg.x(), forceMsg.y(), forceMsg.z());
+            double fNorm = force.Length();
+            if (fNorm > 1e-2)
+            {
+              double L = fNorm * this->dataPtr->forceScale;
+              gz::math::Vector3d u = force / fNorm;
+
+              double shaftDiam = 2.0 * this->dataPtr->arrowRadius;
+              double headDiam = 2.2 * shaftDiam;
+              double headLen = std::max(0.01, 2.5 * shaftDiam);
+              if (headLen > 0.4 * L)
+              {
+                headLen = 0.4 * L;
+              }
+              double shaftLen = std::max(0.001, L - headLen);
+
+              gz::math::Quaterniond rot;
+              rot.SetFrom2Axes(gz::math::Vector3d::UnitZ, u);
+
+              // 1. Shaft (Cylinder)
+              gz::math::Vector3d pShaft = p + (0.5 * shaftLen) * u;
+              auto shaftMarker = markerMsgs.add_marker();
+              shaftMarker->CopyFrom(this->dataPtr->shaftMarkerMsg);
+              shaftMarker->set_id(forceMarkerID);
+              gz::msgs::Set(shaftMarker->mutable_pose(),
+                gz::math::Pose3d(pShaft, rot));
+              gz::msgs::Set(shaftMarker->mutable_scale(),
+                gz::math::Vector3d(shaftDiam, shaftDiam, shaftLen));
+
+              // 2. Head (Cone)
+              gz::math::Vector3d pHead = p + (shaftLen + 0.5 * headLen) * u;
+              auto headMarker = markerMsgs.add_marker();
+              headMarker->CopyFrom(this->dataPtr->headMarkerMsg);
+              headMarker->set_id(forceMarkerID);
+              gz::msgs::Set(headMarker->mutable_pose(),
+                gz::math::Pose3d(pHead, rot));
+              gz::msgs::Set(headMarker->mutable_scale(),
+                gz::math::Vector3d(headDiam, headDiam, headLen));
+
+              forceMarkerID++;
+            }
+          }
         }
       }
       return true;
@@ -318,6 +464,13 @@ void VisualizeContacts::UpdateRadius(double _radius)
 }
 
 //////////////////////////////////////////////////
+void VisualizeContacts::UpdateArrowRadius(double _radius)
+{
+  std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
+  this->dataPtr->arrowRadius = _radius;
+}
+
+//////////////////////////////////////////////////
 void VisualizeContacts::UpdatePeriod(double _period)
 {
   std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
@@ -326,8 +479,13 @@ void VisualizeContacts::UpdatePeriod(double _period)
   // Set markers lifetime
   this->dataPtr->
     positionMarkerMsg.mutable_lifetime()->set_nsec(_period * 1000000);
+  this->dataPtr->
+    shaftMarkerMsg.mutable_lifetime()->set_nsec(_period * 1000000);
+  this->dataPtr->
+    headMarkerMsg.mutable_lifetime()->set_nsec(_period * 1000000);
 }
 
 // Register this plugin
 GZ_ADD_PLUGIN(gz::sim::VisualizeContacts,
                     gz::gui::Plugin)
+

--- a/src/gui/plugins/visualize_contacts/VisualizeContacts.cc
+++ b/src/gui/plugins/visualize_contacts/VisualizeContacts.cc
@@ -85,7 +85,8 @@ constexpr double kMinimumForceToVisualize = 1e-2;
 /// \param[in] _forceMarkerId ID for the force arrow markers
 /// \param[in] _pos Contact position in world coordinates
 /// \param[in] _force Contact force vector in world coordinates
-/// \param[in] _forceScale Scale factor to convert force magnitude to arrow length
+/// \param[in] _forceScale Scale factor to convert force magnitude to arrow
+/// length
 /// \param[in] _arrowRadius Radius of the arrow body cylinder
 /// \param[in] _bodyMarkerMsg Template marker message for arrow body
 /// \param[in] _headMarkerMsg Template marker message for arrow head
@@ -405,7 +406,7 @@ void VisualizeContacts::Update(const UpdateInfo &_info,
   gz::msgs::Marker_V markerMsgs;
 
   // Marker ID for position spheres and force arrows.
-  // Note that the position spheres, arrow bodies and arrow heads 
+  // Note that the position spheres, arrow bodies and arrow heads
   // are in separate marker namespaces.
   int posMarkerID = 1;
   int forceMarkerID = 1;

--- a/src/gui/plugins/visualize_contacts/VisualizeContacts.cc
+++ b/src/gui/plugins/visualize_contacts/VisualizeContacts.cc
@@ -537,4 +537,3 @@ void VisualizeContacts::UpdatePeriod(double _period)
 // Register this plugin
 GZ_ADD_PLUGIN(gz::sim::VisualizeContacts,
                     gz::gui::Plugin)
-

--- a/src/gui/plugins/visualize_contacts/VisualizeContacts.hh
+++ b/src/gui/plugins/visualize_contacts/VisualizeContacts.hh
@@ -33,9 +33,9 @@ inline namespace GZ_SIM_VERSION_NAMESPACE
 {
   class VisualizeContactsPrivate;
 
-  /// \brief Visualize the contacts returned by the Physics plugin. Use the
-  /// checkbox to turn visualization on or off and spin boxes to change
-  /// the size of the markers.
+  /// \brief Visualize the contacts and contact forces returned by the Physics
+  /// plugin. Use the checkboxes to turn visualization on or off and spin boxes
+  /// to change the scale and size of the markers.
   class VisualizeContacts : public gz::sim::GuiSystem
   {
     Q_OBJECT
@@ -61,15 +61,15 @@ inline namespace GZ_SIM_VERSION_NAMESPACE
     /// \param[in] _checked indicates show or hide contact force arrows
     public slots: void OnVisualizeForces(bool _checked);
 
-    /// \brief Update the radius of the contact
-    /// \param[in] _radius new radius of the contact
-    public slots: void UpdateRadius(double _radius);
+    /// \brief Update the radius of the contact point sphere (m)
+    /// \param[in] _radius new radius of the contact point sphere
+    public slots: void UpdateSphereRadius(double _radius);
 
     /// \brief Update the scale of the contact force vectors (m/N)
     /// \param[in] _scale new force scale
     public slots: void UpdateForceScale(double _scale);
 
-    /// \brief Update the radius of the force arrow shaft (m)
+    /// \brief Update the radius of the force arrow (m)
     /// \param[in] _radius new radius of the arrow
     public slots: void UpdateArrowRadius(double _radius);
 

--- a/src/gui/plugins/visualize_contacts/VisualizeContacts.hh
+++ b/src/gui/plugins/visualize_contacts/VisualizeContacts.hh
@@ -57,9 +57,21 @@ inline namespace GZ_SIM_VERSION_NAMESPACE
     /// \param[in] _checked indicates show or hide contacts
     public slots: void OnVisualize(bool _checked);
 
+    /// \brief Callback when show forces checkbox state is changed
+    /// \param[in] _checked indicates show or hide contact force arrows
+    public slots: void OnVisualizeForces(bool _checked);
+
     /// \brief Update the radius of the contact
     /// \param[in] _radius new radius of the contact
     public slots: void UpdateRadius(double _radius);
+
+    /// \brief Update the scale of the contact force vectors (m/N)
+    /// \param[in] _scale new force scale
+    public slots: void UpdateForceScale(double _scale);
+
+    /// \brief Update the radius of the force arrow shaft (m)
+    /// \param[in] _radius new radius of the arrow
+    public slots: void UpdateArrowRadius(double _radius);
 
     /// \brief Update the update period of the markers
     /// \param[in] _period new update period

--- a/src/gui/plugins/visualize_contacts/VisualizeContacts.qml
+++ b/src/gui/plugins/visualize_contacts/VisualizeContacts.qml
@@ -94,11 +94,11 @@ GridLayout {
     Layout.columnSpan: 2
     Layout.fillWidth: true
     id: forceScale
-    maximumValue: 0.1
-    minimumValue: 0.001
-    value: 0.01
+    maximumValue: 1.0
+    minimumValue: 0.005
+    value: 0.1
     decimals: 3
-    stepSize: 0.001
+    stepSize: 0.005
     onEditingFinished: _VisualizeContacts.UpdateForceScale(forceScale.value)
   }
 

--- a/src/gui/plugins/visualize_contacts/VisualizeContacts.qml
+++ b/src/gui/plugins/visualize_contacts/VisualizeContacts.qml
@@ -55,21 +55,21 @@ GridLayout {
 
   Text {
     Layout.columnSpan: 2
-    id: radiusText
+    id: sphereRadiusText
     color: "dimgrey"
-    text: "Radius (m)"
+    text: "Sphere radius (m)"
   }
 
   GzSpinBox {
     Layout.columnSpan: 2
     Layout.fillWidth: true
-    id: radius
+    id: sphereRadius
     maximumValue: 2.00
     minimumValue: 0.01
     value: 0.10
     decimals: 2
     stepSize: 0.05
-    onEditingFinished: _VisualizeContacts.UpdateRadius(radius.value)
+    onEditingFinished: _VisualizeContacts.UpdateSphereRadius(sphereRadius.value)
   }
 
   CheckBox {
@@ -77,7 +77,7 @@ GridLayout {
     id: visualizeForces
     Layout.columnSpan: 4
     text: qsTr("Show Force Vectors")
-    checked: true
+    checked: false
     onClicked: {
       _VisualizeContacts.OnVisualizeForces(checked)
     }
@@ -94,11 +94,11 @@ GridLayout {
     Layout.columnSpan: 2
     Layout.fillWidth: true
     id: forceScale
-    maximumValue: 0.1000
-    minimumValue: 0.0001
-    value: 0.0020
-    decimals: 4
-    stepSize: 0.0010
+    maximumValue: 0.1
+    minimumValue: 0.001
+    value: 0.01
+    decimals: 3
+    stepSize: 0.001
     onEditingFinished: _VisualizeContacts.UpdateForceScale(forceScale.value)
   }
 
@@ -115,7 +115,7 @@ GridLayout {
     id: arrowRadius
     maximumValue: 0.500
     minimumValue: 0.001
-    value: 0.008
+    value: 0.01
     decimals: 3
     stepSize: 0.002
     onEditingFinished: _VisualizeContacts.UpdateArrowRadius(arrowRadius.value)

--- a/src/gui/plugins/visualize_contacts/VisualizeContacts.qml
+++ b/src/gui/plugins/visualize_contacts/VisualizeContacts.qml
@@ -72,6 +72,55 @@ GridLayout {
     onEditingFinished: _VisualizeContacts.UpdateRadius(radius.value)
   }
 
+  CheckBox {
+    Layout.alignment: Qt.AlignHCenter
+    id: visualizeForces
+    Layout.columnSpan: 4
+    text: qsTr("Show Force Vectors")
+    checked: true
+    onClicked: {
+      _VisualizeContacts.OnVisualizeForces(checked)
+    }
+  }
+
+  Text {
+    Layout.columnSpan: 2
+    id: forceScaleText
+    color: "dimgrey"
+    text: "Force scale (m/N)"
+  }
+
+  GzSpinBox {
+    Layout.columnSpan: 2
+    Layout.fillWidth: true
+    id: forceScale
+    maximumValue: 0.1000
+    minimumValue: 0.0001
+    value: 0.0020
+    decimals: 4
+    stepSize: 0.0010
+    onEditingFinished: _VisualizeContacts.UpdateForceScale(forceScale.value)
+  }
+
+  Text {
+    Layout.columnSpan: 2
+    id: arrowRadiusText
+    color: "dimgrey"
+    text: "Arrow radius (m)"
+  }
+
+  GzSpinBox {
+    Layout.columnSpan: 2
+    Layout.fillWidth: true
+    id: arrowRadius
+    maximumValue: 0.500
+    minimumValue: 0.001
+    value: 0.008
+    decimals: 3
+    stepSize: 0.002
+    onEditingFinished: _VisualizeContacts.UpdateArrowRadius(arrowRadius.value)
+  }
+
   Text {
     Layout.columnSpan: 2
     id: updatePeriodText


### PR DESCRIPTION
# 🎉 New feature

## Summary
Adds an option to display a 3D arrow to depict the magnitude and direction of contact force at a contact point in the `VisualizeContacts` GUI plugin.

The arrow scale and radius can be adjusted as shown below.

<img width="403" height="354" alt="Screenshot 2026-09-09 at 11 57 07 AM" src="https://github.com/user-attachments/assets/d5177dbf-3975-453c-9aec-f4b4f003a79c" />

<img width="600" height="492" alt="output_visualize_contact_forces" src="https://github.com/user-attachments/assets/af0358e7-e28f-437f-810c-4e649136674d" />

Also adds a re-check for collision data when "Show contacts" is toggled, to allow new contacts to be picked up without having to close and re-open the plugin widget.

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Test it
```
$ gz sim visualize_contacts.sdf
```

Then enable `Show Force Vectors`. Set force scale to 0.1m/N and radius to 0.1m.

## Checklist
- [x] Signed all commits for DCO
- [x] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Gemini 3.7 Flash

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.